### PR TITLE
Atualiza automaticamente todas as representações após edição no Property Editor

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
@@ -162,6 +162,12 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
     //
     // property editor
     ui->treeViewPropertyEditor->setAlternatingRowColors(true);
+    connect(
+        ui->treeViewPropertyEditor,
+        &ObjectPropertyBrowser::modelPropertiesChanged,
+        this,
+        &MainWindow::_onPropertyEditorModelChanged
+        );
 
     // system preferences
     SystemPreferences::load();
@@ -217,6 +223,34 @@ MainWindow::~MainWindow() {
 
 ModelGraphicsScene* MainWindow::myScene() const {
     return ui->graphicsView->getScene();
+}
+
+void MainWindow::_onPropertyEditorModelChanged() {
+    _actualizeModelSimLanguage();
+    _actualizeModelComponents(true);
+    _actualizeModelDataDefinitions(true);
+    _actualizeModelCppCode();
+    _createModelImage();
+    _actualizeTabPanes();
+
+    ModelGraphicsScene* scene = myScene();
+    if (scene == nullptr) {
+        return;
+    }
+
+    scene->actualizeDiagramArrows();
+    scene->update();
+
+    if (scene->existDiagram()) {
+        const bool wasVisible = scene->visibleDiagram();
+        scene->destroyDiagram();
+        scene->createDiagrams();
+        if (wasVisible) {
+            scene->showDiagrams();
+        } else {
+            scene->hideDiagrams();
+        }
+    }
 }
 
 

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.h
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.h
@@ -179,6 +179,7 @@ private slots:
     void on_actionParallelization_triggered();
 
     void on_horizontalSlider_ZoomGraphical_actionTriggered(int action);
+    void _onPropertyEditorModelChanged();
 
 protected:
     void closeEvent(QCloseEvent *event) override;

--- a/source/applications/gui/qt/GenesysQtGUI/propertyeditor/ComboBoxEnum.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/propertyeditor/ComboBoxEnum.cpp
@@ -1,5 +1,7 @@
 #include "ComboBoxEnum.h"
 
+#include <utility>
+
 ComboBoxEnum::ComboBoxEnum(
     PropertyEditorGenesys* editor,
     SimulationControl* property,
@@ -49,8 +51,9 @@ void ComboBoxEnum::changeValue() {
         return;
     }
 
+    const std::string oldValue = _property->getValue();
     _editor->changeProperty(_property, std::to_string(_comboBox->currentIndex()));
-    if (_afterChange) {
+    if (_afterChange && _property->getValue() != oldValue) {
         _afterChange();
     }
 }

--- a/source/applications/gui/qt/GenesysQtGUI/propertyeditor/ComboBoxEnum.h
+++ b/source/applications/gui/qt/GenesysQtGUI/propertyeditor/ComboBoxEnum.h
@@ -1,58 +1,40 @@
-#include "ComboBoxEnum.h"
+#ifndef COMBOBOXENUM_H
+#define COMBOBOXENUM_H
 
-#include <utility>
+#include <functional>
 
-ComboBoxEnum::ComboBoxEnum(
-    PropertyEditorGenesys* editor,
-    SimulationControl* property,
-    AfterChange afterChange
-    ) : _editor(editor), _property(property), _afterChange(std::move(afterChange)) {
+#include <QObject>
+#include <QWidget>
+#include <QComboBox>
 
-    _window = new QWidget;
-    _comboBox = new QComboBox(_window);
+#include "../../../../kernel/simulator/PropertyGenesys.h"
 
-    configure_options(property);
-    if (property != nullptr) {
-        _comboBox->setCurrentText(QString::fromStdString(property->getValue()));
-    }
+class ComboBoxEnum : public QObject {
+public:
+    using AfterChange = std::function<void()>;
 
-    _window->setFixedSize(160, 28);
-
-    QObject::connect(
-        _comboBox,
-        static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
-        this,
-        &ComboBoxEnum::changeValue
+    ComboBoxEnum(
+        PropertyEditorGenesys* editor,
+        SimulationControl* property,
+        AfterChange afterChange = {}
         );
-}
 
-void ComboBoxEnum::open_box() {
-    _window->show();
-    _window->raise();
-    _window->activateWindow();
-    _comboBox->showPopup();
-}
+    ~ComboBoxEnum() override = default;
 
-void ComboBoxEnum::configure_options(SimulationControl* property) {
-    _comboBox->clear();
-    if (property == nullptr || property->getStrValues() == nullptr) {
-        return;
-    }
+public:
+    void open_box();
+    void configure_options(SimulationControl* property);
 
-    List<std::string>* values = property->getStrValues();
-    for (const std::string& item : *values->list()) {
-        _comboBox->addItem(QString::fromStdString(item));
-    }
-    delete values;
-}
+private Q_SLOTS:
+    void changeValue();
 
-void ComboBoxEnum::changeValue() {
-    if (_editor == nullptr || _property == nullptr) {
-        return;
-    }
+private:
+    QWidget* _window = nullptr;
+    QComboBox* _comboBox = nullptr;
 
-    _editor->changeProperty(_property, std::to_string(_comboBox->currentIndex()));
-    if (_afterChange) {
-        _afterChange();
-    }
-}
+    PropertyEditorGenesys* _editor = nullptr;
+    SimulationControl* _property = nullptr;
+    AfterChange _afterChange;
+};
+
+#endif // COMBOBOXENUM_H

--- a/source/applications/gui/qt/GenesysQtGUI/propertyeditor/DataComponentEditor.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/propertyeditor/DataComponentEditor.cpp
@@ -120,10 +120,13 @@ void DataComponentEditor::editProperty(SimulationControl* property) {
             } else {
                 const QString valueToChange = _newValue->getText(_newValue, "Item", "Enter the value:");
                 if (!valueToChange.isNull()) {
+                    const std::string oldValue = prop->getValue();
                     _editor->changeProperty(prop, valueToChange.toStdString());
                     _view->clear();
                     configure_properties(property);
-                    _notifyChanged();
+                    if (prop->getValue() != oldValue) {
+                        _notifyChanged();
+                    }
                 }
             }
             return;
@@ -157,10 +160,13 @@ void DataComponentEditor::editProperty(List<SimulationControl*>* properties) {
             } else {
                 const QString valueToChange = _newValue->getText(_newValue, "Item", "Enter the value:");
                 if (!valueToChange.isNull()) {
+                    const std::string oldValue = prop->getValue();
                     _editor->changeProperty(prop, valueToChange.toStdString());
                     _view->clear();
                     configure_properties(properties);
-                    _notifyChanged();
+                    if (prop->getValue() != oldValue) {
+                        _notifyChanged();
+                    }
                 }
             }
             return;

--- a/source/applications/gui/qt/GenesysQtGUI/propertyeditor/DataComponentProperty.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/propertyeditor/DataComponentProperty.cpp
@@ -101,9 +101,29 @@ void DataComponentProperty::addElement() {
     }
 
     if (!isInList(newValue.toStdString())) {
+        List<std::string>* oldValues = _property->getStrValues();
+        const unsigned int oldSize = oldValues != nullptr ? oldValues->size() : 0;
+        delete oldValues;
+
         _editor->changeProperty(_property, newValue.toStdString(), false);
         config_values();
-        _notifyChanged();
+
+        List<std::string>* newValues = _property->getStrValues();
+        const unsigned int newSize = newValues != nullptr ? newValues->size() : 0;
+        bool changed = false;
+        if (newValues != nullptr) {
+            for (const std::string& value : *newValues->list()) {
+                if (value == newValue.toStdString()) {
+                    changed = true;
+                    break;
+                }
+            }
+        }
+        delete newValues;
+
+        if (changed || newSize != oldSize) {
+            _notifyChanged();
+        }
     }
 }
 
@@ -118,9 +138,29 @@ void DataComponentProperty::removeElement() {
     }
 
     const QString itemValue = selectedItem->text(0);
+    List<std::string>* oldValues = _property->getStrValues();
+    const unsigned int oldSize = oldValues != nullptr ? oldValues->size() : 0;
+    delete oldValues;
+
     _editor->changeProperty(_property, itemValue.toStdString(), true);
     config_values();
-    _notifyChanged();
+
+    List<std::string>* newValues = _property->getStrValues();
+    const unsigned int newSize = newValues != nullptr ? newValues->size() : 0;
+    bool removed = true;
+    if (newValues != nullptr) {
+        for (const std::string& value : *newValues->list()) {
+            if (value == itemValue.toStdString()) {
+                removed = false;
+                break;
+            }
+        }
+    }
+    delete newValues;
+
+    if (removed || newSize != oldSize) {
+        _notifyChanged();
+    }
 }
 
 void DataComponentProperty::editProperty() {

--- a/source/applications/gui/qt/GenesysQtGUI/propertyeditor/ObjectPropertyBrowser.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/propertyeditor/ObjectPropertyBrowser.cpp
@@ -287,7 +287,7 @@ bool ObjectPropertyBrowser::_openSpecializedEditor(QtProperty* property) {
     }
 
     auto refresh = [this]() {
-        this->objectUpdated();
+        this->_notifyModelChangeApplied();
     };
 
     if (control->getIsList()) {
@@ -316,6 +316,22 @@ bool ObjectPropertyBrowser::_openSpecializedEditor(QtProperty* property) {
         } else {
             auto* editor = new DataComponentEditor(_propertyEditor, control, refresh);
             editor->open_window(control);
+        }
+        return true;
+    }
+
+    if (binding.descriptor.kind == GenesysPropertyKind::Enum
+        || binding.descriptor.kind == GenesysPropertyKind::TimeUnit
+        || control->getIsEnum()) {
+        if (_propertyBox != nullptr) {
+            auto found = _propertyBox->find(control);
+            if (found == _propertyBox->end() || found->second == nullptr) {
+                (*_propertyBox)[control] = new ComboBoxEnum(_propertyEditor, control, refresh);
+            }
+            (*_propertyBox)[control]->open_box();
+        } else {
+            auto* box = new ComboBoxEnum(_propertyEditor, control, refresh);
+            box->open_box();
         }
         return true;
     }
@@ -350,6 +366,9 @@ void ObjectPropertyBrowser::valueChanged(QtProperty *property, const QVariant &v
     }
 
     const std::string newValue = _fromVariant(binding.descriptor, value);
+    if (newValue == binding.descriptor.currentValue) {
+        return;
+    }
 
     std::string errorMessage;
     const bool ok = GenesysPropertyIntrospection::setValue(
@@ -364,7 +383,7 @@ void ObjectPropertyBrowser::valueChanged(QtProperty *property, const QVariant &v
         return;
     }
 
-    objectUpdated();
+    _notifyModelChangeApplied();
 }
 
 void ObjectPropertyBrowser::enumValueChanged(QtProperty *property, int value) {
@@ -375,6 +394,10 @@ void ObjectPropertyBrowser::enumValueChanged(QtProperty *property, int value) {
 
     const Binding binding = it.value();
     if (binding.control == nullptr) {
+        return;
+    }
+
+    if (value == _enumIndexFor(binding.descriptor)) {
         return;
     }
 
@@ -391,7 +414,12 @@ void ObjectPropertyBrowser::enumValueChanged(QtProperty *property, int value) {
         return;
     }
 
+    _notifyModelChangeApplied();
+}
+
+void ObjectPropertyBrowser::_notifyModelChangeApplied() {
     objectUpdated();
+    emit modelPropertiesChanged();
 }
 
 void ObjectPropertyBrowser::objectUpdated() {
@@ -457,7 +485,13 @@ void ObjectPropertyBrowser::contextMenuEvent(QContextMenuEvent* event) {
     }
 
     const Binding binding = it.value();
-    if (!(binding.descriptor.isList || binding.descriptor.isClass)) {
+    const bool specializedProperty =
+        binding.descriptor.isList
+        || binding.descriptor.isClass
+        || binding.descriptor.kind == GenesysPropertyKind::Enum
+        || binding.descriptor.kind == GenesysPropertyKind::TimeUnit;
+
+    if (!specializedProperty) {
         QtTreePropertyBrowser::contextMenuEvent(event);
         return;
     }

--- a/source/applications/gui/qt/GenesysQtGUI/propertyeditor/ObjectPropertyBrowser.h
+++ b/source/applications/gui/qt/GenesysQtGUI/propertyeditor/ObjectPropertyBrowser.h
@@ -49,6 +49,7 @@ private:
     };
 
 private:
+    void _notifyModelChangeApplied();
     void _clearAll();
     void _populateKernelProperties(ModelDataDefinition* mdd);
     QtProperty* _createProperty(const GenesysPropertyDescriptor& desc);
@@ -90,6 +91,9 @@ private slots:
 
 public slots:
     void objectUpdated();
+
+signals:
+    void modelPropertiesChanged();
 };
 
 #endif // OBJECTPROPERTYBROWSER_H


### PR DESCRIPTION
### Motivation
- Garantir que qualquer alteração de propriedade feita via Property Editor seja refletida automaticamente em todas as representações da interface (texto do modelo, árvores de componentes/data definitions, código C++, imagem/diagramas e cena gráfica). 
- Evitar emissões de atualização desnecessárias em refreshs visuais ou quando o valor não mudou (reduzir trabalho e flicker). 
- Preservar a arquitetura atual baseada em `SimulationControl`/`GenesysPropertyIntrospection` sem reintroduzir acoplamento por `QObject::setProperty()`.

### Description
- Adiciona no `ObjectPropertyBrowser` um novo sinal `modelPropertiesChanged()` e o helper `_notifyModelChangeApplied()` que faz `objectUpdated()` seguido da emissão do sinal; os métodos `valueChanged` e `enumValueChanged` agora ignoram no-op e só notifi cam quando `GenesysPropertyIntrospection::setValue(...)` retornar sucesso (arquivos: `ObjectPropertyBrowser.h`, `ObjectPropertyBrowser.cpp`).
- Integra edição especializada de enums/`TimeUnit` ao fluxo do `ObjectPropertyBrowser` (menu de contexto / duplo clique / Enter) usando `ComboBoxEnum` com callback que chama o fluxo centralizado (arquivos: `ObjectPropertyBrowser.cpp`, `ComboBoxEnum.h`, `ComboBoxEnum.cpp`).
- Atualiza editores especializados para disparar callback apenas se houve alteração efetiva: `DataComponentProperty` (add/remove detecta mudança real), `DataComponentEditor` (compara `oldValue` antes/depois), `ComboBoxEnum` (compara valor antigo) (arquivos: `DataComponentProperty.cpp`, `DataComponentEditor.cpp`, `ComboBoxEnum.cpp`).
- Conecta o novo sinal no `MainWindow` e implementa o slot `_onPropertyEditorModelChanged()` que chama ` _actualizeModelSimLanguage()`, `_actualizeModelComponents(true)`, `_actualizeModelDataDefinitions(true)`, `_actualizeModelCppCode()`, `_createModelImage()`, `_actualizeTabPanes()` e também atualiza a cena gráfica chamando `actualizeDiagramArrows()`, `update()` e recriando os diagramas preservando a visibilidade (`existDiagram()`, `visibleDiagram()`, `destroyDiagram()`, `createDiagrams()`, `showDiagrams()/hideDiagrams()`) (arquivos: `mainwindow.h`, `mainwindow.cpp`).

### Testing
- Executado `git diff --check` e verificado que o patch está limpo (sem conflitos de formatação). 
- Tentativa de build com `cmake --build ...` não foi concluída no ambiente atual devido a ausência de cache/configuração (`Error: could not load cache`). 
- Commit realizado com sucesso e alterações registradas (`git show --stat -1`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d474712570832197c7bf975884d66b)