### PR TITLE
Property editor: emit model change events, avoid redundant updates, and harden ObjectPropertyBrowser

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
@@ -162,6 +162,12 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
     //
     // property editor
     ui->treeViewPropertyEditor->setAlternatingRowColors(true);
+    connect(
+        ui->treeViewPropertyEditor,
+        &ObjectPropertyBrowser::modelPropertiesChanged,
+        this,
+        &MainWindow::_onPropertyEditorModelChanged
+        );
 
     // system preferences
     SystemPreferences::load();
@@ -217,6 +223,34 @@ MainWindow::~MainWindow() {
 
 ModelGraphicsScene* MainWindow::myScene() const {
     return ui->graphicsView->getScene();
+}
+
+void MainWindow::_onPropertyEditorModelChanged() {
+    _actualizeModelSimLanguage();
+    _actualizeModelComponents(true);
+    _actualizeModelDataDefinitions(true);
+    _actualizeModelCppCode();
+    _createModelImage();
+    _actualizeTabPanes();
+
+    ModelGraphicsScene* scene = myScene();
+    if (scene == nullptr) {
+        return;
+    }
+
+    scene->actualizeDiagramArrows();
+    scene->update();
+
+    if (scene->existDiagram()) {
+        const bool wasVisible = scene->visibleDiagram();
+        scene->destroyDiagram();
+        scene->createDiagrams();
+        if (wasVisible) {
+            scene->showDiagrams();
+        } else {
+            scene->hideDiagrams();
+        }
+    }
 }
 
 

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.h
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.h
@@ -179,6 +179,7 @@ private slots:
     void on_actionParallelization_triggered();
 
     void on_horizontalSlider_ZoomGraphical_actionTriggered(int action);
+    void _onPropertyEditorModelChanged();
 
 protected:
     void closeEvent(QCloseEvent *event) override;

--- a/source/applications/gui/qt/GenesysQtGUI/propertyeditor/ComboBoxEnum.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/propertyeditor/ComboBoxEnum.cpp
@@ -1,5 +1,7 @@
 #include "ComboBoxEnum.h"
 
+#include <utility>
+
 ComboBoxEnum::ComboBoxEnum(
     PropertyEditorGenesys* editor,
     SimulationControl* property,
@@ -49,8 +51,9 @@ void ComboBoxEnum::changeValue() {
         return;
     }
 
+    const std::string oldValue = _property->getValue();
     _editor->changeProperty(_property, std::to_string(_comboBox->currentIndex()));
-    if (_afterChange) {
+    if (_afterChange && _property->getValue() != oldValue) {
         _afterChange();
     }
 }

--- a/source/applications/gui/qt/GenesysQtGUI/propertyeditor/ComboBoxEnum.h
+++ b/source/applications/gui/qt/GenesysQtGUI/propertyeditor/ComboBoxEnum.h
@@ -1,58 +1,40 @@
-#include "ComboBoxEnum.h"
+#ifndef COMBOBOXENUM_H
+#define COMBOBOXENUM_H
 
-#include <utility>
+#include <functional>
 
-ComboBoxEnum::ComboBoxEnum(
-    PropertyEditorGenesys* editor,
-    SimulationControl* property,
-    AfterChange afterChange
-    ) : _editor(editor), _property(property), _afterChange(std::move(afterChange)) {
+#include <QObject>
+#include <QWidget>
+#include <QComboBox>
 
-    _window = new QWidget;
-    _comboBox = new QComboBox(_window);
+#include "../../../../kernel/simulator/PropertyGenesys.h"
 
-    configure_options(property);
-    if (property != nullptr) {
-        _comboBox->setCurrentText(QString::fromStdString(property->getValue()));
-    }
+class ComboBoxEnum : public QObject {
+public:
+    using AfterChange = std::function<void()>;
 
-    _window->setFixedSize(160, 28);
-
-    QObject::connect(
-        _comboBox,
-        static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
-        this,
-        &ComboBoxEnum::changeValue
+    ComboBoxEnum(
+        PropertyEditorGenesys* editor,
+        SimulationControl* property,
+        AfterChange afterChange = {}
         );
-}
 
-void ComboBoxEnum::open_box() {
-    _window->show();
-    _window->raise();
-    _window->activateWindow();
-    _comboBox->showPopup();
-}
+    ~ComboBoxEnum() override = default;
 
-void ComboBoxEnum::configure_options(SimulationControl* property) {
-    _comboBox->clear();
-    if (property == nullptr || property->getStrValues() == nullptr) {
-        return;
-    }
+public:
+    void open_box();
+    void configure_options(SimulationControl* property);
 
-    List<std::string>* values = property->getStrValues();
-    for (const std::string& item : *values->list()) {
-        _comboBox->addItem(QString::fromStdString(item));
-    }
-    delete values;
-}
+private Q_SLOTS:
+    void changeValue();
 
-void ComboBoxEnum::changeValue() {
-    if (_editor == nullptr || _property == nullptr) {
-        return;
-    }
+private:
+    QWidget* _window = nullptr;
+    QComboBox* _comboBox = nullptr;
 
-    _editor->changeProperty(_property, std::to_string(_comboBox->currentIndex()));
-    if (_afterChange) {
-        _afterChange();
-    }
-}
+    PropertyEditorGenesys* _editor = nullptr;
+    SimulationControl* _property = nullptr;
+    AfterChange _afterChange;
+};
+
+#endif // COMBOBOXENUM_H

--- a/source/applications/gui/qt/GenesysQtGUI/propertyeditor/DataComponentEditor.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/propertyeditor/DataComponentEditor.cpp
@@ -120,10 +120,13 @@ void DataComponentEditor::editProperty(SimulationControl* property) {
             } else {
                 const QString valueToChange = _newValue->getText(_newValue, "Item", "Enter the value:");
                 if (!valueToChange.isNull()) {
+                    const std::string oldValue = prop->getValue();
                     _editor->changeProperty(prop, valueToChange.toStdString());
                     _view->clear();
                     configure_properties(property);
-                    _notifyChanged();
+                    if (prop->getValue() != oldValue) {
+                        _notifyChanged();
+                    }
                 }
             }
             return;
@@ -157,10 +160,13 @@ void DataComponentEditor::editProperty(List<SimulationControl*>* properties) {
             } else {
                 const QString valueToChange = _newValue->getText(_newValue, "Item", "Enter the value:");
                 if (!valueToChange.isNull()) {
+                    const std::string oldValue = prop->getValue();
                     _editor->changeProperty(prop, valueToChange.toStdString());
                     _view->clear();
                     configure_properties(properties);
-                    _notifyChanged();
+                    if (prop->getValue() != oldValue) {
+                        _notifyChanged();
+                    }
                 }
             }
             return;

--- a/source/applications/gui/qt/GenesysQtGUI/propertyeditor/DataComponentProperty.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/propertyeditor/DataComponentProperty.cpp
@@ -101,9 +101,29 @@ void DataComponentProperty::addElement() {
     }
 
     if (!isInList(newValue.toStdString())) {
+        List<std::string>* oldValues = _property->getStrValues();
+        const unsigned int oldSize = oldValues != nullptr ? oldValues->size() : 0;
+        delete oldValues;
+
         _editor->changeProperty(_property, newValue.toStdString(), false);
         config_values();
-        _notifyChanged();
+
+        List<std::string>* newValues = _property->getStrValues();
+        const unsigned int newSize = newValues != nullptr ? newValues->size() : 0;
+        bool changed = false;
+        if (newValues != nullptr) {
+            for (const std::string& value : *newValues->list()) {
+                if (value == newValue.toStdString()) {
+                    changed = true;
+                    break;
+                }
+            }
+        }
+        delete newValues;
+
+        if (changed || newSize != oldSize) {
+            _notifyChanged();
+        }
     }
 }
 
@@ -118,9 +138,29 @@ void DataComponentProperty::removeElement() {
     }
 
     const QString itemValue = selectedItem->text(0);
+    List<std::string>* oldValues = _property->getStrValues();
+    const unsigned int oldSize = oldValues != nullptr ? oldValues->size() : 0;
+    delete oldValues;
+
     _editor->changeProperty(_property, itemValue.toStdString(), true);
     config_values();
-    _notifyChanged();
+
+    List<std::string>* newValues = _property->getStrValues();
+    const unsigned int newSize = newValues != nullptr ? newValues->size() : 0;
+    bool removed = true;
+    if (newValues != nullptr) {
+        for (const std::string& value : *newValues->list()) {
+            if (value == itemValue.toStdString()) {
+                removed = false;
+                break;
+            }
+        }
+    }
+    delete newValues;
+
+    if (removed || newSize != oldSize) {
+        _notifyChanged();
+    }
 }
 
 void DataComponentProperty::editProperty() {

--- a/source/applications/gui/qt/GenesysQtGUI/propertyeditor/ObjectPropertyBrowser.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/propertyeditor/ObjectPropertyBrowser.cpp
@@ -2,11 +2,143 @@
 
 #include <map>
 #include <sstream>
+#include <exception>
 
 #include <QSignalBlocker>
 #include <QString>
 #include <QVariant>
 #include <QMenu>
+
+namespace {
+
+static std::vector<std::string> _copyStringList(List<std::string>* list) {
+    std::vector<std::string> result;
+    if (list == nullptr) {
+        return result;
+    }
+
+    for (const std::string& value : *list->list()) {
+        result.push_back(value);
+    }
+
+    delete list;
+    return result;
+}
+
+static GenesysPropertyKind _deduceKind(const SimulationControl* control) {
+    if (control == nullptr) {
+        return GenesysPropertyKind::Unknown;
+    }
+
+    if (control->getIsList()) {
+        return GenesysPropertyKind::List;
+    }
+    if (control->getIsClass()) {
+        return GenesysPropertyKind::Object;
+    }
+
+    const std::string typeName = control->propertyType();
+
+    if (typeName == Util::TypeOf<Util::TimeUnit>()) {
+        return GenesysPropertyKind::TimeUnit;
+    }
+    if (control->getIsEnum()) {
+        return GenesysPropertyKind::Enum;
+    }
+    if (typeName == Util::TypeOf<bool>()) {
+        return GenesysPropertyKind::Boolean;
+    }
+    if (typeName == Util::TypeOf<int>()) {
+        return GenesysPropertyKind::Integer;
+    }
+    if (typeName == Util::TypeOf<unsigned int>()) {
+        return GenesysPropertyKind::UnsignedInteger;
+    }
+    if (typeName == Util::TypeOf<unsigned short>()) {
+        return GenesysPropertyKind::UnsignedShort;
+    }
+    if (typeName == Util::TypeOf<double>()) {
+        return GenesysPropertyKind::Double;
+    }
+    if (typeName == Util::TypeOf<std::string>()) {
+        return GenesysPropertyKind::String;
+    }
+
+    return GenesysPropertyKind::Unknown;
+}
+
+static GenesysPropertyDescriptor _describeControl(SimulationControl* control) {
+    GenesysPropertyDescriptor desc;
+    if (control == nullptr) {
+        return desc;
+    }
+
+    desc.control = control;
+    desc.ownerClassName = control->getClassname();
+    desc.ownerElementName = control->getElementName();
+    desc.displayName = control->getName();
+    desc.technicalTypeName = control->propertyType();
+    desc.kind = _deduceKind(control);
+    desc.readOnly = control->isReadOnly();
+    desc.isList = control->getIsList();
+    desc.isClass = control->getIsClass();
+    desc.isEnum = control->getIsEnum();
+    desc.currentValue = control->getValue();
+
+    desc.choices = _copyStringList(control->getStrValues());
+
+    if (desc.kind == GenesysPropertyKind::TimeUnit && desc.choices.empty()) {
+        for (int i = 0; i < static_cast<int>(Util::TimeUnit::num_elements); ++i) {
+            desc.choices.push_back(Util::convertEnumToStr(static_cast<Util::TimeUnit>(i)));
+        }
+    }
+
+    return desc;
+}
+
+static std::vector<GenesysPropertyDescriptor> _describeControls(List<SimulationControl*>* controls) {
+    std::vector<GenesysPropertyDescriptor> result;
+    if (controls == nullptr) {
+        return result;
+    }
+
+    for (SimulationControl* control : *controls->list()) {
+        result.push_back(_describeControl(control));
+    }
+
+    return result;
+}
+
+static bool _setControlValue(
+    SimulationControl* control,
+    const std::string& value,
+    bool remove,
+    std::string* errorMessage
+    ) {
+    if (control == nullptr) {
+        if (errorMessage != nullptr) {
+            *errorMessage = "SimulationControl nulo";
+        }
+        return false;
+    }
+
+    try {
+        control->setValue(value, remove);
+        return true;
+    } catch (const std::exception& e) {
+        if (errorMessage != nullptr) {
+            *errorMessage = e.what();
+        }
+        return false;
+    } catch (...) {
+        if (errorMessage != nullptr) {
+            *errorMessage = "Erro desconhecido ao alterar propriedade";
+        }
+        return false;
+    }
+}
+
+} // namespace
 
 ObjectPropertyBrowser::ObjectPropertyBrowser(QWidget* parent)
     : QtTreePropertyBrowser(parent) {
@@ -249,7 +381,7 @@ void ObjectPropertyBrowser::_populateKernelProperties(ModelDataDefinition* mdd) 
     }
 
     const std::vector<GenesysPropertyDescriptor> properties =
-        GenesysPropertyIntrospection::describe(mdd->getProperties());
+        _describeControls(mdd->getProperties());
 
     std::map<std::string, QtProperty*> groups;
 
@@ -287,7 +419,7 @@ bool ObjectPropertyBrowser::_openSpecializedEditor(QtProperty* property) {
     }
 
     auto refresh = [this]() {
-        this->objectUpdated();
+        this->_notifyModelChangeApplied();
     };
 
     if (control->getIsList()) {
@@ -316,6 +448,22 @@ bool ObjectPropertyBrowser::_openSpecializedEditor(QtProperty* property) {
         } else {
             auto* editor = new DataComponentEditor(_propertyEditor, control, refresh);
             editor->open_window(control);
+        }
+        return true;
+    }
+
+    if (binding.descriptor.kind == GenesysPropertyKind::Enum
+        || binding.descriptor.kind == GenesysPropertyKind::TimeUnit
+        || control->getIsEnum()) {
+        if (_propertyBox != nullptr) {
+            auto found = _propertyBox->find(control);
+            if (found == _propertyBox->end() || found->second == nullptr) {
+                (*_propertyBox)[control] = new ComboBoxEnum(_propertyEditor, control, refresh);
+            }
+            (*_propertyBox)[control]->open_box();
+        } else {
+            auto* box = new ComboBoxEnum(_propertyEditor, control, refresh);
+            box->open_box();
         }
         return true;
     }
@@ -350,9 +498,12 @@ void ObjectPropertyBrowser::valueChanged(QtProperty *property, const QVariant &v
     }
 
     const std::string newValue = _fromVariant(binding.descriptor, value);
+    if (newValue == binding.descriptor.currentValue) {
+        return;
+    }
 
     std::string errorMessage;
-    const bool ok = GenesysPropertyIntrospection::setValue(
+    const bool ok = _setControlValue(
         binding.control,
         newValue,
         false,
@@ -364,7 +515,7 @@ void ObjectPropertyBrowser::valueChanged(QtProperty *property, const QVariant &v
         return;
     }
 
-    objectUpdated();
+    _notifyModelChangeApplied();
 }
 
 void ObjectPropertyBrowser::enumValueChanged(QtProperty *property, int value) {
@@ -378,8 +529,12 @@ void ObjectPropertyBrowser::enumValueChanged(QtProperty *property, int value) {
         return;
     }
 
+    if (value == _enumIndexFor(binding.descriptor)) {
+        return;
+    }
+
     std::string errorMessage;
-    const bool ok = GenesysPropertyIntrospection::setValue(
+    const bool ok = _setControlValue(
         binding.control,
         std::to_string(value),
         false,
@@ -391,7 +546,12 @@ void ObjectPropertyBrowser::enumValueChanged(QtProperty *property, int value) {
         return;
     }
 
+    _notifyModelChangeApplied();
+}
+
+void ObjectPropertyBrowser::_notifyModelChangeApplied() {
     objectUpdated();
+    emit modelPropertiesChanged();
 }
 
 void ObjectPropertyBrowser::objectUpdated() {
@@ -409,8 +569,7 @@ void ObjectPropertyBrowser::objectUpdated() {
             continue;
         }
 
-        GenesysPropertyDescriptor fresh =
-            GenesysPropertyIntrospection::describe(binding.control);
+        GenesysPropertyDescriptor fresh = _describeControl(binding.control);
 
         binding.descriptor = fresh;
         _bindings[key] = binding;
@@ -457,7 +616,13 @@ void ObjectPropertyBrowser::contextMenuEvent(QContextMenuEvent* event) {
     }
 
     const Binding binding = it.value();
-    if (!(binding.descriptor.isList || binding.descriptor.isClass)) {
+    const bool specializedProperty =
+        binding.descriptor.isList
+        || binding.descriptor.isClass
+        || binding.descriptor.kind == GenesysPropertyKind::Enum
+        || binding.descriptor.kind == GenesysPropertyKind::TimeUnit;
+
+    if (!specializedProperty) {
         QtTreePropertyBrowser::contextMenuEvent(event);
         return;
     }

--- a/source/applications/gui/qt/GenesysQtGUI/propertyeditor/ObjectPropertyBrowser.h
+++ b/source/applications/gui/qt/GenesysQtGUI/propertyeditor/ObjectPropertyBrowser.h
@@ -49,6 +49,7 @@ private:
     };
 
 private:
+    void _notifyModelChangeApplied();
     void _clearAll();
     void _populateKernelProperties(ModelDataDefinition* mdd);
     QtProperty* _createProperty(const GenesysPropertyDescriptor& desc);
@@ -90,6 +91,9 @@ private slots:
 
 public slots:
     void objectUpdated();
+
+signals:
+    void modelPropertiesChanged();
 };
 
 #endif // OBJECTPROPERTYBROWSER_H


### PR DESCRIPTION
### Motivation
- Ensure the main window reacts to in-place edits in the property editor by triggering full model/UI refreshes when properties change.
- Prevent unnecessary downstream updates and UI work when a property value is set but remains unchanged.
- Improve robustness of property handling by centralizing type deduction and error handling when setting property values, and support specialized editing for enums and time units.

### Description
- Added a `modelPropertiesChanged` signal to `ObjectPropertyBrowser`, connected it in `MainWindow`, and implemented `_onPropertyEditorModelChanged` in `MainWindow` to refresh model language, components, data definitions, C++ code, model image, tab panes, and graphical diagram arrows and diagrams when properties change.
- Reworked the `ComboBoxEnum` interface into a proper header/implementation pair and changed `changeValue` to compare the old value before invoking the `AfterChange` callback so it only fires when the value actually changed.
- Updated `DataComponentEditor` and `DataComponentProperty` to capture old values/sizes and only call `_notifyChanged()` when the property list/value actually changed after the edit/add/remove operation.
- Refactored `ObjectPropertyBrowser` by adding internal helpers to describe controls, deduce property kinds, copy string lists, and safely set values with `try/catch`; replaced previous introspection usage with these helpers; avoided redundant writes when the new value equals the current one; supported opening specialized editors for enums and time units; and added `_notifyModelChangeApplied()` to call `objectUpdated()` and emit `modelPropertiesChanged`.

### Testing
- Built the GUI application using the project's normal build (`cmake --build .` / `make`) with these changes and the build completed successfully.
- Executed the existing automated test suite (`ctest` / `make test`) and the tests passed without regressions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d474712570832197c7bf975884d66b)