### PR TITLE
Enable lazy instantiation for nested class properties in Qt property editor

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/propertyeditor/DataComponentEditor.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/propertyeditor/DataComponentEditor.cpp
@@ -70,11 +70,21 @@ void DataComponentEditor::open_window(List<SimulationControl*>* properties) {
 }
 
 void DataComponentEditor::configure_properties(SimulationControl* property) {
-    if (property == nullptr || property->getProperties() == nullptr) {
+    if (property == nullptr) {
         return;
     }
 
-    for (auto prop : *property->getProperties()->list()) {
+    List<SimulationControl*>* nestedProperties = nullptr;
+    try {
+        nestedProperties = property->getEditableProperties();
+    } catch (...) {
+        return;
+    }
+    if (nestedProperties == nullptr) {
+        return;
+    }
+
+    for (auto prop : *nestedProperties->list()) {
         auto* item = new QTreeWidgetItem(_view);
         item->setText(0, QString::fromStdString(prop->getName()));
         item->setText(1, QString::fromStdString(prop->getValue()));
@@ -96,7 +106,17 @@ void DataComponentEditor::configure_properties(List<SimulationControl*>* propert
 }
 
 void DataComponentEditor::editProperty(SimulationControl* property) {
-    if (property == nullptr || property->getProperties() == nullptr) {
+    if (property == nullptr) {
+        return;
+    }
+
+    List<SimulationControl*>* nestedProperties = nullptr;
+    try {
+        nestedProperties = property->getEditableProperties();
+    } catch (...) {
+        return;
+    }
+    if (nestedProperties == nullptr) {
         return;
     }
 
@@ -106,7 +126,7 @@ void DataComponentEditor::editProperty(SimulationControl* property) {
     }
 
     int index = 0;
-    for (auto prop : *property->getProperties()->list()) {
+    for (auto prop : *nestedProperties->list()) {
         if (index == selectedRow) {
             if (prop->getIsList()) {
                 auto* newList = new DataComponentProperty(_editor, prop, true, _afterChange);

--- a/source/applications/gui/qt/GenesysQtGUI/propertyeditor/ObjectPropertyBrowser.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/propertyeditor/ObjectPropertyBrowser.cpp
@@ -443,6 +443,16 @@ bool ObjectPropertyBrowser::_openSpecializedEditor(QtProperty* property) {
     }
 
     if (control->getIsClass()) {
+        List<SimulationControl*>* children = nullptr;
+        try {
+            children = control->getEditableProperties();
+        } catch (...) {
+            return false;
+        }
+        if (children == nullptr) {
+            return false;
+        }
+
         if (_propertyEditorUI != nullptr) {
             auto found = _propertyEditorUI->find(control);
             if (found == _propertyEditorUI->end() || found->second == nullptr) {

--- a/source/kernel/simulator/SimulationControlAndResponse.h
+++ b/source/kernel/simulator/SimulationControlAndResponse.h
@@ -153,6 +153,16 @@ public:
 public:
     virtual void setValue(std::string value, bool remove=false) = 0;
     virtual List<SimulationControl*>* getProperties(int index=0) { return nullptr; };
+    virtual bool hasObjectInstance() const { return true; }
+    virtual bool ensureObjectInstance() { return hasObjectInstance(); }
+    virtual List<SimulationControl*>* getEditableProperties(int index=0) {
+        if (getIsClass() && !hasObjectInstance()) {
+            if (!ensureObjectInstance()) {
+                return nullptr;
+            }
+        }
+        return getProperties(index);
+    }
 protected:
 	void _ensureWritable(const char* operation) const {
 		if (_readonly) {
@@ -579,11 +589,13 @@ private:
 template <typename T, typename M, typename C>
 class SimulationControlGenericClassNotDC: public SimulationControl {
 public:
-    SimulationControlGenericClassNotDC(M model, GetterGeneric<T> getter, SetterGeneric<T> setter, std::string className, std::string elementName, std::string propertyName, std::string whatsThis="", bool isList=false, bool isClass=true, bool isEnum=false) : SimulationControl(className, elementName, propertyName, whatsThis, isList, isClass, isEnum){
+    using Creator = std::function<T(M)>;
+    SimulationControlGenericClassNotDC(M model, GetterGeneric<T> getter, SetterGeneric<T> setter, std::string className, std::string elementName, std::string propertyName, std::string whatsThis="", bool isList=false, bool isClass=true, bool isEnum=false, Creator creator=nullptr) : SimulationControl(className, elementName, propertyName, whatsThis, isList, isClass, isEnum){
 		static_assert(std::is_pointer<T>::value, "SimulationControlGenericClassNotDC requires pointer type T");
         _model = model;
         _getter= getter;
         _setter = setter;
+        _creator = creator;
         _readonly = setter == nullptr;
         _propertyType = Util::TypeOf<C>();
     }
@@ -614,6 +626,31 @@ public:
         _setter(newVal);
     };
 
+    virtual bool hasObjectInstance() const override {
+        return static_cast<T>(_getter()) != nullptr;
+    }
+
+    virtual bool ensureObjectInstance() override {
+		_ensureWritable("ensure instance of");
+		if (!_setter) {
+			throw std::logic_error("SimulationControlGenericClassNotDC setter is not defined");
+		}
+
+        T current = static_cast<T>(_getter());
+        if (current != nullptr) {
+            return true;
+        }
+
+        T newVal;
+        if (_creator != nullptr) {
+            newVal = _creator(_model);
+        } else {
+            newVal = new C(_model, "");
+        }
+        _setter(newVal);
+        return static_cast<T>(_getter()) != nullptr;
+    }
+
     virtual List<SimulationControl*>* getProperties(int index=0) override {
         T tVal = static_cast<T>(_getter());
 
@@ -628,6 +665,7 @@ private:
     M _model;
     GetterGeneric<T> _getter;
     SetterGeneric<T> _setter;
+    Creator _creator;
 };
 
 template <typename T, typename M, typename C>

--- a/source/plugins/components/Process.cpp
+++ b/source/plugins/components/Process.cpp
@@ -45,7 +45,8 @@ Process::Process(Model* model, std::string name) : ModelComponent(model, Util::T
 	SimulationControlGenericClassNotDC<QueueableItem*, Model*, QueueableItem>* propQueueableItem = new SimulationControlGenericClassNotDC<QueueableItem*, Model*, QueueableItem>(
 									_parentModel,
 									std::bind(&Process::getQueueableItem, this), std::bind(&Process::setQueueableItem, this, std::placeholders::_1),
-									Util::TypeOf<Process>(), getName(), "QueueableItem", "");
+									Util::TypeOf<Process>(), getName(), "QueueableItem", "", false, true, false,
+									[](Model* model) { return new QueueableItem(model, ""); });
 	// SimulationControlGeneric<std::string>* propdelayExpression = new SimulationControlGeneric<std::string>(
 	// 								std::bind(&Process::delayExpression, this), std::bind(&Process::setDelayExpression, this, std::placeholders::_1),
 	// 								Util::TypeOf<Process>(), getName(), "DelayExpression", "");

--- a/source/plugins/components/QueueableItem.cpp
+++ b/source/plugins/components/QueueableItem.cpp
@@ -82,11 +82,15 @@ bool QueueableItem::loadInstance(PersistenceRecord *fields) {
 			if (_queueableType == QueueableItem::QueueableType::QUEUE) {
 				_queueOrSet = _modeldataManager->getDataDefinition(Util::TypeOf<Queue>(), _queueableName);
 			} else if (_queueableType == QueueableItem::QueueableType::SET) {
-				_queueOrSet = _modeldataManager->getDataDefinition(Util::TypeOf<Queue>(), _queueableName);
+				_queueOrSet = _modeldataManager->getDataDefinition(Util::TypeOf<Set>(), _queueableName);
 			}
 			if (_queueOrSet == nullptr) {
 				auto model = _modeldataManager->getParentModel();
-				_queueOrSet = model->getParentSimulator()->getPluginManager()->newInstance<Queue>(model, _queueableName);
+				if (_queueableType == QueueableItem::QueueableType::SET) {
+					_queueOrSet = model->getParentSimulator()->getPluginManager()->newInstance<Set>(model, _queueableName);
+				} else {
+					_queueOrSet = model->getParentSimulator()->getPluginManager()->newInstance<Queue>(model, _queueableName);
+				}
 			}
 		}
 		assert(_queueOrSet != nullptr);
@@ -98,12 +102,12 @@ bool QueueableItem::loadInstance(PersistenceRecord *fields) {
 
 void QueueableItem::saveInstance(PersistenceRecord *fields, bool saveDefaultValues) {
 	fields->saveField("queueableType", static_cast<int> (_queueableType), static_cast<int> (DEFAULT.queueableType), saveDefaultValues);
-	fields->saveField("queueable", _queueOrSet->getName());
+	fields->saveField("queueable", _queueOrSet != nullptr ? _queueOrSet->getName() : "");
 	fields->saveField("index", _index, DEFAULT.index, saveDefaultValues);
 }
 
 std::string QueueableItem::show() {
-	return "queueType=" + std::to_string(static_cast<int> (_queueableType)) + ",queue=\"" + _queueOrSet->getName() + "\",index=\"" + _index + "\"";
+	return "queueType=" + std::to_string(static_cast<int> (_queueableType)) + ",queue=\"" + (_queueOrSet != nullptr ? _queueOrSet->getName() : "") + "\",index=\"" + _index + "\"";
 }
 
 void QueueableItem::_addProperty(PropertyBase* property) {
@@ -132,7 +136,7 @@ std::string QueueableItem::getName() const {
 
 void QueueableItem::setQueue(Queue* queue) {
 	this->_queueOrSet = queue;
-	_queueableName = queue->getName();
+	_queueableName = queue != nullptr ? queue->getName() : "";
 }
 
 Queue* QueueableItem::getQueue() const {
@@ -141,7 +145,7 @@ Queue* QueueableItem::getQueue() const {
 
 void QueueableItem::setSet(Set* set) {
 	this->_queueOrSet = set;
-	_queueableName = set->getName();
+	_queueableName = set != nullptr ? set->getName() : "";
 }
 
 Set* QueueableItem::getSet() const {

--- a/source/plugins/components/Seize.cpp
+++ b/source/plugins/components/Seize.cpp
@@ -46,7 +46,8 @@ Seize::Seize(Model* model, std::string name) : ModelComponent(model, Util::TypeO
     SimulationControlGenericClassNotDC<QueueableItem*, Model*, QueueableItem>* propQueueableItem = new SimulationControlGenericClassNotDC<QueueableItem*, Model*, QueueableItem>(
                                     _parentModel,
                                     std::bind(&Seize::getQueueableItem, this), std::bind(&Seize::setQueueableItem, this, std::placeholders::_1),
-                                    Util::TypeOf<Seize>(), getName(), "QueueableItem", "");
+                                    Util::TypeOf<Seize>(), getName(), "QueueableItem", "", false, true, false,
+                                    [](Model* model) { return new QueueableItem(model, ""); });
     SimulationControlGenericListPointer<SeizableItem*, Model*, SeizableItem>* propRequests = new SimulationControlGenericListPointer<SeizableItem*, Model*, SeizableItem> (
 									_parentModel,
 									std::bind(&Seize::getSeizeRequests, this), std::bind(&Seize::addRequest, this, std::placeholders::_1), std::bind(&Seize::removeRequest, this, std::placeholders::_1),


### PR DESCRIPTION
### Motivation

- The property editor opened empty when a property represented a nested object that was still `nullptr` (notably `QueueableItem` in `Seize`/`Process`), preventing inline creation and editing of subproperties. 
- Provide a clean, reusable kernel-level contract to detect and lazily create nested object instances so the GUI can navigate and edit subproperties without hacks for specific classes.

### Description

- Added lifecycle helpers to the control contract: `hasObjectInstance()`, `ensureObjectInstance()` and `getEditableProperties()` on `SimulationControl` to allow safe detection and on-demand creation of nested objects. 
- Refactored `SimulationControlGenericClassNotDC` to accept an optional `Creator` functor, implement `hasObjectInstance()`/`ensureObjectInstance()` and to create instances lazily (falls back to `new C(_model, "")` when no creator is provided). 
- Updated GUI flows to use the new API: `ObjectPropertyBrowser` now asks `getEditableProperties()` before opening a class editor and `DataComponentEditor` uses `getEditableProperties()` when listing or editing nested properties so editors do not open empty. 
- Applied the lazy-creation wiring to `QueueableItem` for `Seize` and `Process` by providing a creator lambda when registering the `SimulationControlGenericClassNotDC` control. 
- Fixed `QueueableItem` persistence/logic for `QueueableType::SET` (now looks up/creates a `Set`, not a `Queue`) and hardened `saveInstance`, `show`, `setQueue` and `setSet` against `nullptr` to avoid crashes during edit/save workflows.

Files changed (key): `source/kernel/simulator/SimulationControlAndResponse.h`, `source/applications/gui/qt/GenesysQtGUI/propertyeditor/ObjectPropertyBrowser.cpp`, `source/applications/gui/qt/GenesysQtGUI/propertyeditor/DataComponentEditor.cpp`, `source/plugins/components/Seize.cpp`, `source/plugins/components/Process.cpp`, `source/plugins/components/QueueableItem.cpp`.

### Testing

- Ran configuration with `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` which completed successfully. 
- Built core targets with `cmake --build build --target genesys_plugins_components genesys_kernel_simulator_runtime -j4` which succeeded. 
- Ran full build `cmake --build build -j4` which progressed through compilation but failed at an unrelated pre-existing smoke test link step (`genesys_smoke_simulator_start` / `SinkModelComponent` undefined references), not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d47d9d92b88321b8f14663e7f419a7)