### PR TITLE
Fix destructor and enum-switch compile warnings

### DIFF
--- a/source/kernel/simulator/SimulationReporter_if.h
+++ b/source/kernel/simulator/SimulationReporter_if.h
@@ -25,6 +25,7 @@
  */
 class SimulationReporter_if {
 public:
+	virtual ~SimulationReporter_if() = default;
 	/*!
 	 * \brief showReplicationStatistics
 	 */
@@ -49,4 +50,3 @@ public:
 };
 
 #endif /* SIMULATIONREPORTER_IF_H */
-

--- a/source/kernel/statistics/CollectorDatafile_if.h
+++ b/source/kernel/statistics/CollectorDatafile_if.h
@@ -24,6 +24,7 @@
  */
 class CollectorDatafile_if : public Collector_if {
 public:
+	virtual ~CollectorDatafile_if() = default;
 	/*!
 	 * \brief getValue
 	 * \param rank
@@ -54,4 +55,3 @@ public:
 };
 
 #endif /* COLLECTORDATAFILE_IF_H */
-

--- a/source/plugins/components/Buffer.cpp
+++ b/source/plugins/components/Buffer.cpp
@@ -118,10 +118,15 @@ void Buffer::_onDispatchEvent(Entity* entity, unsigned int inputPortNumber) {
 					_parentModel->sendEntityToComponent(entity, _connections->getConnectionAtPort(1));
 					break;
 				case ArrivalOnFullBufferRule::ReplaceLastPosition:
+				{
 					Entity* replaced = _buffer->at(_capacity-1);
 					traceSimulation(this, "Entity "+entity->getName()+" will replace entity "+replaced->getName()+" on the buffer");
 					traceSimulation(this, "Disposing replaced entity "+entity->getName());
 					_parentModel->removeEntity(replaced);
+					break;
+				}
+				case ArrivalOnFullBufferRule::num_elements:
+					traceError("Invalid ArrivalOnFullBufferRule enum value: num_elements");
 					break;
 			}
 		} else { // insert

--- a/source/plugins/components/Release.cpp
+++ b/source/plugins/components/Release.cpp
@@ -144,6 +144,7 @@ Resource* Release::_getResourceFromSeizableItem(SeizableItem* seizable, Entity* 
 				trace("Member index " + std::to_string(index) + " was specifically choosen", TraceManager::Level::L9_mostDetailed);
 				break;
 			case SeizableItem::SelectionRule::PREFEREDORDER:
+			{
 				bestValue = 0;
 				index = 0;
 				unsigned int quantity = _parentModel->parseExpression(seizable->getQuantityExpression());
@@ -186,6 +187,10 @@ Resource* Release::_getResourceFromSeizableItem(SeizableItem* seizable, Entity* 
 					}
 					index = bestIndex;
 				}
+				break;
+			}
+			case SeizableItem::SelectionRule::num_elements:
+				traceError("Invalid SelectionRule enum value: num_elements");
 				break;
 		}
 		trace("Member of set " + set->getName() + " chosen index " + std::to_string(index), TraceManager::Level::L8_detailed);

--- a/source/plugins/components/Seize.cpp
+++ b/source/plugins/components/Seize.cpp
@@ -433,6 +433,7 @@ Resource* Seize::_getResourceFromSeizableItem(SeizableItem* seizable, Entity* en
 				trace("Member index " + std::to_string(index) + " was specifically choosen", TraceManager::Level::L9_mostDetailed);
 				break;
 			case SeizableItem::SelectionRule::PREFEREDORDER:
+			{
 				bestValue = 0;
 				index = 0;
 				unsigned int quantity = _parentModel->parseExpression(seizable->getQuantityExpression());
@@ -475,6 +476,10 @@ Resource* Seize::_getResourceFromSeizableItem(SeizableItem* seizable, Entity* en
 					}
 					index = bestIndex;
 				}
+				break;
+			}
+			case SeizableItem::SelectionRule::num_elements:
+				traceError("Invalid SelectionRule enum value: num_elements");
 				break;
 		}
 		trace("Member of set " + set->getName() + " chosen index " + std::to_string(index), TraceManager::Level::L8_detailed);


### PR DESCRIPTION
### Motivation
- Silence warnings about deleting abstract types through base pointers by making the interfaces safe to delete. 
- Ensure `switch` statements covering enum classes handle the `num_elements` sentinel to avoid `-Wswitch` and cross-initialization jump issues. 

### Description
- Added virtual default destructors to `SimulationReporter_if` and `CollectorDatafile_if` to resolve `-Wdelete-abstract-non-virtual-dtor`. (`source/kernel/simulator/SimulationReporter_if.h`, `source/kernel/statistics/CollectorDatafile_if.h`).
- Made `switch` statements explicitly handle the sentinel enum values (`num_elements`) with an error trace in `Buffer::_onDispatchEvent`, `Release::_getResourceFromSeizableItem`, and `Seize::_getResourceFromSeizableItem`. (`source/plugins/components/Buffer.cpp`, `source/plugins/components/Release.cpp`, `source/plugins/components/Seize.cpp`).
- Added braces to scope case-local declarations where necessary to avoid cross-initialization / jump-to-case compilation errors. (`Buffer.cpp`, `Release.cpp`, `Seize.cpp`).

### Testing
- Ran `cmake -S . -B build` which configured the project successfully. 
- Ran `cmake --build build -j2` and compilation progressed past the modified translation units without the original warnings (modified files compiled). 
- The overall build failed later at link time for an unrelated pre-existing smoke-test target (`genesys_smoke_simulator_start`) due to an unresolved `SinkModelComponent` symbol, so the full test suite did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d47ceeb7e083219b51357d538d5bb0)