### PR TITLE
Refactor Property Editor to inline nested objects and MDD references

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/propertyeditor/DataComponentEditor.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/propertyeditor/DataComponentEditor.cpp
@@ -2,6 +2,10 @@
 
 #include <utility>
 
+#include <QHBoxLayout>
+#include <QVBoxLayout>
+#include <QHeaderView>
+
 #include "DataComponentProperty.h"
 #include "ComboBoxEnum.h"
 
@@ -12,14 +16,27 @@ DataComponentEditor::DataComponentEditor(
     ) : _editor(editor), _afterChange(std::move(afterChange)) {
 
     _window = new QWidget;
+    _window->setWindowTitle("List Item Editor");
+    auto* rootLayout = new QVBoxLayout(_window);
+
     _view = new QTreeWidget(_window);
     _edit = new QPushButton("Edit", _window);
     _newValue = new QInputDialog(_window);
 
     _view->setColumnCount(2);
     _view->setHeaderLabels({"Property", "Value"});
-    _edit->move(270, 15);
-    _window->setFixedSize(400, 220);
+    _view->header()->setStretchLastSection(true);
+
+    auto* lineLayout = new QHBoxLayout();
+    lineLayout->addWidget(_view, 1);
+
+    auto* buttons = new QVBoxLayout();
+    buttons->addWidget(_edit);
+    buttons->addStretch(1);
+    lineLayout->addLayout(buttons);
+
+    rootLayout->addLayout(lineLayout);
+    _window->setMinimumSize(520, 300);
 
     QObject::connect(_edit, &QPushButton::clicked, this, [this, property]() {
         editProperty(property);
@@ -33,14 +50,27 @@ DataComponentEditor::DataComponentEditor(
     ) : _editor(editor), _afterChange(std::move(afterChange)) {
 
     _window = new QWidget;
+    _window->setWindowTitle("List Item Editor");
+    auto* rootLayout = new QVBoxLayout(_window);
+
     _view = new QTreeWidget(_window);
     _edit = new QPushButton("Edit", _window);
     _newValue = new QInputDialog(_window);
 
     _view->setColumnCount(2);
     _view->setHeaderLabels({"Property", "Value"});
-    _edit->move(270, 15);
-    _window->setFixedSize(400, 220);
+    _view->header()->setStretchLastSection(true);
+
+    auto* lineLayout = new QHBoxLayout();
+    lineLayout->addWidget(_view, 1);
+
+    auto* buttons = new QVBoxLayout();
+    buttons->addWidget(_edit);
+    buttons->addStretch(1);
+    lineLayout->addLayout(buttons);
+
+    rootLayout->addLayout(lineLayout);
+    _window->setMinimumSize(520, 300);
 
     QObject::connect(_edit, &QPushButton::clicked, this, [this, properties]() {
         editProperty(properties);
@@ -74,12 +104,7 @@ void DataComponentEditor::configure_properties(SimulationControl* property) {
         return;
     }
 
-    List<SimulationControl*>* nestedProperties = nullptr;
-    try {
-        nestedProperties = property->getEditableProperties();
-    } catch (...) {
-        return;
-    }
+    List<SimulationControl*>* nestedProperties = property->getEditableProperties();
     if (nestedProperties == nullptr) {
         return;
     }
@@ -110,12 +135,7 @@ void DataComponentEditor::editProperty(SimulationControl* property) {
         return;
     }
 
-    List<SimulationControl*>* nestedProperties = nullptr;
-    try {
-        nestedProperties = property->getEditableProperties();
-    } catch (...) {
-        return;
-    }
+    List<SimulationControl*>* nestedProperties = property->getEditableProperties();
     if (nestedProperties == nullptr) {
         return;
     }

--- a/source/applications/gui/qt/GenesysQtGUI/propertyeditor/DataComponentProperty.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/propertyeditor/DataComponentProperty.cpp
@@ -2,6 +2,11 @@
 
 #include <utility>
 
+#include <QHBoxLayout>
+#include <QVBoxLayout>
+#include <QHeaderView>
+#include <QLabel>
+
 #include "DataComponentEditor.h"
 
 DataComponentProperty::DataComponentProperty(
@@ -12,18 +17,34 @@ DataComponentProperty::DataComponentProperty(
     ) : _editor(editor), _property(property), _afterChange(std::move(afterChange)) {
 
     _window = new QWidget;
+    _window->setWindowTitle("List Editor");
+
+    auto* rootLayout = new QVBoxLayout(_window);
+    auto* title = new QLabel("Manage list items (Arena style)", _window);
+    rootLayout->addWidget(title);
+
+    auto* contentLayout = new QHBoxLayout();
     _view = new QTreeWidget(_window);
     _add = new QPushButton("Add", _window);
     _remove = new QPushButton("Remove", _window);
     _edit = new QPushButton("Edit", _window);
     _confirmation = new QInputDialog(_window);
 
-    _add->move(270, 15);
-    _remove->move(270, 50);
-    _edit->move(270, 85);
-
     _view->setHeaderLabels({"Element"});
-    _window->setFixedSize(360, 200);
+    _view->header()->setStretchLastSection(true);
+
+    auto* buttonsLayout = new QVBoxLayout();
+    buttonsLayout->addWidget(_add);
+    buttonsLayout->addWidget(_remove);
+    buttonsLayout->addWidget(_edit);
+    buttonsLayout->addStretch(1);
+
+    contentLayout->addWidget(_view, 1);
+    contentLayout->addLayout(buttonsLayout);
+    rootLayout->addLayout(contentLayout);
+
+    _window->setLayout(rootLayout);
+    _window->setMinimumSize(460, 280);
 
     if (necessaryConfig) {
         config_values();
@@ -60,7 +81,7 @@ void DataComponentProperty::config_values() {
     }
 
     for (const std::string& value : *values->list()) {
-        QTreeWidgetItem* newItem = new QTreeWidgetItem(_view);
+        auto* newItem = new QTreeWidgetItem(_view);
         newItem->setText(0, QString::fromStdString(value));
         _view->addTopLevelItem(newItem);
     }
@@ -95,35 +116,16 @@ void DataComponentProperty::addElement() {
         return;
     }
 
-    QString newValue = _confirmation->getText(_confirmation, "Item", "Enter the value:");
+    const QString prompt = _property->getIsClass() ? "Enter the new item name:" : "Enter the value:";
+    QString newValue = _confirmation->getText(_confirmation, "Add Item", prompt);
     if (newValue.isEmpty()) {
         return;
     }
 
     if (!isInList(newValue.toStdString())) {
-        List<std::string>* oldValues = _property->getStrValues();
-        const unsigned int oldSize = oldValues != nullptr ? oldValues->size() : 0;
-        delete oldValues;
-
         _editor->changeProperty(_property, newValue.toStdString(), false);
         config_values();
-
-        List<std::string>* newValues = _property->getStrValues();
-        const unsigned int newSize = newValues != nullptr ? newValues->size() : 0;
-        bool changed = false;
-        if (newValues != nullptr) {
-            for (const std::string& value : *newValues->list()) {
-                if (value == newValue.toStdString()) {
-                    changed = true;
-                    break;
-                }
-            }
-        }
-        delete newValues;
-
-        if (changed || newSize != oldSize) {
-            _notifyChanged();
-        }
+        _notifyChanged();
     }
 }
 
@@ -138,29 +140,9 @@ void DataComponentProperty::removeElement() {
     }
 
     const QString itemValue = selectedItem->text(0);
-    List<std::string>* oldValues = _property->getStrValues();
-    const unsigned int oldSize = oldValues != nullptr ? oldValues->size() : 0;
-    delete oldValues;
-
     _editor->changeProperty(_property, itemValue.toStdString(), true);
     config_values();
-
-    List<std::string>* newValues = _property->getStrValues();
-    const unsigned int newSize = newValues != nullptr ? newValues->size() : 0;
-    bool removed = true;
-    if (newValues != nullptr) {
-        for (const std::string& value : *newValues->list()) {
-            if (value == itemValue.toStdString()) {
-                removed = false;
-                break;
-            }
-        }
-    }
-    delete newValues;
-
-    if (removed || newSize != oldSize) {
-        _notifyChanged();
-    }
+    _notifyChanged();
 }
 
 void DataComponentProperty::editProperty() {

--- a/source/applications/gui/qt/GenesysQtGUI/propertyeditor/ObjectPropertyBrowser.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/propertyeditor/ObjectPropertyBrowser.cpp
@@ -1,6 +1,7 @@
 #include "ObjectPropertyBrowser.h"
 
 #include <map>
+#include <set>
 #include <sstream>
 #include <exception>
 #include <utility>
@@ -9,137 +10,6 @@
 #include <QString>
 #include <QVariant>
 #include <QMenu>
-
-namespace {
-
-static std::vector<std::string> _copyStringList(List<std::string>* list) {
-    std::vector<std::string> result;
-    if (list == nullptr) {
-        return result;
-    }
-
-    for (const std::string& value : *list->list()) {
-        result.push_back(value);
-    }
-
-    delete list;
-    return result;
-}
-
-static GenesysPropertyKind _deduceKind(const SimulationControl* control) {
-    if (control == nullptr) {
-        return GenesysPropertyKind::Unknown;
-    }
-
-    if (control->getIsList()) {
-        return GenesysPropertyKind::List;
-    }
-    if (control->getIsClass()) {
-        return GenesysPropertyKind::Object;
-    }
-
-    const std::string typeName = control->propertyType();
-
-    if (typeName == Util::TypeOf<Util::TimeUnit>()) {
-        return GenesysPropertyKind::TimeUnit;
-    }
-    if (control->getIsEnum()) {
-        return GenesysPropertyKind::Enum;
-    }
-    if (typeName == Util::TypeOf<bool>()) {
-        return GenesysPropertyKind::Boolean;
-    }
-    if (typeName == Util::TypeOf<int>()) {
-        return GenesysPropertyKind::Integer;
-    }
-    if (typeName == Util::TypeOf<unsigned int>()) {
-        return GenesysPropertyKind::UnsignedInteger;
-    }
-    if (typeName == Util::TypeOf<unsigned short>()) {
-        return GenesysPropertyKind::UnsignedShort;
-    }
-    if (typeName == Util::TypeOf<double>()) {
-        return GenesysPropertyKind::Double;
-    }
-    if (typeName == Util::TypeOf<std::string>()) {
-        return GenesysPropertyKind::String;
-    }
-
-    return GenesysPropertyKind::Unknown;
-}
-
-static GenesysPropertyDescriptor _describeControl(SimulationControl* control) {
-    GenesysPropertyDescriptor desc;
-    if (control == nullptr) {
-        return desc;
-    }
-
-    desc.control = control;
-    desc.ownerClassName = control->getClassname();
-    desc.ownerElementName = control->getElementName();
-    desc.displayName = control->getName();
-    desc.technicalTypeName = control->propertyType();
-    desc.kind = _deduceKind(control);
-    desc.readOnly = control->isReadOnly();
-    desc.isList = control->getIsList();
-    desc.isClass = control->getIsClass();
-    desc.isEnum = control->getIsEnum();
-    desc.currentValue = control->getValue();
-
-    desc.choices = _copyStringList(control->getStrValues());
-
-    if (desc.kind == GenesysPropertyKind::TimeUnit && desc.choices.empty()) {
-        for (int i = 0; i < static_cast<int>(Util::TimeUnit::num_elements); ++i) {
-            desc.choices.push_back(Util::convertEnumToStr(static_cast<Util::TimeUnit>(i)));
-        }
-    }
-
-    return desc;
-}
-
-static std::vector<GenesysPropertyDescriptor> _describeControls(List<SimulationControl*>* controls) {
-    std::vector<GenesysPropertyDescriptor> result;
-    if (controls == nullptr) {
-        return result;
-    }
-
-    for (SimulationControl* control : *controls->list()) {
-        result.push_back(_describeControl(control));
-    }
-
-    return result;
-}
-
-static bool _setControlValue(
-    SimulationControl* control,
-    const std::string& value,
-    bool remove,
-    std::string* errorMessage
-    ) {
-    if (control == nullptr) {
-        if (errorMessage != nullptr) {
-            *errorMessage = "SimulationControl nulo";
-        }
-        return false;
-    }
-
-    try {
-        control->setValue(value, remove);
-        return true;
-    } catch (const std::exception& e) {
-        if (errorMessage != nullptr) {
-            *errorMessage = e.what();
-        }
-        return false;
-    } catch (...) {
-        if (errorMessage != nullptr) {
-            *errorMessage = "Erro desconhecido ao alterar propriedade";
-        }
-        return false;
-    }
-}
-
-} // namespace
 
 ObjectPropertyBrowser::ObjectPropertyBrowser(QWidget* parent)
     : QtTreePropertyBrowser(parent) {
@@ -158,7 +28,6 @@ void ObjectPropertyBrowser::_clearAll() {
     clear();
     _bindings.clear();
     _enumNames.clear();
-    _objectSummaryProperties.clear();
 
     delete _variantFactory;
     delete _enumFactory;
@@ -223,6 +92,10 @@ void ObjectPropertyBrowser::setActiveObject(
     _propertyEditorUI = peUI;
     _propertyBox = pb;
 
+    _rebuildProperties();
+}
+
+void ObjectPropertyBrowser::_rebuildProperties() {
     _clearAll();
 
     if (_modelObject == nullptr) {
@@ -230,7 +103,6 @@ void ObjectPropertyBrowser::setActiveObject(
     }
 
     _populateKernelProperties(_modelObject);
-    objectUpdated();
 }
 
 QStringList ObjectPropertyBrowser::_toQStringList(const std::vector<std::string>& values) const {
@@ -305,15 +177,7 @@ std::string ObjectPropertyBrowser::_fromVariant(const GenesysPropertyDescriptor&
     }
 }
 
-QString ObjectPropertyBrowser::_objectSummary(const GenesysPropertyDescriptor& desc) const {
-    const QString currentValue = QString::fromStdString(desc.currentValue);
-    if (currentValue.isEmpty()) {
-        return "<Object not initialized - double-click to create/edit>";
-    }
-    return currentValue + " (double-click to edit)";
-}
-
-QtProperty* ObjectPropertyBrowser::_createProperty(const GenesysPropertyDescriptor& desc) {
+QtProperty* ObjectPropertyBrowser::_createLeafProperty(const GenesysPropertyDescriptor& desc) {
     const QString name = QString::fromStdString(desc.displayName);
 
     if ((desc.kind == GenesysPropertyKind::Enum || desc.kind == GenesysPropertyKind::TimeUnit)
@@ -334,27 +198,6 @@ QtProperty* ObjectPropertyBrowser::_createProperty(const GenesysPropertyDescript
         return property;
     }
 
-    if (desc.isClass) {
-        QtProperty* group = _groupManager->addProperty(name);
-        group->setToolTip("Nested object property. Double-click, Enter or context menu to edit.");
-        group->setStatusTip("Nested object editor");
-
-        QtVariantProperty* summary = _variantManager->addProperty(QVariant::String, "Value");
-        summary->setValue(_objectSummary(desc));
-        summary->setEnabled(false);
-        group->addSubProperty(summary);
-
-        Binding binding;
-        binding.owner = _modelObject;
-        binding.control = desc.control;
-        binding.descriptor = desc;
-        _bindings[group] = binding;
-        _bindings[summary] = binding;
-
-        _objectSummaryProperties[group] = summary;
-        return group;
-    }
-
     int variantType = QVariant::String;
 
     switch (desc.kind) {
@@ -369,12 +212,6 @@ QtProperty* ObjectPropertyBrowser::_createProperty(const GenesysPropertyDescript
     case GenesysPropertyKind::Double:
         variantType = QVariant::Double;
         break;
-    case GenesysPropertyKind::String:
-    case GenesysPropertyKind::Object:
-    case GenesysPropertyKind::List:
-    case GenesysPropertyKind::Unknown:
-    case GenesysPropertyKind::Enum:
-    case GenesysPropertyKind::TimeUnit:
     default:
         variantType = QVariant::String;
         break;
@@ -383,22 +220,16 @@ QtProperty* ObjectPropertyBrowser::_createProperty(const GenesysPropertyDescript
     QtVariantProperty* property = _variantManager->addProperty(variantType, name);
     property->setValue(_toVariant(desc));
 
-    const bool complexProperty = desc.isList;
-
     const bool editableInline =
         !desc.readOnly &&
-        !complexProperty &&
+        !desc.isList &&
         !(desc.kind == GenesysPropertyKind::Enum || desc.kind == GenesysPropertyKind::TimeUnit);
 
-    property->setEnabled(true);
+    property->setEnabled(editableInline);
 
-    if (editableInline) {
-        property->setValue(_toVariant(desc));
-    }
-
-    if (complexProperty) {
-        property->setToolTip("Use duplo clique, Enter ou menu de contexto para editar.");
-        property->setStatusTip("Complex property editor");
+    if (desc.isList) {
+        property->setToolTip("List property. Use double click, Enter or context menu to open list editor.");
+        property->setStatusTip("List editor");
     }
 
     Binding binding;
@@ -410,13 +241,92 @@ QtProperty* ObjectPropertyBrowser::_createProperty(const GenesysPropertyDescript
     return property;
 }
 
+void ObjectPropertyBrowser::_appendDescriptorRecursively(
+    QtProperty* parent,
+    SimulationControl* control,
+    std::set<const SimulationControl*>& recursionPath,
+    int depth
+    ) {
+    if (parent == nullptr || control == nullptr) {
+        return;
+    }
+
+    GenesysPropertyDescriptor desc = GenesysPropertyIntrospection::describe(control);
+
+    if (!desc.isClass) {
+        QtProperty* leaf = _createLeafProperty(desc);
+        if (leaf != nullptr) {
+            parent->addSubProperty(leaf);
+        }
+        return;
+    }
+
+    QtProperty* group = _groupManager->addProperty(QString::fromStdString(desc.displayName));
+    parent->addSubProperty(group);
+
+    Binding groupBinding;
+    groupBinding.owner = _modelObject;
+    groupBinding.control = control;
+    groupBinding.descriptor = desc;
+    _bindings[group] = groupBinding;
+
+    if (recursionPath.find(control) != recursionPath.end()) {
+        QtVariantProperty* cycleNode = _variantManager->addProperty(QVariant::String, "Cycle");
+        cycleNode->setEnabled(false);
+        cycleNode->setValue("Recursion stopped: object already visited in this branch");
+        group->addSubProperty(cycleNode);
+        return;
+    }
+
+    if (depth > 10) {
+        QtVariantProperty* depthNode = _variantManager->addProperty(QVariant::String, "Depth");
+        depthNode->setEnabled(false);
+        depthNode->setValue("Recursion depth limit reached");
+        group->addSubProperty(depthNode);
+        return;
+    }
+
+    if (desc.isModelDataDefinitionReference && !desc.choices.empty()) {
+        QtProperty* refProperty = _enumManager->addProperty("Reference");
+        _enumNames[refProperty] = _toQStringList(desc.choices);
+        _enumManager->setEnumNames(refProperty, _enumNames[refProperty]);
+        _enumManager->setValue(refProperty, _enumIndexFor(desc));
+        refProperty->setEnabled(!desc.readOnly);
+
+        Binding refBinding = groupBinding;
+        refBinding.isObjectSelector = true;
+        _bindings[refProperty] = refBinding;
+        group->addSubProperty(refProperty);
+    }
+
+    List<SimulationControl*>* childrenList = control->getEditableProperties();
+    if (childrenList == nullptr) {
+        QtVariantProperty* emptyNode = _variantManager->addProperty(QVariant::String, "Info");
+        emptyNode->setEnabled(false);
+        emptyNode->setValue(desc.readOnly ? "Read-only object" : "Object not available");
+        group->addSubProperty(emptyNode);
+        return;
+    }
+
+    std::vector<SimulationControl*> children;
+    for (SimulationControl* child : *childrenList->list()) {
+        children.push_back(child);
+    }
+
+    recursionPath.insert(control);
+    for (SimulationControl* child : children) {
+        _appendDescriptorRecursively(group, child, recursionPath, depth + 1);
+    }
+    recursionPath.erase(control);
+}
+
 void ObjectPropertyBrowser::_populateKernelProperties(ModelDataDefinition* mdd) {
     if (mdd == nullptr) {
         return;
     }
 
     const std::vector<GenesysPropertyDescriptor> properties =
-        _describeControls(mdd->getProperties());
+        GenesysPropertyIntrospection::describe(mdd->getProperties());
 
     std::map<std::string, QtProperty*> groups;
 
@@ -434,10 +344,8 @@ void ObjectPropertyBrowser::_populateKernelProperties(ModelDataDefinition* mdd) 
             group = found->second;
         }
 
-        QtProperty* leaf = _createProperty(desc);
-        if (group != nullptr && leaf != nullptr) {
-            group->addSubProperty(leaf);
-        }
+        std::set<const SimulationControl*> recursionPath;
+        _appendDescriptorRecursively(group, desc.control, recursionPath);
     }
 }
 
@@ -472,47 +380,6 @@ bool ObjectPropertyBrowser::_openSpecializedEditor(QtProperty* property) {
         return true;
     }
 
-    if (control->getIsClass()) {
-        List<SimulationControl*>* children = nullptr;
-        try {
-            children = control->getEditableProperties();
-        } catch (...) {
-            return false;
-        }
-        if (children == nullptr) {
-            return false;
-        }
-
-        if (_propertyEditorUI != nullptr) {
-            auto found = _propertyEditorUI->find(control);
-            if (found == _propertyEditorUI->end() || found->second == nullptr) {
-                (*_propertyEditorUI)[control] =
-                    new DataComponentEditor(_propertyEditor, control, refresh);
-            }
-            (*_propertyEditorUI)[control]->open_window(control);
-        } else {
-            auto* editor = new DataComponentEditor(_propertyEditor, control, refresh);
-            editor->open_window(control);
-        }
-        return true;
-    }
-
-    if (binding.descriptor.kind == GenesysPropertyKind::Enum
-        || binding.descriptor.kind == GenesysPropertyKind::TimeUnit
-        || control->getIsEnum()) {
-        if (_propertyBox != nullptr) {
-            auto found = _propertyBox->find(control);
-            if (found == _propertyBox->end() || found->second == nullptr) {
-                (*_propertyBox)[control] = new ComboBoxEnum(_propertyEditor, control, refresh);
-            }
-            (*_propertyBox)[control]->open_box();
-        } else {
-            auto* box = new ComboBoxEnum(_propertyEditor, control, refresh);
-            box->open_box();
-        }
-        return true;
-    }
-
     return false;
 }
 
@@ -535,10 +402,9 @@ void ObjectPropertyBrowser::valueChanged(QtProperty *property, const QVariant &v
         return;
     }
 
-    if (binding.descriptor.kind == GenesysPropertyKind::Enum
-        || binding.descriptor.kind == GenesysPropertyKind::TimeUnit
-        || binding.descriptor.kind == GenesysPropertyKind::Object
-        || binding.descriptor.kind == GenesysPropertyKind::List) {
+    if (binding.descriptor.isClass || binding.descriptor.isList
+        || binding.descriptor.kind == GenesysPropertyKind::Enum
+        || binding.descriptor.kind == GenesysPropertyKind::TimeUnit) {
         return;
     }
 
@@ -548,7 +414,7 @@ void ObjectPropertyBrowser::valueChanged(QtProperty *property, const QVariant &v
     }
 
     std::string errorMessage;
-    const bool ok = _setControlValue(
+    const bool ok = GenesysPropertyIntrospection::setValue(
         binding.control,
         newValue,
         false,
@@ -556,7 +422,7 @@ void ObjectPropertyBrowser::valueChanged(QtProperty *property, const QVariant &v
         );
 
     if (!ok) {
-        objectUpdated();
+        _rebuildProperties();
         return;
     }
 
@@ -574,20 +440,30 @@ void ObjectPropertyBrowser::enumValueChanged(QtProperty *property, int value) {
         return;
     }
 
-    if (value == _enumIndexFor(binding.descriptor)) {
+    if (value < 0 || value >= static_cast<int>(binding.descriptor.choices.size())) {
+        return;
+    }
+
+    std::string newValue;
+    if (binding.isObjectSelector || binding.descriptor.isModelDataDefinitionReference) {
+        newValue = binding.descriptor.choices[static_cast<std::size_t>(value)];
+    } else if (binding.descriptor.kind == GenesysPropertyKind::Enum
+               || binding.descriptor.kind == GenesysPropertyKind::TimeUnit) {
+        newValue = std::to_string(value);
+    } else {
         return;
     }
 
     std::string errorMessage;
-    const bool ok = _setControlValue(
+    const bool ok = GenesysPropertyIntrospection::setValue(
         binding.control,
-        std::to_string(value),
+        newValue,
         false,
         &errorMessage
         );
 
     if (!ok) {
-        objectUpdated();
+        _rebuildProperties();
         return;
     }
 
@@ -595,61 +471,14 @@ void ObjectPropertyBrowser::enumValueChanged(QtProperty *property, int value) {
 }
 
 void ObjectPropertyBrowser::_notifyModelChangeApplied() {
-    objectUpdated();
+    _rebuildProperties();
     if (_modelChangedCallback) {
         _modelChangedCallback();
     }
 }
 
 void ObjectPropertyBrowser::objectUpdated() {
-    if (_modelObject == nullptr) {
-        return;
-    }
-
-    QSignalBlocker blockerVariant(_variantManager);
-    QSignalBlocker blockerEnum(_enumManager);
-
-    const QList<QtProperty*> keys = _bindings.keys();
-    for (QtProperty* key : keys) {
-        Binding binding = _bindings.value(key);
-        if (binding.control == nullptr) {
-            continue;
-        }
-
-        GenesysPropertyDescriptor fresh = _describeControl(binding.control);
-
-        binding.descriptor = fresh;
-        _bindings[key] = binding;
-
-        if ((fresh.kind == GenesysPropertyKind::Enum || fresh.kind == GenesysPropertyKind::TimeUnit)
-            && !fresh.choices.empty()) {
-
-            _enumNames[key] = _toQStringList(fresh.choices);
-            _enumManager->setEnumNames(key, _enumNames[key]);
-            _enumManager->setValue(key, _enumIndexFor(fresh));
-
-        } else {
-            if (fresh.isClass) {
-                auto summaryIt = _objectSummaryProperties.find(key);
-                if (summaryIt != _objectSummaryProperties.end() && summaryIt.value() != nullptr) {
-                    summaryIt.value()->setValue(_objectSummary(fresh));
-                } else {
-                    QtVariantProperty* variantProperty =
-                        dynamic_cast<QtVariantProperty*>(key);
-                    if (variantProperty != nullptr) {
-                        variantProperty->setValue(_objectSummary(fresh));
-                    }
-                }
-                continue;
-            }
-
-            QtVariantProperty* variantProperty =
-                dynamic_cast<QtVariantProperty*>(key);
-            if (variantProperty != nullptr) {
-                variantProperty->setValue(_toVariant(fresh));
-            }
-        }
-    }
+    _rebuildProperties();
 }
 
 void ObjectPropertyBrowser::keyPressEvent(QKeyEvent* event) {
@@ -671,25 +500,13 @@ void ObjectPropertyBrowser::contextMenuEvent(QContextMenuEvent* event) {
     }
 
     auto it = _bindings.find(item->property());
-    if (it == _bindings.end()) {
-        QtTreePropertyBrowser::contextMenuEvent(event);
-        return;
-    }
-
-    const Binding binding = it.value();
-    const bool specializedProperty =
-        binding.descriptor.isList
-        || binding.descriptor.isClass
-        || binding.descriptor.kind == GenesysPropertyKind::Enum
-        || binding.descriptor.kind == GenesysPropertyKind::TimeUnit;
-
-    if (!specializedProperty) {
+    if (it == _bindings.end() || !it.value().descriptor.isList) {
         QtTreePropertyBrowser::contextMenuEvent(event);
         return;
     }
 
     QMenu menu(this);
-    QAction* editAction = menu.addAction("Edit...");
+    QAction* editAction = menu.addAction("Edit list...");
     QAction* chosen = menu.exec(event->globalPos());
 
     if (chosen == editAction) {

--- a/source/applications/gui/qt/GenesysQtGUI/propertyeditor/ObjectPropertyBrowser.h
+++ b/source/applications/gui/qt/GenesysQtGUI/propertyeditor/ObjectPropertyBrowser.h
@@ -3,6 +3,7 @@
 
 #include <map>
 #include <vector>
+#include <set>
 #include <functional>
 
 #include <QObject>
@@ -49,16 +50,24 @@ private:
         ModelDataDefinition* owner = nullptr;
         SimulationControl* control = nullptr;
         GenesysPropertyDescriptor descriptor;
+        bool isObjectSelector = false;
     };
 
 private:
     void _notifyModelChangeApplied();
     void _clearAll();
+    void _rebuildProperties();
     void _populateKernelProperties(ModelDataDefinition* mdd);
-    QtProperty* _createProperty(const GenesysPropertyDescriptor& desc);
+    void _appendDescriptorRecursively(
+        QtProperty* parent,
+        SimulationControl* control,
+        std::set<const SimulationControl*>& recursionPath,
+        int depth = 0
+        );
+
+    QtProperty* _createLeafProperty(const GenesysPropertyDescriptor& desc);
     QVariant _toVariant(const GenesysPropertyDescriptor& desc) const;
     std::string _fromVariant(const GenesysPropertyDescriptor& desc, const QVariant& value) const;
-    QString _objectSummary(const GenesysPropertyDescriptor& desc) const;
     int _enumIndexFor(const GenesysPropertyDescriptor& desc) const;
     QStringList _toQStringList(const std::vector<std::string>& values) const;
 
@@ -88,7 +97,6 @@ private:
 
     QMap<QtProperty*, Binding> _bindings;
     QMap<QtProperty*, QStringList> _enumNames;
-    QMap<QtProperty*, QtVariantProperty*> _objectSummaryProperties;
     ModelChangedCallback _modelChangedCallback;
 
 private slots:

--- a/source/kernel/simulator/GenesysPropertyIntrospection.cpp
+++ b/source/kernel/simulator/GenesysPropertyIntrospection.cpp
@@ -91,6 +91,8 @@ GenesysPropertyDescriptor GenesysPropertyIntrospection::describe(SimulationContr
     desc.isList = control->getIsList();
     desc.isClass = control->getIsClass();
     desc.isEnum = control->getIsEnum();
+    desc.isInlineObject = desc.isClass && !desc.isList;
+    desc.isModelDataDefinitionReference = control->isModelDataDefinitionReference();
     desc.currentValue = control->getValue();
 
     desc.choices = _copyStringList(control->getStrValues());

--- a/source/kernel/simulator/GenesysPropertyIntrospection.h
+++ b/source/kernel/simulator/GenesysPropertyIntrospection.h
@@ -34,6 +34,8 @@ struct GenesysPropertyDescriptor {
     bool isList = false;
     bool isClass = false;
     bool isEnum = false;
+    bool isInlineObject = false;
+    bool isModelDataDefinitionReference = false;
 
     std::string currentValue;
     std::vector<std::string> choices;

--- a/source/kernel/simulator/SimulationControlAndResponse.h
+++ b/source/kernel/simulator/SimulationControlAndResponse.h
@@ -155,6 +155,7 @@ public:
     virtual List<SimulationControl*>* getProperties(int index=0) { return nullptr; };
     virtual bool hasObjectInstance() const { return true; }
     virtual bool ensureObjectInstance() { return hasObjectInstance(); }
+    virtual bool isModelDataDefinitionReference() const { return false; }
     virtual List<SimulationControl*>* getEditableProperties(int index=0) {
         if (getIsClass() && !hasObjectInstance()) {
             if (!ensureObjectInstance()) {
@@ -568,6 +569,18 @@ public:
 
 		_setter(newVal);
 	};
+
+    virtual bool isModelDataDefinitionReference() const override { return true; }
+
+    virtual List<std::string>* getStrValues() override {
+        List<std::string>* strOptions = new List<std::string>();
+        for (auto modeldata : *_model->getDataManager()->getDataDefinitionList(_propertyType)->list()) {
+            if (modeldata != nullptr) {
+                strOptions->insert(modeldata->getName());
+            }
+        }
+        return strOptions;
+    }
 
     virtual List<SimulationControl*>* getProperties(int index=0) override {
         T tVal = static_cast<T>(_getter());


### PR DESCRIPTION
### Motivation
- Make the Property Editor the primary editor for single-object properties and references to `ModelDataDefinition` so objects such as `QueueableItem`, `Queue`, `Set`, `Resource`, `Variable`, `Label`, `Station`, `Storage` and similar are editable inline in a hierarchical/expandable tree instead of via per-object popups or plain text fields.
- Preserve specialized dialogs only for lists (Arena-like Add/Remove/Edit UX) while enabling recursive inline exploration of nested objects and MDD references.
- Provide a robust, general solution (not a `QueueableItem` hack) with protections against recursion/cycles and lazy instance creation where supported by the kernel introspection API.

### Description
- Refactored the inspector to render single-object class properties as hierarchical inline groups with recursive expansion and editable leaves in the `ObjectPropertyBrowser` by building property subtrees instead of showing object summaries; lazy creation and recursion safeguards were added. Main GUI changes: `source/applications/gui/qt/GenesysQtGUI/propertyeditor/ObjectPropertyBrowser.h` and `.../ObjectPropertyBrowser.cpp`.
- Added kernel-side metadata via `GenesysPropertyIntrospection` to indicate inline-object and MDD-reference characteristics (`isInlineObject`, `isModelDataDefinitionReference`) and used those flags to drive the GUI behavior; modified `source/kernel/simulator/GenesysPropertyIntrospection.h` and `.../GenesysPropertyIntrospection.cpp`.
- Extended `SimulationControl` implementations to advertise MDD-reference semantics and to expose selectable instance names so the inspector can display an inline selector (combo) and create/select MDD instances lazily; changes in `source/kernel/simulator/SimulationControlAndResponse.h` (notably `SimulationControlGenericClass` overrides for `isModelDataDefinitionReference` and `getStrValues`).
- Kept dialogs for lists only and reworked list editors to Arena-like Add/Remove/Edit layout (clear header, item list, `Add`/`Remove`/`Edit` buttons); updated `source/applications/gui/qt/GenesysQtGUI/propertyeditor/DataComponentProperty.cpp` and `.../DataComponentEditor.cpp`.
- Implemented recursion/cycle protection by tracking visited `SimulationControl*` in a recursion path and a depth guard to avoid infinite expansion and show a concise stopping node instead.
- Files modified: `ObjectPropertyBrowser.h`, `ObjectPropertyBrowser.cpp`, `DataComponentProperty.cpp`, `DataComponentEditor.cpp`, `GenesysPropertyIntrospection.h`, `GenesysPropertyIntrospection.cpp`, and `SimulationControlAndResponse.h`.

### Testing
- Ran a full build: `cmake -S . -B build && cmake --build build -j2`; build progressed through most targets but failed at a late link stage for an existing smoke test target with an unresolved `SinkModelComponent` symbol (linker error in `genesys_smoke_simulator_start`), which appears unrelated to the property-editor and introspection changes; therefore the build did not fully complete successfully.
- Attempted GUI-specific configure: `cmake -S . -B build-gui -DGENESYS_BUILD_GUI=ON`, which completed configure but project configuration currently forces GUI OFF in this repository setup (variable unused), so no GUI binary was produced in that run.
- No unit tests were run separately beyond the build (the build produced many test binaries up to the failure point); the changes compile in many compilation units but the final smoke-test link failure prevented a fully green build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4fb307e7483218b4913e07efef72a)