### PR TITLE
Add virtual default destructors to interfaces and tighten enum switch handling in components

### DIFF
--- a/source/applications/GenesysApplication_if.h
+++ b/source/applications/GenesysApplication_if.h
@@ -16,6 +16,7 @@
 
 class GenesysApplication_if {
 public:
+	virtual ~GenesysApplication_if() = default;
 	virtual int main(int argc, char** argv) = 0;
 };
 

--- a/source/applications/terminal/GenesysShell/GenesysShell_if.h
+++ b/source/applications/terminal/GenesysShell/GenesysShell_if.h
@@ -19,6 +19,7 @@
 
 class GenesysShell_if : public GenesysApplication_if {
 public:
+	virtual ~GenesysShell_if() = default;
 	virtual void openModel(std::string filename) = 0;
 	virtual void saveModelAs(std::string filename) = 0;
 	virtual void saveModel() = 0;
@@ -53,4 +54,3 @@ public:
 };
 
 #endif /* GENESYSSHELL_IF_H */
-

--- a/source/kernel/simulator/ExperimetManager_if.h
+++ b/source/kernel/simulator/ExperimetManager_if.h
@@ -27,6 +27,7 @@
  */
 class ExperimentManager_if {
 public:
+	virtual ~ExperimentManager_if() = default;
 	/*! \brief Returns the list of scenarios that compose the experiment. */
 	virtual List<SimulationScenario*>* getScenarios() const = 0;
 	//virtual List<PropertyBase*>* getControls() const = 0;
@@ -44,4 +45,3 @@ public:
 };
 
 #endif /* EXPERIMENTMANAGER_IF_H */
-

--- a/source/kernel/simulator/ModelChecker_if.h
+++ b/source/kernel/simulator/ModelChecker_if.h
@@ -25,6 +25,7 @@
  */
 class ModelChecker_if {
 public:
+	virtual ~ModelChecker_if() = default;
 	/*!
 	 * \brief checkAll
 	 * \return
@@ -58,4 +59,3 @@ public:
 };
 
 #endif /* MODELCHECKER_IF_H */
-

--- a/source/kernel/simulator/ModelPersistence_if.h
+++ b/source/kernel/simulator/ModelPersistence_if.h
@@ -30,6 +30,7 @@ class PersistenceRecord;
  */
 class ModelPersistence_if {
 public:
+	virtual ~ModelPersistence_if() = default;
 
 	enum class Options : int {
 		SAVEDEFAULTS = 1, HIDEIDKEY = 2, HIDETYPEKEY = 4, HIDENAMEKEY = 8, SORTALPHLY = 16
@@ -54,4 +55,3 @@ public:
 };
 
 #endif /* MODELPERSISTENCE_IF_H */
-

--- a/source/kernel/simulator/Parser_if.h
+++ b/source/kernel/simulator/Parser_if.h
@@ -28,6 +28,7 @@ class genesyspp_driver;
  */
 class Parser_if {
 public:
+	virtual ~Parser_if() = default;
 	/*!
 	 * \brief parse
 	 * \param expression
@@ -72,4 +73,3 @@ public:
 };
 
 #endif /* PARSER_IF_H */
-

--- a/source/kernel/simulator/PluginConnector_if.h
+++ b/source/kernel/simulator/PluginConnector_if.h
@@ -28,6 +28,7 @@
  */
 class PluginConnector_if {
 public:
+	virtual ~PluginConnector_if() = default;
 	/*!
 	 * \brief check
 	 * \param dynamicLibraryFilename

--- a/source/kernel/simulator/ScenarioExperiment_if.h
+++ b/source/kernel/simulator/ScenarioExperiment_if.h
@@ -15,7 +15,8 @@
 #define SCENARIOEXPERIMENT_IF_H
 
 class ScenarioExperiment_if {
+public:
+	virtual ~ScenarioExperiment_if() = default;
 };
 
 #endif /* SCENARIOEXPERIMENT_IF_H */
-

--- a/source/kernel/simulator/SimulationReporter_if.h
+++ b/source/kernel/simulator/SimulationReporter_if.h
@@ -25,6 +25,7 @@
  */
 class SimulationReporter_if {
 public:
+	virtual ~SimulationReporter_if() = default;
 	/*!
 	 * \brief showReplicationStatistics
 	 */
@@ -49,4 +50,3 @@ public:
 };
 
 #endif /* SIMULATIONREPORTER_IF_H */
-

--- a/source/kernel/statistics/CollectorDatafile_if.h
+++ b/source/kernel/statistics/CollectorDatafile_if.h
@@ -24,6 +24,7 @@
  */
 class CollectorDatafile_if : public Collector_if {
 public:
+	virtual ~CollectorDatafile_if() = default;
 	/*!
 	 * \brief getValue
 	 * \param rank
@@ -54,4 +55,3 @@ public:
 };
 
 #endif /* COLLECTORDATAFILE_IF_H */
-

--- a/source/kernel/statistics/Collector_if.h
+++ b/source/kernel/statistics/Collector_if.h
@@ -41,6 +41,7 @@ CollectorClearHandler setCollectorClearHandler(void (Class::*function)(), Class 
  */
 class Collector_if {
 public:
+	virtual ~Collector_if() = default;
 	/*!
 	 * \brief clear
 	 */
@@ -81,4 +82,3 @@ public:
 };
 
 #endif /* COLLECTOR_IF_H */
-

--- a/source/kernel/statistics/Sampler_if.h
+++ b/source/kernel/statistics/Sampler_if.h
@@ -23,6 +23,7 @@
  */
 class Sampler_if {
 public:
+	virtual ~Sampler_if() = default;
 
 	/*!
 	 * \brief Encapsulates generator-specific configuration/state parameters.
@@ -90,4 +91,3 @@ public:
 };
 
 #endif /* Sampler_IF_H */
-

--- a/source/kernel/statistics/StatisticsDataFile_if.h
+++ b/source/kernel/statistics/StatisticsDataFile_if.h
@@ -28,6 +28,7 @@ class StatisticsDatafile_if : public Statistics_if {
 	//    virtual CollectorDatafile_if* getCollector() = 0;
 	//    virtual void setCollector(Collector_if* collector) = 0;
 public:
+	virtual ~StatisticsDatafile_if() = default;
 	/*!
 	 * \brief mode
 	 * \return
@@ -91,4 +92,3 @@ public:
 };
 
 #endif /* STATISTICSDATAFILE_IF_H */
-

--- a/source/kernel/statistics/Statistics_if.h
+++ b/source/kernel/statistics/Statistics_if.h
@@ -25,6 +25,7 @@
  */
 class Statistics_if {
 public:
+	virtual ~Statistics_if() = default;
 	/*! \brief Returns the data collector associated with these statistics. */
 	virtual Collector_if* getCollector() const = 0;
 	/*! \brief Sets the collector used as source for statistical calculations. */
@@ -100,4 +101,3 @@ public:
 };
 
 #endif /* STATISTICS_IF_H */
-

--- a/source/plugins/components/Buffer.cpp
+++ b/source/plugins/components/Buffer.cpp
@@ -118,10 +118,15 @@ void Buffer::_onDispatchEvent(Entity* entity, unsigned int inputPortNumber) {
 					_parentModel->sendEntityToComponent(entity, _connections->getConnectionAtPort(1));
 					break;
 				case ArrivalOnFullBufferRule::ReplaceLastPosition:
+				{
 					Entity* replaced = _buffer->at(_capacity-1);
 					traceSimulation(this, "Entity "+entity->getName()+" will replace entity "+replaced->getName()+" on the buffer");
 					traceSimulation(this, "Disposing replaced entity "+entity->getName());
 					_parentModel->removeEntity(replaced);
+					break;
+				}
+				case ArrivalOnFullBufferRule::num_elements:
+					traceError("Invalid ArrivalOnFullBufferRule enum value: num_elements");
 					break;
 			}
 		} else { // insert

--- a/source/plugins/components/Release.cpp
+++ b/source/plugins/components/Release.cpp
@@ -144,6 +144,7 @@ Resource* Release::_getResourceFromSeizableItem(SeizableItem* seizable, Entity* 
 				trace("Member index " + std::to_string(index) + " was specifically choosen", TraceManager::Level::L9_mostDetailed);
 				break;
 			case SeizableItem::SelectionRule::PREFEREDORDER:
+			{
 				bestValue = 0;
 				index = 0;
 				unsigned int quantity = _parentModel->parseExpression(seizable->getQuantityExpression());
@@ -186,6 +187,10 @@ Resource* Release::_getResourceFromSeizableItem(SeizableItem* seizable, Entity* 
 					}
 					index = bestIndex;
 				}
+				break;
+			}
+			case SeizableItem::SelectionRule::num_elements:
+				traceError("Invalid SelectionRule enum value: num_elements");
 				break;
 		}
 		trace("Member of set " + set->getName() + " chosen index " + std::to_string(index), TraceManager::Level::L8_detailed);

--- a/source/plugins/components/Seize.cpp
+++ b/source/plugins/components/Seize.cpp
@@ -433,6 +433,7 @@ Resource* Seize::_getResourceFromSeizableItem(SeizableItem* seizable, Entity* en
 				trace("Member index " + std::to_string(index) + " was specifically choosen", TraceManager::Level::L9_mostDetailed);
 				break;
 			case SeizableItem::SelectionRule::PREFEREDORDER:
+			{
 				bestValue = 0;
 				index = 0;
 				unsigned int quantity = _parentModel->parseExpression(seizable->getQuantityExpression());
@@ -475,6 +476,10 @@ Resource* Seize::_getResourceFromSeizableItem(SeizableItem* seizable, Entity* en
 					}
 					index = bestIndex;
 				}
+				break;
+			}
+			case SeizableItem::SelectionRule::num_elements:
+				traceError("Invalid SelectionRule enum value: num_elements");
 				break;
 		}
 		trace("Member of set " + set->getName() + " chosen index " + std::to_string(index), TraceManager::Level::L8_detailed);

--- a/source/tools/DataAnalyser_if.h
+++ b/source/tools/DataAnalyser_if.h
@@ -21,6 +21,7 @@
 
 class DataAnalyser_if {
 public:
+	virtual ~DataAnalyser_if() = default;
 	virtual bool loadDataSet(std::string datafilename) = 0;
 	virtual bool saveDataSet(std::string datasetname) = 0;
 	virtual void newDataSet(std::string datasetname, std::string datafilename) = 0;
@@ -32,4 +33,3 @@ public:
 
 
 #endif /* DATAANALYSERIF_H */
-

--- a/source/tools/Fitter_if.h
+++ b/source/tools/Fitter_if.h
@@ -18,6 +18,7 @@
 
 class Fitter_if {
 public:
+	virtual ~Fitter_if() = default;
 	virtual bool isNormalDistributed(double confidencelevel) = 0;
 	virtual void fitUniform(double *sqrerror, double *min, double *max) = 0;
 	virtual void fitTriangular(double *sqrerror, double *min, double *mo, double *max) = 0;
@@ -33,4 +34,3 @@ public:
 };
 
 #endif /* FITTER_IF_H */
-

--- a/source/tools/HypothesisTester_if.h
+++ b/source/tools/HypothesisTester_if.h
@@ -25,6 +25,7 @@ typedef bool (*checkProportionFunction)(double value);
  */
 class HypothesisTester_if {
 public:
+	virtual ~HypothesisTester_if() = default;
 
 	class ConfidenceInterval {
 	public:
@@ -152,4 +153,3 @@ public:
 };
 
 #endif /* HYPOTHESISTESTER_IF_H */
-

--- a/source/tools/Solver_if.h
+++ b/source/tools/Solver_if.h
@@ -21,6 +21,7 @@
  */
 class Solver_if {
 public:
+	virtual ~Solver_if() = default;
 	virtual void setPrecision(double e) = 0;
 	virtual double getPrecision() = 0;
 	virtual void setMaxSteps(double steps) = 0;
@@ -36,4 +37,3 @@ public:
 };
 
 #endif /* SOLVER_IF_H */
-


### PR DESCRIPTION
### Motivation
- Ensure proper polymorphic destruction for many interface types to avoid undefined behavior when deleting via base pointers.
- Fix switch-case scoping and handle out-of-range enum sentinel values to remove potential fallthroughs and make error conditions explicit.

### Description
- Added `virtual ~...() = default;` destructors to a number of interface classes, including `GenesysApplication_if`, `GenesysShell_if`, `ExperimentManager_if`, `ModelChecker_if`, `ModelPersistence_if`, `Parser_if`, `PluginConnector_if`, `ScenarioExperiment_if`, `SimulationReporter_if`, `CollectorDatafile_if`, `Collector_if`, `Sampler_if`, `StatisticsDatafile_if`, `Statistics_if`, `DataAnalyser_if`, `Fitter_if`, `HypothesisTester_if`, and `Solver_if` to allow safe deletion through base pointers.
- Introduced braces around multi-statement `case` blocks in `Buffer`, `Seize`, and `Release` to fix scoping issues.
- Added explicit handling for sentinel/invalid enum values (e.g., `num_elements`) in selection/arrival `switch` statements to emit `traceError` and avoid silently undefined behavior.

### Testing
- Performed a project compilation to verify the changes integrate with existing headers and component code, and the build completed successfully using the standard build system invocation (`make`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d47ceeb7e083219b51357d538d5bb0)