### PR TITLE
Fix MainWindow QAction autoconnect inconsistencies (Phase 1)

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.h
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.h
@@ -50,7 +50,8 @@ private slots:
 	void on_actionEditUndo_triggered();
 	void on_actionEditRedo_triggered();
 	void on_actionEditFind_triggered();
-	void on_actionReplace_triggered();
+	// void on_actionReplace_triggered(); // old name (without menu namespace)
+	void on_actionEditReplace_triggered();
 	void on_actionEditCut_triggered();
 	void on_actionEditCopy_triggered();
 	void on_actionEditPaste_triggered();

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.h
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.h
@@ -50,7 +50,7 @@ private slots:
 	void on_actionEditUndo_triggered();
 	void on_actionEditRedo_triggered();
 	void on_actionEditFind_triggered();
-	void on_actionEditReplace_triggered();
+	void on_actionReplace_triggered();
 	void on_actionEditCut_triggered();
 	void on_actionEditCopy_triggered();
 	void on_actionEditPaste_triggered();
@@ -110,6 +110,7 @@ private slots:
 	void on_actionAlignLeft_triggered();
 
 	void on_actionToolsParserGrammarChecker_triggered();
+	// Legacy slot: there is no matching QAction in mainwindow.ui at this moment.
 	void on_actionToolsExperimentation_triggered();
 	void on_actionToolsOptimizator_triggered();
 	void on_actionToolsDataAnalyzer_triggered();
@@ -126,7 +127,9 @@ private slots:
 	void on_actionModelCheck_triggered();
 
 	void on_actionConnect_triggered();
-	void on_actionComponent_Breakpoint_triggered();
+	void on_actionGModelComponentBreakpoint_triggered();
+	void on_actionShowInternalElements_triggered();
+	void on_actionShowAttachedElements_triggered();
 
 
     // widget events

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.ui
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.ui
@@ -870,6 +870,7 @@
     <addaction name="actionEditDelete"/>
     <addaction name="separator"/>
     <addaction name="actionEditFind"/>
+    <addaction name="actionReplace"/>
     <addaction name="separator"/>
    </widget>
    <widget class="QMenu" name="menuTools">

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.ui
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.ui
@@ -870,7 +870,8 @@
     <addaction name="actionEditDelete"/>
     <addaction name="separator"/>
     <addaction name="actionEditFind"/>
-    <addaction name="actionReplace"/>
+    <!-- <addaction name="actionReplace"/> -->
+    <addaction name="actionEditReplace"/>
     <addaction name="separator"/>
    </widget>
    <widget class="QMenu" name="menuTools">
@@ -1547,7 +1548,8 @@ li.checked::marker { content: &quot;\2612&quot;; }
     <string>Ctrl+F</string>
    </property>
   </action>
-  <action name="actionReplace">
+  <!-- <action name="actionReplace"> -->
+  <action name="actionEditReplace">
    <property name="icon">
     <iconset resource="GenesysQtGUI_resources.qrc">
      <normaloff>:/icons3/resources/icons/pack3/ico/find.ico</normaloff>:/icons3/resources/icons/pack3/ico/find.ico</iconset>
@@ -1559,6 +1561,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
     <string>Ctrl+R</string>
    </property>
   </action>
+  <!-- </action> -->
   <action name="actionEditCut">
    <property name="enabled">
     <bool>false</bool>

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow_controller.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow_controller.cpp
@@ -223,7 +223,10 @@ void MainWindow::on_actionEditFind_triggered() {
 }
 
 
-void MainWindow::on_actionReplace_triggered() {
+// void MainWindow::on_actionReplace_triggered() {
+//     _showMessageNotImplemented();
+// }
+void MainWindow::on_actionEditReplace_triggered() {
     _showMessageNotImplemented();
 }
 

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow_controller.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow_controller.cpp
@@ -223,7 +223,7 @@ void MainWindow::on_actionEditFind_triggered() {
 }
 
 
-void MainWindow::on_actionEditReplace_triggered() {
+void MainWindow::on_actionReplace_triggered() {
     _showMessageNotImplemented();
 }
 
@@ -525,30 +525,35 @@ void MainWindow::on_actionSimulatorPreferences_triggered()
 
 void MainWindow::on_actionAlignMiddle_triggered()
 {
+    // Legacy slot kept for compatibility with old .ui action names.
     _showMessageNotImplemented();
 }
 
 
 void MainWindow::on_actionAlignTop_triggered()
 {
+    // Legacy slot kept for compatibility with old .ui action names.
     _showMessageNotImplemented();
 }
 
 
 void MainWindow::on_actionAlignRight_triggered()
 {
+    // Legacy slot kept for compatibility with old .ui action names.
     _showMessageNotImplemented();
 }
 
 
 void MainWindow::on_actionAlignCenter_triggered()
 {
+    // Legacy slot kept for compatibility with old .ui action names.
     _showMessageNotImplemented();
 }
 
 
 void MainWindow::on_actionAlignLeft_triggered()
 {
+    // Legacy slot kept for compatibility with old .ui action names.
     _showMessageNotImplemented();
 }
 
@@ -628,6 +633,7 @@ void MainWindow::on_actionToolsParserGrammarChecker_triggered()
 
 void MainWindow::on_actionToolsExperimentation_triggered()
 {
+    // Legacy slot: action is not exposed in current mainwindow.ui.
     _showMessageNotImplemented();
 }
 
@@ -1071,10 +1077,12 @@ void MainWindow::on_tabWidget_Model_tabBarClicked(int index) {
 }
 
 void MainWindow::on_checkBox_ShowElements_stateChanged(int arg1) {
+    ui->actionShowAttachedElements->setChecked(arg1 == Qt::Checked);
     bool result = _createModelImage();
 }
 
 void MainWindow::on_checkBox_ShowInternals_stateChanged(int arg1) {
+    ui->actionShowInternalElements->setChecked(arg1 == Qt::Checked);
     bool result = _createModelImage();
 }
 
@@ -1203,7 +1211,7 @@ void MainWindow::on_tabWidgetModelLanguages_currentChanged(int index) {
     _actualizeActions();
 }
 
-void MainWindow::on_actionComponent_Breakpoint_triggered() {
+void MainWindow::on_actionGModelComponentBreakpoint_triggered() {
     if (ui->graphicsView->selectedItems().size() == 1) {
         QGraphicsItem* gi = ui->graphicsView->selectedItems().at(0);
         GraphicalModelComponent* gmc = dynamic_cast<GraphicalModelComponent*> (gi);
@@ -1217,6 +1225,24 @@ void MainWindow::on_actionComponent_Breakpoint_triggered() {
             }
         }
         _actualizeDebugBreakpoints(false);
+    }
+}
+
+void MainWindow::on_actionShowInternalElements_triggered() {
+    const bool checked = ui->actionShowInternalElements->isChecked();
+    if (ui->checkBox_ShowInternals->isChecked() != checked) {
+        ui->checkBox_ShowInternals->setChecked(checked);
+    } else {
+        _createModelImage();
+    }
+}
+
+void MainWindow::on_actionShowAttachedElements_triggered() {
+    const bool checked = ui->actionShowAttachedElements->isChecked();
+    if (ui->checkBox_ShowElements->isChecked() != checked) {
+        ui->checkBox_ShowElements->setChecked(checked);
+    } else {
+        _createModelImage();
     }
 }
 


### PR DESCRIPTION
### Motivation
- Ensure Qt autoconnect naming consistency between `mainwindow.ui`, `mainwindow.h` and `.cpp` so toolbar/menu actions trigger their intended slots. 
- Address Phase 1 scope: small, local fixes that make visible GUI actions have matching slots without large refactors. 
- Remove ambiguity around legacy/unused QAction names while preserving current UI behavior.

### Description
- Align Replace action wiring by renaming the header/cpp slot to `on_actionReplace_triggered` and adding `actionReplace` into the Edit menu in `mainwindow.ui` so autoconnect works. 
- Fix the component-breakpoint wiring by providing `on_actionGModelComponentBreakpoint_triggered` to match `actionGModelComponentBreakpoint` and reuse the existing implementation. 
- Add minimal, functional slots `on_actionShowInternalElements_triggered` and `on_actionShowAttachedElements_triggered` that keep the checkbox state and action state synchronized and call `_createModelImage()` to update the view. 
- Mark legacy slots (alignment slots and `on_actionToolsExperimentation_triggered`) with explanatory comments to signal they are intentionally retained as compatibility stubs. 

### Testing
- Ran an automated audit script (`python` parsing `mainwindow.ui` vs header+cpp) which reports all concrete UI actions mapped to header+cpp slots except the menu container `actionArranje`, confirming autoconnect consistency. 
- Attempted a local build with `make -j2`, but the environment lacks Qt tooling (`qmake not found`) so a full compilation could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5007bc6ac8321ab8c8d50df90e559)