### PR TITLE
Add virtual destructors, add `override` specifiers and improve enum/switch safety across interfaces and components

### DIFF
--- a/source/applications/GenesysApplication_if.h
+++ b/source/applications/GenesysApplication_if.h
@@ -16,6 +16,7 @@
 
 class GenesysApplication_if {
 public:
+	virtual ~GenesysApplication_if() = default;
 	virtual int main(int argc, char** argv) = 0;
 };
 

--- a/source/applications/terminal/GenesysShell/GenesysShell_if.h
+++ b/source/applications/terminal/GenesysShell/GenesysShell_if.h
@@ -19,6 +19,7 @@
 
 class GenesysShell_if : public GenesysApplication_if {
 public:
+	virtual ~GenesysShell_if() = default;
 	virtual void openModel(std::string filename) = 0;
 	virtual void saveModelAs(std::string filename) = 0;
 	virtual void saveModel() = 0;
@@ -53,4 +54,3 @@ public:
 };
 
 #endif /* GENESYSSHELL_IF_H */
-

--- a/source/applications/terminal/examples/smarts/Smart_OnEvent.h
+++ b/source/applications/terminal/examples/smarts/Smart_OnEvent.h
@@ -22,19 +22,18 @@ public:
 public:
 	virtual int main(int argc, char** argv) override;
 public:
-	void onBreakpointHandler(SimulationEvent* re);
-	void onEntityCreateHandler(SimulationEvent* re);
-	void onEntityMoveHandler(SimulationEvent* re);
-	void onSimulationStartHandler(SimulationEvent* re);
-	void onReplicationStartHandler(SimulationEvent* re);
-	void onReplicationStepHandler(SimulationEvent* re);
-	void onProcessEventHandler(SimulationEvent* re);
-	void onReplicationEndHandler(SimulationEvent* re);
-	void onSimulationEndHandler(SimulationEvent* re);
-	void onSimulationPausedHandler(SimulationEvent* re);
-	void onSimulationResumeHandler(SimulationEvent* re);
-	void onEntityRemoveHandler(SimulationEvent* re);
+	virtual void onBreakpointHandler(SimulationEvent* re) override;
+	virtual void onEntityCreateHandler(SimulationEvent* re) override;
+	virtual void onEntityMoveHandler(SimulationEvent* re) override;
+	virtual void onSimulationStartHandler(SimulationEvent* re) override;
+	virtual void onReplicationStartHandler(SimulationEvent* re) override;
+	virtual void onReplicationStepHandler(SimulationEvent* re) override;
+	virtual void onProcessEventHandler(SimulationEvent* re) override;
+	virtual void onReplicationEndHandler(SimulationEvent* re) override;
+	virtual void onSimulationEndHandler(SimulationEvent* re) override;
+	virtual void onSimulationPausedHandler(SimulationEvent* re) override;
+	virtual void onSimulationResumeHandler(SimulationEvent* re) override;
+	virtual void onEntityRemoveHandler(SimulationEvent* re) override;
 };
 
 #endif /* SMART_ONEVENT_H */
-

--- a/source/kernel/simulator/ExperimetManager_if.h
+++ b/source/kernel/simulator/ExperimetManager_if.h
@@ -27,6 +27,7 @@
  */
 class ExperimentManager_if {
 public:
+	virtual ~ExperimentManager_if() = default;
 	/*! \brief Returns the list of scenarios that compose the experiment. */
 	virtual List<SimulationScenario*>* getScenarios() const = 0;
 	//virtual List<PropertyBase*>* getControls() const = 0;
@@ -44,4 +45,3 @@ public:
 };
 
 #endif /* EXPERIMENTMANAGER_IF_H */
-

--- a/source/kernel/simulator/ModelChecker_if.h
+++ b/source/kernel/simulator/ModelChecker_if.h
@@ -25,6 +25,7 @@
  */
 class ModelChecker_if {
 public:
+	virtual ~ModelChecker_if() = default;
 	/*!
 	 * \brief checkAll
 	 * \return
@@ -58,4 +59,3 @@ public:
 };
 
 #endif /* MODELCHECKER_IF_H */
-

--- a/source/kernel/simulator/ModelPersistence_if.h
+++ b/source/kernel/simulator/ModelPersistence_if.h
@@ -30,6 +30,7 @@ class PersistenceRecord;
  */
 class ModelPersistence_if {
 public:
+	virtual ~ModelPersistence_if() = default;
 
 	enum class Options : int {
 		SAVEDEFAULTS = 1, HIDEIDKEY = 2, HIDETYPEKEY = 4, HIDENAMEKEY = 8, SORTALPHLY = 16
@@ -54,4 +55,3 @@ public:
 };
 
 #endif /* MODELPERSISTENCE_IF_H */
-

--- a/source/kernel/simulator/Parser_if.h
+++ b/source/kernel/simulator/Parser_if.h
@@ -28,6 +28,7 @@ class genesyspp_driver;
  */
 class Parser_if {
 public:
+	virtual ~Parser_if() = default;
 	/*!
 	 * \brief parse
 	 * \param expression
@@ -72,4 +73,3 @@ public:
 };
 
 #endif /* PARSER_IF_H */
-

--- a/source/kernel/simulator/PluginConnector_if.h
+++ b/source/kernel/simulator/PluginConnector_if.h
@@ -28,6 +28,7 @@
  */
 class PluginConnector_if {
 public:
+	virtual ~PluginConnector_if() = default;
 	/*!
 	 * \brief check
 	 * \param dynamicLibraryFilename

--- a/source/kernel/simulator/ScenarioExperiment_if.h
+++ b/source/kernel/simulator/ScenarioExperiment_if.h
@@ -15,7 +15,8 @@
 #define SCENARIOEXPERIMENT_IF_H
 
 class ScenarioExperiment_if {
+public:
+	virtual ~ScenarioExperiment_if() = default;
 };
 
 #endif /* SCENARIOEXPERIMENT_IF_H */
-

--- a/source/kernel/simulator/SimulationReporter_if.h
+++ b/source/kernel/simulator/SimulationReporter_if.h
@@ -25,6 +25,7 @@
  */
 class SimulationReporter_if {
 public:
+	virtual ~SimulationReporter_if() = default;
 	/*!
 	 * \brief showReplicationStatistics
 	 */
@@ -49,4 +50,3 @@ public:
 };
 
 #endif /* SIMULATIONREPORTER_IF_H */
-

--- a/source/kernel/statistics/CollectorDatafile_if.h
+++ b/source/kernel/statistics/CollectorDatafile_if.h
@@ -24,6 +24,7 @@
  */
 class CollectorDatafile_if : public Collector_if {
 public:
+	virtual ~CollectorDatafile_if() = default;
 	/*!
 	 * \brief getValue
 	 * \param rank
@@ -54,4 +55,3 @@ public:
 };
 
 #endif /* COLLECTORDATAFILE_IF_H */
-

--- a/source/kernel/statistics/Collector_if.h
+++ b/source/kernel/statistics/Collector_if.h
@@ -41,6 +41,7 @@ CollectorClearHandler setCollectorClearHandler(void (Class::*function)(), Class 
  */
 class Collector_if {
 public:
+	virtual ~Collector_if() = default;
 	/*!
 	 * \brief clear
 	 */
@@ -81,4 +82,3 @@ public:
 };
 
 #endif /* COLLECTOR_IF_H */
-

--- a/source/kernel/statistics/Sampler_if.h
+++ b/source/kernel/statistics/Sampler_if.h
@@ -23,6 +23,7 @@
  */
 class Sampler_if {
 public:
+	virtual ~Sampler_if() = default;
 
 	/*!
 	 * \brief Encapsulates generator-specific configuration/state parameters.
@@ -90,4 +91,3 @@ public:
 };
 
 #endif /* Sampler_IF_H */
-

--- a/source/kernel/statistics/StatisticsDataFile_if.h
+++ b/source/kernel/statistics/StatisticsDataFile_if.h
@@ -28,6 +28,7 @@ class StatisticsDatafile_if : public Statistics_if {
 	//    virtual CollectorDatafile_if* getCollector() = 0;
 	//    virtual void setCollector(Collector_if* collector) = 0;
 public:
+	virtual ~StatisticsDatafile_if() = default;
 	/*!
 	 * \brief mode
 	 * \return
@@ -91,4 +92,3 @@ public:
 };
 
 #endif /* STATISTICSDATAFILE_IF_H */
-

--- a/source/kernel/statistics/Statistics_if.h
+++ b/source/kernel/statistics/Statistics_if.h
@@ -25,6 +25,7 @@
  */
 class Statistics_if {
 public:
+	virtual ~Statistics_if() = default;
 	/*! \brief Returns the data collector associated with these statistics. */
 	virtual Collector_if* getCollector() const = 0;
 	/*! \brief Sets the collector used as source for statistical calculations. */
@@ -100,4 +101,3 @@ public:
 };
 
 #endif /* STATISTICS_IF_H */
-

--- a/source/plugins/components/Buffer.cpp
+++ b/source/plugins/components/Buffer.cpp
@@ -118,10 +118,15 @@ void Buffer::_onDispatchEvent(Entity* entity, unsigned int inputPortNumber) {
 					_parentModel->sendEntityToComponent(entity, _connections->getConnectionAtPort(1));
 					break;
 				case ArrivalOnFullBufferRule::ReplaceLastPosition:
+				{
 					Entity* replaced = _buffer->at(_capacity-1);
 					traceSimulation(this, "Entity "+entity->getName()+" will replace entity "+replaced->getName()+" on the buffer");
 					traceSimulation(this, "Disposing replaced entity "+entity->getName());
 					_parentModel->removeEntity(replaced);
+					break;
+				}
+				case ArrivalOnFullBufferRule::num_elements:
+					traceError("Invalid ArrivalOnFullBufferRule enum value: num_elements");
 					break;
 			}
 		} else { // insert

--- a/source/plugins/components/CellularAutomata/LocalRule_Elementary.h
+++ b/source/plugins/components/CellularAutomata/LocalRule_Elementary.h
@@ -14,7 +14,7 @@ public:
     LocalRule_Elementary(const LocalRule_Elementary& orig): LocalRule(orig) { }
     virtual ~LocalRule_Elementary()=default;
 public:
-    virtual void applyRule(Cell* cell) {
+    virtual void applyRule(Cell* cell) override {
 		long number = 0;
         int bit, power = 2;
         for (Cell* neigh : cell->getNeighbors()) {

--- a/source/plugins/components/CellularAutomata/LocalRule_GameOfLife.h
+++ b/source/plugins/components/CellularAutomata/LocalRule_GameOfLife.h
@@ -11,7 +11,7 @@ public:
     LocalRule_GameOfLife(const LocalRule_GameOfLife& orig): LocalRule(orig) { }
     virtual ~LocalRule_GameOfLife()=default;
 public:
-    virtual void applyRule(Cell* cell) {
+    virtual void applyRule(Cell* cell) override {
         unsigned int living = 0;
         for (Cell* neigh : cell->getNeighbors()) {
 			living += neigh->getCurrentState().getValue();

--- a/source/plugins/components/CellularAutomata/LocalRule_Growty.h
+++ b/source/plugins/components/CellularAutomata/LocalRule_Growty.h
@@ -10,7 +10,7 @@ public:
     LocalRule_Growty(const LocalRule_Growty& orig): LocalRule(orig) {}
     virtual ~LocalRule_Growty() = default;
 public:
-    virtual void applyRule(Cell* cell) {
+    virtual void applyRule(Cell* cell) override {
         unsigned int sum = 0;
         for (Cell* neigh : cell->getNeighbors()) {
 			sum += neigh->getCurrentState().getValue();

--- a/source/plugins/components/ModalModelFSM.h
+++ b/source/plugins/components/ModalModelFSM.h
@@ -15,7 +15,7 @@ public: // static
 
 protected: /// virtual protected methods that could be overriden by derived classes, if needed
 	/*! This method is called by ModelChecker during model check. The component should check itself to verify if user parameters are ok (ex: correct syntax for the parser) and everithing in its parameters allow the model too run without errors in this component */
-	virtual bool _check(std::string& errorMessage);
+	virtual bool _check(std::string& errorMessage) override;
 	/*! This method returns all changes in the parser that are needed by plugins of this ModelDatas. When connecting a new plugin, ParserChangesInformation are used to change parser source code, whch is after compiled and dinamically linked to to simulator kernel to reflect the changes */
 	// virtual ParserChangesInformation* _getParserChangesInformation();
 	/*! This method is called by ModelSimulation when initianting the replication. The model should set all value for a new replication (Ex: setting back to 0 any internal counter, clearing lists, etc. */

--- a/source/plugins/components/Release.cpp
+++ b/source/plugins/components/Release.cpp
@@ -144,6 +144,7 @@ Resource* Release::_getResourceFromSeizableItem(SeizableItem* seizable, Entity* 
 				trace("Member index " + std::to_string(index) + " was specifically choosen", TraceManager::Level::L9_mostDetailed);
 				break;
 			case SeizableItem::SelectionRule::PREFEREDORDER:
+			{
 				bestValue = 0;
 				index = 0;
 				unsigned int quantity = _parentModel->parseExpression(seizable->getQuantityExpression());
@@ -186,6 +187,10 @@ Resource* Release::_getResourceFromSeizableItem(SeizableItem* seizable, Entity* 
 					}
 					index = bestIndex;
 				}
+				break;
+			}
+			case SeizableItem::SelectionRule::num_elements:
+				traceError("Invalid SelectionRule enum value: num_elements");
 				break;
 		}
 		trace("Member of set " + set->getName() + " chosen index " + std::to_string(index), TraceManager::Level::L8_detailed);

--- a/source/plugins/components/Seize.cpp
+++ b/source/plugins/components/Seize.cpp
@@ -433,6 +433,7 @@ Resource* Seize::_getResourceFromSeizableItem(SeizableItem* seizable, Entity* en
 				trace("Member index " + std::to_string(index) + " was specifically choosen", TraceManager::Level::L9_mostDetailed);
 				break;
 			case SeizableItem::SelectionRule::PREFEREDORDER:
+			{
 				bestValue = 0;
 				index = 0;
 				unsigned int quantity = _parentModel->parseExpression(seizable->getQuantityExpression());
@@ -475,6 +476,10 @@ Resource* Seize::_getResourceFromSeizableItem(SeizableItem* seizable, Entity* en
 					}
 					index = bestIndex;
 				}
+				break;
+			}
+			case SeizableItem::SelectionRule::num_elements:
+				traceError("Invalid SelectionRule enum value: num_elements");
 				break;
 		}
 		trace("Member of set " + set->getName() + " chosen index " + std::to_string(index), TraceManager::Level::L8_detailed);

--- a/source/plugins/components/Seize.h
+++ b/source/plugins/components/Seize.h
@@ -36,7 +36,7 @@ public:
 	virtual ~WaitingResource() = default;
 public:
 
-	virtual std::string show() {
+	virtual std::string show() override {
 		return Waiting::show() +
 				",quantity=" + std::to_string(this->_quantity);
 	}
@@ -180,4 +180,3 @@ private:
 };
 
 #endif /* SEIZE_H */
-

--- a/source/tools/DataAnalyser_if.h
+++ b/source/tools/DataAnalyser_if.h
@@ -21,6 +21,7 @@
 
 class DataAnalyser_if {
 public:
+	virtual ~DataAnalyser_if() = default;
 	virtual bool loadDataSet(std::string datafilename) = 0;
 	virtual bool saveDataSet(std::string datasetname) = 0;
 	virtual void newDataSet(std::string datasetname, std::string datafilename) = 0;
@@ -32,4 +33,3 @@ public:
 
 
 #endif /* DATAANALYSERIF_H */
-

--- a/source/tools/Fitter_if.h
+++ b/source/tools/Fitter_if.h
@@ -18,6 +18,7 @@
 
 class Fitter_if {
 public:
+	virtual ~Fitter_if() = default;
 	virtual bool isNormalDistributed(double confidencelevel) = 0;
 	virtual void fitUniform(double *sqrerror, double *min, double *max) = 0;
 	virtual void fitTriangular(double *sqrerror, double *min, double *mo, double *max) = 0;
@@ -33,4 +34,3 @@ public:
 };
 
 #endif /* FITTER_IF_H */
-

--- a/source/tools/HypothesisTester_if.h
+++ b/source/tools/HypothesisTester_if.h
@@ -25,6 +25,7 @@ typedef bool (*checkProportionFunction)(double value);
  */
 class HypothesisTester_if {
 public:
+	virtual ~HypothesisTester_if() = default;
 
 	class ConfidenceInterval {
 	public:
@@ -152,4 +153,3 @@ public:
 };
 
 #endif /* HYPOTHESISTESTER_IF_H */
-

--- a/source/tools/Solver_if.h
+++ b/source/tools/Solver_if.h
@@ -21,6 +21,7 @@
  */
 class Solver_if {
 public:
+	virtual ~Solver_if() = default;
 	virtual void setPrecision(double e) = 0;
 	virtual double getPrecision() = 0;
 	virtual void setMaxSteps(double steps) = 0;
@@ -36,4 +37,3 @@ public:
 };
 
 #endif /* SOLVER_IF_H */
-


### PR DESCRIPTION
### Motivation
- Ensure proper polymorphic destruction for many interface-like classes and improve maintainability by making overrides explicit and handling invalid enum values in switch statements.

### Description
- Added `virtual ~...() = default;` destructors to multiple interface classes such as `GenesysApplication_if`, `GenesysShell_if`, `ExperimentManager_if`, `ModelChecker_if`, `ModelPersistence_if`, `Parser_if`, `PluginConnector_if`, `ScenarioExperiment_if`, `SimulationReporter_if`, `CollectorDatafile_if`, `Collector_if`, `Sampler_if`, `StatisticsDatafile_if`, `Statistics_if`, `DataAnalyser_if`, `Fitter_if`, `HypothesisTester_if`, and `Solver_if` to guarantee safe deletion through base pointers.
- Marked overriding methods with `override` in several components and examples, including event handlers in `Smart_OnEvent`, `applyRule` implementations in cellular automata rules, `WaitingResource::show`, and `ModalModelFSM::_check` to make intent explicit and enable compiler checks.
- Improved enum switch safety and control-flow in runtime components (`Buffer`, `Seize`, `Release`) by adding scoped blocks for cases where needed and handling sentinel/invalid enum values (e.g. `num_elements`) with error traces.
- Minor control/formatting fixes (braces and small logic clarifications) in component sources to reduce compiler warnings and harden behavior.

### Testing
- Performed a full project build (`make` / project build) to verify compilation with the new destructors and `override` annotations, and the build completed successfully.
- Ran the project's automated unit/integration test suite and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d47ceeb7e083219b51357d538d5bb0)