### PR TITLE
Fix plugin tree drag/drop to prevent self-drop duplication

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
@@ -49,6 +49,11 @@
 
 MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWindow) {
     ui->setupUi(this);
+    // Keep plugins tree as drag source only (never a drop target).
+    ui->treeWidget_Plugins->setDragDropMode(QAbstractItemView::DragOnly);
+    ui->treeWidget_Plugins->setAcceptDrops(false);
+    ui->treeWidget_Plugins->viewport()->setAcceptDrops(false);
+    ui->treeWidget_Plugins->setDropIndicatorShown(false);
     //
     // Genesys Simulator
     simulator = new Simulator();

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.ui
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.ui
@@ -1026,7 +1026,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
         <bool>true</bool>
        </property>
        <property name="dragDropMode">
-        <enum>QAbstractItemView::DragDrop</enum>
+        <enum>QAbstractItemView::DragOnly</enum>
        </property>
        <property name="defaultDropAction">
         <enum>Qt::CopyAction</enum>


### PR DESCRIPTION
### Motivation
- Prevent `treeWidget_Plugins` from accepting drops on itself (which caused duplicated/reinserted items) while preserving the ability to drag items from the tree to `graphicsView`.

### Description
- Changed the UI property in `source/applications/gui/qt/GenesysQtGUI/mainwindow.ui` to make `treeWidget_Plugins` `DragOnly` (replaced `QAbstractItemView::DragDrop` with `QAbstractItemView::DragOnly`).
- Added runtime safeguards immediately after `ui->setupUi(this)` in `MainWindow::MainWindow(...)` (`source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp`) to enforce drag-only behavior via `setDragDropMode(QAbstractItemView::DragOnly)`, `setAcceptDrops(false)`, `viewport()->setAcceptDrops(false)`, and `setDropIndicatorShown(false)`.

### Testing
- Ran automated repository checks searching for reconfiguration or drop handlers related to `treeWidget_Plugins` with ripgrep (`rg`) and verified no other code re-enables drops for that widget (searches succeeded).
- Verified the `mainwindow.ui` and `mainwindow.cpp` diffs to confirm the `DragOnly` change and the runtime safeguards were applied (diff check succeeded).
- No unit/build was executed in this change set; the edits are minimal UI/runtime flags and are expected to compile without changing plugin loading or `ModelGraphicsView` logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5197749fc8321950fd74657be405a)