### PR TITLE
Fase 3 GUI: Replace no editor, export de diagrama e unificação de Group/Ungroup

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
@@ -295,13 +295,37 @@ void MainWindow::_actualizeActions() {
     bool opened = simulator->getModelManager()->current() != nullptr;
     bool running = false;
     bool paused = false;
-    unsigned int numSelectedGraphicals = 0;
+    bool canCutCopyDelete = false;
+    bool canPaste = false;
+    bool canGroup = false;
+    bool canUngroup = false;
+    bool canConnect = false;
     unsigned int actualCommandundoRedo = 0; //@TODO
     unsigned int maxCommandundoRedo = 0; //@TODO
     if (opened) {
         running = simulator->getModelManager()->current()->getSimulation()->isRunning();
         paused = simulator->getModelManager()->current()->getSimulation()->isPaused();
-        numSelectedGraphicals = 0;//@TODO get total of selected graphical objects (this should br on another "actualize", I think
+
+        ModelGraphicsScene* scene = ui->graphicsView->getScene();
+        if (scene != nullptr) {
+            const QList<QGraphicsItem*> selectedItems = scene->selectedItems();
+            canCutCopyDelete = !selectedItems.isEmpty();
+            canPaste = !_draw_copy->empty() || !_gmc_copies->empty() || !_group_copy->empty() || !_ports_copies->empty();
+
+            int selectedComponents = 0;
+            bool selectedGroup = false;
+            for (QGraphicsItem* item : selectedItems) {
+                if (dynamic_cast<GraphicalModelComponent*>(item) != nullptr) {
+                    selectedComponents++;
+                } else if (dynamic_cast<QGraphicsItemGroup*>(item) != nullptr) {
+                    selectedGroup = true;
+                }
+            }
+
+            canGroup = selectedComponents >= 2 && !selectedGroup;
+            canUngroup = selectedItems.size() == 1 && selectedGroup;
+            canConnect = scene->connectingStep() == 0;
+        }
     }
 
     //
@@ -346,11 +370,16 @@ void MainWindow::_actualizeActions() {
 
     // based on SELECTED GRAPHICAL OBJECTS or on COMMANDS DONE (UNDO/REDO)
     ui->toolBarArranje->setEnabled(opened && !running);
-    // TODO: MUDAR, ESTÁ HARDCODED, DEVERIA SER DISPONIBILIZADO COM UM COMPONENENTE FOSSE
-    // TODO: SELECIONADO
-    ui->actionEditCopy->setEnabled(0 && !running);
-    ui->actionEditCut->setEnabled(0 && !running);
-    ui->actionEditDelete->setEnabled((numSelectedGraphicals>0) && !running);
+    ui->actionEditCopy->setEnabled(canCutCopyDelete && !running);
+    ui->actionEditCut->setEnabled(canCutCopyDelete && !running);
+    ui->actionEditDelete->setEnabled(canCutCopyDelete && !running);
+    ui->actionEditPaste->setEnabled(canPaste && !running);
+    ui->actionConnect->setEnabled(opened && canConnect && !running);
+    ui->actionViewGroup->setEnabled(opened && canGroup && !running);
+    ui->actionEditGroup->setEnabled(opened && canGroup && !running);
+    ui->actionViewUngroup->setEnabled(opened && canUngroup && !running);
+    ui->actionEditUngroup->setEnabled(opened && canUngroup && !running);
+    ui->actionEditReplace->setEnabled(opened && !running);
 
     // sliders
     ui->horizontalSlider_ZoomGraphical->setEnabled(opened && !running);

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow_controller.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow_controller.cpp
@@ -40,6 +40,18 @@
 #include <QRegularExpression>
 #include <QRandomGenerator>
 #include <QSignalBlocker>
+#include <QDialog>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QFormLayout>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QDialogButtonBox>
+#include <QLabel>
+#include <QCheckBox>
+#include <QImage>
+#include <QPainter>
+#include <QFileInfo>
 #include "../../../../kernel/simulator/ModelSimulation.h"
 
 
@@ -229,7 +241,149 @@ void MainWindow::on_actionEditFind_triggered() {
 //     _showMessageNotImplemented();
 // }
 void MainWindow::on_actionEditReplace_triggered() {
-    _showMessageNotImplemented();
+    if (ui->TextCodeEditor == nullptr) {
+        return;
+    }
+
+    auto* editor = ui->TextCodeEditor;
+
+    QDialog dialog(this);
+    dialog.setWindowTitle(tr("Replace"));
+    dialog.setModal(false);
+
+    auto* layout = new QVBoxLayout(&dialog);
+    auto* formLayout = new QFormLayout();
+    auto* findLine = new QLineEdit(&dialog);
+    auto* replaceLine = new QLineEdit(&dialog);
+    auto* caseSensitive = new QCheckBox(tr("Case sensitive"), &dialog);
+    auto* statusLabel = new QLabel(&dialog);
+    statusLabel->setWordWrap(true);
+    statusLabel->setText(tr("Ready."));
+
+    static QString lastFindText;
+    static QString lastReplaceText;
+    findLine->setText(lastFindText);
+    replaceLine->setText(lastReplaceText);
+
+    formLayout->addRow(tr("Find:"), findLine);
+    formLayout->addRow(tr("Replace with:"), replaceLine);
+
+    auto* buttonFindNext = new QPushButton(tr("Find Next"), &dialog);
+    auto* buttonReplace = new QPushButton(tr("Replace"), &dialog);
+    auto* buttonReplaceAll = new QPushButton(tr("Replace All"), &dialog);
+    auto* buttonBox = new QDialogButtonBox(QDialogButtonBox::Close, &dialog);
+
+    auto* actionLayout = new QHBoxLayout();
+    actionLayout->addWidget(buttonFindNext);
+    actionLayout->addWidget(buttonReplace);
+    actionLayout->addWidget(buttonReplaceAll);
+
+    layout->addLayout(formLayout);
+    layout->addWidget(caseSensitive);
+    layout->addLayout(actionLayout);
+    layout->addWidget(statusLabel);
+    layout->addWidget(buttonBox);
+
+    auto findNext = [&]() -> bool {
+        const QString findText = findLine->text();
+        if (findText.isEmpty()) {
+            statusLabel->setText(tr("Enter text to find."));
+            return false;
+        }
+
+        QTextDocument::FindFlags flags;
+        if (caseSensitive->isChecked()) {
+            flags |= QTextDocument::FindCaseSensitively;
+        }
+
+        bool found = editor->find(findText, flags);
+        if (!found) {
+            QTextCursor cursor = editor->textCursor();
+            cursor.movePosition(QTextCursor::Start);
+            editor->setTextCursor(cursor);
+            found = editor->find(findText, flags);
+        }
+
+        if (found) {
+            statusLabel->setText(tr("Occurrence selected."));
+            lastFindText = findText;
+            lastReplaceText = replaceLine->text();
+            return true;
+        }
+
+        statusLabel->setText(tr("No occurrences found."));
+        return false;
+    };
+
+    connect(buttonFindNext, &QPushButton::clicked, &dialog, [&]() {
+        findNext();
+    });
+
+    connect(buttonReplace, &QPushButton::clicked, &dialog, [&]() {
+        const QString findText = findLine->text();
+        if (findText.isEmpty()) {
+            statusLabel->setText(tr("Enter text to find."));
+            return;
+        }
+
+        QTextCursor cursor = editor->textCursor();
+        const bool matchesSelection = cursor.hasSelection() &&
+                ((caseSensitive->isChecked() && cursor.selectedText() == findText) ||
+                 (!caseSensitive->isChecked() && cursor.selectedText().compare(findText, Qt::CaseInsensitive) == 0));
+
+        if (!matchesSelection && !findNext()) {
+            return;
+        }
+
+        cursor = editor->textCursor();
+        if (cursor.hasSelection()) {
+            cursor.insertText(replaceLine->text());
+            editor->setTextCursor(cursor);
+            statusLabel->setText(tr("Occurrence replaced."));
+            lastFindText = findText;
+            lastReplaceText = replaceLine->text();
+            findNext();
+        }
+    });
+
+    connect(buttonReplaceAll, &QPushButton::clicked, &dialog, [&]() {
+        const QString findText = findLine->text();
+        if (findText.isEmpty()) {
+            statusLabel->setText(tr("Enter text to find."));
+            return;
+        }
+
+        QTextDocument::FindFlags flags;
+        if (caseSensitive->isChecked()) {
+            flags |= QTextDocument::FindCaseSensitively;
+        }
+
+        QTextCursor scanCursor(editor->document());
+        scanCursor.movePosition(QTextCursor::Start);
+        int replacements = 0;
+
+        scanCursor.beginEditBlock();
+        while (true) {
+            QTextCursor found = editor->document()->find(findText, scanCursor, flags);
+            if (found.isNull()) {
+                break;
+            }
+            found.insertText(replaceLine->text());
+            scanCursor = found;
+            replacements++;
+        }
+        scanCursor.endEditBlock();
+
+        editor->setFocus();
+        lastFindText = findText;
+        lastReplaceText = replaceLine->text();
+        statusLabel->setText(tr("%1 occurrence(s) replaced.").arg(replacements));
+    });
+
+    connect(buttonBox, &QDialogButtonBox::rejected, &dialog, &QDialog::reject);
+
+    findLine->setFocus();
+    dialog.exec();
 }
 
 
@@ -645,13 +799,13 @@ void MainWindow::on_actionAnimateStatistics_triggered()
 
 void MainWindow::on_actionEditGroup_triggered()
 {
-    _showMessageNotImplemented();
+    on_actionViewGroup_triggered();
 }
 
 
 void MainWindow::on_actionEditUngroup_triggered()
 {
-    _showMessageNotImplemented();
+    on_actionViewUngroup_triggered();
 }
 
 
@@ -1291,7 +1445,60 @@ void MainWindow::on_actionConnect_triggered() {
 }
 
 void MainWindow::on_pushButton_Export_clicked() {
-    _showMessageNotImplemented();
+    QPixmap modelPixmap = ui->label_ModelGraphic->pixmap();
+    if (modelPixmap.isNull()) {
+        _createModelImage();
+        modelPixmap = ui->label_ModelGraphic->pixmap();
+    }
+
+    if (modelPixmap.isNull()) {
+        ModelGraphicsScene* scene = ui->graphicsView->getScene();
+        if (scene == nullptr || scene->items().isEmpty()) {
+            QMessageBox::information(this, tr("Export Diagram"), tr("There is no diagram/image available to export."));
+            return;
+        }
+
+        QRectF bounds = scene->itemsBoundingRect();
+        if (!bounds.isValid() || bounds.isEmpty()) {
+            QMessageBox::information(this, tr("Export Diagram"), tr("There is no diagram/image available to export."));
+            return;
+        }
+
+        QImage image(bounds.size().toSize() + QSize(20, 20), QImage::Format_ARGB32_Premultiplied);
+        image.fill(Qt::white);
+        QPainter painter(&image);
+        painter.setRenderHint(QPainter::Antialiasing, true);
+        painter.translate(-bounds.topLeft() + QPointF(10.0, 10.0));
+        scene->render(&painter);
+        painter.end();
+        modelPixmap = QPixmap::fromImage(image);
+    }
+
+    const QString defaultName = QDir::currentPath() + "/model-diagram.png";
+    const QString filters = tr("PNG Image (*.png);;JPEG Image (*.jpg *.jpeg);;Bitmap Image (*.bmp)");
+    QString selectedFilter;
+    QString fileName = QFileDialog::getSaveFileName(this, tr("Export Diagram"), defaultName, filters, &selectedFilter, QFileDialog::DontUseNativeDialog);
+    if (fileName.isEmpty()) {
+        return;
+    }
+
+    QString format = "PNG";
+    if (selectedFilter.contains("*.jpg") || selectedFilter.contains("*.jpeg")) {
+        format = "JPG";
+    } else if (selectedFilter.contains("*.bmp")) {
+        format = "BMP";
+    }
+
+    if (QFileInfo(fileName).suffix().isEmpty()) {
+        fileName += "." + format.toLower();
+    }
+
+    if (!modelPixmap.save(fileName, format.toStdString().c_str())) {
+        QMessageBox::warning(this, tr("Export Diagram"), tr("Could not export diagram to file."));
+        return;
+    }
+
+    QMessageBox::information(this, tr("Export Diagram"), tr("Diagram exported successfully."));
 }
 
 void MainWindow::on_tabWidgetModelLanguages_currentChanged(int index) {

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow_scene.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow_scene.cpp
@@ -62,21 +62,7 @@ void MainWindow::sceneChanged(const QList<QRectF> &region) {
     /**
      * Bloco 2: habilita/desabilita ações de edição conforme itens/copias disponíveis.
      */
-    bool res = _checkItemsScene();
-
-    if (res) {
-        ui->actionEditCut->setEnabled(true);
-        ui->actionEditCopy->setEnabled(true);
-    } else {
-        ui->actionEditCut->setEnabled(false);
-        ui->actionEditCopy->setEnabled(false);
-    }
-
-    if (!_draw_copy->empty() || !_gmc_copies->empty() || !_group_copy->empty() || !_ports_copies->empty()) {
-        ui->actionEditPaste->setEnabled(true);
-    } else {
-        ui->actionEditPaste->setEnabled(false);
-    }
+    _actualizeActions();
 
     /**
      * Bloco 3: atualiza estado visual final da cena.
@@ -135,6 +121,7 @@ void MainWindow::sceneSelectionChanged() {
     }
     // Se nenhum item estiver selecionado ou se mais de um item estiver selecionado
     ui->treeViewPropertyEditor->clear();
+    _actualizeActions();
 }
 
 //-----------------------------------------


### PR DESCRIPTION
### Motivation

- Tornar a GUI de edição mais coerente e usável na Fase 3, implementando funcionalidades que estavam em stub e alinhando o estado das ações com o contexto da cena.
- Fornecer uma ferramenta de Replace no editor de texto e permitir exportar o diagrama visual sem alterar o fluxo gráfico -> modelo -> SimulLang.

### Description

- Implementei Replace no editor textual substituindo o stub de `on_actionEditReplace_triggered()` por um diálogo local com `Find Next`, `Replace`, `Replace All` e opção case-sensitive que opera diretamente sobre `TextCodeEditor` sem reconstruir o modelo (arquivo modificado: `mainwindow_controller.cpp`).
- Implementei Export do diagrama em `on_pushButton_Export_clicked()` que abre `QFileDialog`, exporta PNG/JPG/BMP, tenta usar `label_ModelGraphic` (chama `_createModelImage()` se necessário) e faz fallback renderizando a `QGraphicsScene` quando preciso, com mensagens de erro/sucesso ao usuário (arquivo modificado: `mainwindow_controller.cpp`).
- Unifiquei Group/Ungroup fazendo `on_actionEditGroup_triggered()` e `on_actionEditUngroup_triggered()` delegarem para a lógica já usada em View, evitando duplicação e garantindo comportamento idêntico (arquivo modificado: `mainwindow_controller.cpp`).
- Revisei a lógica de habilitar/ desabilitar ações em `_actualizeActions()` e sincronizei atualizações para melhorar a UX: Cut/Copy/Delete habilitados só com seleção, Paste conforme buffer, Group/Ungroup coerentes com seleção, Connect desabilitado quando em modo de conexão e Replace habilitado quando houver modelo e não estiver em execução; também passei a chamar `_actualizeActions()` a partir de `sceneChanged()` e `sceneSelectionChanged()` para manter menus/toolbar sincronizados (arquivo modificado: `mainwindow.cpp` e `mainwindow_scene.cpp`).

### Testing

- Executei a configuração do projeto com GUI ativada via `cmake --preset debug -DGENESYS_BUILD_GUI_APPLICATION=ON`, que abortou na etapa de configuração por ausência de `qmake` no PATH (ambiente sem Qt/qmake), portanto não foi possível gerar binários GUI neste ambiente de CI; resultado: falha de configuração por dependência de ambiente.
- Não foram executados testes unitários ou build da aplicação GUI neste ambiente devido ao erro de configuração descrito acima.
- As alterações são locais e pequenas, projetadas para serem compiláveis em um ambiente com Qt/qmake disponível; validação funcional manual ou por CI com Qt instalado é recomendada como próximo passo.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d51c86e6ac83219b7bc826b83199c1)