### PR TITLE
Unify main window X close flow with Simulator->Exit in Qt GUI

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
@@ -953,10 +953,14 @@ void MainWindow::unselectDrawIcons() {
 }
 
 void MainWindow::closeEvent(QCloseEvent *event) {
-    // limpando referencia do ultimo elemento selecionado em property editor
-    ui->treeViewPropertyEditor->clearCurrentlyConnectedObject();
-
-    QMainWindow::closeEvent(event);
+    if (_closingApproved || _confirmApplicationExit()) {
+        _closingApproved = true;
+        // limpando referencia do ultimo elemento selecionado em property editor
+        ui->treeViewPropertyEditor->clearCurrentlyConnectedObject();
+        event->accept();
+        return;
+    }
+    event->ignore();
 }
 
 void MainWindow::_initUiForNewModel(Model* m) {

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.h
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.h
@@ -273,9 +273,13 @@ private: // attributes to be saved and loaded withing the graphical model
 	int _zoomValue; // todo should be set for each open graphical model, such as view rect, etc
 private: // misc useful
     bool _check(bool success = true);
+	bool _hasPendingModelChanges() const;
+	bool _confirmApplicationExit();
 	bool _textModelHasChanged = false;
 	bool _graphicalModelHasChanged = false;
 	bool _modelWasOpened = false;
+	// Avoids duplicated prompts when exit is approved and Qt emits close events during shutdown.
+	bool _closingApproved = false;
 	QString _autoLoadPluginsFilename = "autoloadplugins.txt";
     bool _checkItemsScene();
 	QString _modelfilename;

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow_controller.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow_controller.cpp
@@ -52,6 +52,7 @@
 #include <QImage>
 #include <QPainter>
 #include <QFileInfo>
+#include <QCoreApplication>
 #include "../../../../kernel/simulator/ModelSimulation.h"
 
 
@@ -1030,20 +1031,51 @@ void MainWindow::on_actionModelCheck_triggered()
 
 void MainWindow::on_actionSimulatorExit_triggered()
 {
-    QMessageBox::StandardButton res;
-    if (this->_textModelHasChanged) {
-        res = QMessageBox::question(this, "Exit GenESyS", "Model has changed. Do you want to save it?", QMessageBox::Yes | QMessageBox::No);
-        if (res == QMessageBox::Yes) {
+    if (!_confirmApplicationExit()) {
+        return;
+    }
+
+    _closingApproved = true;
+    QCoreApplication::quit();
+}
+
+bool MainWindow::_hasPendingModelChanges() const {
+    Model* currentModel = simulator->getModelManager()->current();
+    if (currentModel == nullptr) {
+        return false;
+    }
+
+    return _textModelHasChanged || currentModel->hasChanged();
+}
+
+bool MainWindow::_confirmApplicationExit() {
+    if (_hasPendingModelChanges()) {
+        QMessageBox::StandardButton saveReply = QMessageBox::question(
+                this,
+                "Exit GenESyS",
+                "Model has changed. Do you want to save it?",
+                QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel,
+                QMessageBox::Yes);
+
+        if (saveReply == QMessageBox::Cancel) {
+            return false;
+        }
+
+        if (saveReply == QMessageBox::Yes) {
             this->on_actionModelSave_triggered();
-            return;
+            if (_hasPendingModelChanges()) {
+                return false;
+            }
         }
     }
-    res = QMessageBox::question(this, "Exit GenESyS", "Do you want to exit GenESyS?", QMessageBox::Yes | QMessageBox::No);
-    if (res == QMessageBox::Yes) {
-        std::exit(EXIT_SUCCESS);
-    } else {
-        // it does not quit, but the window is closed. Check it. @TODO
-    }
+
+    QMessageBox::StandardButton exitReply = QMessageBox::question(
+            this,
+            "Exit GenESyS",
+            "Do you want to exit GenESyS?",
+            QMessageBox::Yes | QMessageBox::No,
+            QMessageBox::No);
+    return exitReply == QMessageBox::Yes;
 }
 
 


### PR DESCRIPTION
### Motivation
- Eliminar a divergência entre fechar a janela principal pelo botão X e pelo menu `Simulator -> Exit`, garantindo fluxos idênticos de confirmação e salvamento.
- Substituir encerramento bruto por `std::exit(EXIT_SUCCESS)` por um encerramento idiomático do Qt e evitar prompts duplicados durante o shutdown.

### Description
- Centralizei a política de encerramento em `MainWindow::_confirmApplicationExit()` que faz a detecção de alterações pendentes, pergunta sobre salvar, tenta salvar e solicita confirmação final de saída.
- Adicionei `MainWindow::_hasPendingModelChanges()` para harmonizar o critério de mudanças pendentes usando `_textModelHasChanged || current()->hasChanged()`.
- Refatorei `on_actionSimulatorExit_triggered()` para chamar apenas `_confirmApplicationExit()` e, em caso afirmativo, marcar `_closingApproved` e chamar `QCoreApplication::quit()` (substituindo `std::exit`).
- Atualizei `closeEvent(QCloseEvent*)` para redirecionar o botão X ao mesmo fluxo de confirmação; o evento é `accept()` somente se a saída foi aprovada, caso contrário é `ignore()`; a limpeza do property editor (`clearCurrentlyConnectedObject()`) foi preservada e executada somente quando o fechamento está aprovado.
- Introduzi o flag `_closingApproved` com comentário explicativo para evitar reentrada/duplicidade de prompts durante a cascata de eventos de fechamento do Qt.

### Testing
- Executei `git diff --check` para verificar problemas simples de formatação e diffs; passou sem erros.
- Usei buscas automáticas (`rg`) para confirmar que o antigo `std::exit` foi removido do fluxo de menu e que os novos helpers (`_confirmApplicationExit`, `_hasPendingModelChanges`, `_closingApproved`) foram adicionados; as buscas retornaram as alterações esperadas.
- Commit das mudanças em `source/applications/gui/qt/GenesysQtGUI/{mainwindow.h,mainwindow.cpp,mainwindow_controller.cpp}` foi criado com sucesso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d52677e0048321bc0357385337c366)