### PR TITLE
Harden Qt GUI lifecycle around scene/MainWindow signal teardown

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
@@ -2287,6 +2287,10 @@ void ModelGraphicsScene::focusOutEvent(QFocusEvent *focusEvent) {
 }
 
 void ModelGraphicsScene::dropEvent(QGraphicsSceneDragDropEvent *event) {
+    qInfo() << "ModelGraphicsScene::dropEvent scene=" << this
+            << " draggedItem=" << _objectBeingDragged
+            << " simulator=" << _simulator
+            << " currentModel=" << (_simulator ? _simulator->getModelManager()->current() : nullptr);
     if (checkIgnoreEvent()) {
         event->ignore();
         return;

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsView.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsView.cpp
@@ -172,6 +172,13 @@ void ModelGraphicsView::setCanNotifyGraphicalModelEventHandlers(bool can) {
 	_notifyGraphicalModelEventHandlers = can;
 }
 
+void ModelGraphicsView::clearEventHandlers() {
+    _sceneMouseEventHandler = nullptr;
+    _sceneWheelInEventHandler = nullptr;
+    _sceneWheelOutEventHandler = nullptr;
+    _sceneGraphicalModelEventHandler = nullptr;
+}
+
 //---------------------------------------------------------
 
 void ModelGraphicsView::contextMenuEvent(QContextMenuEvent *event) {

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsView.h
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsView.h
@@ -101,6 +101,7 @@ public: // events and notifications
     void notifySceneWheelOutEventHandler();
     void notifySceneGraphicalModelEventHandler(const GraphicalModelEvent& modelGraphicsEvent);
     void setCanNotifyGraphicalModelEventHandlers(bool can);
+    void clearEventHandlers();
     void setParentWidget(QWidget *parentWidget);
 protected:// slots:
     void changed(const QList<QRectF> &region);

--- a/source/applications/gui/qt/GenesysQtGUI/main.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/main.cpp
@@ -48,17 +48,7 @@ void _appendLogLine(const QString& line) {
 }
 
 void _qtMessageHandler(QtMsgType type, const QMessageLogContext& context, const QString& msg) {
-    const QString now = QDateTime::currentDateTime().toString(Qt::ISODateWithMs);
-    QString level;
-    switch (type) {
-        case QtDebugMsg: level = "DEBUG"; break;
-        case QtInfoMsg: level = "INFO"; break;
-        case QtWarningMsg: level = "WARN"; break;
-        case QtCriticalMsg: level = "CRITICAL"; break;
-        case QtFatalMsg: level = "FATAL"; break;
-    }
-    QString where = QString("%1:%2").arg(context.file ? context.file : "unknown").arg(context.line);
-    QString line = QString("[%1] [%2] [%3] %4").arg(now, level, where, msg);
+    const QString line = qFormatLogMessage(type, context, msg);
     _appendLogLine(line);
     std::cerr << line.toStdString() << std::endl;
     if (type == QtFatalMsg) {
@@ -96,6 +86,7 @@ void _signalHandler(int signalNumber) {
 }
 
 void _installCrashAndLogHandlers() {
+    qSetMessagePattern("[%{time yyyy-MM-ddTHH:mm:ss.zzz}] [%{if-debug}DEBUG%{endif}%{if-info}INFO%{endif}%{if-warning}WARN%{endif}%{if-critical}CRITICAL%{endif}%{if-fatal}FATAL%{endif}] [tid:%{threadid}] [%{file}:%{line}] [%{function}] %{message}");
     _logPath = _defaultLogPath();
     _appendLogLine(QString("[%1] [INFO] Logging started at %2")
                    .arg(QDateTime::currentDateTime().toString(Qt::ISODateWithMs), _logPath));

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
@@ -209,6 +209,12 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
 }
 
 MainWindow::~MainWindow() {
+    _shuttingDown = true;
+    _disconnectSceneSignals("~MainWindow");
+    disconnect();
+    if (ui != nullptr && ui->graphicsView != nullptr) {
+        ui->graphicsView->clearEventHandlers();
+    }
     delete ui;
     delete simulator;
     delete propertyGenesys;
@@ -221,6 +227,37 @@ MainWindow::~MainWindow() {
     delete _draw_copy;
     delete _group_copy;
     delete undoView;
+}
+
+void MainWindow::_disconnectSceneSignals(const char* context) {
+    if (_sceneChangedConnection) {
+        QObject::disconnect(_sceneChangedConnection);
+        _sceneChangedConnection = QMetaObject::Connection();
+    }
+    if (_sceneFocusItemChangedConnection) {
+        QObject::disconnect(_sceneFocusItemChangedConnection);
+        _sceneFocusItemChangedConnection = QMetaObject::Connection();
+    }
+    if (_sceneSelectionChangedConnection) {
+        QObject::disconnect(_sceneSelectionChangedConnection);
+        _sceneSelectionChangedConnection = QMetaObject::Connection();
+    }
+    QObject* sceneObject = (ui != nullptr && ui->graphicsView != nullptr) ? ui->graphicsView->scene() : nullptr;
+    qInfo() << "Scene/MainWindow signal connections disconnected. context=" << context
+            << " scene=" << sceneObject << " mainWindow=" << this;
+}
+
+void MainWindow::_connectSceneSignals() {
+    _disconnectSceneSignals("_connectSceneSignals");
+    if (ui == nullptr || ui->graphicsView == nullptr || ui->graphicsView->scene() == nullptr) {
+        qWarning() << "Skipping scene connection because ui/graphicsView/scene is null";
+        return;
+    }
+    _sceneChangedConnection = connect(ui->graphicsView->scene(), &QGraphicsScene::changed, this, &MainWindow::sceneChanged);
+    _sceneFocusItemChangedConnection = connect(ui->graphicsView->scene(), &QGraphicsScene::focusItemChanged, this, &MainWindow::sceneFocusItemChanged);
+    _sceneSelectionChangedConnection = connect(ui->graphicsView->scene(), &QGraphicsScene::selectionChanged, this, &MainWindow::sceneSelectionChanged);
+    qInfo() << "Scene/MainWindow signal connections attached. scene=" << ui->graphicsView->scene()
+            << " mainWindow=" << this;
 }
 
 ModelGraphicsScene* MainWindow::myScene() const {

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.h
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.h
@@ -6,6 +6,7 @@
 #include <QTreeWidgetItem>
 #include <QGraphicsItem>
 #include <QUndoView>
+#include <QMetaObject>
 #include <memory>
 
 #include "propertyeditor/DataComponentProperty.h"
@@ -234,6 +235,8 @@ private: // simulator related
 	std::string _addCppCodeLine(std::string line, unsigned int indent = 0);
 private: // view
 	void _initModelGraphicsView();
+    void _connectSceneSignals();
+    void _disconnectSceneSignals(const char* context);
 	void _initUiForNewModel(Model* m);
 	void _actualizeActions();
     void _actualizeUndo();
@@ -331,6 +334,10 @@ private:
     bool _graphicalSimulation = false;
     bool _modelCheked = false;
     bool _loaded = false;
+    bool _shuttingDown = false;
+    QMetaObject::Connection _sceneChangedConnection;
+    QMetaObject::Connection _sceneFocusItemChangedConnection;
+    QMetaObject::Connection _sceneSelectionChangedConnection;
 	//CodeEditor* textCodeEdit_Model;
 };
 #endif // MAINWINDOW_H

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow_controller.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow_controller.cpp
@@ -932,6 +932,13 @@ void MainWindow::on_actionModelOpen_triggered()
 
 void MainWindow::on_actionModelSave_triggered()
 {
+    QObject* triggerSender = sender();
+    qInfo() << "on_actionModelSave_triggered sender="
+            << (triggerSender ? triggerSender->metaObject()->className() : "nullptr")
+            << " objectName=" << (triggerSender ? triggerSender->objectName() : QString())
+            << " senderPtr=" << triggerSender
+            << " scenePtr=" << (ui && ui->graphicsView ? ui->graphicsView->scene() : nullptr)
+            << " modelPtr=" << simulator->getModelManager()->current();
     QString fileName = QFileDialog::getSaveFileName(this,
                                                     tr("Save Model"), _modelfilename,
                                                     tr("Genesys Model (*.gen)"), nullptr, QFileDialog::DontUseNativeDialog);
@@ -966,6 +973,10 @@ void MainWindow::on_actionModelSave_triggered()
 
 void MainWindow::on_actionModelClose_triggered()
 {
+    qInfo() << "on_actionModelClose_triggered scenePtr="
+            << (ui && ui->graphicsView ? ui->graphicsView->scene() : nullptr)
+            << " modelPtr=" << simulator->getModelManager()->current();
+    _disconnectSceneSignals("on_actionModelClose_triggered(begin)");
     if (_textModelHasChanged || simulator->getModelManager()->current()->hasChanged()) {
         QMessageBox msgBox;
         msgBox.setIcon(QMessageBox::Question);
@@ -1010,6 +1021,7 @@ void MainWindow::on_actionModelClose_triggered()
 
     _clearModelEditors();
 
+    _connectSceneSignals();
     _actualizeActions();
     _actualizeTabPanes();
     //QMessageBox::information(this, "Close Model", "Model successfully closed");

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow_modelrepresentations.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow_modelrepresentations.cpp
@@ -1222,9 +1222,7 @@ void MainWindow::_initModelGraphicsView() {
     ((ModelGraphicsView *)(ui->graphicsView))->setSceneWheelInEventHandler(this, &MainWindow::_onSceneWheelInEvent);
     ((ModelGraphicsView *)(ui->graphicsView))->setSceneWheelOutEventHandler(this, &MainWindow::_onSceneWheelOutEvent);
     ((ModelGraphicsView*) (ui->graphicsView))->setGraphicalModelEventHandler(this, &MainWindow::_onSceneGraphicalModelEvent);
-    connect(ui->graphicsView->scene(), &QGraphicsScene::changed, this, &MainWindow::sceneChanged);
-    connect(ui->graphicsView->scene(), &QGraphicsScene::focusItemChanged, this, &MainWindow::sceneFocusItemChanged);
-    connect(ui->graphicsView->scene(), &QGraphicsScene::selectionChanged, this, &MainWindow::sceneSelectionChanged);
+    _connectSceneSignals();
 
     // Cria uma stack undo/redo
     ui->graphicsView->getScene()->setUndoStack(new QUndoStack(this));

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow_scene.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow_scene.cpp
@@ -45,6 +45,9 @@ void MainWindow::_onSceneGraphicalModelEvent(const GraphicalModelEvent& /*event*
  * @param region Regiões invalidadas da cena.
  */
 void MainWindow::sceneChanged(const QList<QRectF> &region) {
+    if (_shuttingDown || ui == nullptr || ui->graphicsView == nullptr || ui->graphicsView->getScene() == nullptr) {
+        return;
+    }
     Q_UNUSED(region);
     /**
      * Bloco 1: sincroniza estado de undo/redo e flags de alteração textual.
@@ -106,6 +109,9 @@ void MainWindow::sceneFocusItemChanged(QGraphicsItem *newFocusItem, QGraphicsIte
  * Atualiza o Property Editor para um único componente selecionado e limpa em caso contrário.
  */
 void MainWindow::sceneSelectionChanged() {
+    if (_shuttingDown || ui == nullptr || ui->graphicsView == nullptr) {
+        return;
+    }
     QGraphicsItem * item;
     GraphicalModelComponent* gmc;
 


### PR DESCRIPTION
### Motivation
- A fatal Qt ASSERT indicated a slot on `MainWindow` was being invoked while the receiver was in an invalid/destructing state, likely caused by `QGraphicsScene` signals delivered during scene/model teardown. 
- The goal is to reduce the chance of signal dispatch into partially-destroyed objects by explicitly managing connections, guarding slots during shutdown, and improving logging for future diagnosis.

### Description
- Added explicit `QMetaObject::Connection` members and helper methods ` _connectSceneSignals()` / `_disconnectSceneSignals(const char*)` to `MainWindow` and replaced ad-hoc scene `connect(...)` calls with these managed connections, preventing duplicate/fragile connections and enabling clean teardown. (`mainwindow.h`, `mainwindow.cpp`, `mainwindow_modelrepresentations.cpp`).
- Hardened `MainWindow` destructor and model-close flow by setting a `_shuttingDown` flag, disconnecting scene signals before heavy scene/model clearing, disconnecting `this` broadly, and clearing view-level callbacks to avoid late callbacks to `this` (`mainwindow.cpp`, `mainwindow_controller.cpp`).
- Introduced defensive guards in scene-related slots (`sceneChanged`, `sceneSelectionChanged`) that early-return when shutdown or UI/scene pointers are invalid to avoid processing during teardown (`mainwindow_scene.cpp`).
- Added `ModelGraphicsView::clearEventHandlers()` and call sites to reliably clear stored `std::function` handlers, plus contextual `qInfo()` logging in `dropEvent` and in model save/close handlers; standardized Qt logging with `qSetMessagePattern` and `qFormatLogMessage` for richer timestamps, file/line, function and thread id (`ModelGraphicsView.h/.cpp`, `ModelGraphicsScene.cpp`, `mainwindow_controller.cpp`, `main.cpp`).
- Files changed: `mainwindow.h`, `mainwindow.cpp`, `mainwindow_scene.cpp`, `mainwindow_modelrepresentations.cpp`, `mainwindow_controller.cpp`, `graphicals/ModelGraphicsView.h`, `graphicals/ModelGraphicsView.cpp`, `graphicals/ModelGraphicsScene.cpp`, `main.cpp`.

### Testing
- Ran CMake configure with `cmake -S . -B build`, which completed successfully in this environment. 
- Attempted to build the GUI target with `cmake --build build -j2 --target GenesysQtGUI`, which reported no rule for that specific target in the current generator, so that exact target was not built here. 
- Started a full parallel build with `cmake --build build -j2`, which progressed and compiled many translation units (build advanced) but did not finish within the execution window available for this session; no compile errors related to the edits were observed in the produced build log snippets.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5265fe4a483218c1f983e10712f13)