### PR TITLE
Finalize Phase 4: deterministic GUI .gui restoration (grid, snap, viewpoint, groups, flags)

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
@@ -975,6 +975,21 @@ void ModelGraphicsScene::showGrid()
     _grid.visible = !_grid.visible;
 }
 
+// Ajusta visibilidade do grid sem depender da semântica de toggle de showGrid().
+void ModelGraphicsScene::setGridVisible(bool visible) {
+    if (_grid.visible != visible) {
+        showGrid();
+    } else if (_grid.visible && _grid.lines->empty()) {
+        showGrid();
+        showGrid();
+    }
+}
+
+// Retorna o estado visual corrente do grid para persistência/restauração.
+bool ModelGraphicsScene::isGridVisible() const {
+    return _grid.visible;
+}
+
 void ModelGraphicsScene::createDiagrams()
 {
     Model * m = _simulator->getModelManager()->current();

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.h
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.h
@@ -148,6 +148,10 @@ public:
     };
     GRID *grid();
     void showGrid();
+    // Aplica o estado visual do grid de forma determinística sem alternância implícita.
+    void setGridVisible(bool visible);
+    // Informa o estado visual atual do grid para sincronização com QAction.
+    bool isGridVisible() const;
     void snapItemsToGrid();
     void actualizeDiagramArrows();
     void showDiagrams();
@@ -310,4 +314,3 @@ private:
 };
 
 #endif /* MODELGRAPHICSSCENE_H */
-

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow_controller.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow_controller.cpp
@@ -547,7 +547,8 @@ void MainWindow::on_actionEditPaste_triggered() {
 
 
 void MainWindow::on_actionShowGrid_triggered() {
-    ui->graphicsView->getScene()->showGrid();
+    // Aplica o estado de grid da action diretamente na cena para evitar inversão por toggle.
+    ui->graphicsView->getScene()->setGridVisible(ui->actionShowGrid->isChecked());
 }
 
 
@@ -1148,11 +1149,8 @@ void MainWindow::on_treeWidgetDataDefnitions_itemChanged(QTreeWidgetItem *item, 
 void MainWindow::on_actionShowSnap_triggered()
 {
     ModelGraphicsScene* scene = (ModelGraphicsScene*) (ui->graphicsView->scene());
-    if (scene->getSnapToGrid()) {
-        scene->setSnapToGrid(false);
-    } else {
-        scene->setSnapToGrid(true);
-    }
+    // Sincroniza o snap com o estado checkado da action de forma determinística.
+    scene->setSnapToGrid(ui->actionShowSnap->isChecked());
 }
 
 void MainWindow::on_actionViewGroup_triggered()

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow_modelrepresentations.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow_modelrepresentations.cpp
@@ -31,6 +31,7 @@
 #include <QRegularExpression>
 #include <QRandomGenerator>
 #include <QScrollBar>
+#include <QTimer>
 #include <QUrl>
 
 static QString _encodeGuiText(const QString& text) {
@@ -913,6 +914,11 @@ Model *MainWindow::_loadGraphicalModel(std::string filename) {
         _clearModelEditors();
 
         bool firstLine = true;
+        // Armazena o estado da view para aplicar no final do load, após reconstrução da cena.
+        bool hasPersistedViewState = false;
+        int restoredViewpointX = 0;
+        int restoredViewpointY = 0;
+        bool restoredDiagrams = false;
 
         QHash<int, QGraphicsItem*> persistedItems;
 
@@ -954,21 +960,31 @@ Model *MainWindow::_loadGraphicalModel(std::string filename) {
                         viewpointY = viewpointMatch.captured(2).toInt();
                     }
 
-                    ui->actionShowGrid->setChecked(grid);
-                    myScene()->showGrid();
-                    ui->actionShowSnap->setChecked(snap);
-                    myScene()->setSnapToGrid(snap);
-                    ui->actionShowRule->setChecked(rule);
-                    ui->actionShowGuides->setChecked(guides);
-                    ui->actionShowInternalElements->setChecked(internals);
-                    ui->actionShowAttachedElements->setChecked(attached);
-                    ui->actionDiagrams->setChecked(diagrams);
+                    // Restaura o estado visual do grid sem usar toggle implícito.
+                    ui->actionShowGrid->setChecked(grid != 0);
+                    myScene()->setGridVisible(grid != 0);
+                    // Restaura o snap de forma determinística e sincronizada com a action.
+                    ui->actionShowSnap->setChecked(snap != 0);
+                    myScene()->setSnapToGrid(snap != 0);
+                    // Restaura flags de view ainda sem backend visual completo apenas no estado da action.
+                    ui->actionShowRule->setChecked(rule != 0);
+                    ui->actionShowGuides->setChecked(guides != 0);
+                    // Reaplica internals/attached acionando o mesmo fluxo usado pela interface.
+                    ui->actionShowInternalElements->setChecked(internals != 0);
+                    on_actionShowInternalElements_triggered();
+                    ui->actionShowAttachedElements->setChecked(attached != 0);
+                    on_actionShowAttachedElements_triggered();
+                    // Armazena a flag de diagramas para aplicar após reconstrução dos itens.
+                    restoredDiagrams = (diagrams != 0);
+                    ui->actionDiagrams->setChecked(restoredDiagrams);
 
                     if (zoom > 0) {
                         ui->horizontalSlider_ZoomGraphical->setValue(zoom + TraitsGUI<GMainWindow>::zoomButtonChange);
                     }
-                    ui->graphicsView->horizontalScrollBar()->setValue(viewpointX);
-                    ui->graphicsView->verticalScrollBar()->setValue(viewpointY);
+                    // Adia a restauração do viewpoint para o final do load.
+                    hasPersistedViewState = true;
+                    restoredViewpointX = viewpointX;
+                    restoredViewpointY = viewpointY;
                 }
                 firstLine = false;
                 continue;
@@ -1347,19 +1363,51 @@ Model *MainWindow::_loadGraphicalModel(std::string filename) {
                 }
 
                 if (groupItems.size() > 1) {
+                    // Reconstrói grupo somente com itens ainda não agrupados para evitar inconsistências.
+                    bool canCreateGroup = true;
+                    for (QGraphicsItem* item : groupItems) {
+                        if (item == nullptr || item->group() != nullptr) {
+                            canCreateGroup = false;
+                            break;
+                        }
+                    }
+                    if (!canCreateGroup) {
+                        continue;
+                    }
+
+                    // Cria o grupo e reestabelece flags/estruturas internas usadas por group/ungroup.
                     QGraphicsItemGroup* group = new QGraphicsItemGroup();
                     for (QGraphicsItem* item : groupItems) {
                         group->addToGroup(item);
                     }
+                    group->setHandlesChildEvents(false);
                     group->setFlag(QGraphicsItem::ItemIsSelectable, true);
                     group->setFlag(QGraphicsItem::ItemIsMovable, true);
                     myScene()->addItem(group);
                     myScene()->getGraphicalGroups()->append(group);
+                    myScene()->insertOldPositionItem(group, group->pos());
+                    for (QGraphicsItem* child : group->childItems()) {
+                        myScene()->insertOldPositionItem(child, child->pos());
+                        child->setSelected(false);
+                    }
+                    group->setSelected(false);
                     if (!groupComponents.isEmpty()) {
                         myScene()->insertComponentGroup(group, groupComponents);
                     }
                 }
             }
+        }
+
+        // Reaplica o estado de diagramas após reconstrução dos componentes/geometrias/grupos.
+        on_actionDiagrams_triggered();
+        // Reaplica o viewpoint no ciclo de eventos seguinte para garantir ranges válidos de scrollbar.
+        if (hasPersistedViewState) {
+            QTimer::singleShot(0, this, [this, restoredViewpointX, restoredViewpointY]() {
+                QScrollBar* hBar = ui->graphicsView->horizontalScrollBar();
+                QScrollBar* vBar = ui->graphicsView->verticalScrollBar();
+                hBar->setValue(qBound(hBar->minimum(), restoredViewpointX, hBar->maximum()));
+                vBar->setValue(qBound(vBar->minimum(), restoredViewpointY, vBar->maximum()));
+            });
         }
 
         ui->textEdit_Console->append("\n");


### PR DESCRIPTION
### Motivation
- Corrigir restauração não-determinística do arquivo `.gui` onde o grid era reestabelecido por um toggle (`showGrid()`), podendo inverter o estado salvo.
- Garantir que flags visuais (snap, internals, attached, diagrams) sejam aplicadas de verdade na interface e sincronizem QAction/checkboxes.
- Reaplicar o `viewpoint` apenas depois da reconstrução completa da cena e consolidar restauração de grupos para evitar inconsistências de seleção/movimentação.

### Description
- Adicionada API explícita no scene para controlar o grid sem toggle: `ModelGraphicsScene::setGridVisible(bool)` e `ModelGraphicsScene::isGridVisible()`, com comentários inline explicando o propósito (arquivo modificado: `graphicals/ModelGraphicsScene.h` / `graphicals/ModelGraphicsScene.cpp`).
- Atualizados handlers de UI para aplicar estados de forma determinística: `on_actionShowGrid_triggered()` passa a usar `setGridVisible(ui->actionShowGrid->isChecked())` e `on_actionShowSnap_triggered()` sincroniza `setSnapToGrid(ui->actionShowSnap->isChecked())` (arquivo modificado: `mainwindow_controller.cpp`).
- No carregamento de `.gui` (`_loadGraphicalModel` em `mainwindow_modelrepresentations.cpp`) as flags são restauradas de forma efetiva (grid, snap, internals, attached, diagrams), internals/attached reaplicados via os handlers existentes para manter checkbox/action coerentes, diagrams reaplicado ao final e viewpoint adiado e reaplicado com `QTimer::singleShot(0, ...)` fazendo clamp nos valores das scrollbars.
- Consolidação da restauração de grupos: evita recriar grupo quando um membro já está agrupado, reaplica flags relevantes (`ItemIsSelectable`, `ItemIsMovable`, `setHandlesChildEvents(false)`), registra posições antigas para grupo e filhos via `insertOldPositionItem` e preserva `insertComponentGroup` para compatibilidade com group/ungroup posteriores (arquivo modificado: `mainwindow_modelrepresentations.cpp`).
- Todas as alterações em `.h`/`.cpp` incluem comentários técnicos locais imediatamente acima dos trechos alterados conforme diretriz de documentação.

### Testing
- Executado `cmake --preset debug` para configuração do build do projeto (kernel + infra) e a configuração completou com sucesso (salvo que a GUI não foi construída nessa invocação). (sucesso)
- Tentativa de configurar build com GUI (`-DGENESYS_BUILD_GUI_APPLICATION=ON`) falhou por limitações do ambiente onde `qmake` não estava disponível, portanto a compilação do binário GUI não foi verificada aqui (falha por ambiente: `qmake` ausente).
- Não foram adicionados testes automáticos novos; mudanças foram mantidas localizadas e compiláveis no código fonte para facilitar verificação de GUI quando `qmake` estiver disponível.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5394823e88321ba5904472c8723fa)