### PR TITLE
Corrige restauração/visibilidade de diagrams ao carregar .gui

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow_controller.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow_controller.cpp
@@ -1264,11 +1264,21 @@ void MainWindow::on_horizontalSliderAnimationSpeed_valueChanged(int value)
 
 void MainWindow::on_actionDiagrams_triggered()
 {
+    // Obtém a cena gráfica ativa para sincronizar a QAction com o estado real dos diagramas.
     ModelGraphicsScene* scene = (ModelGraphicsScene*) (ui->graphicsView->scene());
     if (ui->actionDiagrams->isChecked()) {
-        if (scene->existDiagram()) scene->showDiagrams();
+        // Cria o diagrama sob demanda quando a ação está marcada e a cena ainda não possui estrutura de diagrama.
+        if (!scene->existDiagram()) scene->createDiagrams();
+        // Exibe o diagrama após garantir que sua estrutura existe na cena.
+        scene->showDiagrams();
     } else {
+        // Oculta o diagrama apenas quando ele já existe para preservar o estado interno da cena.
         if (scene->existDiagram()) scene->hideDiagrams();
+    }
+    // Realinha o estado da QAction com a visibilidade efetiva para evitar divergência após load/toggle.
+    const bool diagramsVisible = scene->existDiagram() && scene->visibleDiagram();
+    if (ui->actionDiagrams->isChecked() != diagramsVisible) {
+        ui->actionDiagrams->setChecked(diagramsVisible);
     }
 }
 


### PR DESCRIPTION
### Motivation
- Resolver o caso em que `diagrams=1` no arquivo `.gui` deixava a QAction `Diagrams` marcada sem efetivamente criar/exibir o diagrama na cena recém-carregada, mantendo o comportamento seguro para `diagrams=0` e para toggles manuais.

### Description
- Atualiza `on_actionDiagrams_triggered()` em `mainwindow_controller.cpp` para criar o diagrama sob demanda quando a action estiver marcada, mostrar o diagrama em sequência, ocultá-lo somente se já existir, e por fim sincronizar `ui->actionDiagrams` com o estado real (`existDiagram() && visibleDiagram()`); comentários técnicos locais foram adicionados imediatamente acima dos trechos alterados.

### Testing
- Nenhum teste automatizado foi executado para esta mudança; validação feita por inspeção do diff e verificação local dos pontos afetados (buscas e diff do código).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d53c9e1a50832191839d576fbb2694)