### PR TITLE
refactor(gui): extract Phase‑1 services for model-language, Graphviz and C++ exporters

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
@@ -62,9 +62,12 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
     simulator = new Simulator();
     _simulationController = std::make_unique<SimulationController>(this, simulator);
     // This block initializes phase-1 service objects used for progressive delegation from MainWindow.
-    _modelLanguageSynchronizer = std::make_unique<ModelLanguageSynchronizer>();
-    _graphvizModelExporter = std::make_unique<GraphvizModelExporter>();
-    _cppModelExporter = std::make_unique<CppModelExporter>();
+    _modelLanguageSynchronizer = std::make_unique<ModelLanguageSynchronizer>(simulator, ui, &_textModelHasChanged, this, [this]() {
+        // Keep event-handler ownership in MainWindow while delegating model-language synchronization.
+        _setOnEventHandlers();
+    });
+    _graphvizModelExporter = std::make_unique<GraphvizModelExporter>(simulator, ui);
+    _cppModelExporter = std::make_unique<CppModelExporter>(simulator, ui);
     simulator->getTraceManager()->setTraceLevel(TraitsApp<GenesysApplication_if>::traceLevel);
     simulator->getTraceManager()->addTraceHandler<MainWindow>(this, &MainWindow::_simulatorTraceHandler);
     simulator->getTraceManager()->addTraceErrorHandler<MainWindow>(this, &MainWindow::_simulatorTraceErrorHandler);

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow_modelrepresentations.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow_modelrepresentations.cpp
@@ -47,7 +47,7 @@ static QString _decodeGuiText(const QString& text) {
 
 void MainWindow::_actualizeModelSimLanguage() {
     // This wrapper delegates model-language synchronization to a dedicated phase-1 service.
-    _modelLanguageSynchronizer->actualizeModelSimLanguage(simulator, ui, &_textModelHasChanged);
+    _modelLanguageSynchronizer->actualizeModelSimLanguage();
 }
 
 void MainWindow::_clearModelEditors() {
@@ -62,10 +62,7 @@ void MainWindow::_clearModelEditors() {
 
 bool MainWindow::_setSimulationModelBasedOnText() {
     // This wrapper delegates text-to-model synchronization while keeping MainWindow as temporary API surface.
-    return _modelLanguageSynchronizer->setSimulationModelBasedOnText(this, simulator, ui, _textModelHasChanged, [this]() {
-        // This callback preserves existing event-handler wiring behavior after model creation.
-        _setOnEventHandlers();
-    });
+    return _modelLanguageSynchronizer->setSimulationModelBasedOnText();
 }
 
 std::string MainWindow::_adjustDotName(std::string name) {
@@ -80,7 +77,7 @@ void MainWindow::_insertTextInDot(std::string text, unsigned int compLevel, unsi
 
 void MainWindow::_recursiveCreateModelGraphicPicture(ModelDataDefinition* componentOrData, std::list<ModelDataDefinition*>* visited, std::map<unsigned int, std::map<unsigned int, std::list<std::string>*>*>* dotmap) {
     // This wrapper delegates recursive DOT generation to the phase-1 Graphviz service.
-    _graphvizModelExporter->recursiveCreateModelGraphicPicture(simulator, ui, componentOrData, visited, dotmap);
+    _graphvizModelExporter->recursiveCreateModelGraphicPicture(componentOrData, visited, dotmap);
 }
 
 std::string MainWindow::_addCppCodeLine(std::string line, unsigned int indent) {
@@ -90,7 +87,7 @@ std::string MainWindow::_addCppCodeLine(std::string line, unsigned int indent) {
 
 void MainWindow::_actualizeModelCppCode() {
     // This wrapper delegates full C++ code export rendering to the phase-1 exporter service.
-    _cppModelExporter->actualizeModelCppCode(simulator, ui);
+    _cppModelExporter->actualizeModelCppCode();
 }
 
 bool MainWindow::graphicalModelHasChanged() const {
@@ -104,7 +101,7 @@ void MainWindow::setGraphicalModelHasChanged(bool graphicalModelHasChanged) {
 
 bool MainWindow::_createModelImage() {
     // This wrapper delegates model diagram image creation to the phase-1 Graphviz service.
-    return _graphvizModelExporter->createModelImage(simulator, ui, [this]() {
+    return _graphvizModelExporter->createModelImage([this]() {
         // This callback preserves MainWindow-controlled text-to-model synchronization flow.
         return this->_setSimulationModelBasedOnText();
     });

--- a/source/applications/gui/qt/GenesysQtGUI/services/CppModelExporter.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/services/CppModelExporter.cpp
@@ -20,6 +20,12 @@
 #include <map>
 #include <utility>
 
+
+CppModelExporter::CppModelExporter(Simulator* simulator, Ui::MainWindow* ui)
+    : _simulator(simulator)
+    , _ui(ui) {
+}
+
 std::string CppModelExporter::addCppCodeLine(const std::string& line, unsigned int indent) const {
     // This block preserves tab-indentation semantics used by existing generated output.
     std::string text;
@@ -30,14 +36,14 @@ std::string CppModelExporter::addCppCodeLine(const std::string& line, unsigned i
     return text;
 }
 
-void CppModelExporter::actualizeModelCppCode(Simulator* simulator, Ui::MainWindow* ui) const {
+void CppModelExporter::actualizeModelCppCode() const {
     // This guard preserves safety when dependencies are missing.
-    if (simulator == nullptr || ui == nullptr) {
+    if (_simulator == nullptr || _ui == nullptr) {
         return;
     }
 
     // This block preserves generation flow only when a model is currently loaded.
-    Model* m = simulator->getModelManager()->current();
+    Model* m = _simulator->getModelManager()->current();
     if (m != nullptr) {
         unsigned short tabs = 0;
         std::string text;
@@ -150,9 +156,9 @@ void CppModelExporter::actualizeModelCppCode(Simulator* simulator, Ui::MainWindo
         code->insert({"8end", text});
 
         // This block preserves final rendering order into the C++ code editor pane.
-        ui->plainTextEditCppCode->clear();
+        _ui->plainTextEditCppCode->clear();
         for (std::pair<std::string, std::string> codeSection : *code) {
-            ui->plainTextEditCppCode->appendPlainText(QString::fromStdString(codeSection.second));
+            _ui->plainTextEditCppCode->appendPlainText(QString::fromStdString(codeSection.second));
         }
     }
 }

--- a/source/applications/gui/qt/GenesysQtGUI/services/CppModelExporter.h
+++ b/source/applications/gui/qt/GenesysQtGUI/services/CppModelExporter.h
@@ -12,11 +12,15 @@ class MainWindow;
 // This service encapsulates generation of C++ model code shown in the GUI editor.
 class CppModelExporter {
 public:
-    // This method preserves legacy indentation formatting for generated C++ lines.
-    std::string addCppCodeLine(const std::string& line, unsigned int indent = 0) const;
+    // MainWindow provides explicit dependencies once, keeping wrappers thin and stable.
+    CppModelExporter(Simulator* simulator, Ui::MainWindow* ui);
 
-    // This method regenerates and displays the C++ representation for the current model.
-    void actualizeModelCppCode(Simulator* simulator, Ui::MainWindow* ui) const;
+    std::string addCppCodeLine(const std::string& line, unsigned int indent = 0) const;
+    void actualizeModelCppCode() const;
+
+private:
+    Simulator* _simulator;
+    Ui::MainWindow* _ui;
 };
 
 #endif // CPPMODELEXPORTER_H

--- a/source/applications/gui/qt/GenesysQtGUI/services/GraphvizModelExporter.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/services/GraphvizModelExporter.cpp
@@ -50,6 +50,11 @@ static std::string _escapeDotLabelText(const std::string& text) {
     return escaped;
 }
 
+
+GraphvizModelExporter::GraphvizModelExporter(Simulator* simulator, Ui::MainWindow* ui)
+    : _simulator(simulator)
+    , _ui(ui) {
+}
 std::string GraphvizModelExporter::adjustDotName(std::string name) const {
     // This block preserves identifier normalization behavior used by current DOT output.
     std::string text = Util::StrReplace(name, "[", "_");
@@ -87,9 +92,7 @@ void GraphvizModelExporter::insertTextInDot(std::string text,
     }
 }
 
-void GraphvizModelExporter::recursiveCreateModelGraphicPicture(Simulator* simulator,
-                                                               Ui::MainWindow* ui,
-                                                               ModelDataDefinition* componentOrData,
+void GraphvizModelExporter::recursiveCreateModelGraphicPicture(ModelDataDefinition* componentOrData,
                                                                std::list<ModelDataDefinition*>* visited,
                                                                std::map<unsigned int, std::map<unsigned int, std::list<std::string>*>*>* dotmap) const {
     // This local style bundle preserves the existing visual styling and ranking semantics.
@@ -112,15 +115,15 @@ void GraphvizModelExporter::recursiveCreateModelGraphicPicture(Simulator* simula
     // This block preserves traversal bookkeeping to avoid duplicate DOT generation.
     visited->insert(visited->end(), componentOrData);
     std::string text;
-    unsigned int modellevel = simulator->getModelManager()->current()->getLevel();
+    unsigned int modellevel = _simulator->getModelManager()->current()->getLevel();
     std::list<ModelDataDefinition*>::iterator visitedIt;
     ModelComponent* parentComponentSuperLevel = nullptr;
     unsigned int level = componentOrData->getLevel();
 
     // This block emits model component nodes according to level visibility flags.
     if (dynamic_cast<ModelComponent*> (componentOrData) != nullptr) {
-        if (level != modellevel && !ui->checkBox_ShowLevels->isChecked()) {
-            parentComponentSuperLevel = simulator->getModelManager()->current()->getComponentManager()->find(level);
+        if (level != modellevel && !_ui->checkBox_ShowLevels->isChecked()) {
+            parentComponentSuperLevel = _simulator->getModelManager()->current()->getComponentManager()->find(level);
             assert(parentComponentSuperLevel != nullptr);
             visitedIt = std::find(visited->begin(), visited->end(), parentComponentSuperLevel);
             if (visitedIt == visited->end()) {
@@ -142,7 +145,7 @@ void GraphvizModelExporter::recursiveCreateModelGraphicPicture(Simulator* simula
     // This block emits attached/internal data definitions and related edges.
     std::string dataname;
     std::string componentName = parentComponentSuperLevel != nullptr ? parentComponentSuperLevel->getName() : componentOrData->getName();
-    if (ui->checkBox_ShowInternals->isChecked()) {
+    if (_ui->checkBox_ShowInternals->isChecked()) {
         for (std::pair<std::string, ModelDataDefinition*> dataPair : *componentOrData->getInternalData()) {
             dataname = adjustDotName(dataPair.second->getName());
             level = dataPair.second->getLevel();
@@ -151,18 +154,18 @@ void GraphvizModelExporter::recursiveCreateModelGraphicPicture(Simulator* simula
                 if (dynamic_cast<ModelComponent*> (dataPair.second) == nullptr) {
                     text = "  " + dataname + " [" + DOT.nodeDataDefInternal + ", label=\"" + _escapeDotLabelText(dataPair.second->getClassname()) + "|" + _escapeDotLabelText(dataPair.second->getName()) + "\"]" + ";\n";
                     insertTextInDot(text, level, DOT.rankDataDefInternal, dotmap, true);
-                    if (ui->checkBox_ShowRecursive->isChecked()) {
-                        recursiveCreateModelGraphicPicture(simulator, ui, dataPair.second, visited, dotmap);
+                    if (_ui->checkBox_ShowRecursive->isChecked()) {
+                        recursiveCreateModelGraphicPicture(dataPair.second, visited, dotmap);
                     }
                 }
             }
-            if (dataPair.second->getLevel() == modellevel || ui->checkBox_ShowLevels->isChecked()) {
+            if (dataPair.second->getLevel() == modellevel || _ui->checkBox_ShowLevels->isChecked()) {
                 text = "    " + dataname + "->" + adjustDotName(componentName) + " [" + DOT.edgeDataDefInternal + ", label=\"" + _escapeDotLabelText(dataPair.first) + "\"];\n";
                 insertTextInDot(text, modellevel, DOT.rankEdge, dotmap);
             }
         }
     }
-    if (ui->checkBox_ShowElements->isChecked()) {
+    if (_ui->checkBox_ShowElements->isChecked()) {
         for (std::pair<std::string, ModelDataDefinition*> dataPair : *componentOrData->getAttachedData()) {
             dataname = adjustDotName(dataPair.second->getName());
             level = dataPair.second->getLevel();
@@ -172,8 +175,8 @@ void GraphvizModelExporter::recursiveCreateModelGraphicPicture(Simulator* simula
                     text = "  " + dataname + " [" + DOT.nodeDataDefAttached + ", label=\"" + _escapeDotLabelText(dataPair.second->getClassname()) + "|" + _escapeDotLabelText(dataPair.second->getName()) + "\"]" + ";\n";
                     insertTextInDot(text, level, DOT.rankDataDefAttached, dotmap, true);
                 }
-                if (ui->checkBox_ShowRecursive->isChecked()) {
-                    recursiveCreateModelGraphicPicture(simulator, ui, dataPair.second, visited, dotmap);
+                if (_ui->checkBox_ShowRecursive->isChecked()) {
+                    recursiveCreateModelGraphicPicture(dataPair.second, visited, dotmap);
                 }
             }
             text = "    " + dataname + "->" + adjustDotName(componentName) + " [" + DOT.edgeDataDefAttached + ", label=\"" + _escapeDotLabelText(dataPair.first) + "\"];\n";
@@ -189,9 +192,9 @@ void GraphvizModelExporter::recursiveCreateModelGraphicPicture(Simulator* simula
             Connection* connection = component->getConnectionManager()->getConnectionAtPort(i);
             visitedIt = std::find(visited->begin(), visited->end(), connection->component);
             if (visitedIt == visited->end()) {
-                recursiveCreateModelGraphicPicture(simulator, ui, connection->component, visited, dotmap);
+                recursiveCreateModelGraphicPicture(connection->component, visited, dotmap);
             }
-            if (connection->component->getLevel() == modellevel || ui->checkBox_ShowLevels->isChecked()) {
+            if (connection->component->getLevel() == modellevel || _ui->checkBox_ShowLevels->isChecked()) {
                 text = "    " + adjustDotName(componentName) + "->" + adjustDotName(connection->component->getName()) + "[" + DOT.edgeComponent + "];\n";
                 insertTextInDot(text, modellevel, DOT.rankEdge, dotmap);
             }
@@ -199,12 +202,10 @@ void GraphvizModelExporter::recursiveCreateModelGraphicPicture(Simulator* simula
     }
 }
 
-bool GraphvizModelExporter::createModelImage(Simulator* simulator,
-                                             Ui::MainWindow* ui,
-                                             const std::function<bool()>& setSimulationModelBasedOnText) const {
+bool GraphvizModelExporter::createModelImage(const std::function<bool()>& setSimulationModelBasedOnText) const {
     // This block preserves model synchronization precondition prior to DOT generation.
     bool res = setSimulationModelBasedOnText ? setSimulationModelBasedOnText() : false;
-    if (!res || simulator == nullptr || ui == nullptr || simulator->getModelManager()->current() == nullptr) {
+    if (!res || _simulator == nullptr || _ui == nullptr || _simulator->getModelManager()->current() == nullptr) {
         return false;
     }
 
@@ -214,24 +215,24 @@ bool GraphvizModelExporter::createModelImage(Simulator* simulator,
     std::map<unsigned int, std::map<unsigned int, std::list<std::string>*>*>* dotmap = new std::map<unsigned int, std::map<unsigned int, std::list<std::string>*>*>();
 
     std::list<ModelDataDefinition*>* visited = new std::list<ModelDataDefinition*>();
-    for (SourceModelComponent* source : *simulator->getModelManager()->current()->getComponentManager()->getSourceComponents()) {
+    for (SourceModelComponent* source : *_simulator->getModelManager()->current()->getComponentManager()->getSourceComponents()) {
         if (std::find(visited->begin(), visited->end(), source) == visited->end()) {
-            recursiveCreateModelGraphicPicture(simulator, ui, source, visited, dotmap);
+            recursiveCreateModelGraphicPicture(source, visited, dotmap);
         }
     }
-    for (ModelComponent* transfer : *simulator->getModelManager()->current()->getComponentManager()->getTransferInComponents()) {
+    for (ModelComponent* transfer : *_simulator->getModelManager()->current()->getComponentManager()->getTransferInComponents()) {
         if (std::find(visited->begin(), visited->end(), transfer) == visited->end()) {
-            recursiveCreateModelGraphicPicture(simulator, ui, transfer, visited, dotmap);
+            recursiveCreateModelGraphicPicture(transfer, visited, dotmap);
         }
     }
-    for (ModelComponent* comp : *simulator->getModelManager()->current()->getComponentManager()->getAllComponents()) {
+    for (ModelComponent* comp : *_simulator->getModelManager()->current()->getComponentManager()->getAllComponents()) {
         if (std::find(visited->begin(), visited->end(), comp) == visited->end()) {
-            recursiveCreateModelGraphicPicture(simulator, ui, comp, visited, dotmap);
+            recursiveCreateModelGraphicPicture(comp, visited, dotmap);
         }
     }
 
     // This block preserves aggregation of level subgraphs into final DOT content.
-    unsigned int modelLevel = simulator->getModelManager()->current()->getLevel();
+    unsigned int modelLevel = _simulator->getModelManager()->current()->getLevel();
     for (std::pair<unsigned int, std::map<unsigned int, std::list<std::string>*>*> dotpair : *dotmap) {
         if (dotpair.first == modelLevel) {
             dot += "\n  // model level\n";
@@ -245,10 +246,10 @@ bool GraphvizModelExporter::createModelImage(Simulator* simulator,
                 }
                 dot += "  }\n";
             }
-        } else if (ui->checkBox_ShowLevels->isChecked()) {
+        } else if (_ui->checkBox_ShowLevels->isChecked()) {
             dot += "\n\n // submodel level  " + std::to_string(dotpair.first) + "\n";
             dot += " subgraph cluster_level_" + std::to_string(dotpair.first) + " {\n";
-            dot += "   graph[style=filled; fillcolor=mistyrose2] label=\"" + simulator->getModelManager()->current()->getComponentManager()->find(dotpair.first)->getName() + "\";\n";
+            dot += "   graph[style=filled; fillcolor=mistyrose2] label=\"" + _simulator->getModelManager()->current()->getComponentManager()->find(dotpair.first)->getName() + "\";\n";
             for (std::pair<unsigned int, std::list<std::string>*> dotpair2 : *dotpair.second) {
                 dot += "  {\n";
                 if (dotpair2.first == 0) dot += "     rank=min  // " + std::to_string(dotpair2.first) + "\n";
@@ -286,8 +287,8 @@ bool GraphvizModelExporter::createModelImage(Simulator* simulator,
             std::string command = "dot -Tpng " + dotfilename + " -o " + pngfilename;
             system(command.c_str());
             QPixmap pm(QString::fromStdString(pngfilename));
-            ui->label_ModelGraphic->setPixmap(pm);
-            ui->label_ModelGraphic->setScaledContents(false);
+            _ui->label_ModelGraphic->setPixmap(pm);
+            _ui->label_ModelGraphic->setScaledContents(false);
             return true;
         } catch (...) {
         }

--- a/source/applications/gui/qt/GenesysQtGUI/services/GraphvizModelExporter.h
+++ b/source/applications/gui/qt/GenesysQtGUI/services/GraphvizModelExporter.h
@@ -16,27 +16,23 @@ class MainWindow;
 // This service encapsulates Graphviz DOT generation and PNG rendering for model representation.
 class GraphvizModelExporter {
 public:
-    // This method normalizes identifiers so they are DOT-compatible while preserving current naming rules.
-    std::string adjustDotName(std::string name) const;
+    // MainWindow provides explicit dependencies once, keeping wrappers thin and stable.
+    GraphvizModelExporter(Simulator* simulator, Ui::MainWindow* ui);
 
-    // This method inserts generated DOT text into the ranked map structure used by the legacy algorithm.
+    std::string adjustDotName(std::string name) const;
     void insertTextInDot(std::string text,
                          unsigned int compLevel,
                          unsigned int compRank,
                          std::map<unsigned int, std::map<unsigned int, std::list<std::string>*>*>* dotmap,
                          bool isNode = false) const;
-
-    // This method traverses model components and data definitions recursively to build DOT structures.
-    void recursiveCreateModelGraphicPicture(Simulator* simulator,
-                                            Ui::MainWindow* ui,
-                                            ModelDataDefinition* componentOrData,
+    void recursiveCreateModelGraphicPicture(ModelDataDefinition* componentOrData,
                                             std::list<ModelDataDefinition*>* visited,
                                             std::map<unsigned int, std::map<unsigned int, std::list<std::string>*>*>* dotmap) const;
+    bool createModelImage(const std::function<bool()>& setSimulationModelBasedOnText) const;
 
-    // This method creates the model image by orchestrating model synchronization and DOT rendering.
-    bool createModelImage(Simulator* simulator,
-                          Ui::MainWindow* ui,
-                          const std::function<bool()>& setSimulationModelBasedOnText) const;
+private:
+    Simulator* _simulator;
+    Ui::MainWindow* _ui;
 };
 
 #endif // GRAPHVIZMODELEXPORTER_H

--- a/source/applications/gui/qt/GenesysQtGUI/services/ModelLanguageSynchronizer.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/services/ModelLanguageSynchronizer.cpp
@@ -1,28 +1,34 @@
 #include "services/ModelLanguageSynchronizer.h"
 
-// This include gives access to generated Qt widgets used by the service implementation.
 #include "ui_mainwindow.h"
 
-// These includes provide kernel simulator/model APIs used to keep UI and model synchronized.
 #include "../../../../kernel/simulator/Simulator.h"
 #include "../../../../kernel/simulator/Model.h"
 #include "../../../../kernel/simulator/ModelPersistence_if.h"
 
-// This include provides QMessageBox used by the existing error-reporting behavior.
 #include <QMessageBox>
 
-// These includes provide stream facilities used by the existing text serialization flow.
 #include <fstream>
 #include <string>
 
-void ModelLanguageSynchronizer::actualizeModelSimLanguage(Simulator* simulator, Ui::MainWindow* ui, bool* textModelHasChangedFlag) const {
-    // This guard preserves safety when dependencies are not available.
-    if (simulator == nullptr || ui == nullptr || textModelHasChangedFlag == nullptr) {
+ModelLanguageSynchronizer::ModelLanguageSynchronizer(Simulator* simulator,
+                                                     Ui::MainWindow* ui,
+                                                     bool* textModelHasChangedFlag,
+                                                     QWidget* ownerWidget,
+                                                     std::function<void()> setOnEventHandlers)
+    : _simulator(simulator)
+    , _ui(ui)
+    , _textModelHasChangedFlag(textModelHasChangedFlag)
+    , _ownerWidget(ownerWidget)
+    , _setOnEventHandlers(std::move(setOnEventHandlers)) {
+}
+
+void ModelLanguageSynchronizer::actualizeModelSimLanguage() const {
+    if (_simulator == nullptr || _ui == nullptr || _textModelHasChangedFlag == nullptr) {
         return;
     }
 
-    // This block keeps the same persistence roundtrip currently used to regenerate model language text.
-    Model* model = simulator->getModelManager()->current();
+    Model* model = _simulator->getModelManager()->current();
     if (model != nullptr) {
         model->getPersistence()->setOption(ModelPersistence_if::Options::SAVEDEFAULTS, true);
         std::string tempFilename = "./temp.tmp";
@@ -32,46 +38,38 @@ void ModelLanguageSynchronizer::actualizeModelSimLanguage(Simulator* simulator, 
         std::string line;
         std::ifstream file(tempFilename);
         if (file.is_open()) {
-            ui->TextCodeEditor->clear();
+            _ui->TextCodeEditor->clear();
             while (std::getline(file, line)) {
-                ui->TextCodeEditor->appendPlainText(QString::fromStdString(line));
+                _ui->TextCodeEditor->appendPlainText(QString::fromStdString(line));
             }
             file.close();
-            *textModelHasChangedFlag = false;
+            *_textModelHasChangedFlag = false;
         }
     }
 }
 
-bool ModelLanguageSynchronizer::setSimulationModelBasedOnText(QWidget* ownerWidget,
-                                                              Simulator* simulator,
-                                                              Ui::MainWindow* ui,
-                                                              bool textModelHasChanged,
-                                                              const std::function<void()>& setOnEventHandlers) const {
-    // This guard preserves safety when dependencies are not available.
-    if (simulator == nullptr || ui == nullptr) {
+bool ModelLanguageSynchronizer::setSimulationModelBasedOnText() const {
+    if (_simulator == nullptr || _ui == nullptr) {
         return false;
     }
 
-    // This block intentionally keeps the legacy TODO semantics for text-change handling.
-    Model* model = simulator->getModelManager()->current();
-    if (textModelHasChanged) {
-        // @TODO: Keep behavior unchanged in phase 1 while delegating logic to a service.
-        // simulator->getModels()->remove(model);
+    Model* model = _simulator->getModelManager()->current();
+    if (_textModelHasChangedFlag != nullptr && *_textModelHasChangedFlag) {
+        // Keep phase-1 behavior unchanged: text change handling is still deferred by legacy TODO.
+        // _simulator->getModels()->remove(model);
         // model = nullptr;
     }
 
-    // This block preserves the existing "create from text only when model is null" behavior.
     if (model == nullptr) {
-        QString modelLanguage = ui->TextCodeEditor->toPlainText();
-        if (!simulator->getModelManager()->createFromLanguage(modelLanguage.toStdString())) {
-            QMessageBox::critical(ownerWidget, "Check Model", "Error in the model text. See console for more information.");
+        QString modelLanguage = _ui->TextCodeEditor->toPlainText();
+        if (!_simulator->getModelManager()->createFromLanguage(modelLanguage.toStdString())) {
+            QMessageBox::critical(_ownerWidget, "Check Model", "Error in the model text. See console for more information.");
         }
-        model = simulator->getModelManager()->current();
-        if (model != nullptr && setOnEventHandlers) {
-            setOnEventHandlers();
+        model = _simulator->getModelManager()->current();
+        if (model != nullptr && _setOnEventHandlers) {
+            _setOnEventHandlers();
         }
     }
 
-    // This return keeps the same success condition currently used by MainWindow.
-    return simulator->getModelManager()->current() != nullptr;
+    return _simulator->getModelManager()->current() != nullptr;
 }

--- a/source/applications/gui/qt/GenesysQtGUI/services/ModelLanguageSynchronizer.h
+++ b/source/applications/gui/qt/GenesysQtGUI/services/ModelLanguageSynchronizer.h
@@ -13,15 +13,22 @@ class MainWindow;
 // This service encapsulates synchronization between the textual model editor and kernel model state.
 class ModelLanguageSynchronizer {
 public:
-    // This method refreshes the textual model editor from the current kernel model serialization.
-    void actualizeModelSimLanguage(Simulator* simulator, Ui::MainWindow* ui, bool* textModelHasChangedFlag) const;
+    // MainWindow provides explicit dependencies once, keeping wrappers thin and stable.
+    ModelLanguageSynchronizer(Simulator* simulator,
+                              Ui::MainWindow* ui,
+                              bool* textModelHasChangedFlag,
+                              QWidget* ownerWidget,
+                              std::function<void()> setOnEventHandlers);
 
-    // This method creates or refreshes the simulation model from text while preserving the current behavior.
-    bool setSimulationModelBasedOnText(QWidget* ownerWidget,
-                                       Simulator* simulator,
-                                       Ui::MainWindow* ui,
-                                       bool textModelHasChanged,
-                                       const std::function<void()>& setOnEventHandlers) const;
+    void actualizeModelSimLanguage() const;
+    bool setSimulationModelBasedOnText() const;
+
+private:
+    Simulator* _simulator;
+    Ui::MainWindow* _ui;
+    bool* _textModelHasChangedFlag;
+    QWidget* _ownerWidget;
+    std::function<void()> _setOnEventHandlers;
 };
 
 #endif // MODELLANGUAGESYNCHRONIZER_H


### PR DESCRIPTION
### Motivation
- Reduce MainWindow responsibility by extracting Phase 1 model-representation duties into dedicated services while preserving existing behavior and API surface. 
- Keep `MainWindow` as the UI owner and provide thin delegating wrappers so the refactor is incremental and low-risk. 

### Description
- Added constructor-injected service classes and moved Phase 1 responsibilities into them, preserving logic and interfaces used by `MainWindow`.
- Created/updated these service types with explicit dependencies: `ModelLanguageSynchronizer`, `GraphvizModelExporter`, and `CppModelExporter`.
- Kept `MainWindow` wrapper methods with the same signatures and replaced internal calls to the old inline logic by delegating to the new services; initialization now constructs services with explicit `simulator`, `ui`, flag and callback where required.
- Files changed (created/updated):
  - Modified: `source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp`
  - Modified: `source/applications/gui/qt/GenesysQtGUI/mainwindow_modelrepresentations.cpp`
  - Added/Modified service headers and implementations:
    - `source/applications/gui/qt/GenesysQtGUI/services/ModelLanguageSynchronizer.h`
    - `source/applications/gui/qt/GenesysQtGUI/services/ModelLanguageSynchronizer.cpp`
    - `source/applications/gui/qt/GenesysQtGUI/services/GraphvizModelExporter.h`
    - `source/applications/gui/qt/GenesysQtGUI/services/GraphvizModelExporter.cpp`
    - `source/applications/gui/qt/GenesysQtGUI/services/CppModelExporter.h`
    - `source/applications/gui/qt/GenesysQtGUI/services/CppModelExporter.cpp`
- Small explanatory comments were added where `MainWindow` now delegates to a service to make the new boundary clear.
- Phase 1 scope only: the refactor does not touch simulation event handlers, trace handlers, scene handlers, clipboard logic, model lifecycle logic, file formats, or signal/slot topology beyond constructor wiring.

### Testing
- Ran repository status and committed the changes successfully (`git commit`), ensuring the working tree is clean after the edits (commit present locally).
- Attempted a qmake generation sanity check (`qmake GenesysQtGUI.pro`), but `qmake` is not available in the execution environment so a build/configuration verification could not be executed here (manual/local CI build recommended).

Note: This PR intentionally stops at Phase 1 (service extraction and delegation); no Phase 2+ changes were introduced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d551940fec83219fa0c19c90a9b49e)