### PR TITLE
Introduce service objects for model-language sync and exporters; inject GUI dependencies into services

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
@@ -62,9 +62,12 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
     simulator = new Simulator();
     _simulationController = std::make_unique<SimulationController>(this, simulator);
     // This block initializes phase-1 service objects used for progressive delegation from MainWindow.
-    _modelLanguageSynchronizer = std::make_unique<ModelLanguageSynchronizer>();
-    _graphvizModelExporter = std::make_unique<GraphvizModelExporter>();
-    _cppModelExporter = std::make_unique<CppModelExporter>();
+    _modelLanguageSynchronizer = std::make_unique<ModelLanguageSynchronizer>(simulator, ui->TextCodeEditor, &_textModelHasChanged, this, [this]() {
+        // Keep event-handler ownership in MainWindow while delegating model-language synchronization.
+        _setOnEventHandlers();
+    });
+    _graphvizModelExporter = std::make_unique<GraphvizModelExporter>(simulator, ui->label_ModelGraphic, ui->checkBox_ShowInternals, ui->checkBox_ShowElements, ui->checkBox_ShowRecursive, ui->checkBox_ShowLevels);
+    _cppModelExporter = std::make_unique<CppModelExporter>(simulator, ui->plainTextEditCppCode);
     simulator->getTraceManager()->setTraceLevel(TraitsApp<GenesysApplication_if>::traceLevel);
     simulator->getTraceManager()->addTraceHandler<MainWindow>(this, &MainWindow::_simulatorTraceHandler);
     simulator->getTraceManager()->addTraceErrorHandler<MainWindow>(this, &MainWindow::_simulatorTraceErrorHandler);

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.h
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.h
@@ -272,6 +272,7 @@ private: // interface and model main elements to join
 	Ui::MainWindow *ui;
 	Simulator* simulator;
     std::unique_ptr<class SimulationController> _simulationController;
+    // Phase-1 services keep model-representation logic outside MainWindow while wrappers remain stable.
     std::unique_ptr<ModelLanguageSynchronizer> _modelLanguageSynchronizer;
     std::unique_ptr<GraphvizModelExporter> _graphvizModelExporter;
     std::unique_ptr<CppModelExporter> _cppModelExporter;

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow_modelrepresentations.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow_modelrepresentations.cpp
@@ -47,7 +47,7 @@ static QString _decodeGuiText(const QString& text) {
 
 void MainWindow::_actualizeModelSimLanguage() {
     // This wrapper delegates model-language synchronization to a dedicated phase-1 service.
-    _modelLanguageSynchronizer->actualizeModelSimLanguage(simulator, ui, &_textModelHasChanged);
+    _modelLanguageSynchronizer->actualizeModelSimLanguage();
 }
 
 void MainWindow::_clearModelEditors() {
@@ -62,10 +62,7 @@ void MainWindow::_clearModelEditors() {
 
 bool MainWindow::_setSimulationModelBasedOnText() {
     // This wrapper delegates text-to-model synchronization while keeping MainWindow as temporary API surface.
-    return _modelLanguageSynchronizer->setSimulationModelBasedOnText(this, simulator, ui, _textModelHasChanged, [this]() {
-        // This callback preserves existing event-handler wiring behavior after model creation.
-        _setOnEventHandlers();
-    });
+    return _modelLanguageSynchronizer->setSimulationModelBasedOnText();
 }
 
 std::string MainWindow::_adjustDotName(std::string name) {
@@ -80,7 +77,7 @@ void MainWindow::_insertTextInDot(std::string text, unsigned int compLevel, unsi
 
 void MainWindow::_recursiveCreateModelGraphicPicture(ModelDataDefinition* componentOrData, std::list<ModelDataDefinition*>* visited, std::map<unsigned int, std::map<unsigned int, std::list<std::string>*>*>* dotmap) {
     // This wrapper delegates recursive DOT generation to the phase-1 Graphviz service.
-    _graphvizModelExporter->recursiveCreateModelGraphicPicture(simulator, ui, componentOrData, visited, dotmap);
+    _graphvizModelExporter->recursiveCreateModelGraphicPicture(componentOrData, visited, dotmap);
 }
 
 std::string MainWindow::_addCppCodeLine(std::string line, unsigned int indent) {
@@ -90,7 +87,7 @@ std::string MainWindow::_addCppCodeLine(std::string line, unsigned int indent) {
 
 void MainWindow::_actualizeModelCppCode() {
     // This wrapper delegates full C++ code export rendering to the phase-1 exporter service.
-    _cppModelExporter->actualizeModelCppCode(simulator, ui);
+    _cppModelExporter->actualizeModelCppCode();
 }
 
 bool MainWindow::graphicalModelHasChanged() const {
@@ -104,7 +101,7 @@ void MainWindow::setGraphicalModelHasChanged(bool graphicalModelHasChanged) {
 
 bool MainWindow::_createModelImage() {
     // This wrapper delegates model diagram image creation to the phase-1 Graphviz service.
-    return _graphvizModelExporter->createModelImage(simulator, ui, [this]() {
+    return _graphvizModelExporter->createModelImage([this]() {
         // This callback preserves MainWindow-controlled text-to-model synchronization flow.
         return this->_setSimulationModelBasedOnText();
     });

--- a/source/applications/gui/qt/GenesysQtGUI/services/CppModelExporter.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/services/CppModelExporter.cpp
@@ -1,8 +1,6 @@
 #include "services/CppModelExporter.h"
 
 // This include gives access to generated Qt widgets where generated C++ text is displayed.
-#include "ui_mainwindow.h"
-
 // These includes provide kernel model APIs used by C++ code generation.
 #include "../../../../kernel/simulator/Simulator.h"
 #include "../../../../kernel/simulator/Model.h"
@@ -14,11 +12,18 @@
 #include "../../../../kernel/util/Util.h"
 
 // This include provides QString conversion APIs used by the target text widget.
+#include <QPlainTextEdit>
 #include <QString>
 
 // These includes provide STL containers and utilities used by code assembly.
 #include <map>
 #include <utility>
+
+
+CppModelExporter::CppModelExporter(Simulator* simulator, QPlainTextEdit* cppCodeEditor)
+    : _simulator(simulator)
+    , _cppCodeEditor(cppCodeEditor) {
+}
 
 std::string CppModelExporter::addCppCodeLine(const std::string& line, unsigned int indent) const {
     // This block preserves tab-indentation semantics used by existing generated output.
@@ -30,14 +35,14 @@ std::string CppModelExporter::addCppCodeLine(const std::string& line, unsigned i
     return text;
 }
 
-void CppModelExporter::actualizeModelCppCode(Simulator* simulator, Ui::MainWindow* ui) const {
+void CppModelExporter::actualizeModelCppCode() const {
     // This guard preserves safety when dependencies are missing.
-    if (simulator == nullptr || ui == nullptr) {
+    if (_simulator == nullptr || _cppCodeEditor == nullptr) {
         return;
     }
 
     // This block preserves generation flow only when a model is currently loaded.
-    Model* m = simulator->getModelManager()->current();
+    Model* m = _simulator->getModelManager()->current();
     if (m != nullptr) {
         unsigned short tabs = 0;
         std::string text;
@@ -150,9 +155,9 @@ void CppModelExporter::actualizeModelCppCode(Simulator* simulator, Ui::MainWindo
         code->insert({"8end", text});
 
         // This block preserves final rendering order into the C++ code editor pane.
-        ui->plainTextEditCppCode->clear();
+        _cppCodeEditor->clear();
         for (std::pair<std::string, std::string> codeSection : *code) {
-            ui->plainTextEditCppCode->appendPlainText(QString::fromStdString(codeSection.second));
+            _cppCodeEditor->appendPlainText(QString::fromStdString(codeSection.second));
         }
     }
 }

--- a/source/applications/gui/qt/GenesysQtGUI/services/CppModelExporter.h
+++ b/source/applications/gui/qt/GenesysQtGUI/services/CppModelExporter.h
@@ -3,20 +3,21 @@
 
 #include <string>
 
+class QPlainTextEdit;
 class Simulator;
-
-namespace Ui {
-class MainWindow;
-}
 
 // This service encapsulates generation of C++ model code shown in the GUI editor.
 class CppModelExporter {
 public:
-    // This method preserves legacy indentation formatting for generated C++ lines.
-    std::string addCppCodeLine(const std::string& line, unsigned int indent = 0) const;
+    // MainWindow provides explicit dependencies once, keeping wrappers thin and stable.
+    CppModelExporter(Simulator* simulator, QPlainTextEdit* cppCodeEditor);
 
-    // This method regenerates and displays the C++ representation for the current model.
-    void actualizeModelCppCode(Simulator* simulator, Ui::MainWindow* ui) const;
+    std::string addCppCodeLine(const std::string& line, unsigned int indent = 0) const;
+    void actualizeModelCppCode() const;
+
+private:
+    Simulator* _simulator;
+    QPlainTextEdit* _cppCodeEditor;
 };
 
 #endif // CPPMODELEXPORTER_H

--- a/source/applications/gui/qt/GenesysQtGUI/services/GraphvizModelExporter.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/services/GraphvizModelExporter.cpp
@@ -1,8 +1,6 @@
 #include "services/GraphvizModelExporter.h"
 
 // This include gives access to generated Qt widgets consumed by the exporter.
-#include "ui_mainwindow.h"
-
 // These includes provide kernel/model types required by DOT generation.
 #include "../../../../kernel/simulator/Simulator.h"
 #include "../../../../kernel/simulator/ModelDataDefinition.h"
@@ -15,6 +13,8 @@
 #include "../../../../kernel/util/Util.h"
 
 // These includes provide Qt classes used by image generation and UI updates.
+#include <QCheckBox>
+#include <QLabel>
 #include <QPixmap>
 #include <QRegularExpression>
 #include <QStringList>
@@ -50,6 +50,20 @@ static std::string _escapeDotLabelText(const std::string& text) {
     return escaped;
 }
 
+
+GraphvizModelExporter::GraphvizModelExporter(Simulator* simulator,
+                                             QLabel* modelGraphicLabel,
+                                             QCheckBox* showInternals,
+                                             QCheckBox* showElements,
+                                             QCheckBox* showRecursive,
+                                             QCheckBox* showLevels)
+    : _simulator(simulator)
+    , _modelGraphicLabel(modelGraphicLabel)
+    , _showInternals(showInternals)
+    , _showElements(showElements)
+    , _showRecursive(showRecursive)
+    , _showLevels(showLevels) {
+}
 std::string GraphvizModelExporter::adjustDotName(std::string name) const {
     // This block preserves identifier normalization behavior used by current DOT output.
     std::string text = Util::StrReplace(name, "[", "_");
@@ -87,9 +101,7 @@ void GraphvizModelExporter::insertTextInDot(std::string text,
     }
 }
 
-void GraphvizModelExporter::recursiveCreateModelGraphicPicture(Simulator* simulator,
-                                                               Ui::MainWindow* ui,
-                                                               ModelDataDefinition* componentOrData,
+void GraphvizModelExporter::recursiveCreateModelGraphicPicture(ModelDataDefinition* componentOrData,
                                                                std::list<ModelDataDefinition*>* visited,
                                                                std::map<unsigned int, std::map<unsigned int, std::list<std::string>*>*>* dotmap) const {
     // This local style bundle preserves the existing visual styling and ranking semantics.
@@ -112,15 +124,15 @@ void GraphvizModelExporter::recursiveCreateModelGraphicPicture(Simulator* simula
     // This block preserves traversal bookkeeping to avoid duplicate DOT generation.
     visited->insert(visited->end(), componentOrData);
     std::string text;
-    unsigned int modellevel = simulator->getModelManager()->current()->getLevel();
+    unsigned int modellevel = _simulator->getModelManager()->current()->getLevel();
     std::list<ModelDataDefinition*>::iterator visitedIt;
     ModelComponent* parentComponentSuperLevel = nullptr;
     unsigned int level = componentOrData->getLevel();
 
     // This block emits model component nodes according to level visibility flags.
     if (dynamic_cast<ModelComponent*> (componentOrData) != nullptr) {
-        if (level != modellevel && !ui->checkBox_ShowLevels->isChecked()) {
-            parentComponentSuperLevel = simulator->getModelManager()->current()->getComponentManager()->find(level);
+        if (level != modellevel && !_showLevels->isChecked()) {
+            parentComponentSuperLevel = _simulator->getModelManager()->current()->getComponentManager()->find(level);
             assert(parentComponentSuperLevel != nullptr);
             visitedIt = std::find(visited->begin(), visited->end(), parentComponentSuperLevel);
             if (visitedIt == visited->end()) {
@@ -142,7 +154,7 @@ void GraphvizModelExporter::recursiveCreateModelGraphicPicture(Simulator* simula
     // This block emits attached/internal data definitions and related edges.
     std::string dataname;
     std::string componentName = parentComponentSuperLevel != nullptr ? parentComponentSuperLevel->getName() : componentOrData->getName();
-    if (ui->checkBox_ShowInternals->isChecked()) {
+    if (_showInternals->isChecked()) {
         for (std::pair<std::string, ModelDataDefinition*> dataPair : *componentOrData->getInternalData()) {
             dataname = adjustDotName(dataPair.second->getName());
             level = dataPair.second->getLevel();
@@ -151,18 +163,18 @@ void GraphvizModelExporter::recursiveCreateModelGraphicPicture(Simulator* simula
                 if (dynamic_cast<ModelComponent*> (dataPair.second) == nullptr) {
                     text = "  " + dataname + " [" + DOT.nodeDataDefInternal + ", label=\"" + _escapeDotLabelText(dataPair.second->getClassname()) + "|" + _escapeDotLabelText(dataPair.second->getName()) + "\"]" + ";\n";
                     insertTextInDot(text, level, DOT.rankDataDefInternal, dotmap, true);
-                    if (ui->checkBox_ShowRecursive->isChecked()) {
-                        recursiveCreateModelGraphicPicture(simulator, ui, dataPair.second, visited, dotmap);
+                    if (_showRecursive->isChecked()) {
+                        recursiveCreateModelGraphicPicture(dataPair.second, visited, dotmap);
                     }
                 }
             }
-            if (dataPair.second->getLevel() == modellevel || ui->checkBox_ShowLevels->isChecked()) {
+            if (dataPair.second->getLevel() == modellevel || _showLevels->isChecked()) {
                 text = "    " + dataname + "->" + adjustDotName(componentName) + " [" + DOT.edgeDataDefInternal + ", label=\"" + _escapeDotLabelText(dataPair.first) + "\"];\n";
                 insertTextInDot(text, modellevel, DOT.rankEdge, dotmap);
             }
         }
     }
-    if (ui->checkBox_ShowElements->isChecked()) {
+    if (_showElements->isChecked()) {
         for (std::pair<std::string, ModelDataDefinition*> dataPair : *componentOrData->getAttachedData()) {
             dataname = adjustDotName(dataPair.second->getName());
             level = dataPair.second->getLevel();
@@ -172,8 +184,8 @@ void GraphvizModelExporter::recursiveCreateModelGraphicPicture(Simulator* simula
                     text = "  " + dataname + " [" + DOT.nodeDataDefAttached + ", label=\"" + _escapeDotLabelText(dataPair.second->getClassname()) + "|" + _escapeDotLabelText(dataPair.second->getName()) + "\"]" + ";\n";
                     insertTextInDot(text, level, DOT.rankDataDefAttached, dotmap, true);
                 }
-                if (ui->checkBox_ShowRecursive->isChecked()) {
-                    recursiveCreateModelGraphicPicture(simulator, ui, dataPair.second, visited, dotmap);
+                if (_showRecursive->isChecked()) {
+                    recursiveCreateModelGraphicPicture(dataPair.second, visited, dotmap);
                 }
             }
             text = "    " + dataname + "->" + adjustDotName(componentName) + " [" + DOT.edgeDataDefAttached + ", label=\"" + _escapeDotLabelText(dataPair.first) + "\"];\n";
@@ -189,9 +201,9 @@ void GraphvizModelExporter::recursiveCreateModelGraphicPicture(Simulator* simula
             Connection* connection = component->getConnectionManager()->getConnectionAtPort(i);
             visitedIt = std::find(visited->begin(), visited->end(), connection->component);
             if (visitedIt == visited->end()) {
-                recursiveCreateModelGraphicPicture(simulator, ui, connection->component, visited, dotmap);
+                recursiveCreateModelGraphicPicture(connection->component, visited, dotmap);
             }
-            if (connection->component->getLevel() == modellevel || ui->checkBox_ShowLevels->isChecked()) {
+            if (connection->component->getLevel() == modellevel || _showLevels->isChecked()) {
                 text = "    " + adjustDotName(componentName) + "->" + adjustDotName(connection->component->getName()) + "[" + DOT.edgeComponent + "];\n";
                 insertTextInDot(text, modellevel, DOT.rankEdge, dotmap);
             }
@@ -199,12 +211,10 @@ void GraphvizModelExporter::recursiveCreateModelGraphicPicture(Simulator* simula
     }
 }
 
-bool GraphvizModelExporter::createModelImage(Simulator* simulator,
-                                             Ui::MainWindow* ui,
-                                             const std::function<bool()>& setSimulationModelBasedOnText) const {
+bool GraphvizModelExporter::createModelImage(const std::function<bool()>& setSimulationModelBasedOnText) const {
     // This block preserves model synchronization precondition prior to DOT generation.
     bool res = setSimulationModelBasedOnText ? setSimulationModelBasedOnText() : false;
-    if (!res || simulator == nullptr || ui == nullptr || simulator->getModelManager()->current() == nullptr) {
+    if (!res || _simulator == nullptr || _modelGraphicLabel == nullptr || _showInternals == nullptr || _showElements == nullptr || _showRecursive == nullptr || _showLevels == nullptr || _simulator->getModelManager()->current() == nullptr) {
         return false;
     }
 
@@ -214,24 +224,24 @@ bool GraphvizModelExporter::createModelImage(Simulator* simulator,
     std::map<unsigned int, std::map<unsigned int, std::list<std::string>*>*>* dotmap = new std::map<unsigned int, std::map<unsigned int, std::list<std::string>*>*>();
 
     std::list<ModelDataDefinition*>* visited = new std::list<ModelDataDefinition*>();
-    for (SourceModelComponent* source : *simulator->getModelManager()->current()->getComponentManager()->getSourceComponents()) {
+    for (SourceModelComponent* source : *_simulator->getModelManager()->current()->getComponentManager()->getSourceComponents()) {
         if (std::find(visited->begin(), visited->end(), source) == visited->end()) {
-            recursiveCreateModelGraphicPicture(simulator, ui, source, visited, dotmap);
+            recursiveCreateModelGraphicPicture(source, visited, dotmap);
         }
     }
-    for (ModelComponent* transfer : *simulator->getModelManager()->current()->getComponentManager()->getTransferInComponents()) {
+    for (ModelComponent* transfer : *_simulator->getModelManager()->current()->getComponentManager()->getTransferInComponents()) {
         if (std::find(visited->begin(), visited->end(), transfer) == visited->end()) {
-            recursiveCreateModelGraphicPicture(simulator, ui, transfer, visited, dotmap);
+            recursiveCreateModelGraphicPicture(transfer, visited, dotmap);
         }
     }
-    for (ModelComponent* comp : *simulator->getModelManager()->current()->getComponentManager()->getAllComponents()) {
+    for (ModelComponent* comp : *_simulator->getModelManager()->current()->getComponentManager()->getAllComponents()) {
         if (std::find(visited->begin(), visited->end(), comp) == visited->end()) {
-            recursiveCreateModelGraphicPicture(simulator, ui, comp, visited, dotmap);
+            recursiveCreateModelGraphicPicture(comp, visited, dotmap);
         }
     }
 
     // This block preserves aggregation of level subgraphs into final DOT content.
-    unsigned int modelLevel = simulator->getModelManager()->current()->getLevel();
+    unsigned int modelLevel = _simulator->getModelManager()->current()->getLevel();
     for (std::pair<unsigned int, std::map<unsigned int, std::list<std::string>*>*> dotpair : *dotmap) {
         if (dotpair.first == modelLevel) {
             dot += "\n  // model level\n";
@@ -245,10 +255,10 @@ bool GraphvizModelExporter::createModelImage(Simulator* simulator,
                 }
                 dot += "  }\n";
             }
-        } else if (ui->checkBox_ShowLevels->isChecked()) {
+        } else if (_showLevels->isChecked()) {
             dot += "\n\n // submodel level  " + std::to_string(dotpair.first) + "\n";
             dot += " subgraph cluster_level_" + std::to_string(dotpair.first) + " {\n";
-            dot += "   graph[style=filled; fillcolor=mistyrose2] label=\"" + simulator->getModelManager()->current()->getComponentManager()->find(dotpair.first)->getName() + "\";\n";
+            dot += "   graph[style=filled; fillcolor=mistyrose2] label=\"" + _simulator->getModelManager()->current()->getComponentManager()->find(dotpair.first)->getName() + "\";\n";
             for (std::pair<unsigned int, std::list<std::string>*> dotpair2 : *dotpair.second) {
                 dot += "  {\n";
                 if (dotpair2.first == 0) dot += "     rank=min  // " + std::to_string(dotpair2.first) + "\n";
@@ -286,8 +296,8 @@ bool GraphvizModelExporter::createModelImage(Simulator* simulator,
             std::string command = "dot -Tpng " + dotfilename + " -o " + pngfilename;
             system(command.c_str());
             QPixmap pm(QString::fromStdString(pngfilename));
-            ui->label_ModelGraphic->setPixmap(pm);
-            ui->label_ModelGraphic->setScaledContents(false);
+                        _modelGraphicLabel->setPixmap(pm);
+            _modelGraphicLabel->setScaledContents(false);
             return true;
         } catch (...) {
         }

--- a/source/applications/gui/qt/GenesysQtGUI/services/GraphvizModelExporter.h
+++ b/source/applications/gui/qt/GenesysQtGUI/services/GraphvizModelExporter.h
@@ -6,37 +6,40 @@
 #include <map>
 #include <string>
 
+class QLabel;
+class QCheckBox;
 class Simulator;
 class ModelDataDefinition;
-
-namespace Ui {
-class MainWindow;
-}
 
 // This service encapsulates Graphviz DOT generation and PNG rendering for model representation.
 class GraphvizModelExporter {
 public:
-    // This method normalizes identifiers so they are DOT-compatible while preserving current naming rules.
-    std::string adjustDotName(std::string name) const;
+    // MainWindow provides explicit dependencies once, keeping wrappers thin and stable.
+    GraphvizModelExporter(Simulator* simulator,
+                          QLabel* modelGraphicLabel,
+                          QCheckBox* showInternals,
+                          QCheckBox* showElements,
+                          QCheckBox* showRecursive,
+                          QCheckBox* showLevels);
 
-    // This method inserts generated DOT text into the ranked map structure used by the legacy algorithm.
+    std::string adjustDotName(std::string name) const;
     void insertTextInDot(std::string text,
                          unsigned int compLevel,
                          unsigned int compRank,
                          std::map<unsigned int, std::map<unsigned int, std::list<std::string>*>*>* dotmap,
                          bool isNode = false) const;
-
-    // This method traverses model components and data definitions recursively to build DOT structures.
-    void recursiveCreateModelGraphicPicture(Simulator* simulator,
-                                            Ui::MainWindow* ui,
-                                            ModelDataDefinition* componentOrData,
+    void recursiveCreateModelGraphicPicture(ModelDataDefinition* componentOrData,
                                             std::list<ModelDataDefinition*>* visited,
                                             std::map<unsigned int, std::map<unsigned int, std::list<std::string>*>*>* dotmap) const;
+    bool createModelImage(const std::function<bool()>& setSimulationModelBasedOnText) const;
 
-    // This method creates the model image by orchestrating model synchronization and DOT rendering.
-    bool createModelImage(Simulator* simulator,
-                          Ui::MainWindow* ui,
-                          const std::function<bool()>& setSimulationModelBasedOnText) const;
+private:
+    Simulator* _simulator;
+    QLabel* _modelGraphicLabel;
+    QCheckBox* _showInternals;
+    QCheckBox* _showElements;
+    QCheckBox* _showRecursive;
+    QCheckBox* _showLevels;
 };
 
 #endif // GRAPHVIZMODELEXPORTER_H

--- a/source/applications/gui/qt/GenesysQtGUI/services/ModelLanguageSynchronizer.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/services/ModelLanguageSynchronizer.cpp
@@ -1,28 +1,33 @@
 #include "services/ModelLanguageSynchronizer.h"
 
-// This include gives access to generated Qt widgets used by the service implementation.
-#include "ui_mainwindow.h"
-
-// These includes provide kernel simulator/model APIs used to keep UI and model synchronized.
 #include "../../../../kernel/simulator/Simulator.h"
 #include "../../../../kernel/simulator/Model.h"
 #include "../../../../kernel/simulator/ModelPersistence_if.h"
 
-// This include provides QMessageBox used by the existing error-reporting behavior.
 #include <QMessageBox>
+#include <QPlainTextEdit>
 
-// These includes provide stream facilities used by the existing text serialization flow.
 #include <fstream>
 #include <string>
 
-void ModelLanguageSynchronizer::actualizeModelSimLanguage(Simulator* simulator, Ui::MainWindow* ui, bool* textModelHasChangedFlag) const {
-    // This guard preserves safety when dependencies are not available.
-    if (simulator == nullptr || ui == nullptr || textModelHasChangedFlag == nullptr) {
+ModelLanguageSynchronizer::ModelLanguageSynchronizer(Simulator* simulator,
+                                                     QPlainTextEdit* modelTextEditor,
+                                                     bool* textModelHasChangedFlag,
+                                                     QWidget* ownerWidget,
+                                                     std::function<void()> onModelCreatedOrLoaded)
+    : _simulator(simulator)
+    , _modelTextEditor(modelTextEditor)
+    , _textModelHasChangedFlag(textModelHasChangedFlag)
+    , _ownerWidget(ownerWidget)
+    , _onModelCreatedOrLoaded(std::move(onModelCreatedOrLoaded)) {
+}
+
+void ModelLanguageSynchronizer::actualizeModelSimLanguage() const {
+    if (_simulator == nullptr || _modelTextEditor == nullptr || _textModelHasChangedFlag == nullptr) {
         return;
     }
 
-    // This block keeps the same persistence roundtrip currently used to regenerate model language text.
-    Model* model = simulator->getModelManager()->current();
+    Model* model = _simulator->getModelManager()->current();
     if (model != nullptr) {
         model->getPersistence()->setOption(ModelPersistence_if::Options::SAVEDEFAULTS, true);
         std::string tempFilename = "./temp.tmp";
@@ -32,46 +37,38 @@ void ModelLanguageSynchronizer::actualizeModelSimLanguage(Simulator* simulator, 
         std::string line;
         std::ifstream file(tempFilename);
         if (file.is_open()) {
-            ui->TextCodeEditor->clear();
+            _modelTextEditor->clear();
             while (std::getline(file, line)) {
-                ui->TextCodeEditor->appendPlainText(QString::fromStdString(line));
+                _modelTextEditor->appendPlainText(QString::fromStdString(line));
             }
             file.close();
-            *textModelHasChangedFlag = false;
+            *_textModelHasChangedFlag = false;
         }
     }
 }
 
-bool ModelLanguageSynchronizer::setSimulationModelBasedOnText(QWidget* ownerWidget,
-                                                              Simulator* simulator,
-                                                              Ui::MainWindow* ui,
-                                                              bool textModelHasChanged,
-                                                              const std::function<void()>& setOnEventHandlers) const {
-    // This guard preserves safety when dependencies are not available.
-    if (simulator == nullptr || ui == nullptr) {
+bool ModelLanguageSynchronizer::setSimulationModelBasedOnText() const {
+    if (_simulator == nullptr || _modelTextEditor == nullptr) {
         return false;
     }
 
-    // This block intentionally keeps the legacy TODO semantics for text-change handling.
-    Model* model = simulator->getModelManager()->current();
-    if (textModelHasChanged) {
-        // @TODO: Keep behavior unchanged in phase 1 while delegating logic to a service.
-        // simulator->getModels()->remove(model);
+    Model* model = _simulator->getModelManager()->current();
+    if (_textModelHasChangedFlag != nullptr && *_textModelHasChangedFlag) {
+        // Keep phase-1 behavior unchanged: text change handling is still deferred by legacy TODO.
+        // _simulator->getModels()->remove(model);
         // model = nullptr;
     }
 
-    // This block preserves the existing "create from text only when model is null" behavior.
     if (model == nullptr) {
-        QString modelLanguage = ui->TextCodeEditor->toPlainText();
-        if (!simulator->getModelManager()->createFromLanguage(modelLanguage.toStdString())) {
-            QMessageBox::critical(ownerWidget, "Check Model", "Error in the model text. See console for more information.");
+        QString modelLanguage = _modelTextEditor->toPlainText();
+        if (!_simulator->getModelManager()->createFromLanguage(modelLanguage.toStdString())) {
+            QMessageBox::critical(_ownerWidget, "Check Model", "Error in the model text. See console for more information.");
         }
-        model = simulator->getModelManager()->current();
-        if (model != nullptr && setOnEventHandlers) {
-            setOnEventHandlers();
+        model = _simulator->getModelManager()->current();
+        if (model != nullptr && _onModelCreatedOrLoaded) {
+            _onModelCreatedOrLoaded();
         }
     }
 
-    // This return keeps the same success condition currently used by MainWindow.
-    return simulator->getModelManager()->current() != nullptr;
+    return _simulator->getModelManager()->current() != nullptr;
 }

--- a/source/applications/gui/qt/GenesysQtGUI/services/ModelLanguageSynchronizer.h
+++ b/source/applications/gui/qt/GenesysQtGUI/services/ModelLanguageSynchronizer.h
@@ -4,24 +4,28 @@
 #include <functional>
 
 class QWidget;
+class QPlainTextEdit;
 class Simulator;
-
-namespace Ui {
-class MainWindow;
-}
 
 // This service encapsulates synchronization between the textual model editor and kernel model state.
 class ModelLanguageSynchronizer {
 public:
-    // This method refreshes the textual model editor from the current kernel model serialization.
-    void actualizeModelSimLanguage(Simulator* simulator, Ui::MainWindow* ui, bool* textModelHasChangedFlag) const;
+    // MainWindow provides explicit dependencies once, keeping wrappers thin and stable.
+    ModelLanguageSynchronizer(Simulator* simulator,
+                              QPlainTextEdit* modelTextEditor,
+                              bool* textModelHasChangedFlag,
+                              QWidget* ownerWidget,
+                              std::function<void()> onModelCreatedOrLoaded);
 
-    // This method creates or refreshes the simulation model from text while preserving the current behavior.
-    bool setSimulationModelBasedOnText(QWidget* ownerWidget,
-                                       Simulator* simulator,
-                                       Ui::MainWindow* ui,
-                                       bool textModelHasChanged,
-                                       const std::function<void()>& setOnEventHandlers) const;
+    void actualizeModelSimLanguage() const;
+    bool setSimulationModelBasedOnText() const;
+
+private:
+    Simulator* _simulator;
+    QPlainTextEdit* _modelTextEditor;
+    bool* _textModelHasChangedFlag;
+    QWidget* _ownerWidget;
+    std::function<void()> _onModelCreatedOrLoaded;
 };
 
 #endif // MODELLANGUAGESYNCHRONIZER_H


### PR DESCRIPTION
### Motivation
- Decouple model-representation and export logic from `MainWindow` by encapsulating it into dedicated services so the MainWindow surface remains a thin wrapper. 
- Reduce direct coupling to generated `Ui::MainWindow` by having services accept explicit widget and `Simulator` dependencies.

### Description
- Added service constructors and stateful members so `ModelLanguageSynchronizer`, `GraphvizModelExporter`, and `CppModelExporter` now accept `Simulator` and the specific Qt widgets they operate on (e.g. `QPlainTextEdit`, `QLabel`, `QCheckBox`) and store them as members. 
- Updated `MainWindow` to construct these services with the required dependencies and to pass a callback for post-model-creation event wiring via `ModelLanguageSynchronizer`'s constructor. 
- Removed direct `Ui::MainWindow` usage from service implementations and converted previous static/wrapper calls in `mainwindow.cpp`/`mainwindow_modelrepresentations.cpp` to call the new service methods (e.g. `actualizeModelSimLanguage()`, `createModelImage()`, `actualizeModelCppCode()`, `setSimulationModelBasedOnText()`). 
- Cleaned up headers and includes (forward-declared Qt widget types where appropriate) and preserved legacy behaviors (DOT name adjustments, code indentation, file-based DOT -> PNG flow, message-box error reporting) while relocating logic into the service classes.

### Testing
- Performed a full project build using `make` which completed successfully without compilation errors. 
- Ran the project's automated test suite with `ctest --output-on-failure`, and existing tests completed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d551940fec83219fa0c19c90a9b49e)