### PR TITLE
refactor(gui): Phase‑1 model‑representation service wiring and comments

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/GenesysQtGUI.pro
+++ b/source/applications/gui/qt/GenesysQtGUI/GenesysQtGUI.pro
@@ -240,6 +240,7 @@ SOURCES += \
     ../../../terminal/examples/teaching/Rectifier.cpp \
     codeeditor/CodeEditor.cpp \
     controllers/SimulationController.cpp \
+    # Phase-1 GUI refactor services for model representations.
     services/ModelLanguageSynchronizer.cpp \
     services/GraphvizModelExporter.cpp \
     services/CppModelExporter.cpp \
@@ -553,6 +554,7 @@ HEADERS += \
     TraitsGUI.h \
     UtilGUI.h \
     controllers/SimulationController.h \
+    # Phase-1 GUI refactor service headers.
     services/ModelLanguageSynchronizer.h \
     services/GraphvizModelExporter.h \
     services/CppModelExporter.h \

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
@@ -66,7 +66,13 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
         // Keep event-handler ownership in MainWindow while delegating model-language synchronization.
         _setOnEventHandlers();
     });
-    _graphvizModelExporter = std::make_unique<GraphvizModelExporter>(simulator, ui->label_ModelGraphic, ui->checkBox_ShowInternals, ui->checkBox_ShowElements, ui->checkBox_ShowRecursive, ui->checkBox_ShowLevels);
+    // Keep Graphviz exporter dependencies explicit to avoid broad MainWindow coupling.
+    _graphvizModelExporter = std::make_unique<GraphvizModelExporter>(simulator,
+                                                                     ui->label_ModelGraphic,
+                                                                     ui->checkBox_ShowInternals,
+                                                                     ui->checkBox_ShowElements,
+                                                                     ui->checkBox_ShowRecursive,
+                                                                     ui->checkBox_ShowLevels);
     _cppModelExporter = std::make_unique<CppModelExporter>(simulator, ui->plainTextEditCppCode);
     simulator->getTraceManager()->setTraceLevel(TraitsApp<GenesysApplication_if>::traceLevel);
     simulator->getTraceManager()->addTraceHandler<MainWindow>(this, &MainWindow::_simulatorTraceHandler);

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.h
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.h
@@ -273,8 +273,11 @@ private: // interface and model main elements to join
 	Simulator* simulator;
     std::unique_ptr<class SimulationController> _simulationController;
     // Phase-1 services keep model-representation logic outside MainWindow while wrappers remain stable.
+    // Synchronize textual model language with the kernel model manager.
     std::unique_ptr<ModelLanguageSynchronizer> _modelLanguageSynchronizer;
+    // Generate Graphviz DOT and rendered model images for the GUI pane.
     std::unique_ptr<GraphvizModelExporter> _graphvizModelExporter;
+    // Generate C++ model representation text for the code viewer pane.
     std::unique_ptr<CppModelExporter> _cppModelExporter;
 	PropertyEditorGenesys* propertyGenesys;
     std::map<SimulationControl*, DataComponentProperty*>* propertyList;

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow_modelrepresentations.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow_modelrepresentations.cpp
@@ -37,10 +37,12 @@
 #include <QTimer>
 #include <QUrl>
 
+// Encode free-form GUI text safely for persistence records.
 static QString _encodeGuiText(const QString& text) {
     return QString::fromUtf8(QUrl::toPercentEncoding(text));
 }
 
+// Decode persisted GUI text back to plain UTF-8 text.
 static QString _decodeGuiText(const QString& text) {
     return QUrl::fromPercentEncoding(text.toUtf8());
 }

--- a/source/applications/gui/qt/GenesysQtGUI/services/CppModelExporter.h
+++ b/source/applications/gui/qt/GenesysQtGUI/services/CppModelExporter.h
@@ -6,7 +6,7 @@
 class QPlainTextEdit;
 class Simulator;
 
-// This service encapsulates generation of C++ model code shown in the GUI editor.
+// This Phase-1 service encapsulates generation of C++ model code shown in the GUI editor.
 class CppModelExporter {
 public:
     // MainWindow provides explicit dependencies once, keeping wrappers thin and stable.

--- a/source/applications/gui/qt/GenesysQtGUI/services/GraphvizModelExporter.h
+++ b/source/applications/gui/qt/GenesysQtGUI/services/GraphvizModelExporter.h
@@ -11,7 +11,7 @@ class QCheckBox;
 class Simulator;
 class ModelDataDefinition;
 
-// This service encapsulates Graphviz DOT generation and PNG rendering for model representation.
+// This Phase-1 service encapsulates Graphviz DOT generation and PNG rendering for model representation.
 class GraphvizModelExporter {
 public:
     // MainWindow provides explicit dependencies once, keeping wrappers thin and stable.

--- a/source/applications/gui/qt/GenesysQtGUI/services/ModelLanguageSynchronizer.h
+++ b/source/applications/gui/qt/GenesysQtGUI/services/ModelLanguageSynchronizer.h
@@ -7,7 +7,7 @@ class QWidget;
 class QPlainTextEdit;
 class Simulator;
 
-// This service encapsulates synchronization between the textual model editor and kernel model state.
+// This Phase-1 service encapsulates synchronization between the textual model editor and kernel model state.
 class ModelLanguageSynchronizer {
 public:
     // MainWindow provides explicit dependencies once, keeping wrappers thin and stable.


### PR DESCRIPTION
### Motivation
- Complete the conservative Phase 1 refactor by ensuring the model‑representation responsibilities are owned by dedicated services and that MainWindow remains a thin compatibility surface.  
- Make the Phase 1 wiring and responsibilities explicit in code/comments to aid reviewability while preserving existing runtime behavior.

### Description
- Added short, review‑focused Phase‑1 comments and small formatting fixes and kept MainWindow wrappers delegating to the services without changing behavior.  
- Ensured the three Phase‑1 services are referenced and their responsibilities remain outside MainWindow; updated `GenesysQtGUI.pro` with Phase‑1 comment markers around the service `.cpp` and `.h` entries.  
- Files modified: `source/applications/gui/qt/GenesysQtGUI/mainwindow.h`, `source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp`, `source/applications/gui/qt/GenesysQtGUI/mainwindow_modelrepresentations.cpp`, `source/applications/gui/qt/GenesysQtGUI/GenesysQtGUI.pro`, and small comment edits to the service headers: `source/applications/gui/qt/GenesysQtGUI/services/ModelLanguageSynchronizer.h`, `source/applications/gui/qt/GenesysQtGUI/services/GraphvizModelExporter.h`, `source/applications/gui/qt/GenesysQtGUI/services/CppModelExporter.h`.  
- No behavioral changes were introduced and no later‑phase refactor work was mixed in; I intentionally stopped at Phase 1.

### Testing
- Verified presence of the six Phase‑1 service files with a filesystem check; result: all six files present.  
- Verified qmake project entries exist for the three service `.cpp` and `.h` files in `GenesysQtGUI.pro`.  
- Performed repository validation via `git status` and a commit confirming a clean working state; these checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d55f149c7c83219a412d806311807e)