### PR TITLE
Phase 1: Delegate Graphviz image creation to GraphvizModelExporter with sync callback

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
@@ -72,7 +72,9 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
                                                                      ui->checkBox_ShowInternals,
                                                                      ui->checkBox_ShowElements,
                                                                      ui->checkBox_ShowRecursive,
-                                                                     ui->checkBox_ShowLevels);
+                                                                     ui->checkBox_ShowLevels,
+                                                                     // Keep synchronization behavior unchanged via a narrow callback dependency.
+                                                                     [this]() { return this->_setSimulationModelBasedOnText(); });
     _cppModelExporter = std::make_unique<CppModelExporter>(simulator, ui->plainTextEditCppCode);
     simulator->getTraceManager()->setTraceLevel(TraitsApp<GenesysApplication_if>::traceLevel);
     simulator->getTraceManager()->addTraceHandler<MainWindow>(this, &MainWindow::_simulatorTraceHandler);

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow_modelrepresentations.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow_modelrepresentations.cpp
@@ -103,10 +103,7 @@ void MainWindow::setGraphicalModelHasChanged(bool graphicalModelHasChanged) {
 
 bool MainWindow::_createModelImage() {
     // This wrapper delegates model diagram image creation to the phase-1 Graphviz service.
-    return _graphvizModelExporter->createModelImage([this]() {
-        // This callback preserves MainWindow-controlled text-to-model synchronization flow.
-        return this->_setSimulationModelBasedOnText();
-    });
+    return _graphvizModelExporter->createModelImage();
 }
 
 //-----------------------------------------------------------------

--- a/source/applications/gui/qt/GenesysQtGUI/services/GraphvizModelExporter.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/services/GraphvizModelExporter.cpp
@@ -26,6 +26,8 @@
 #include <cstdlib>
 #include <cstdio>
 #include <fstream>
+// This include provides std::move used to store constructor callbacks.
+#include <utility>
 
 // This helper keeps legacy label escaping semantics for Graphviz output.
 static std::string _escapeDotLabelText(const std::string& text) {
@@ -57,13 +59,16 @@ GraphvizModelExporter::GraphvizModelExporter(Simulator* simulator,
                                              QCheckBox* showInternals,
                                              QCheckBox* showElements,
                                              QCheckBox* showRecursive,
-                                             QCheckBox* showLevels)
+                                             QCheckBox* showLevels,
+                                             std::function<bool()> ensureModelSynchronized)
     : _simulator(simulator)
     , _modelGraphicLabel(modelGraphicLabel)
     , _showInternals(showInternals)
     , _showElements(showElements)
     , _showRecursive(showRecursive)
-    , _showLevels(showLevels) {
+    , _showLevels(showLevels)
+    // Keep model-text synchronization callback local to this service dependency set.
+    , _ensureModelSynchronized(std::move(ensureModelSynchronized)) {
 }
 std::string GraphvizModelExporter::adjustDotName(std::string name) const {
     // This block preserves identifier normalization behavior used by current DOT output.
@@ -212,9 +217,9 @@ void GraphvizModelExporter::recursiveCreateModelGraphicPicture(ModelDataDefiniti
     }
 }
 
-bool GraphvizModelExporter::createModelImage(const std::function<bool()>& setSimulationModelBasedOnText) const {
+bool GraphvizModelExporter::createModelImage() const {
     // This block preserves model synchronization precondition prior to DOT generation.
-    bool res = setSimulationModelBasedOnText ? setSimulationModelBasedOnText() : false;
+    bool res = _ensureModelSynchronized ? _ensureModelSynchronized() : false;
     if (!res || _simulator == nullptr || _modelGraphicLabel == nullptr || _showInternals == nullptr || _showElements == nullptr || _showRecursive == nullptr || _showLevels == nullptr || _simulator->getModelManager()->current() == nullptr) {
         return false;
     }

--- a/source/applications/gui/qt/GenesysQtGUI/services/GraphvizModelExporter.h
+++ b/source/applications/gui/qt/GenesysQtGUI/services/GraphvizModelExporter.h
@@ -15,12 +15,14 @@ class ModelDataDefinition;
 class GraphvizModelExporter {
 public:
     // MainWindow provides explicit dependencies once, keeping wrappers thin and stable.
+    // Receive a narrow callback to preserve text-to-model sync precondition before image export.
     GraphvizModelExporter(Simulator* simulator,
                           QLabel* modelGraphicLabel,
                           QCheckBox* showInternals,
                           QCheckBox* showElements,
                           QCheckBox* showRecursive,
-                          QCheckBox* showLevels);
+                          QCheckBox* showLevels,
+                          std::function<bool()> ensureModelSynchronized);
 
     std::string adjustDotName(std::string name) const;
     void insertTextInDot(std::string text,
@@ -31,7 +33,8 @@ public:
     void recursiveCreateModelGraphicPicture(ModelDataDefinition* componentOrData,
                                             std::list<ModelDataDefinition*>* visited,
                                             std::map<unsigned int, std::map<unsigned int, std::list<std::string>*>*>* dotmap) const;
-    bool createModelImage(const std::function<bool()>& setSimulationModelBasedOnText) const;
+    // Keep image generation API wrapper-friendly while internally invoking synchronization callback.
+    bool createModelImage() const;
 
 private:
     Simulator* _simulator;
@@ -40,6 +43,8 @@ private:
     QCheckBox* _showElements;
     QCheckBox* _showRecursive;
     QCheckBox* _showLevels;
+    // Keep synchronization dependency narrow and explicit.
+    std::function<bool()> _ensureModelSynchronized;
 };
 
 #endif // GRAPHVIZMODELEXPORTER_H


### PR DESCRIPTION
### Motivation
- Reduce MainWindow responsibility by moving Graphviz image/ DOT orchestration into the Phase‑1 exporter service while preserving existing behavior. 
- Keep MainWindow API stable via thin delegating wrappers so incremental refactor remains reviewable and reversible. 
- Preserve the pre-export text→model synchronization step by providing a narrow callback to the exporter rather than broad MainWindow coupling.

### Description
- Added a narrow constructor dependency to `GraphvizModelExporter`: `std::function<bool()> ensureModelSynchronized`, stored as `_ensureModelSynchronized`, and changed `createModelImage(...)` to `createModelImage()` which invokes the stored callback internally; modified header and implementation accordingly (`source/applications/gui/qt/GenesysQtGUI/services/GraphvizModelExporter.h`, `.../GraphvizModelExporter.cpp`).
- Kept constructor storage semantics explicit by including `<utility>` and using `std::move` when storing the callback in the exporter implementation (`GraphvizModelExporter.cpp`).
- Injected a narrow lambda from `MainWindow` that delegates to the existing `_setSimulationModelBasedOnText()` when constructing `_graphvizModelExporter`, preserving the original synchronization ordering and avoiding passing `MainWindow*` broadly (`source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp`).
- Replaced the previous inline callback usage in the MainWindow wrapper `_createModelImage()` with a thin delegating call to the service (`source/applications/gui/qt/GenesysQtGUI/mainwindow_modelrepresentations.cpp`).
- No behavior-changing refactors of controllers, scene, simulator event handlers, lifecycle, plugin catalog, serialization, or other subsystems were performed in this change.
- I intentionally stopped at Phase 1.

### Testing
- Searched code usages of `createModelImage(` to confirm compatibility and call sites using `rg` which returned expected locations; command succeeded. 
- Verified repository working tree and committed the change with `git status` and `git commit` which reported success. 
- Performed quick file inspections (`nl` / `sed`) of modified files to ensure the callback is passed and the wrapper only delegates; inspections succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d561ec454083219cef3731d7847bcc)