### PR TITLE
Phase 3: Extract ModelInspectorController and delegate MainWindow model-inspection responsibilities

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/GenesysQtGUI.pro
+++ b/source/applications/gui/qt/GenesysQtGUI/GenesysQtGUI.pro
@@ -240,6 +240,8 @@ SOURCES += \
     ../../../terminal/examples/teaching/Rectifier.cpp \
     codeeditor/CodeEditor.cpp \
     controllers/SimulationController.cpp \
+    # Phase-3 GUI refactor controller for model-inspector responsibilities.
+    controllers/ModelInspectorController.cpp \
     # Phase-1 GUI refactor services for model representations.
     services/ModelLanguageSynchronizer.cpp \
     services/GraphvizModelExporter.cpp \
@@ -556,6 +558,8 @@ HEADERS += \
     TraitsGUI.h \
     UtilGUI.h \
     controllers/SimulationController.h \
+    # Phase-3 GUI refactor controller header for model-inspector responsibilities.
+    controllers/ModelInspectorController.h \
     # Phase-1 GUI refactor service headers.
     services/ModelLanguageSynchronizer.h \
     services/GraphvizModelExporter.h \

--- a/source/applications/gui/qt/GenesysQtGUI/controllers/ModelInspectorController.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/ModelInspectorController.cpp
@@ -1,0 +1,167 @@
+#include "ModelInspectorController.h"
+
+#include "graphicals/ModelGraphicsView.h"
+
+#include "../../../../kernel/simulator/Model.h"
+#include "../../../../kernel/simulator/ModelComponent.h"
+#include "../../../../kernel/simulator/ModelDataDefinition.h"
+#include "../../../../kernel/simulator/ModelDataManager.h"
+#include "graphicals/ModelGraphicsScene.h"
+#include "graphicals/GraphicalModelComponent.h"
+#include "../../../../kernel/simulator/ModelManager.h"
+#include "../../../../kernel/simulator/Simulator.h"
+#include "../../../../kernel/util/Util.h"
+
+#include <Qt>
+
+// Build the controller with narrow Qt/kernel dependencies for Phase 3.
+ModelInspectorController::ModelInspectorController(Simulator* simulator,
+                                                   QTreeWidget* componentsTree,
+                                                   QTreeWidget* dataDefinitionsTree,
+                                                   ModelGraphicsView* graphicsView)
+    : _simulator(simulator),
+      _componentsTree(componentsTree),
+      _dataDefinitionsTree(dataDefinitionsTree),
+      _graphicsView(graphicsView) {
+}
+
+// Keep the Components tree actualization behavior equivalent to legacy MainWindow logic.
+void ModelInspectorController::actualizeModelComponents(bool force) const {
+    Q_UNUSED(force)
+
+    Model* m = _simulator->getModelManager()->current();
+    _componentsTree->clear();
+    if (m == nullptr) {
+        return;
+    }
+
+    for (ModelComponent* comp : *m->getComponentManager()->getAllComponents()) {
+        QList<QTreeWidgetItem*> items = _componentsTree->findItems(
+            QString::fromStdString(std::to_string(comp->getId())),
+            Qt::MatchExactly | Qt::MatchRecursive,
+            0);
+        if (items.size() == 0) {
+            QTreeWidgetItem* treeComp = new QTreeWidgetItem(_componentsTree);
+            treeComp->setText(0, QString::fromStdString(std::to_string(comp->getId())));
+            treeComp->setText(1, QString::fromStdString(comp->getClassname()));
+            treeComp->setText(2, QString::fromStdString(comp->getName()));
+            std::string properties = "";
+            for (auto prop : *comp->getProperties()->list()) {
+                properties += prop->getName() + ":" + prop->getValue() + ", ";
+            }
+            properties = properties.substr(0, properties.length() - 2);
+            treeComp->setText(3, QString::fromStdString(properties));
+        }
+    }
+
+    _componentsTree->resizeColumnToContents(0);
+    _componentsTree->resizeColumnToContents(1);
+    _componentsTree->resizeColumnToContents(2);
+}
+
+// Keep the Data Definitions tree actualization behavior equivalent to legacy MainWindow logic.
+void ModelInspectorController::actualizeModelDataDefinitions(bool force) const {
+    Q_UNUSED(force)
+
+    Model* m = _simulator->getModelManager()->current();
+    _dataDefinitionsTree->clear();
+    if (m == nullptr) {
+        return;
+    }
+
+    for (std::string dataTypename : *m->getDataManager()->getDataDefinitionClassnames()) {
+        for (ModelDataDefinition* comp : *m->getDataManager()->getDataDefinitionList(dataTypename)->list()) {
+            QList<QTreeWidgetItem*> items = _dataDefinitionsTree->findItems(
+                QString::fromStdString(std::to_string(comp->getId())),
+                Qt::MatchExactly | Qt::MatchRecursive,
+                0);
+            if (items.size() == 0) {
+                QTreeWidgetItem* treeComp = new QTreeWidgetItem(_dataDefinitionsTree);
+                treeComp->setText(0, QString::fromStdString(std::to_string(comp->getId())));
+                treeComp->setText(1, QString::fromStdString(comp->getClassname()));
+                treeComp->setText(2, QString::fromStdString(comp->getName()));
+                std::string properties = "";
+                for (auto prop : *comp->getProperties()->list()) {
+                    properties += prop->getName() + ":" + prop->getValue() + ", ";
+                }
+                properties = properties.substr(0, properties.length() - 2);
+                treeComp->setText(3, QString::fromStdString(properties));
+            }
+        }
+    }
+
+    _dataDefinitionsTree->resizeColumnToContents(0);
+    _dataDefinitionsTree->resizeColumnToContents(1);
+    _dataDefinitionsTree->resizeColumnToContents(2);
+}
+
+// Preserve rename-start behavior by enabling editability only for the name column.
+void ModelInspectorController::beginDataDefinitionNameEdit(QTreeWidgetItem* item, int column) const {
+    if (item == nullptr) {
+        return;
+    }
+
+    if (column == 2) {
+        item->setFlags(item->flags() | Qt::ItemIsEditable);
+        _dataDefinitionsTree->editItem(item, column);
+        item->setFlags(item->flags() & ~Qt::ItemIsEditable);
+    }
+}
+
+// Preserve rename-apply behavior by updating matched data-definition names in the model.
+void ModelInspectorController::applyDataDefinitionNameChange(QTreeWidgetItem* item, int column) const {
+    if (item == nullptr) {
+        return;
+    }
+
+    if (column == 2) {
+        QString after = item->text(column);
+        Model* m = _simulator->getModelManager()->current();
+        if (m == nullptr) {
+            return;
+        }
+
+        for (std::string dataTypename : *m->getDataManager()->getDataDefinitionClassnames()) {
+            for (ModelDataDefinition* comp : *m->getDataManager()->getDataDefinitionList(dataTypename)->list()) {
+                QString id = QString::fromStdString(Util::StrIndex(comp->getId()));
+                if (id.contains(item->text(0))) {
+                    comp->setName(after.toStdString());
+                }
+            }
+        }
+    }
+}
+
+// Preserve tree-to-scene selection synchronization and viewport centering behavior.
+void ModelInspectorController::syncSelectedComponentTreeItemToScene() const {
+    QList<QTreeWidgetItem*> selectedItems = _componentsTree->selectedItems();
+    if (selectedItems.isEmpty()) {
+        return;
+    }
+
+    bool ok = false;
+    const Util::identification compId = selectedItems.first()->text(0).toULongLong(&ok);
+    if (!ok) {
+        return;
+    }
+
+    ModelGraphicsScene* scene = _graphicsView->getScene();
+    if (scene == nullptr) {
+        return;
+    }
+
+    GraphicalModelComponent* gmc = scene->findGraphicalModelComponent(compId);
+    if (gmc == nullptr) {
+        return;
+    }
+
+    if (scene->selectedItems().size() == 1 && scene->selectedItems().first() == gmc) {
+        _graphicsView->ensureVisible(gmc);
+        return;
+    }
+
+    scene->clearSelection();
+    gmc->setSelected(true);
+    _graphicsView->ensureVisible(gmc);
+    _graphicsView->centerOn(gmc);
+}

--- a/source/applications/gui/qt/GenesysQtGUI/controllers/ModelInspectorController.h
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/ModelInspectorController.h
@@ -1,0 +1,40 @@
+#ifndef MODELINSPECTORCONTROLLER_H
+#define MODELINSPECTORCONTROLLER_H
+
+#include <QTreeWidget>
+
+class Simulator;
+class ModelGraphicsView;
+
+// Encapsulate Phase 3 model-inspection and tree/scene synchronization logic.
+class ModelInspectorController {
+public:
+    // Inject only the narrow dependencies required by the model-inspector workflow.
+    ModelInspectorController(Simulator* simulator,
+                             QTreeWidget* componentsTree,
+                             QTreeWidget* dataDefinitionsTree,
+                             ModelGraphicsView* graphicsView);
+
+    // Synchronize the Components tree with the current model state.
+    void actualizeModelComponents(bool force) const;
+    // Synchronize the Data Definitions tree with the current model state.
+    void actualizeModelDataDefinitions(bool force) const;
+    // Start in-place edition for a data-definition name when column is editable.
+    void beginDataDefinitionNameEdit(QTreeWidgetItem* item, int column) const;
+    // Apply renamed data-definition names back into the current model.
+    void applyDataDefinitionNameChange(QTreeWidgetItem* item, int column) const;
+    // Synchronize tree selection with graphical scene selection and viewport.
+    void syncSelectedComponentTreeItemToScene() const;
+
+private:
+    // Keep simulator access scoped to model-inspection responsibilities.
+    Simulator* _simulator;
+    // Keep direct access to the Components tree used by this controller.
+    QTreeWidget* _componentsTree;
+    // Keep direct access to the Data Definitions tree used by this controller.
+    QTreeWidget* _dataDefinitionsTree;
+    // Keep direct access to the graphics view for selection synchronization.
+    ModelGraphicsView* _graphicsView;
+};
+
+#endif // MODELINSPECTORCONTROLLER_H

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
@@ -11,6 +11,7 @@
 #include "TraitsGUI.h"
 #include "graphicals/GraphicalConnection.h"
 #include "controllers/SimulationController.h"
+#include "controllers/ModelInspectorController.h"
 #include "services/ModelLanguageSynchronizer.h"
 #include "services/GraphvizModelExporter.h"
 #include "services/CppModelExporter.h"
@@ -184,6 +185,11 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
     //
     // graphicsView
     _initModelGraphicsView();
+    // Initialize the Phase 3 model-inspector controller after view and simulator dependencies are ready.
+    _modelInspectorController = std::make_unique<ModelInspectorController>(simulator,
+                                                                           ui->treeWidgetComponents,
+                                                                           ui->treeWidgetDataDefnitions,
+                                                                           ui->graphicsView);
     // Initialize Phase 2 services using narrow dependencies and compatibility callbacks.
     _graphicalModelBuilder = std::make_unique<GraphicalModelBuilder>(simulator,
                                                                       ui->graphicsView,

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.h
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.h
@@ -30,6 +30,7 @@ class GraphvizModelExporter;
 class CppModelExporter;
 class GraphicalModelSerializer;
 class GraphicalModelBuilder;
+class ModelInspectorController;
 
 /**
  * @brief Main Qt window of Genesys GUI.
@@ -285,6 +286,8 @@ private: // interface and model main elements to join
     std::unique_ptr<GraphicalModelSerializer> _graphicalModelSerializer;
     // Rebuild graphical components and links through the Phase 2 builder service.
     std::unique_ptr<GraphicalModelBuilder> _graphicalModelBuilder;
+    // Add the Phase 3 model-inspector controller owned by MainWindow.
+    std::unique_ptr<ModelInspectorController> _modelInspectorController;
 	PropertyEditorGenesys* propertyGenesys;
     std::map<SimulationControl*, DataComponentProperty*>* propertyList;
     std::map<SimulationControl*, DataComponentEditor*>* propertyEditorUI;

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow_controller.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow_controller.cpp
@@ -1366,45 +1366,14 @@ void MainWindow::on_actionSimulationConfigure_triggered()
 
 void MainWindow::on_treeWidgetDataDefnitions_itemDoubleClicked(QTreeWidgetItem *item, int column)
 {
-
-    // Check if the column index is 2 (Name column)
-    if (column == 2) {
-
-        // Set the Qt::ItemIsEditable flag to enable editing for the specific item
-        // It's required to set the flag here because otherwise all the other fields could changed too.
-        item->setFlags(item->flags() | Qt::ItemIsEditable);
-
-        // Initiate the editing of the specified item in the specified column in the QTreeWidget
-        ui->treeWidgetDataDefnitions->editItem(item, column);
-
-        // Reset the Qt::ItemIsEditable flag to disable further editing after the edit operation
-        item->setFlags(item->flags() & ~Qt::ItemIsEditable);
-
-    }
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 3 refactor.
+    _modelInspectorController->beginDataDefinitionNameEdit(item, column);
 }
 
 void MainWindow::on_treeWidgetDataDefnitions_itemChanged(QTreeWidgetItem *item, int column)
 {
-
-    // Check if the column index is 2 (Name column)
-    if (column == 2) {
-
-        // Get the changes
-        QString after = item->text(column);
-        Model * m = simulator->getModelManager()->current();
-
-        // Save in the model
-        for (std::string dataTypename : *m->getDataManager()->getDataDefinitionClassnames()) {
-            for (ModelDataDefinition* comp : *m->getDataManager()->getDataDefinitionList(dataTypename)->list()) {
-
-                QString id = QString::fromStdString(Util::StrIndex(comp->getId()));
-
-                if (id.contains(item->text(0)))
-                    comp->setName(after.toStdString());
-            }
-        }
-    }
-
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 3 refactor.
+    _modelInspectorController->applyDataDefinitionNameChange(item, column);
 }
 
 
@@ -1915,36 +1884,8 @@ void MainWindow::on_actionShowAttachedElements_triggered() {
 }
 
 void MainWindow::on_treeWidgetComponents_itemSelectionChanged() {
-    QList<QTreeWidgetItem*> selectedItems = ui->treeWidgetComponents->selectedItems();
-    if (selectedItems.isEmpty()) {
-        return;
-    }
-
-    bool ok = false;
-    const Util::identification compId = selectedItems.first()->text(0).toULongLong(&ok);
-    if (!ok) {
-        return;
-    }
-
-    ModelGraphicsScene* scene = ui->graphicsView->getScene();
-    if (scene == nullptr) {
-        return;
-    }
-
-    GraphicalModelComponent* gmc = scene->findGraphicalModelComponent(compId);
-    if (gmc == nullptr) {
-        return;
-    }
-
-    if (scene->selectedItems().size() == 1 && scene->selectedItems().first() == gmc) {
-        ui->graphicsView->ensureVisible(gmc);
-        return;
-    }
-
-    scene->clearSelection();
-    gmc->setSelected(true);
-    ui->graphicsView->ensureVisible(gmc);
-    ui->graphicsView->centerOn(gmc);
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 3 refactor.
+    _modelInspectorController->syncSelectedComponentTreeItemToScene();
 }
 
 void MainWindow::on_treeWidget_Plugins_itemClicked(QTreeWidgetItem *item, int column) {

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow_modelrepresentations.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow_modelrepresentations.cpp
@@ -124,29 +124,8 @@ void MainWindow::_recursivalyGenerateGraphicalModelFromModel(ModelComponent* com
 }
 
 void MainWindow::_actualizeModelComponents(bool force) {
-    Model* m = simulator->getModelManager()->current();
-    ui->treeWidgetComponents->clear();
-    if (m == nullptr) {
-        return;
-    }
-    for (ModelComponent* comp : *m->getComponentManager()->getAllComponents()) {
-        QList<QTreeWidgetItem *> items = ui->treeWidgetComponents->findItems(QString::fromStdString(std::to_string(comp->getId())), Qt::MatchExactly | Qt::MatchRecursive, 0);
-        if (items.size() == 0) {
-            QTreeWidgetItem* treeComp = new QTreeWidgetItem(ui->treeWidgetComponents);
-            treeComp->setText(0, QString::fromStdString(std::to_string(comp->getId())));
-            treeComp->setText(1, QString::fromStdString(comp->getClassname()));
-            treeComp->setText(2, QString::fromStdString(comp->getName()));
-            std::string properties = "";
-            for (auto prop : *comp->getProperties()->list()) {
-                properties += prop->getName() + ":" + prop->getValue() + ", ";
-            }
-            properties = properties.substr(0, properties.length() - 2);
-            treeComp->setText(3, QString::fromStdString(properties));
-        }
-    }
-    ui->treeWidgetComponents->resizeColumnToContents(0);
-    ui->treeWidgetComponents->resizeColumnToContents(1);
-    ui->treeWidgetComponents->resizeColumnToContents(2);
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 3 refactor.
+    _modelInspectorController->actualizeModelComponents(force);
 }
 
 void MainWindow::_actualizeModelTextHasChanged(bool hasChanged) {
@@ -156,31 +135,8 @@ void MainWindow::_actualizeModelTextHasChanged(bool hasChanged) {
 }
 
 void MainWindow::_actualizeModelDataDefinitions(bool force) {
-    Model* m = simulator->getModelManager()->current();
-    ui->treeWidgetDataDefnitions->clear();
-    if (m == nullptr) {
-        return;
-    }
-    for (std::string dataTypename : *m->getDataManager()->getDataDefinitionClassnames()) {
-        for (ModelDataDefinition* comp : *m->getDataManager()->getDataDefinitionList(dataTypename)->list()) {
-            QList<QTreeWidgetItem *> items = ui->treeWidgetDataDefnitions->findItems(QString::fromStdString(std::to_string(comp->getId())), Qt::MatchExactly | Qt::MatchRecursive, 0);
-            if (items.size() == 0) {
-                QTreeWidgetItem* treeComp = new QTreeWidgetItem(ui->treeWidgetDataDefnitions);
-                treeComp->setText(0, QString::fromStdString(std::to_string(comp->getId())));
-                treeComp->setText(1, QString::fromStdString(comp->getClassname()));
-                treeComp->setText(2, QString::fromStdString(comp->getName()));
-                std::string properties = "";
-                for (auto prop : *comp->getProperties()->list()) {
-                    properties += prop->getName() + ":" + prop->getValue() + ", ";
-                }
-                properties = properties.substr(0, properties.length() - 2);
-                treeComp->setText(3, QString::fromStdString(properties));
-            }
-        }
-    }
-    ui->treeWidgetDataDefnitions->resizeColumnToContents(0);
-    ui->treeWidgetDataDefnitions->resizeColumnToContents(1);
-    ui->treeWidgetDataDefnitions->resizeColumnToContents(2);
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 3 refactor.
+    _modelInspectorController->actualizeModelDataDefinitions(force);
 }
 
 void MainWindow::_actualizeGraphicalModel(SimulationEvent * re) {


### PR DESCRIPTION
### Motivation
- Reduce MainWindow responsibility by moving model-inspection and tree/scene sync logic into a focused controller while preserving existing UI behavior and slot signatures.
- Keep Phase 1 and Phase 2 refactors unchanged and provide a narrow, testable API for Phase 3 responsibilities (`Components` tree, `Data Definitions` tree, rename flow, and tree→scene sync).
- Maintain backward compatibility by keeping thin delegating wrappers in `MainWindow` so incremental migration is non-breaking.

### Description
- Added a new controller `ModelInspectorController` with narrow dependencies: `Simulator*`, `QTreeWidget* componentsTree`, `QTreeWidget* dataDefinitionsTree`, and `ModelGraphicsView* graphicsView` in files `controllers/ModelInspectorController.h` and `controllers/ModelInspectorController.cpp`.
- Moved implementations for the following behaviors from `MainWindow` into the controller and preserved the original semantics (use of `findItems`, `resizeColumnToContents`, editable `column == 2`, scene centering, and model updates): `actualizeModelComponents`, `actualizeModelDataDefinitions`, begin/apply data-definition rename flow, and component-tree selection→scene synchronization.
- Kept the original `MainWindow` methods/slots as thin compatibility wrappers that only delegate to the controller and include the required short comment immediately above each delegating line (e.g., `// Keep this wrapper temporarily for compatibility during the incremental Phase 3 refactor.`).
- Added a `std::unique_ptr<ModelInspectorController> _modelInspectorController;` member to `MainWindow` and initialized it in the `MainWindow` constructor after `ui->setupUi(...)`, simulator creation and after `_initModelGraphicsView()` so dependencies are ready.
- Updated `GenesysQtGUI.pro` to include the new `ModelInspectorController.cpp` in `SOURCES` and `ModelInspectorController.h` in `HEADERS`.
- Ensured all newly created or altered code regions include short English comments immediately above each changed/added snippet as required by the Phase 3 commenting policy.

### Testing
- Ran `git -C /workspace/Genesys-Simulator diff --check` to ensure no whitespace or trivial patch problems; it succeeded.
- Verified repository status with `git -C /workspace/Genesys-Simulator status --short` and committed the changes; the commit completed successfully.
- Confirmed commit id and current branch with `git -C /workspace/Genesys-Simulator rev-parse --short HEAD && git -C /workspace/Genesys-Simulator branch --show-current` to document work (commit `4a465e84` on branch `work`).
- No unit tests were present for GUI controller behavior; only repository and sanity checks were executed and succeeded.


## Phase 3 execution report

### What I completed
- Implemented a new `ModelInspectorController` and moved Phase 3 model-inspection/tree-sync logic into it.
- Added `MainWindow` ownership and initialization of the controller and replaced Phase 3 `MainWindow` implementations with thin delegating wrappers.
- Updated `GenesysQtGUI.pro` to include the new controller source and header.
- Included required short English comments above each created or modified code snippet and intentionally stopped at Phase 3.

### What I could not complete
- Work directly on the branch named `WiP20261` because that branch was not available in the local checkout; changes were made on the available branch (`work`).

### Why anything remains incomplete
- The requested branch `WiP20261` was not present in the workspace, so I performed the Phase 3 refactor on the currently-checked-out branch (`work`).

### Files created
- `source/applications/gui/qt/GenesysQtGUI/controllers/ModelInspectorController.h`
- `source/applications/gui/qt/GenesysQtGUI/controllers/ModelInspectorController.cpp`

### Files modified
- `source/applications/gui/qt/GenesysQtGUI/mainwindow.h`
- `source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp`
- `source/applications/gui/qt/GenesysQtGUI/mainwindow_modelrepresentations.cpp`
- `source/applications/gui/qt/GenesysQtGUI/mainwindow_controller.cpp`
- `source/applications/gui/qt/GenesysQtGUI/GenesysQtGUI.pro`

### Phase status
- [ ] Phase 3 incomplete
- [x] Phase 3 complete

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d56a40d2288321918710794e3ec088)