### PR TITLE
Phase 5: Extract plugin catalog into PluginCatalogController

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/GenesysQtGUI.pro
+++ b/source/applications/gui/qt/GenesysQtGUI/GenesysQtGUI.pro
@@ -245,6 +245,8 @@ SOURCES += \
     # Phase-4 GUI refactor controllers for trace and simulation-event responsibilities.
     controllers/TraceConsoleController.cpp \
     controllers/SimulationEventController.cpp \
+    # Phase-5 GUI refactor controller for plugin-catalog responsibilities.
+    controllers/PluginCatalogController.cpp \
     # Phase-1 GUI refactor services for model representations.
     services/ModelLanguageSynchronizer.cpp \
     services/GraphvizModelExporter.cpp \
@@ -566,6 +568,8 @@ HEADERS += \
     # Phase-4 GUI refactor controller headers for trace and simulation-event responsibilities.
     controllers/TraceConsoleController.h \
     controllers/SimulationEventController.h \
+    # Phase-5 GUI refactor controller header for plugin-catalog responsibilities.
+    controllers/PluginCatalogController.h \
     # Phase-1 GUI refactor service headers.
     services/ModelLanguageSynchronizer.h \
     services/GraphvizModelExporter.h \
@@ -705,4 +709,3 @@ DISTFILES += \
 RESOURCES += \
     GenesysQtGUI_resources.qrc \
     propertyeditor/qtpropertybrowser/qtpropertybrowser.qrc
-

--- a/source/applications/gui/qt/GenesysQtGUI/controllers/PluginCatalogController.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/PluginCatalogController.cpp
@@ -1,0 +1,162 @@
+#include "PluginCatalogController.h"
+
+#include "../../../../kernel/simulator/Plugin.h"
+#include "../../../../kernel/simulator/PluginInformation.h"
+#include "../../../../kernel/simulator/Simulator.h"
+
+#include <QBrush>
+#include <QFont>
+#include <QIcon>
+#include <QPlainTextEdit>
+#include <QTreeWidget>
+#include <QTreeWidgetItem>
+
+// Store narrow dependencies for Phase 5 plugin-catalog delegation.
+PluginCatalogController::PluginCatalogController(Simulator* simulator,
+                                                 QTreeWidget* pluginsTree,
+                                                 QPlainTextEdit* modelTextEditor,
+                                                 std::map<std::string, QColor>* pluginCategoryColor)
+    : _simulator(simulator),
+      _pluginsTree(pluginsTree),
+      _modelTextEditor(modelTextEditor),
+      _pluginCategoryColor(pluginCategoryColor) {
+}
+
+// Preserve legacy plugin insertion behavior while keeping MainWindow thin.
+void PluginCatalogController::insertPluginUI(Plugin* plugin) const {
+    if (plugin == nullptr || !plugin->isIsValidPlugin() || _pluginsTree == nullptr) {
+        return;
+    }
+
+    // Keep the legacy plugin metadata formatting for tooltip/status text.
+    QTreeWidgetItem* treeItemChild = new QTreeWidgetItem();
+    std::string plugtextAdds = "[" + plugin->getPluginInfo()->getCategory() + "]: ";
+    if (plugin->getPluginInfo()->isComponent()) {
+        plugtextAdds += " Component";
+        treeItemChild->setIcon(0, QIcon(":/icons3/resources/icons/pack3/ico/component.ico"));
+    } else {
+        plugtextAdds += " DataDefinition";
+        treeItemChild->setIcon(0, QIcon(":/icons3/resources/icons/pack3/ico/calendarred.ico"));
+    }
+    if (plugin->getPluginInfo()->isSink()) {
+        plugtextAdds += ", Sink";
+        treeItemChild->setForeground(0, Qt::blue);
+        treeItemChild->setIcon(0, QIcon(":/icons3/resources/icons/pack3/ico/loadinv.ico"));
+    }
+    if (plugin->getPluginInfo()->isSource()) {
+        plugtextAdds += ", Source";
+        treeItemChild->setForeground(0, Qt::blue);
+        treeItemChild->setIcon(0, QIcon(":/icons3/resources/icons/pack3/ico/load.ico"));
+    }
+    if (plugin->getPluginInfo()->isReceiveTransfer()) {
+        plugtextAdds += ", ReceiveTransfer";
+        treeItemChild->setForeground(0, Qt::blue);
+        treeItemChild->setIcon(0, QIcon(":/icons3/resources/icons/pack3/ico/load.ico"));
+    }
+    if (plugin->getPluginInfo()->isSendTransfer()) {
+        plugtextAdds += ", SendTransfer";
+        treeItemChild->setForeground(0, Qt::blue);
+        treeItemChild->setIcon(0, QIcon(":/icons3/resources/icons/pack3/ico/loadinv.ico"));
+    }
+    plugtextAdds += "\n\nDescrption: " + plugin->getPluginInfo()->getDescriptionHelp();
+    plugtextAdds += "\n\nTemplate: " + plugin->getPluginInfo()->getLanguageTemplate() + " (double click to add to model)";
+
+    // Preserve the component/data-definition category routing logic.
+    QString category = plugin->getPluginInfo()->isComponent()
+            ? QString::fromStdString(plugin->getPluginInfo()->getCategory())
+            : "Data Definition";
+    QTreeWidgetItem* treeRootItem = ensureCategoryRoot(category, plugin->getPluginInfo()->getCategory());
+    if (treeRootItem == nullptr) {
+        delete treeItemChild;
+        return;
+    }
+
+    // Keep legacy icon color selection based on root category color.
+    if (plugin->getPluginInfo()->isComponent()
+            && !plugin->getPluginInfo()->isSendTransfer()
+            && !plugin->getPluginInfo()->isReceiveTransfer()
+            && !plugin->getPluginInfo()->isSink()
+            && !plugin->getPluginInfo()->isSource()) {
+        const QColor rootColor = treeRootItem->background(0).color();
+        if (rootColor.blue() < 32 && rootColor.green() < 32 && rootColor.red() < 32) {
+            treeItemChild->setIcon(0, QIcon(":/icons3/resources/icons/pack3/ico/componentblack.ico"));
+        } else if (rootColor.red() >= rootColor.blue() && rootColor.red() > rootColor.green()) {
+            treeItemChild->setIcon(0, QIcon(":/icons3/resources/icons/pack3/ico/componentred.ico"));
+        } else if (rootColor.blue() > rootColor.red() && rootColor.blue() > rootColor.green()) {
+            treeItemChild->setIcon(0, QIcon(":/icons3/resources/icons/pack3/ico/componentblue.ico"));
+        } else if (rootColor.red() > rootColor.blue() && rootColor.green() > rootColor.blue()) {
+            treeItemChild->setIcon(0, QIcon(":/icons3/resources/icons/pack3/ico/componentyellow.ico"));
+        }
+    }
+
+    // Keep plugin metadata fields used by drag/drop and tooltip/status interactions.
+    treeItemChild->setWhatsThis(0, QString::fromStdString(plugin->getPluginInfo()->getPluginTypename()));
+    treeItemChild->setText(0, QString::fromStdString(plugin->getPluginInfo()->getPluginTypename()));
+    treeItemChild->setToolTip(0, QString::fromStdString(plugtextAdds));
+    treeItemChild->setStatusTip(0, QString::fromStdString(plugin->getPluginInfo()->getLanguageTemplate()));
+    treeRootItem->addChild(treeItemChild);
+}
+
+// Keep fake-plugin entry point available even when no fake plugins are inserted.
+void PluginCatalogController::insertFakePlugins() const {
+}
+
+// Preserve plugin-tree expansion behavior for non-text-editing mode.
+void PluginCatalogController::handlePluginItemDoubleClicked(QTreeWidgetItem* item, int column) const {
+    Q_UNUSED(column);
+    if (_pluginsTree == nullptr || item == nullptr) {
+        return;
+    }
+    if (_modelTextEditor != nullptr && _modelTextEditor->isEnabled()) {
+        return;
+    }
+    for (int i = 0; i < _pluginsTree->topLevelItemCount(); i++) {
+        _pluginsTree->topLevelItem(i)->setExpanded(false);
+    }
+    _pluginsTree->expandItem(item);
+}
+
+// Keep single-click handler as a no-op to preserve current behavior.
+void PluginCatalogController::handlePluginItemClicked(QTreeWidgetItem* item, int column) const {
+    Q_UNUSED(item);
+    Q_UNUSED(column);
+}
+
+// Create category roots with the same legacy names, colors, and map updates.
+QTreeWidgetItem* PluginCatalogController::ensureCategoryRoot(const QString& category, const std::string& pluginCategoryName) const {
+    if (_pluginsTree == nullptr) {
+        return nullptr;
+    }
+    QList<QTreeWidgetItem*> founds = _pluginsTree->findItems(category, Qt::MatchContains);
+    if (founds.size() != 0) {
+        return *founds.begin();
+    }
+
+    // Keep the legacy category-root visual formatting.
+    QTreeWidgetItem* treeRootItem = new QTreeWidgetItem(_pluginsTree);
+    treeRootItem->setText(0, category);
+    treeRootItem->setForeground(0, QBrush(Qt::white));
+    QBrush bbackground(Qt::black);
+    if (category == "Data Definition") {
+        bbackground.setColor(Qt::darkRed);
+    } else if (category == "Discrete Processing") {
+        bbackground.setColor(Qt::darkGreen);
+    } else if (category == "Decisions") {
+        bbackground.setColor(Qt::darkYellow);
+    } else if (category == "Grouping") {
+        bbackground.setColor(Qt::magenta);
+    } else if (category == "Input Output") {
+        bbackground.setColor(Qt::darkCyan);
+    } else if (category == "Material Handling") {
+        bbackground.setColor(Qt::darkBlue);
+    }
+    treeRootItem->setBackground(0, bbackground);
+    treeRootItem->setFont(0, QFont("Nimbus Sans", 12, QFont::Bold));
+    treeRootItem->setExpanded(false);
+
+    // Preserve category-color map updates for graphical-model integration.
+    if (_pluginCategoryColor != nullptr && pluginCategoryName == category.toStdString()) {
+        _pluginCategoryColor->insert({pluginCategoryName, bbackground.color()});
+    }
+    return treeRootItem;
+}

--- a/source/applications/gui/qt/GenesysQtGUI/controllers/PluginCatalogController.h
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/PluginCatalogController.h
@@ -1,0 +1,45 @@
+#ifndef PLUGINCATALOGCONTROLLER_H
+#define PLUGINCATALOGCONTROLLER_H
+
+#include <map>
+#include <string>
+
+#include <QColor>
+
+class Plugin;
+class Simulator;
+class QPlainTextEdit;
+class QString;
+class QTreeWidget;
+class QTreeWidgetItem;
+
+// Encapsulate Phase 5 plugin-catalog and plugin-palette UI behavior.
+class PluginCatalogController {
+public:
+    // Inject only the dependencies required to manage plugin catalog UI behavior.
+    PluginCatalogController(Simulator* simulator,
+                            QTreeWidget* pluginsTree,
+                            QPlainTextEdit* modelTextEditor,
+                            std::map<std::string, QColor>* pluginCategoryColor);
+
+    // Populate plugin-tree entries while preserving legacy visual behavior.
+    void insertPluginUI(Plugin* plugin) const;
+    // Keep fake plugin insertion extension point for compatibility.
+    void insertFakePlugins() const;
+    // Handle plugin-tree double-click behavior delegated from MainWindow.
+    void handlePluginItemDoubleClicked(QTreeWidgetItem* item, int column) const;
+    // Handle plugin-tree single-click behavior delegated from MainWindow.
+    void handlePluginItemClicked(QTreeWidgetItem* item, int column) const;
+
+private:
+    // Resolve or create the category root item with legacy styling and colors.
+    QTreeWidgetItem* ensureCategoryRoot(const QString& category, const std::string& pluginCategoryName) const;
+
+private:
+    Simulator* _simulator;
+    QTreeWidget* _pluginsTree;
+    QPlainTextEdit* _modelTextEditor;
+    std::map<std::string, QColor>* _pluginCategoryColor;
+};
+
+#endif /* PLUGINCATALOGCONTROLLER_H */

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
@@ -15,6 +15,8 @@
 #include "controllers/ModelInspectorController.h"
 #include "controllers/TraceConsoleController.h"
 #include "controllers/SimulationEventController.h"
+// Add Phase 5 controller include for plugin-catalog responsibilities.
+#include "controllers/PluginCatalogController.h"
 #include "services/ModelLanguageSynchronizer.h"
 #include "services/GraphvizModelExporter.h"
 #include "services/CppModelExporter.h"
@@ -219,6 +221,11 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
             [this](bool force) { _actualizeDebugEntities(force); },
             [this](bool force) { _actualizeDebugVariables(force); },
             [this](SimulationEvent* re) { _actualizeGraphicalModel(re); }});
+    // Initialize the Phase 5 plugin-catalog controller after simulator and plugin-tree dependencies are ready.
+    _pluginCatalogController = std::make_unique<PluginCatalogController>(simulator,
+                                                                         ui->treeWidget_Plugins,
+                                                                         ui->TextCodeEditor,
+                                                                         _pluginCategoryColor);
     // Initialize Phase 2 services using narrow dependencies and compatibility callbacks.
     _graphicalModelBuilder = std::make_unique<GraphicalModelBuilder>(simulator,
                                                                       ui->graphicsView,

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.h
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.h
@@ -33,6 +33,7 @@ class GraphicalModelBuilder;
 class ModelInspectorController;
 class TraceConsoleController;
 class SimulationEventController;
+class PluginCatalogController;
 
 /**
  * @brief Main Qt window of Genesys GUI.
@@ -297,6 +298,8 @@ private: // interface and model main elements to join
     std::unique_ptr<TraceConsoleController> _traceConsoleController;
     // Add the Phase 4 simulation-event controller owned by MainWindow.
     std::unique_ptr<SimulationEventController> _simulationEventController;
+    // Add the Phase 5 plugin-catalog controller owned by MainWindow.
+    std::unique_ptr<PluginCatalogController> _pluginCatalogController;
 	PropertyEditorGenesys* propertyGenesys;
     std::map<SimulationControl*, DataComponentProperty*>* propertyList;
     std::map<SimulationControl*, DataComponentEditor*>* propertyEditorUI;

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow_controller.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow_controller.cpp
@@ -2,6 +2,8 @@
 #include "ui_mainwindow.h"
 // Include the Phase 3 controller interface required by compatibility wrappers.
 #include "controllers/ModelInspectorController.h"
+// Include the Phase 5 controller interface required by plugin-tree wrappers.
+#include "controllers/PluginCatalogController.h"
 
 #include "dialogs/dialogBreakpoint.h"
 #include "dialogs/Dialogmodelinformation.h"
@@ -1721,37 +1723,8 @@ void MainWindow::on_tabWidgetCentral_tabBarClicked(int index) {
 }
 
 void MainWindow::on_treeWidget_Plugins_itemDoubleClicked(QTreeWidgetItem *item, int column) {
-    if (ui->TextCodeEditor->isEnabled()) { // add text to modelsimulation
-        /*
-        if (item->toolTip(0).contains("DataDefinition")) {
-            QTextCursor cursor = ui->TextCodeEditor->textCursor();
-            QTextCursor cursorSaved = cursor;
-            cursor.movePosition(QTextCursor::Start);
-            ui->TextCodeEditor->setTextCursor(cursor);
-            if (ui->TextCodeEditor->find("# Model Components")) {
-                ui->TextCodeEditor->moveCursor(QTextCursor::MoveOperation::Left, QTextCursor::MoveMode::MoveAnchor);
-                ui->TextCodeEditor->moveCursor(QTextCursor::MoveOperation::Up, QTextCursor::MoveMode::MoveAnchor);
-                ui->TextCodeEditor->insertPlainText(item->statusTip(0) + "\n");
-            } else {
-                ui->TextCodeEditor->appendPlainText(item->statusTip(0));
-            }
-        } else {
-            ui->TextCodeEditor->appendPlainText(item->statusTip(0));
-        }
-         */
-    } else {
-        // treeRoot? Always?
-        for (int i = 0; i < ui->treeWidget_Plugins->topLevelItemCount(); i++) {
-            //if (ui->treeWidget_Plugins->topLevelItem(i) != item) {
-            ui->treeWidget_Plugins->topLevelItem(i)->setExpanded(false);
-            //} else {
-            //	ui->treeWidget_Plugins->expandItem(item);
-            //	//ui->treeWidget_Plugins->topLevelItem(i)->setExpanded(true);
-            //}
-        }
-        //ui->treeWidget_Plugins->setAnimated(true);
-        ui->treeWidget_Plugins->expandItem(item);
-    }
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 5 refactor.
+    _pluginCatalogController->handlePluginItemDoubleClicked(item, column);
 }
 
 void MainWindow::on_graphicsView_rubberBandChanged(const QRect &viewportRect, const QPointF &fromScenePoint, const QPointF &toScenePoint) {
@@ -1891,7 +1864,8 @@ void MainWindow::on_treeWidgetComponents_itemSelectionChanged() {
 }
 
 void MainWindow::on_treeWidget_Plugins_itemClicked(QTreeWidgetItem *item, int column) {
-    //showMessageNotImplemented();
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 5 refactor.
+    _pluginCatalogController->handlePluginItemClicked(item, column);
 }
 
 void MainWindow::on_TextCodeEditor_textChanged() {

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow_simulator.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow_simulator.cpp
@@ -3,6 +3,8 @@
 // Include dedicated Phase 4 controllers used by simulator compatibility wrappers.
 #include "controllers/TraceConsoleController.h"
 #include "controllers/SimulationEventController.h"
+// Include the Phase 5 controller used by plugin-catalog compatibility wrappers.
+#include "controllers/PluginCatalogController.h"
 
 
 //-------------------------
@@ -100,110 +102,11 @@ void MainWindow::_setOnEventHandlers() {
 //-------------------------
 
 void MainWindow::_insertPluginUI(Plugin * plugin) {
-    if (plugin != nullptr) {
-        if (plugin->isIsValidPlugin()) {
-            QTreeWidgetItem *treeItemChild = new QTreeWidgetItem();
-            //QTreeWidgetItem *treeItem = new QTreeWidgetItem; //(ui->treeWidget_Plugins);
-            std::string plugtextAdds = "[" + plugin->getPluginInfo()->getCategory() + "]: ";
-            QBrush brush;
-            if (plugin->getPluginInfo()->isComponent()) {
-                plugtextAdds += " Component";
-                //brush.setColor(Qt::white);
-                //treeItemChild->setBackground(brush);
-                //treeItemChild->setBackgroundColor(Qt::white);
-                treeItemChild->setIcon(0, QIcon(":/icons3/resources/icons/pack3/ico/component.ico"));
-            } else {
-                plugtextAdds += " DataDefinition";
-                //brush.setColor(Qt::lightGray);
-                //treeItemChild->setBackground(brush);
-                //treeItemChild->setBackgroundColor(Qt::lightGray);
-                treeItemChild->setIcon(0, QIcon(":/icons3/resources/icons/pack3/ico/calendarred.ico"));
-                //treeItemChild->setFont(QFont::Style::StyleItalic);
-            }
-            if (plugin->getPluginInfo()->isSink()) {
-                plugtextAdds += ", Sink";
-                treeItemChild->setForeground(0, Qt::blue); //setTextColor(0, Qt::blue);
-                treeItemChild->setIcon(0, QIcon(":/icons3/resources/icons/pack3/ico/loadinv.ico"));
-            }
-            if (plugin->getPluginInfo()->isSource()) {
-                plugtextAdds += ", Source";
-                treeItemChild->setForeground(0, Qt::blue); //setTextColor(0, Qt::blue);
-                treeItemChild->setIcon(0, QIcon(":/icons3/resources/icons/pack3/ico/load.ico"));
-            }
-            if (plugin->getPluginInfo()->isReceiveTransfer()) {
-                plugtextAdds += ", ReceiveTransfer";
-                treeItemChild->setForeground(0, Qt::blue); //setTextColor(0, Qt::blue);
-                treeItemChild->setIcon(0, QIcon(":/icons3/resources/icons/pack3/ico/load.ico"));
-            }
-            if (plugin->getPluginInfo()->isSendTransfer()) {
-                plugtextAdds += ", SendTransfer";
-                treeItemChild->setForeground(0, Qt::blue); //setTextColor(0, Qt::blue);
-                treeItemChild->setIcon(0, QIcon(":/icons3/resources/icons/pack3/ico/loadinv.ico"));
-            }
-            //treeItem->setText(0,QString::fromStdString(plugtextAdds));
-            plugtextAdds += "\n\nDescrption: " + plugin->getPluginInfo()->getDescriptionHelp();
-            plugtextAdds += "\n\nTemplate: " + plugin->getPluginInfo()->getLanguageTemplate() + " (double click to add to model)";
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 5 refactor.
+    _pluginCatalogController->insertPluginUI(plugin);
+}
 
-            QTreeWidgetItem *treeRootItem;
-            QString category;
-            if (plugin->getPluginInfo()->isComponent())
-                category = QString::fromStdString(plugin->getPluginInfo()->getCategory());
-            else
-                category = "Data Definition";
-            QList<QTreeWidgetItem*> founds = ui->treeWidget_Plugins->findItems(category, Qt::MatchContains);
-            if (founds.size() == 0) {
-                QFont font("Nimbus Sans", 12, QFont::Bold);
-                treeRootItem = new QTreeWidgetItem(ui->treeWidget_Plugins);
-                treeRootItem->setText(0, category);
-                QBrush bforeground(Qt::white);
-                treeRootItem->setForeground(0, bforeground);
-                QBrush bbackground(Qt::black);
-                if (category == "Data Definition") {
-                    bbackground.setColor(Qt::darkRed);
-                } else if (category == "Discrete Processing") {
-                    bbackground.setColor(Qt::darkGreen);
-                } else if (category == "Decisions") {
-                    bbackground.setColor(Qt::darkYellow);
-                } else if (category == "Grouping") {
-                    bbackground.setColor(Qt::magenta);
-                } else if (category == "Input Output") {
-                    bbackground.setColor(Qt::darkCyan);
-                } else if (category == "Material Handling") {
-                    bbackground.setColor(Qt::darkBlue);
-                }
-                treeRootItem->setBackground(0, bbackground);
-                treeRootItem->setFont(0, font);
-                treeRootItem->setExpanded(false); //(true);
-                //treeRootItem->sortChildren(0, Qt::AscendingOrder);
-                if (plugin->getPluginInfo()->getCategory() == category.toStdString()) {
-                    _pluginCategoryColor->insert({plugin->getPluginInfo()->getCategory(), bbackground.color()});
-                }
-            } else {
-                treeRootItem = *founds.begin();
-            }
-            if (plugin->getPluginInfo()->isComponent() && !plugin->getPluginInfo()->isSendTransfer() && !plugin->getPluginInfo()->isReceiveTransfer() && !plugin->getPluginInfo()->isSink() && !plugin->getPluginInfo()->isSource()) {
-                if (treeRootItem->background(0).color().blue() < 32 && treeRootItem->background(0).color().green() < 32 && treeRootItem->background(0).color().red() < 32) {
-                    treeItemChild->setIcon(0, QIcon(":/icons3/resources/icons/pack3/ico/componentblack.ico"));
-                } else if (treeRootItem->background(0).color().red() >= treeRootItem->background(0).color().blue() &&
-                           treeRootItem->background(0).color().red() > treeRootItem->background(0).color().green()) {
-                    treeItemChild->setIcon(0, QIcon(":/icons3/resources/icons/pack3/ico/componentred.ico"));
-                } else if (treeRootItem->background(0).color().blue() > treeRootItem->background(0).color().red() &&
-                           treeRootItem->background(0).color().blue() > treeRootItem->background(0).color().green()) {
-                    treeItemChild->setIcon(0, QIcon(":/icons3/resources/icons/pack3/ico/componentblue.ico"));
-                } else if (treeRootItem->background(0).color().red() > treeRootItem->background(0).color().blue() &&
-                           treeRootItem->background(0).color().green() > treeRootItem->background(0).color().blue()) {
-                    treeItemChild->setIcon(0, QIcon(":/icons3/resources/icons/pack3/ico/componentyellow.ico"));
-                }
-            }
-            treeItemChild->setWhatsThis(0, QString::fromStdString(plugin->getPluginInfo()->getPluginTypename()));
-            /* TODO: Qt6 has no more setTextColor */
-            //treeItemChild->setTextColor(0, treeRootItem->background(0).color());
-            //treeItemChild->setTextColor(0, treeRootItem->backgroundColor(0));
-            treeItemChild->setText(0, QString::fromStdString(plugin->getPluginInfo()->getPluginTypename()));
-            treeItemChild->setToolTip(0, QString::fromStdString(plugtextAdds));
-            treeItemChild->setStatusTip(0, QString::fromStdString(plugin->getPluginInfo()->getLanguageTemplate()));
-            //treeItemChild->setFlags(Qt::ItemIsSelectable | Qt::ItemIsDragEnabled | Qt::ItemNeverHasChildren);
-            treeRootItem->addChild(treeItemChild);
-        }
-    }
+void MainWindow::_insertFakePlugins() {
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 5 refactor.
+    _pluginCatalogController->insertFakePlugins();
 }


### PR DESCRIPTION
### Motivation
- Reduce MainWindow responsibilities by moving plugin-catalog / plugin-palette UI logic into a dedicated controller while preserving existing behavior and slot signatures. 
- Preserve category roots, colors, icons, tooltips/status-tip/whatsThis metadata and expand/collapse behavior used by the plugin tree. 
- Provide a narrow, testable API to support future refactors without touching unrelated subsystems (lifecycle, clipboard, scene, etc.).

### Description
- Added a new controller `PluginCatalogController` (header + implementation) that encapsulates plugin-tree population and interaction handling, including category-root creation and category-color map updates. The controller files are `controllers/PluginCatalogController.h` and `controllers/PluginCatalogController.cpp` and implement the public API `insertPluginUI`, `insertFakePlugins`, `handlePluginItemDoubleClicked`, and `handlePluginItemClicked`.
- Moved the real plugin-insertion and plugin-tree double/single-click logic out of `MainWindow` into `PluginCatalogController` while preserving the original visual/metadata behavior and icon-selection rules.
- Kept thin MainWindow compatibility wrappers for Phase 5 methods so external call sites and slot signatures remain stable; wrappers simply delegate to the controller and include short explanatory comments. The wrapped methods are `_insertPluginUI(Plugin*)`, `_insertFakePlugins()`, `on_treeWidget_Plugins_itemDoubleClicked(...)`, and `on_treeWidget_Plugins_itemClicked(...)`.
- Made `MainWindow` own the controller via `std::unique_ptr<PluginCatalogController> _pluginCatalogController;` and initialized it in the constructor after `ui->setupUi(this)`, simulator creation and the plugin-tree/category-color map are available; kept constructor dependency injection narrow (simulator, `ui->treeWidget_Plugins`, `ui->TextCodeEditor`, `_pluginCategoryColor`).
- Updated `GenesysQtGUI.pro` to include the new controller in `SOURCES` and `HEADERS`.
- All created or modified code blocks include a short English comment immediately above each new or changed region describing intent (per mandated commenting policy).

Files created
- `source/applications/gui/qt/GenesysQtGUI/controllers/PluginCatalogController.h`
- `source/applications/gui/qt/GenesysQtGUI/controllers/PluginCatalogController.cpp`

Files modified
- `source/applications/gui/qt/GenesysQtGUI/mainwindow.h` (controller member + forward declaration)
- `source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp` (controller include + initialization)
- `source/applications/gui/qt/GenesysQtGUI/mainwindow_simulator.cpp` (compatibility wrappers for plugin insertion)
- `source/applications/gui/qt/GenesysQtGUI/mainwindow_controller.cpp` (compatibility wrappers for plugin-tree slots)
- `source/applications/gui/qt/GenesysQtGUI/GenesysQtGUI.pro` (added controller source/header entries)

### Testing
- Ran static checks and repository inspections: `git diff --check` succeeded and reported no whitespace or index errors. (passed)
- Verified wrappers and delegation by grepping for moved symbols and confirming that `_insertPluginUI`, `_insertFakePlugins`, `on_treeWidget_Plugins_itemDoubleClicked` and `on_treeWidget_Plugins_itemClicked` in `MainWindow` now only delegate to `_pluginCatalogController` (manual code inspection via `rg`/`sed`). (passed)
- Committed the changes locally and created a commit (`Phase 5: extract plugin catalog UI controller`). (passed)
- No full project compile or runtime tests were executed in this environment; no unit tests were added in this PR.

Notes and constraints
- Work intentionally stops at Phase 5; no lifecycle, clipboard, scene, or broad controller decomposition beyond plugin-catalog responsibilities was touched. 
- Compatibility wrappers remain in `MainWindow` by design and are thin delegating functions. 
- The branch `WiP20261` requested was not available in the environment, so changes were applied to the current local branch; this is intentional and reported in the execution report below.

```markdown
## Phase 5 execution report

### What I completed
- Created `PluginCatalogController.h/.cpp` and moved plugin-catalog/plugin-palette logic into it (`insertPluginUI`, category root/color behavior, click/double-click handlers).
- Added `MainWindow` ownership for the new controller and initialized it in the constructor with narrow dependencies.
- Converted `_insertPluginUI`, `_insertFakePlugins`, `on_treeWidget_Plugins_itemDoubleClicked`, and `on_treeWidget_Plugins_itemClicked` into thin compatibility wrappers that delegate to `PluginCatalogController`.
- Updated `GenesysQtGUI.pro` to include new Phase 5 controller source/header files.
- Added short English comments immediately above all created/modified code regions.
- Committed changes and created PR metadata via `make_pr`.

### What I could not complete
- I could not validate against a local branch literally named `WiP20261` because it is not present in this environment.

### Why anything remains incomplete
- The environment has only branch `work`; there is no `WiP20261` ref available locally to check out.

### Files created
- source/applications/gui/qt/GenesysQtGUI/controllers/PluginCatalogController.h
- source/applications/gui/qt/GenesysQtGUI/controllers/PluginCatalogController.cpp

### Files modified
- source/applications/gui/qt/GenesysQtGUI/mainwindow.h
- source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
- source/applications/gui/qt/GenesysQtGUI/mainwindow_simulator.cpp
- source/applications/gui/qt/GenesysQtGUI/mainwindow_controller.cpp
- source/applications/gui/qt/GenesysQtGUI/GenesysQtGUI.pro

### Phase status
- [ ] Phase 5 incomplete
- [x] Phase 5 complete
```

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d572bf6b8c8321a35412fb7e5e6055)