### PR TITLE
Phase 6: extract PropertyEditorController and harden ObjectPropertyBrowser

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/GenesysQtGUI.pro
+++ b/source/applications/gui/qt/GenesysQtGUI/GenesysQtGUI.pro
@@ -247,6 +247,8 @@ SOURCES += \
     controllers/SimulationEventController.cpp \
     # Phase-5 GUI refactor controller for plugin-catalog responsibilities.
     controllers/PluginCatalogController.cpp \
+    # Phase-6 GUI refactor controller for property-editor responsibilities.
+    controllers/PropertyEditorController.cpp \
     # Phase-1 GUI refactor services for model representations.
     services/ModelLanguageSynchronizer.cpp \
     services/GraphvizModelExporter.cpp \
@@ -570,6 +572,8 @@ HEADERS += \
     controllers/SimulationEventController.h \
     # Phase-5 GUI refactor controller header for plugin-catalog responsibilities.
     controllers/PluginCatalogController.h \
+    # Phase-6 GUI refactor controller header for property-editor responsibilities.
+    controllers/PropertyEditorController.h \
     # Phase-1 GUI refactor service headers.
     services/ModelLanguageSynchronizer.h \
     services/GraphvizModelExporter.h \

--- a/source/applications/gui/qt/GenesysQtGUI/controllers/PropertyEditorController.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/PropertyEditorController.cpp
@@ -1,0 +1,120 @@
+#include "PropertyEditorController.h"
+
+#include "graphicals/ModelGraphicsView.h"
+#include "graphicals/ModelGraphicsScene.h"
+#include "graphicals/GraphicalModelComponent.h"
+#include "propertyeditor/ObjectPropertyBrowser.h"
+
+#include <QGraphicsItem>
+#include <QDebug>
+
+// Build the Phase 6 controller with narrow dependencies for property-editor orchestration.
+PropertyEditorController::PropertyEditorController(
+    ObjectPropertyBrowser* propertyBrowser,
+    ModelGraphicsView* graphicsView,
+    PropertyEditorGenesys* propertyGenesys,
+    std::map<SimulationControl*, DataComponentProperty*>* propertyList,
+    std::map<SimulationControl*, DataComponentEditor*>* propertyEditorUI,
+    std::map<SimulationControl*, ComboBoxEnum*>* propertyBox,
+    std::function<void()> actualizeModelSimLanguage,
+    std::function<void(bool)> actualizeModelComponents,
+    std::function<void(bool)> actualizeModelDataDefinitions,
+    std::function<void()> actualizeModelCppCode,
+    std::function<bool()> createModelImage,
+    std::function<void()> actualizeTabPanes,
+    std::function<void()> actualizeActions)
+    : _propertyBrowser(propertyBrowser),
+      _graphicsView(graphicsView),
+      _propertyGenesys(propertyGenesys),
+      _propertyList(propertyList),
+      _propertyEditorUI(propertyEditorUI),
+      _propertyBox(propertyBox),
+      _actualizeModelSimLanguage(std::move(actualizeModelSimLanguage)),
+      _actualizeModelComponents(std::move(actualizeModelComponents)),
+      _actualizeModelDataDefinitions(std::move(actualizeModelDataDefinitions)),
+      _actualizeModelCppCode(std::move(actualizeModelCppCode)),
+      _createModelImage(std::move(createModelImage)),
+      _actualizeTabPanes(std::move(actualizeTabPanes)),
+      _actualizeActions(std::move(actualizeActions)) {
+}
+
+// Keep property-browser cleanup centralized so stale selection bindings are removed safely.
+void PropertyEditorController::clearPropertyEditorSelection() const {
+    if (_propertyBrowser == nullptr) {
+        return;
+    }
+
+    _propertyBrowser->clearCurrentlyConnectedObject();
+    _propertyBrowser->clear();
+}
+
+// Preserve legacy single-selection behavior while moving orchestration out of MainWindow.
+void PropertyEditorController::sceneSelectionChanged() const {
+    if (_graphicsView == nullptr || _propertyBrowser == nullptr) {
+        return;
+    }
+
+    const QList<QGraphicsItem*> selectedItems = _graphicsView->selectedItems();
+    if (selectedItems.size() == 1) {
+        QGraphicsItem* item = selectedItems.at(0);
+        GraphicalModelComponent* gmc = dynamic_cast<GraphicalModelComponent*>(item);
+        if (gmc != nullptr) {
+            _propertyBrowser->setActiveObject(
+                gmc,
+                gmc->getComponent(),
+                _propertyGenesys,
+                _propertyList,
+                _propertyEditorUI,
+                _propertyBox);
+            return;
+        }
+    }
+
+    // Clear bindings when none or multiple scene items are selected.
+    clearPropertyEditorSelection();
+    if (_actualizeActions) {
+        _actualizeActions();
+    }
+}
+
+// Preserve the existing post-edit cascade while preventing stale scene pointer reuse.
+void PropertyEditorController::onPropertyEditorModelChanged() const {
+    if (_actualizeModelSimLanguage) {
+        _actualizeModelSimLanguage();
+    }
+    if (_actualizeModelComponents) {
+        _actualizeModelComponents(true);
+    }
+    if (_actualizeModelDataDefinitions) {
+        _actualizeModelDataDefinitions(true);
+    }
+    if (_actualizeModelCppCode) {
+        _actualizeModelCppCode();
+    }
+    if (_createModelImage) {
+        _createModelImage();
+    }
+    if (_actualizeTabPanes) {
+        _actualizeTabPanes();
+    }
+
+    ModelGraphicsScene* scene = (_graphicsView != nullptr) ? _graphicsView->getScene() : nullptr;
+    if (scene == nullptr) {
+        qWarning() << "Skipping property-editor scene refresh because scene is null";
+        return;
+    }
+
+    scene->actualizeDiagramArrows();
+    scene->update();
+
+    if (scene->existDiagram()) {
+        const bool wasVisible = scene->visibleDiagram();
+        scene->destroyDiagram();
+        scene->createDiagrams();
+        if (wasVisible) {
+            scene->showDiagrams();
+        } else {
+            scene->hideDiagrams();
+        }
+    }
+}

--- a/source/applications/gui/qt/GenesysQtGUI/controllers/PropertyEditorController.h
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/PropertyEditorController.h
@@ -1,0 +1,61 @@
+#ifndef PROPERTYEDITORCONTROLLER_H
+#define PROPERTYEDITORCONTROLLER_H
+
+#include <functional>
+#include <map>
+
+class ObjectPropertyBrowser;
+class ModelGraphicsView;
+class PropertyEditorGenesys;
+class SimulationControl;
+class DataComponentProperty;
+class DataComponentEditor;
+class ComboBoxEnum;
+
+// Encapsulate Phase 6 property-editor and scene-selection orchestration outside MainWindow.
+class PropertyEditorController {
+public:
+    // Inject only the property-editor dependencies needed by the Phase 6 flow.
+    PropertyEditorController(ObjectPropertyBrowser* propertyBrowser,
+                             ModelGraphicsView* graphicsView,
+                             PropertyEditorGenesys* propertyGenesys,
+                             std::map<SimulationControl*, DataComponentProperty*>* propertyList,
+                             std::map<SimulationControl*, DataComponentEditor*>* propertyEditorUI,
+                             std::map<SimulationControl*, ComboBoxEnum*>* propertyBox,
+                             std::function<void()> actualizeModelSimLanguage,
+                             std::function<void(bool)> actualizeModelComponents,
+                             std::function<void(bool)> actualizeModelDataDefinitions,
+                             std::function<void()> actualizeModelCppCode,
+                             std::function<bool()> createModelImage,
+                             std::function<void()> actualizeTabPanes,
+                             std::function<void()> actualizeActions);
+
+    // Synchronize current scene selection into the property editor safely.
+    void sceneSelectionChanged() const;
+    // Execute the post-edit model/UI update cascade safely.
+    void onPropertyEditorModelChanged() const;
+    // Clear property editor selection and bindings defensively.
+    void clearPropertyEditorSelection() const;
+
+private:
+    // Keep direct access to the property browser used by this controller.
+    ObjectPropertyBrowser* _propertyBrowser;
+    // Keep direct access to the graphical view used for selection inspection.
+    ModelGraphicsView* _graphicsView;
+    // Keep direct access to property-editor dependencies required for activation.
+    PropertyEditorGenesys* _propertyGenesys;
+    std::map<SimulationControl*, DataComponentProperty*>* _propertyList;
+    std::map<SimulationControl*, DataComponentEditor*>* _propertyEditorUI;
+    std::map<SimulationControl*, ComboBoxEnum*>* _propertyBox;
+
+    // Keep narrow callbacks for MainWindow-owned update methods.
+    std::function<void()> _actualizeModelSimLanguage;
+    std::function<void(bool)> _actualizeModelComponents;
+    std::function<void(bool)> _actualizeModelDataDefinitions;
+    std::function<void()> _actualizeModelCppCode;
+    std::function<bool()> _createModelImage;
+    std::function<void()> _actualizeTabPanes;
+    std::function<void()> _actualizeActions;
+};
+
+#endif // PROPERTYEDITORCONTROLLER_H

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
@@ -17,6 +17,8 @@
 #include "controllers/SimulationEventController.h"
 // Add Phase 5 controller include for plugin-catalog responsibilities.
 #include "controllers/PluginCatalogController.h"
+// Add Phase 6 controller include for property-editor and scene-selection orchestration.
+#include "controllers/PropertyEditorController.h"
 #include "services/ModelLanguageSynchronizer.h"
 #include "services/GraphvizModelExporter.h"
 #include "services/CppModelExporter.h"
@@ -255,6 +257,22 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
     //
     // property editor
     ui->treeViewPropertyEditor->setAlternatingRowColors(true);
+    // Initialize the Phase 6 property-editor controller after view/editor dependencies are available.
+    _propertyEditorController = std::make_unique<PropertyEditorController>(
+        ui->treeViewPropertyEditor,
+        ui->graphicsView,
+        propertyGenesys,
+        propertyList,
+        propertyEditorUI,
+        propertyBox,
+        [this]() { _actualizeModelSimLanguage(); },
+        [this](bool force) { _actualizeModelComponents(force); },
+        [this](bool force) { _actualizeModelDataDefinitions(force); },
+        [this]() { _actualizeModelCppCode(); },
+        [this]() { return _createModelImage(); },
+        [this]() { _actualizeTabPanes(); },
+        [this]() { _actualizeActions(); });
+    // Keep callback wiring in MainWindow while delegating behavior to the Phase 6 controller.
     ui->treeViewPropertyEditor->setModelChangedCallback([this]() {
         this->_onPropertyEditorModelChanged();
     });
@@ -353,30 +371,9 @@ ModelGraphicsScene* MainWindow::myScene() const {
 }
 
 void MainWindow::_onPropertyEditorModelChanged() {
-    _actualizeModelSimLanguage();
-    _actualizeModelComponents(true);
-    _actualizeModelDataDefinitions(true);
-    _actualizeModelCppCode();
-    _createModelImage();
-    _actualizeTabPanes();
-
-    ModelGraphicsScene* scene = myScene();
-    if (scene == nullptr) {
-        return;
-    }
-
-    scene->actualizeDiagramArrows();
-    scene->update();
-
-    if (scene->existDiagram()) {
-        const bool wasVisible = scene->visibleDiagram();
-        scene->destroyDiagram();
-        scene->createDiagrams();
-        if (wasVisible) {
-            scene->showDiagrams();
-        } else {
-            scene->hideDiagrams();
-        }
+    // Keep this wrapper for compatibility during the incremental Phase 6 refactor.
+    if (_propertyEditorController != nullptr) {
+        _propertyEditorController->onPropertyEditorModelChanged();
     }
 }
 

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.h
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.h
@@ -34,6 +34,7 @@ class ModelInspectorController;
 class TraceConsoleController;
 class SimulationEventController;
 class PluginCatalogController;
+class PropertyEditorController;
 
 /**
  * @brief Main Qt window of Genesys GUI.
@@ -300,6 +301,8 @@ private: // interface and model main elements to join
     std::unique_ptr<SimulationEventController> _simulationEventController;
     // Add the Phase 5 plugin-catalog controller owned by MainWindow.
     std::unique_ptr<PluginCatalogController> _pluginCatalogController;
+    // Add the Phase 6 property-editor controller owned by MainWindow.
+    std::unique_ptr<PropertyEditorController> _propertyEditorController;
 	PropertyEditorGenesys* propertyGenesys;
     std::map<SimulationControl*, DataComponentProperty*>* propertyList;
     std::map<SimulationControl*, DataComponentEditor*>* propertyEditorUI;

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow_scene.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow_scene.cpp
@@ -109,25 +109,11 @@ void MainWindow::sceneFocusItemChanged(QGraphicsItem *newFocusItem, QGraphicsIte
  * Atualiza o Property Editor para um único componente selecionado e limpa em caso contrário.
  */
 void MainWindow::sceneSelectionChanged() {
-    if (_shuttingDown || ui == nullptr || ui->graphicsView == nullptr) {
+    // Keep this wrapper for compatibility during the incremental Phase 6 refactor.
+    if (_shuttingDown || _propertyEditorController == nullptr) {
         return;
     }
-    QGraphicsItem * item;
-    GraphicalModelComponent* gmc;
-
-    if (!ui->graphicsView->selectedItems().isEmpty()) {
-        if (ui->graphicsView->selectedItems().size() == 1) {
-            item = ui->graphicsView->selectedItems().at(0);
-            gmc = dynamic_cast<GraphicalModelComponent*> (item);
-            if (gmc != nullptr) {
-                ui->treeViewPropertyEditor->setActiveObject(gmc, gmc->getComponent(), propertyGenesys, propertyList, propertyEditorUI, propertyBox);
-                return;
-            }
-        }
-    }
-    // Se nenhum item estiver selecionado ou se mais de um item estiver selecionado
-    ui->treeViewPropertyEditor->clear();
-    _actualizeActions();
+    _propertyEditorController->sceneSelectionChanged();
 }
 
 //-----------------------------------------

--- a/source/applications/gui/qt/GenesysQtGUI/propertyeditor/ObjectPropertyBrowser.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/propertyeditor/ObjectPropertyBrowser.cpp
@@ -10,6 +10,7 @@
 #include <QString>
 #include <QVariant>
 #include <QMenu>
+#include <QDebug>
 
 ObjectPropertyBrowser::ObjectPropertyBrowser(QWidget* parent)
     : QtTreePropertyBrowser(parent) {
@@ -67,9 +68,11 @@ void ObjectPropertyBrowser::_clearAll() {
 }
 
 void ObjectPropertyBrowser::clearCurrentlyConnectedObject() {
+    // Fully detach object/editor pointers before clearing UI bindings.
     _graphicalObject = nullptr;
     _modelObject = nullptr;
     _propertyEditor = nullptr;
+    _pendingRebuild = false;
     _clearAll();
 }
 
@@ -85,6 +88,10 @@ void ObjectPropertyBrowser::setActiveObject(
     std::map<SimulationControl*, DataComponentEditor*>* peUI,
     std::map<SimulationControl*, ComboBoxEnum*>* pb
     ) {
+    // Always detach stale bindings first to avoid stale-pointer use during rebinding.
+    clearCurrentlyConnectedObject();
+
+    // Bind the new active object and editor dependencies for the next safe rebuild.
     _graphicalObject = obj;
     _modelObject = mdd;
     _propertyEditor = peg;
@@ -92,13 +99,42 @@ void ObjectPropertyBrowser::setActiveObject(
     _propertyEditorUI = peUI;
     _propertyBox = pb;
 
-    _rebuildProperties();
+    // Rebuild once with guard logic so nested signals cannot recurse unsafely.
+    _rebuildPropertiesGuarded();
+}
+
+// Rebuild properties with explicit suppression of nested recursive rebuild execution.
+void ObjectPropertyBrowser::_rebuildPropertiesGuarded() {
+    if (_isRebuildingProperties) {
+        _pendingRebuild = true;
+        return;
+    }
+
+    _isRebuildingProperties = true;
+    do {
+        _pendingRebuild = false;
+        _rebuildProperties();
+    } while (_pendingRebuild);
+    _isRebuildingProperties = false;
+}
+
+// Validate that active objects are still attached before applying property edits.
+bool ObjectPropertyBrowser::_hasValidActiveBindingContext() const {
+    if (_modelObject == nullptr) {
+        return false;
+    }
+    if (_graphicalObject.isNull()) {
+        return false;
+    }
+    return true;
 }
 
 void ObjectPropertyBrowser::_rebuildProperties() {
+    // Clear existing browser state first so stale bindings cannot survive across rebuilds.
     _clearAll();
 
     if (_modelObject == nullptr) {
+        qInfo() << "Skipping property rebuild because model object is null";
         return;
     }
 
@@ -431,6 +467,11 @@ bool ObjectPropertyBrowser::_createObjectForProperty(QtProperty* property) {
 }
 
 void ObjectPropertyBrowser::valueChanged(QtProperty *property, const QVariant &value) {
+    // Drop edits while a guarded rebuild is in progress to avoid reentrant mutation.
+    if (_isRebuildingProperties) {
+        return;
+    }
+
     auto it = _bindings.find(property);
     if (it == _bindings.end()) {
         return;
@@ -438,6 +479,10 @@ void ObjectPropertyBrowser::valueChanged(QtProperty *property, const QVariant &v
 
     const Binding binding = it.value();
     if (binding.control == nullptr) {
+        return;
+    }
+    if (!_hasValidActiveBindingContext()) {
+        qWarning() << "Ignoring valueChanged because active binding context became invalid";
         return;
     }
 
@@ -462,7 +507,8 @@ void ObjectPropertyBrowser::valueChanged(QtProperty *property, const QVariant &v
         );
 
     if (!ok) {
-        _rebuildProperties();
+        // Rebuild safely after failed setValue to restore editor consistency.
+        _rebuildPropertiesGuarded();
         return;
     }
 
@@ -470,6 +516,11 @@ void ObjectPropertyBrowser::valueChanged(QtProperty *property, const QVariant &v
 }
 
 void ObjectPropertyBrowser::enumValueChanged(QtProperty *property, int value) {
+    // Drop enum edits while a guarded rebuild is in progress to avoid reentrant mutation.
+    if (_isRebuildingProperties) {
+        return;
+    }
+
     auto it = _bindings.find(property);
     if (it == _bindings.end()) {
         return;
@@ -477,6 +528,10 @@ void ObjectPropertyBrowser::enumValueChanged(QtProperty *property, int value) {
 
     const Binding binding = it.value();
     if (binding.control == nullptr) {
+        return;
+    }
+    if (!_hasValidActiveBindingContext()) {
+        qWarning() << "Ignoring enumValueChanged because active binding context became invalid";
         return;
     }
 
@@ -503,7 +558,8 @@ void ObjectPropertyBrowser::enumValueChanged(QtProperty *property, int value) {
         );
 
     if (!ok) {
-        _rebuildProperties();
+        // Rebuild safely after failed enum update to restore editor consistency.
+        _rebuildPropertiesGuarded();
         return;
     }
 
@@ -511,14 +567,28 @@ void ObjectPropertyBrowser::enumValueChanged(QtProperty *property, int value) {
 }
 
 void ObjectPropertyBrowser::_notifyModelChangeApplied() {
-    _rebuildProperties();
+    // Suppress nested notification loops when model callbacks trigger additional edits.
+    if (_isNotifyingModelChange) {
+        _pendingRebuild = true;
+        return;
+    }
+
+    _isNotifyingModelChange = true;
+    _rebuildPropertiesGuarded();
     if (_modelChangedCallback) {
         _modelChangedCallback();
+    }
+    _isNotifyingModelChange = false;
+
+    // Process deferred rebuild requests emitted during guarded callback execution.
+    if (_pendingRebuild) {
+        _rebuildPropertiesGuarded();
     }
 }
 
 void ObjectPropertyBrowser::objectUpdated() {
-    _rebuildProperties();
+    // Route external updates through the guarded rebuild path to avoid recursive crashes.
+    _rebuildPropertiesGuarded();
 }
 
 void ObjectPropertyBrowser::keyPressEvent(QKeyEvent* event) {

--- a/source/applications/gui/qt/GenesysQtGUI/propertyeditor/ObjectPropertyBrowser.h
+++ b/source/applications/gui/qt/GenesysQtGUI/propertyeditor/ObjectPropertyBrowser.h
@@ -7,6 +7,7 @@
 #include <functional>
 
 #include <QObject>
+#include <QPointer>
 #include <QMap>
 #include <QStringList>
 #include <QContextMenuEvent>
@@ -81,7 +82,22 @@ protected:
     void mouseDoubleClickEvent(QMouseEvent* event) override;
 
 private:
-    QObject* _graphicalObject = nullptr;
+    // Guard against reentrant callback chains during property rebuild and notification.
+    bool _isRebuildingProperties = false;
+    // Guard against nested model-change notifications triggered by editor callbacks.
+    bool _isNotifyingModelChange = false;
+    // Keep track of pending rebuild requests raised during guarded execution.
+    bool _pendingRebuild = false;
+
+private:
+    // Execute property rebuild with reentrancy suppression and deferred retry support.
+    void _rebuildPropertiesGuarded();
+    // Check whether active editor bindings are currently valid before mutating model state.
+    bool _hasValidActiveBindingContext() const;
+
+private:
+    // Track the selected graphical object safely in case Qt destroys it during callbacks.
+    QPointer<QObject> _graphicalObject = nullptr;
     ModelDataDefinition* _modelObject = nullptr;
     PropertyEditorGenesys* _propertyEditor = nullptr;
 


### PR DESCRIPTION
### Motivation
- Move Property Editor / scene-selection orchestration out of `MainWindow` into a dedicated controller to reduce stale-pointer and reentrancy crash risk.
- Harden the Property Editor runtime flow to prevent `GenesysQtGUI exited with code 139` caused by invalid-memory / stale-pointer / recursive callbacks during edits.
- Keep MainWindow compatibility wrappers and visible behavior unchanged while applying surgical safety fixes limited to Phase 6 scope.

### Description
- Added `PropertyEditorController` (`controllers/PropertyEditorController.h` and `.cpp`) to own scene-selection→property-editor binding, post-edit model refresh cascade, and safe editor clearing.
- Integrated the controller into `MainWindow` by adding a `std::unique_ptr<PropertyEditorController> _propertyEditorController`, initializing it after `ui->setupUi(...)`, and keeping `sceneSelectionChanged()` and `_onPropertyEditorModelChanged()` as thin delegating wrappers.
- Hardened `ObjectPropertyBrowser` by introducing reentrancy guards (`_isRebuildingProperties`, `_isNotifyingModelChange`, `_pendingRebuild`), a guarded rebuild path (`_rebuildPropertiesGuarded()`), `QPointer` for `_graphicalObject`, safer detach/rebind in `clearCurrentlyConnectedObject()`/`setActiveObject()`, and defensive early returns in `valueChanged()`, `enumValueChanged()`, `_notifyModelChangeApplied()`, and `objectUpdated()`.
- Updated `GenesysQtGUI.pro` to include the new controller source and header files and made small logging additions for helpful diagnostics during invalid-state transitions.

### Testing
- Ran `git diff --check` which passed with no whitespace errors.
- Verified repository state with `git status --short` and committed the changes successfully (commit present locally).
- Attempted `git checkout WiP20261` which failed because the branch is not present in this repository snapshot, so all work was applied on the current local branch instead.
- No automated build or unit-test suite was executed in this rollout; recommend CI/build and sanitizer runs as follow-up.

## Phase 6 execution report

### What I completed
- Created `PropertyEditorController.h` and `PropertyEditorController.cpp` and moved scene-selection handling and property-editor model-changed orchestration into the controller.
- Added `_propertyEditorController` ownership in `MainWindow` and initialized it with narrow callback dependencies; `sceneSelectionChanged()` and `_onPropertyEditorModelChanged()` are now compatibility wrappers that delegate to the controller.
- Hardened `ObjectPropertyBrowser` with reentrancy guards, deferred rebuild handling, `QPointer` usage for the graphical object, safe detach/rebind, and suppression of nested notify/rebuild loops.
- Updated `GenesysQtGUI.pro` to include the new controller files and added targeted diagnostic logging for invalid-state transitions.

### What I could not complete
- I could not operate directly on branch `WiP20261` because it does not exist in this repository snapshot, so changes were applied on the current local branch.

### Why anything remains incomplete
- `git checkout WiP20261` failed with: `pathspec 'WiP20261' did not match any file(s) known to git`, so I proceeded on the available branch to implement the Phase 6 work.

### Crash-hardening notes
- Hardened these crash-prone code paths: `ObjectPropertyBrowser::setActiveObject(...)`, `ObjectPropertyBrowser::_rebuildProperties()` (via `_rebuildPropertiesGuarded()`), `ObjectPropertyBrowser::valueChanged(...)`, `ObjectPropertyBrowser::enumValueChanged(...)`, `ObjectPropertyBrowser::_notifyModelChangeApplied()`, and `ObjectPropertyBrowser::objectUpdated()`.
- Converted `_graphicalObject` to `QPointer<QObject>` to reduce use-after-delete risk for QObject-backed graphical wrappers.
- Added defensive early-returns when the active binding context becomes invalid and suppressed nested rebuild/notify cycles with explicit flags.
- Recommended residual runtime validation by a human tester: reproduce the original Property Editor edit that caused `code 139`, stress-test rapid selection + edits, exercise list/enum editors that trigger model rebuilds, and run AddressSanitizer/Valgrind on a debug build to detect any remaining lifetime issues.

### Files created
- source/applications/gui/qt/GenesysQtGUI/controllers/PropertyEditorController.h
- source/applications/gui/qt/GenesysQtGUI/controllers/PropertyEditorController.cpp

### Files modified
- source/applications/gui/qt/GenesysQtGUI/mainwindow.h
- source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
- source/applications/gui/qt/GenesysQtGUI/mainwindow_scene.cpp
- source/applications/gui/qt/GenesysQtGUI/propertyeditor/ObjectPropertyBrowser.h
- source/applications/gui/qt/GenesysQtGUI/propertyeditor/ObjectPropertyBrowser.cpp
- source/applications/gui/qt/GenesysQtGUI/GenesysQtGUI.pro

### Phase status
- [ ] Phase 6 incomplete
- [x] Phase 6 complete

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d57605ee148321936c39d1d779cf3d)