### PR TITLE
Phase 8: Extract simulation command UI into SimulationCommandController

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/GenesysQtGUI.pro
+++ b/source/applications/gui/qt/GenesysQtGUI/GenesysQtGUI.pro
@@ -251,6 +251,8 @@ SOURCES += \
     controllers/PropertyEditorController.cpp \
     # Phase-7 GUI refactor controller for model/application lifecycle responsibilities.
     controllers/ModelLifecycleController.cpp \
+    # Phase-8 GUI refactor controller for simulation-command responsibilities.
+    controllers/SimulationCommandController.cpp \
     # Phase-1 GUI refactor services for model representations.
     services/ModelLanguageSynchronizer.cpp \
     services/GraphvizModelExporter.cpp \
@@ -578,6 +580,8 @@ HEADERS += \
     controllers/PropertyEditorController.h \
     # Phase-7 GUI refactor controller header for model/application lifecycle responsibilities.
     controllers/ModelLifecycleController.h \
+    # Phase-8 GUI refactor controller header for simulation-command responsibilities.
+    controllers/SimulationCommandController.h \
     # Phase-1 GUI refactor service headers.
     services/ModelLanguageSynchronizer.h \
     services/GraphvizModelExporter.h \

--- a/source/applications/gui/qt/GenesysQtGUI/controllers/ModelLifecycleController.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/ModelLifecycleController.cpp
@@ -1,6 +1,7 @@
 #include "ModelLifecycleController.h"
 
-#include "../ui_mainwindow.h"
+// Use the generated UI header through the project include path for portability across build folders.
+#include "ui_mainwindow.h"
 #include "../dialogs/Dialogmodelinformation.h"
 #include "../dialogs/dialogsimulationconfigure.h"
 #include "../graphicals/ModelGraphicsScene.h"

--- a/source/applications/gui/qt/GenesysQtGUI/controllers/SimulationCommandController.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/SimulationCommandController.cpp
@@ -1,0 +1,121 @@
+#include "controllers/SimulationCommandController.h"
+
+#include "controllers/SimulationController.h"
+#include "animations/AnimationTransition.h"
+#include "../../../../kernel/simulator/ModelSimulation.h"
+
+SimulationCommandController::SimulationCommandController(
+    SimulationController* simulationController,
+    const std::function<void(const std::string&)>& insertCommandInConsole,
+    const std::function<void()>& actualizeActions,
+    const std::function<bool()>& checkModel,
+    const std::function<bool()>& setSimulationModelBasedOnText)
+    : _simulationController(simulationController),
+      _insertCommandInConsole(insertCommandInConsole),
+      _actualizeActions(actualizeActions),
+      _checkModel(checkModel),
+      _setSimulationModelBasedOnText(setSimulationModelBasedOnText) {
+}
+
+// Move simulation start orchestration into the dedicated Phase 8 controller.
+void SimulationCommandController::onActionSimulationStartTriggered(bool modelChecked) const {
+    if (!_simulationController || !_simulationController->ensureReady(
+            true,
+            modelChecked,
+            _checkModel,
+            _setSimulationModelBasedOnText)) {
+        return;
+    }
+
+    ModelSimulation* simulation = _simulationController->currentSimulation();
+    if (simulation == nullptr) {
+        return;
+    }
+
+    AnimationTransition::setRunning(true);
+    AnimationTransition::setPause(false);
+    _insertCommandInConsole("start");
+    simulation->start();
+}
+
+// Move simulation step orchestration into the dedicated Phase 8 controller.
+void SimulationCommandController::onActionSimulationStepTriggered(bool modelChecked) const {
+    if (!_simulationController || !_simulationController->ensureReady(
+            true,
+            modelChecked,
+            _checkModel,
+            _setSimulationModelBasedOnText)) {
+        return;
+    }
+
+    ModelSimulation* simulation = _simulationController->currentSimulation();
+    if (simulation == nullptr) {
+        return;
+    }
+
+    AnimationTransition::setRunning(true);
+    AnimationTransition::setPause(false);
+    _insertCommandInConsole("step");
+    simulation->step();
+}
+
+// Move simulation pause orchestration into the dedicated Phase 8 controller.
+void SimulationCommandController::onActionSimulationPauseTriggered() const {
+    if (!_simulationController || !_simulationController->hasCurrentModelSimulation()) {
+        return;
+    }
+
+    ModelSimulation* simulation = _simulationController->currentSimulation();
+    if (simulation == nullptr) {
+        return;
+    }
+
+    AnimationTransition::setRunning(true);
+    AnimationTransition::setPause(true);
+
+    _insertCommandInConsole("pause");
+    simulation->pause();
+}
+
+// Move simulation resume orchestration into the dedicated Phase 8 controller.
+void SimulationCommandController::onActionSimulationResumeTriggered(bool modelChecked) const {
+    if (!_simulationController || !_simulationController->ensureReady(
+            false,
+            modelChecked,
+            _checkModel,
+            _setSimulationModelBasedOnText)) {
+        return;
+    }
+
+    ModelSimulation* simulation = _simulationController->currentSimulation();
+    if (simulation == nullptr) {
+        return;
+    }
+
+    AnimationTransition::setRunning(true);
+    AnimationTransition::setPause(false);
+
+    _insertCommandInConsole("resume");
+    simulation->start();
+}
+
+// Move simulation stop orchestration into the dedicated Phase 8 controller.
+void SimulationCommandController::onActionSimulationStopTriggered() const {
+    if (!_simulationController || !_simulationController->hasCurrentModelSimulation()) {
+        return;
+    }
+
+    ModelSimulation* simulation = _simulationController->currentSimulation();
+    if (simulation == nullptr) {
+        return;
+    }
+
+    AnimationTransition::setRunning(false);
+    AnimationTransition::setPause(false);
+
+    _insertCommandInConsole("stop");
+
+    simulation->stop();
+
+    _actualizeActions();
+}

--- a/source/applications/gui/qt/GenesysQtGUI/controllers/SimulationCommandController.h
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/SimulationCommandController.h
@@ -1,0 +1,43 @@
+#ifndef SIMULATIONCOMMANDCONTROLLER_H
+#define SIMULATIONCOMMANDCONTROLLER_H
+
+#include <functional>
+#include <string>
+
+class SimulationController;
+
+/**
+ * @brief Phase 8 controller for UI-level simulation command orchestration.
+ */
+class SimulationCommandController {
+public:
+    /**
+     * @brief Creates a command controller with narrow callbacks from MainWindow.
+     */
+    SimulationCommandController(
+        SimulationController* simulationController,
+        const std::function<void(const std::string&)>& insertCommandInConsole,
+        const std::function<void()>& actualizeActions,
+        const std::function<bool()>& checkModel,
+        const std::function<bool()>& setSimulationModelBasedOnText);
+
+    /** @brief Delegates the start simulation command flow. */
+    void onActionSimulationStartTriggered(bool modelChecked) const;
+    /** @brief Delegates the step simulation command flow. */
+    void onActionSimulationStepTriggered(bool modelChecked) const;
+    /** @brief Delegates the pause simulation command flow. */
+    void onActionSimulationPauseTriggered() const;
+    /** @brief Delegates the resume simulation command flow. */
+    void onActionSimulationResumeTriggered(bool modelChecked) const;
+    /** @brief Delegates the stop simulation command flow. */
+    void onActionSimulationStopTriggered() const;
+
+private:
+    SimulationController* _simulationController;
+    std::function<void(const std::string&)> _insertCommandInConsole;
+    std::function<void()> _actualizeActions;
+    std::function<bool()> _checkModel;
+    std::function<bool()> _setSimulationModelBasedOnText;
+};
+
+#endif // SIMULATIONCOMMANDCONTROLLER_H

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
@@ -21,6 +21,8 @@
 #include "controllers/PropertyEditorController.h"
 // Add Phase 7 controller include for model/application lifecycle orchestration.
 #include "controllers/ModelLifecycleController.h"
+// Add Phase 8 controller include for simulation-command orchestration.
+#include "controllers/SimulationCommandController.h"
 #include "services/ModelLanguageSynchronizer.h"
 #include "services/GraphvizModelExporter.h"
 #include "services/CppModelExporter.h"
@@ -278,6 +280,14 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
     ui->treeViewPropertyEditor->setModelChangedCallback([this]() {
         this->_onPropertyEditorModelChanged();
     });
+    // Initialize the Phase 8 simulation-command controller after simulation controller and callbacks are available.
+    _simulationCommandController = std::make_unique<SimulationCommandController>(
+        _simulationController.get(),
+        [this](const std::string& command) { _insertCommandInConsole(command); },
+        [this]() { _actualizeActions(); },
+        [this]() { return _check(false); },
+        [this]() { return _setSimulationModelBasedOnText(); });
+
     // Initialize the Phase 7 model-lifecycle controller after simulator/UI/callback dependencies are ready.
     _modelLifecycleController = std::make_unique<ModelLifecycleController>(
         this,

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.h
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.h
@@ -36,6 +36,7 @@ class SimulationEventController;
 class PluginCatalogController;
 class PropertyEditorController;
 class ModelLifecycleController;
+class SimulationCommandController;
 
 /**
  * @brief Main Qt window of Genesys GUI.
@@ -283,6 +284,8 @@ private: // interface and model main elements to join
 	Ui::MainWindow *ui;
 	Simulator* simulator;
     std::unique_ptr<class SimulationController> _simulationController;
+    // Add the Phase 8 simulation-command controller owned by MainWindow.
+    std::unique_ptr<SimulationCommandController> _simulationCommandController;
     // Phase-1 services keep model-representation logic outside MainWindow while wrappers remain stable.
     // Synchronize textual model language with the kernel model manager.
     std::unique_ptr<ModelLanguageSynchronizer> _modelLanguageSynchronizer;

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow_controller.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow_controller.cpp
@@ -6,6 +6,8 @@
 #include "controllers/PluginCatalogController.h"
 // Include the Phase 7 controller interface required by lifecycle compatibility wrappers.
 #include "controllers/ModelLifecycleController.h"
+// Include the Phase 8 controller interface required by simulation-command compatibility wrappers.
+#include "controllers/SimulationCommandController.h"
 
 #include "dialogs/dialogBreakpoint.h"
 #include "dialogs/Dialogmodelinformation.h"
@@ -86,22 +88,10 @@
  * @todo Move command execution details (animation flags + console command) into SimulationController.
  */
 void MainWindow::on_actionSimulationStop_triggered() {
-    if (!_simulationController || !_simulationController->hasCurrentModelSimulation()) {
-        return;
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 8 refactor.
+    if (_simulationCommandController != nullptr) {
+        _simulationCommandController->onActionSimulationStopTriggered();
     }
-    ModelSimulation* simulation = _simulationController->currentSimulation();
-    if (simulation == nullptr) {
-        return;
-    }
-
-    AnimationTransition::setRunning(false);
-    AnimationTransition::setPause(false);
-
-    _insertCommandInConsole("stop");
-
-    simulation->stop();
-
-    _actualizeActions();
 }
 
 /**
@@ -115,23 +105,10 @@ void MainWindow::on_actionSimulationStop_triggered() {
  * @todo Replace lambda callbacks by explicit command objects for better unit testing.
  */
 void MainWindow::on_actionSimulationStart_triggered() {
-    if (!_simulationController || !_simulationController->ensureReady(
-            true,
-            _modelCheked,
-            [this]() { return _check(false); },
-            [this]() { return _setSimulationModelBasedOnText(); })) {
-        return;
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 8 refactor.
+    if (_simulationCommandController != nullptr) {
+        _simulationCommandController->onActionSimulationStartTriggered(_modelCheked);
     }
-
-    ModelSimulation* simulation = _simulationController->currentSimulation();
-    if (simulation == nullptr) {
-        return;
-    }
-
-    AnimationTransition::setRunning(true);
-    AnimationTransition::setPause(false);
-    _insertCommandInConsole("start");
-    simulation->start();
 }
 
 /**
@@ -142,23 +119,10 @@ void MainWindow::on_actionSimulationStart_triggered() {
  * @todo Consolidate duplicated animation-toggle code between start and step.
  */
 void MainWindow::on_actionSimulationStep_triggered() {
-    if (!_simulationController || !_simulationController->ensureReady(
-            true,
-            _modelCheked,
-            [this]() { return _check(false); },
-            [this]() { return _setSimulationModelBasedOnText(); })) {
-        return;
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 8 refactor.
+    if (_simulationCommandController != nullptr) {
+        _simulationCommandController->onActionSimulationStepTriggered(_modelCheked);
     }
-
-    ModelSimulation* simulation = _simulationController->currentSimulation();
-    if (simulation == nullptr) {
-        return;
-    }
-
-    AnimationTransition::setRunning(true);
-    AnimationTransition::setPause(false);
-    _insertCommandInConsole("step");
-    simulation->step();
 }
 
 /**
@@ -167,20 +131,10 @@ void MainWindow::on_actionSimulationStep_triggered() {
  * @todo Add explicit feedback when pause is requested in invalid state.
  */
 void MainWindow::on_actionSimulationPause_triggered() {
-    if (!_simulationController || !_simulationController->hasCurrentModelSimulation()) {
-        return;
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 8 refactor.
+    if (_simulationCommandController != nullptr) {
+        _simulationCommandController->onActionSimulationPauseTriggered();
     }
-
-    ModelSimulation* simulation = _simulationController->currentSimulation();
-    if (simulation == nullptr) {
-        return;
-    }
-
-    AnimationTransition::setRunning(true);
-    AnimationTransition::setPause(true);
-
-    _insertCommandInConsole("pause");
-    simulation->pause();
 }
 
 /**
@@ -190,24 +144,10 @@ void MainWindow::on_actionSimulationPause_triggered() {
  *       to avoid semantic coupling with `start()`.
  */
 void MainWindow::on_actionSimulationResume_triggered() {
-    if (!_simulationController || !_simulationController->ensureReady(
-            false,
-            _modelCheked,
-            [this]() { return _check(false); },
-            [this]() { return _setSimulationModelBasedOnText(); })) {
-        return;
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 8 refactor.
+    if (_simulationCommandController != nullptr) {
+        _simulationCommandController->onActionSimulationResumeTriggered(_modelCheked);
     }
-
-    ModelSimulation* simulation = _simulationController->currentSimulation();
-    if (simulation == nullptr) {
-        return;
-    }
-
-    AnimationTransition::setRunning(true);
-    AnimationTransition::setPause(false);
-
-    _insertCommandInConsole("resume");
-    simulation->start();
 }
 
 

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow_scene.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow_scene.cpp
@@ -1,5 +1,7 @@
 #include "mainwindow.h"
 #include "ui_mainwindow.h"
+// Include the Phase 6 controller type so member calls compile with a complete class definition.
+#include "controllers/PropertyEditorController.h"
 
 //-----------------------------------------
 


### PR DESCRIPTION
### Motivation
- Remove simulation-command orchestration from `MainWindow` by extracting start/step/pause/resume/stop UI flows into a dedicated controller while preserving existing MainWindow slot signatures and runtime behavior.

### Description
- Created `controllers/SimulationCommandController.h` and `controllers/SimulationCommandController.cpp` to host the UI-level orchestration for `start`, `step`, `pause`, `resume`, and `stop` using a narrow dependency on the existing `SimulationController` and small callbacks (`insertCommandInConsole`, `actualizeActions`, `checkModel`, `setSimulationModelBasedOnText`).
- Added `std::unique_ptr<SimulationCommandController> _simulationCommandController;` to `MainWindow`, and initialized it in the `MainWindow` constructor after `_simulationController` with the required narrow callbacks.
- Replaced the detailed simulation command implementations in `mainwindow_controller.cpp` with thin compatibility wrappers that delegate to the new controller, keeping slot signatures stable and preserving the wrappers intentionally for incremental refactor safety.
- Updated `GenesysQtGUI.pro` to include the new controller source and header so they are built.
- Preserved existing semantics: `SimulationController::ensureReady(...)` usage, console command strings (`start`,`step`,`pause`,`resume`,`stop`), `AnimationTransition::setRunning/setPause` toggles, null/current-model guards, and `resume` behavior (delegates to `simulation->start()`).

### Testing
- `git diff --check` was run and reported no whitespace/patch errors (success).
- `git status --short` and the working-tree checks were used to verify modified/created files (success), and changes were committed successfully.
- Attempt to switch to branch `WiP20261` failed in this environment because that branch is not present locally (informational; work proceeded against the available branch).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d587ced9e883218b54e380b316cecb)