### PR TITLE
Phase 9: extract edit/clipboard orchestration into EditCommandController

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/GenesysQtGUI.pro
+++ b/source/applications/gui/qt/GenesysQtGUI/GenesysQtGUI.pro
@@ -253,6 +253,8 @@ SOURCES += \
     controllers/ModelLifecycleController.cpp \
     # Phase-8 GUI refactor controller for simulation-command responsibilities.
     controllers/SimulationCommandController.cpp \
+    # Phase-9 GUI refactor controller for edit-command responsibilities.
+    controllers/EditCommandController.cpp \
     # Phase-1 GUI refactor services for model representations.
     services/ModelLanguageSynchronizer.cpp \
     services/GraphvizModelExporter.cpp \
@@ -582,6 +584,8 @@ HEADERS += \
     controllers/ModelLifecycleController.h \
     # Phase-8 GUI refactor controller header for simulation-command responsibilities.
     controllers/SimulationCommandController.h \
+    # Phase-9 GUI refactor controller header for edit-command responsibilities.
+    controllers/EditCommandController.h \
     # Phase-1 GUI refactor service headers.
     services/ModelLanguageSynchronizer.h \
     services/GraphvizModelExporter.h \

--- a/source/applications/gui/qt/GenesysQtGUI/controllers/EditCommandController.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/EditCommandController.cpp
@@ -1,0 +1,435 @@
+#include "EditCommandController.h"
+
+#include "../actions/DeleteUndoCommand.h"
+#include "../actions/PasteUndoCommand.h"
+#include "../animations/AnimationCounter.h"
+#include "../animations/AnimationVariable.h"
+#include "../graphicals/GraphicalComponentPort.h"
+#include "../graphicals/GraphicalConnection.h"
+#include "../graphicals/GraphicalModelComponent.h"
+#include "../graphicals/ModelGraphicsScene.h"
+#include "../graphicals/ModelGraphicsView.h"
+#include "../../../../kernel/simulator/ModelComponent.h"
+#include "../../../../kernel/simulator/Plugin.h"
+#include "../../../../kernel/simulator/Simulator.h"
+
+#include <QGraphicsEllipseItem>
+#include <QGraphicsItemGroup>
+#include <QGraphicsLineItem>
+#include <QGraphicsPolygonItem>
+#include <QGraphicsRectItem>
+#include <QPair>
+#include <QUndoCommand>
+#include <QUndoStack>
+
+// Bind Phase 9 dependencies required to preserve existing edit command behavior.
+EditCommandController::EditCommandController(Simulator* simulator,
+                                             ModelGraphicsView* graphicsView,
+                                             std::function<void()> actualizeActions,
+                                             bool* cut,
+                                             QList<GraphicalModelComponent*>** gmcCopies,
+                                             QList<GraphicalConnection*>** portsCopies,
+                                             QList<QGraphicsItem*>** drawCopy,
+                                             QList<QGraphicsItemGroup*>** groupCopy)
+    : _simulator(simulator),
+      _graphicsView(graphicsView),
+      _actualizeActions(std::move(actualizeActions)),
+      _cut(cut),
+      _gmcCopies(gmcCopies),
+      _portsCopies(portsCopies),
+      _drawCopy(drawCopy),
+      _groupCopy(groupCopy) {
+}
+
+// Resolve the shared model scene used by all delegated edit commands.
+ModelGraphicsScene* EditCommandController::scene() const {
+    return (_graphicsView != nullptr) ? _graphicsView->getScene() : nullptr;
+}
+
+// Preserve undo-stack behavior while moving orchestration out of MainWindow.
+void EditCommandController::onActionEditUndoTriggered() const {
+    ModelGraphicsScene* currentScene = scene();
+    if (currentScene != nullptr && currentScene->getUndoStack() != nullptr) {
+        currentScene->getUndoStack()->undo();
+    }
+}
+
+// Preserve redo-stack behavior while moving orchestration out of MainWindow.
+void EditCommandController::onActionEditRedoTriggered() const {
+    ModelGraphicsScene* currentScene = scene();
+    if (currentScene != nullptr && currentScene->getUndoStack() != nullptr) {
+        currentScene->getUndoStack()->redo();
+    }
+}
+
+// Preserve cut semantics and copy-buffer preparation exactly as before.
+void EditCommandController::onActionEditCutTriggered() const {
+    (*_gmcCopies)->clear();
+    (*_portsCopies)->clear();
+    (*_groupCopy)->clear();
+    (*_drawCopy)->clear();
+
+    QList<QGraphicsItem*> selecteds = _graphicsView->scene()->selectedItems();
+    if (selecteds.size() > 0) {
+        ModelGraphicsScene* currentScene = scene();
+        *_cut = true;
+
+        for (QGraphicsItem* item : _graphicsView->scene()->selectedItems()) {
+            QList<GraphicalModelComponent*> groupComponents;
+            QList<GraphicalConnection*>* connGroup = new QList<GraphicalConnection*>();
+
+            if (GraphicalModelComponent* gmc = dynamic_cast<GraphicalModelComponent*>(item)) {
+                (*_gmcCopies)->append(gmc);
+            } else if (QGraphicsItemGroup* group = dynamic_cast<QGraphicsItemGroup*>(item)) {
+                for (int i = 0; i < group->childItems().size(); i++) {
+                    GraphicalModelComponent* component = dynamic_cast<GraphicalModelComponent*>(group->childItems().at(i));
+
+                    if (!component->getGraphicalInputPorts().empty() && !component->getGraphicalInputPorts().at(0)->getConnections()->empty()) {
+                        for (int j = 0; j < component->getGraphicalInputPorts().at(0)->getConnections()->size(); ++j) {
+                            connGroup->append(component->getGraphicalInputPorts().at(0)->getConnections()->at(j));
+                        }
+                    }
+
+                    for (int j = 0; j < component->getGraphicalOutputPorts().size(); ++j) {
+                        GraphicalComponentPort* port = component->getGraphicalOutputPorts().at(j);
+                        if (!port->getConnections()->empty()) {
+                            connGroup->append(port->getConnections()->at(0));
+                        }
+                    }
+
+                    (*_gmcCopies)->append(component);
+                    groupComponents.append(component);
+                }
+
+                saveItemForCopy(&groupComponents, connGroup);
+                (*_groupCopy)->append(group);
+                currentScene->insertComponentGroup(group, groupComponents);
+                for (unsigned int k = 0; k < static_cast<unsigned int>(connGroup->size()); k++) {
+                    (*_portsCopies)->append(connGroup->at(k));
+                }
+            } else if (GraphicalConnection* port = dynamic_cast<GraphicalConnection*>(item)) {
+                (*_portsCopies)->append(port);
+            } else {
+                (*_drawCopy)->append(item);
+            }
+
+            delete connGroup;
+        }
+
+        saveItemForCopy(*_gmcCopies, *_portsCopies);
+        QUndoCommand* deleteUndoCommand = new DeleteUndoCommand(selecteds, currentScene);
+        currentScene->getUndoStack()->push(deleteUndoCommand);
+    }
+}
+
+// Preserve copy semantics and selection cleanup exactly as before.
+void EditCommandController::onActionEditCopyTriggered() const {
+    (*_gmcCopies)->clear();
+    (*_portsCopies)->clear();
+    (*_groupCopy)->clear();
+    (*_drawCopy)->clear();
+
+    QList<QGraphicsItem*> selected = _graphicsView->scene()->selectedItems();
+    QList<GraphicalModelComponent*> gmcCopiesCopy;
+
+    if (selected.size() > 0) {
+        *_cut = false;
+        for (QGraphicsItem* item : _graphicsView->scene()->selectedItems()) {
+            if (GraphicalModelComponent* gmc = dynamic_cast<GraphicalModelComponent*>(item)) {
+                gmc->setSelected(false);
+                (*_gmcCopies)->append(gmc);
+                gmcCopiesCopy.append(gmc);
+            } else if (GraphicalConnection* conn = dynamic_cast<GraphicalConnection*>(item)) {
+                conn->setSelected(false);
+                (*_portsCopies)->append(conn);
+            } else if (QGraphicsItemGroup* group = dynamic_cast<QGraphicsItemGroup*>(item)) {
+                group->setSelected(false);
+                (*_groupCopy)->append(group);
+
+                for (int i = 0; i < group->childItems().size(); i++) {
+                    GraphicalModelComponent* component = dynamic_cast<GraphicalModelComponent*>(group->childItems().at(i));
+                    gmcCopiesCopy.append(component);
+                }
+            } else {
+                item->setSelected(false);
+                (*_drawCopy)->append(item);
+            }
+        }
+
+        saveItemForCopy(&gmcCopiesCopy, *_portsCopies);
+        gmcCopiesCopy.clear();
+    }
+}
+
+// Preserve paste behavior and post-paste buffer cleanup semantics.
+void EditCommandController::onActionEditPasteTriggered() const {
+    if ((*_gmcCopies)->size() > 0 || (*_drawCopy)->size() > 0 || (*_groupCopy)->size() > 0) {
+        ModelGraphicsScene* currentScene = scene();
+        if (!*_cut) {
+            helpCopy();
+        }
+
+        QUndoCommand* pasteUndoCommand = new PasteUndoCommand(*_gmcCopies, *_portsCopies, *_groupCopy, *_drawCopy, currentScene);
+        currentScene->getUndoStack()->push(pasteUndoCommand);
+
+        (*_gmcCopies)->clear();
+        (*_portsCopies)->clear();
+        (*_drawCopy)->clear();
+        (*_groupCopy)->clear();
+        *_cut = false;
+    }
+}
+
+// Preserve delete behavior and action-state refresh callback.
+void EditCommandController::onActionEditDeleteTriggered() const {
+    QList<QGraphicsItem*> selecteds = _graphicsView->scene()->selectedItems();
+    if (selecteds.isEmpty()) {
+        return;
+    }
+
+    ModelGraphicsScene* currentScene = scene();
+    QUndoCommand* deleteUndoCommand = new DeleteUndoCommand(selecteds, currentScene);
+    currentScene->getUndoStack()->push(deleteUndoCommand);
+    if (_actualizeActions) {
+        _actualizeActions();
+    }
+}
+
+// Keep edit-group action delegating to the shared grouping implementation.
+void EditCommandController::onActionEditGroupTriggered() const {
+    onActionViewGroupTriggered();
+}
+
+// Keep edit-ungroup action delegating to the shared ungrouping implementation.
+void EditCommandController::onActionEditUngroupTriggered() const {
+    onActionViewUngroupTriggered();
+}
+
+// Preserve direct scene grouping behavior.
+void EditCommandController::onActionViewGroupTriggered() const {
+    scene()->groupComponents(false);
+}
+
+// Preserve direct scene ungrouping behavior.
+void EditCommandController::onActionViewUngroupTriggered() const {
+    scene()->ungroupComponents();
+}
+
+// Preserve copy-buffer connection filtering behavior used by cut/copy/group flows.
+void EditCommandController::saveItemForCopy(QList<GraphicalModelComponent*>* gmcList, QList<GraphicalConnection*>* connList) const {
+    for (GraphicalConnection* conn : *connList) {
+        ModelComponent* source = conn->getSource()->component;
+        ModelComponent* dst = conn->getDestination()->component;
+
+        GraphicalModelComponent* sourceSelected = nullptr;
+        GraphicalModelComponent* dstSelected = nullptr;
+        for (GraphicalModelComponent* comp : *gmcList) {
+            if (source != nullptr && comp->getComponent()->getId() == source->getId()) {
+                sourceSelected = comp;
+            }
+            if (dst != nullptr && comp->getComponent()->getId() == dst->getId()) {
+                dstSelected = comp;
+            }
+        }
+
+        if (sourceSelected == nullptr || dstSelected == nullptr) {
+            connList->removeOne(conn);
+        }
+    }
+}
+
+// Preserve deep copy of components, connections, drawings, and groups for paste support.
+void EditCommandController::helpCopy() const {
+    ModelGraphicsScene* currentScene = scene();
+
+    QList<QPair<GraphicalModelComponent*, GraphicalModelComponent*>>* aux = new QList<QPair<GraphicalModelComponent*, GraphicalModelComponent*>>();
+    QList<GraphicalModelComponent*>* gmcAux = new QList<GraphicalModelComponent*>();
+    QList<GraphicalModelComponent*>* gmcOldGroupAux = new QList<GraphicalModelComponent*>();
+    QList<GraphicalModelComponent*>* gmcNewGroupAux = new QList<GraphicalModelComponent*>();
+    QList<GraphicalConnection*>* portsAux = new QList<GraphicalConnection*>();
+    QList<QGraphicsItem*>* drawingAux = new QList<QGraphicsItem*>();
+    QList<QGraphicsItemGroup*>* groupAux = new QList<QGraphicsItemGroup*>();
+
+    for (GraphicalModelComponent* gmc : **_gmcCopies) {
+        if (gmc->group()) {
+            continue;
+        }
+
+        ModelComponent* previousComponent = gmc->getComponent();
+        _simulator->getModelManager()->current()->getComponentManager()->insert(previousComponent);
+        const std::string pluginname = previousComponent->getClassname();
+        Plugin* plugin = _simulator->getPluginManager()->find(pluginname);
+        QPointF position = gmc->pos();
+        QColor color = gmc->getColor();
+        ModelComponent* component = static_cast<ModelComponent*>(plugin->newInstance(_simulator->getModelManager()->current()));
+
+        GraphicalModelComponent* newgmc = new GraphicalModelComponent(plugin, component, position, color);
+        GraphicalModelComponent* oldgmc = currentScene->findGraphicalModelComponent(previousComponent->getId());
+        aux->append(qMakePair(oldgmc, newgmc));
+        gmcAux->append(newgmc);
+    }
+
+    for (QGraphicsItemGroup* group : **_groupCopy) {
+        QList<GraphicalConnection*>* connGroup = new QList<GraphicalConnection*>();
+        unsigned int size = group->childItems().size();
+
+        for (unsigned int i = 0; i < size; i++) {
+            GraphicalModelComponent* gmc = dynamic_cast<GraphicalModelComponent*>(group->childItems().at(0));
+            group->removeFromGroup(gmc);
+
+            ModelComponent* previousComponent = gmc->getComponent();
+            _simulator->getModelManager()->current()->getComponentManager()->insert(previousComponent);
+            const std::string pluginname = previousComponent->getClassname();
+            Plugin* plugin = _simulator->getPluginManager()->find(pluginname);
+            QPointF position = gmc->pos();
+            QColor color = gmc->getColor();
+            ModelComponent* component = static_cast<ModelComponent*>(plugin->newInstance(_simulator->getModelManager()->current()));
+
+            GraphicalModelComponent* newgmc = new GraphicalModelComponent(plugin, component, position, color);
+            GraphicalModelComponent* oldgmc = currentScene->findGraphicalModelComponent(previousComponent->getId());
+
+            if (!oldgmc->getGraphicalInputPorts().empty() && !oldgmc->getGraphicalInputPorts().at(0)->getConnections()->empty()) {
+                connGroup->removeOne(oldgmc->getGraphicalInputPorts().at(0)->getConnections()->at(0));
+                connGroup->append(oldgmc->getGraphicalInputPorts().at(0)->getConnections()->at(0));
+            }
+
+            for (int j = 0; j < oldgmc->getGraphicalOutputPorts().size(); ++j) {
+                GraphicalComponentPort* port = oldgmc->getGraphicalOutputPorts().at(j);
+                if (!port->getConnections()->empty()) {
+                    connGroup->removeOne(port->getConnections()->at(0));
+                    connGroup->append(port->getConnections()->at(0));
+                }
+            }
+
+            gmcOldGroupAux->append(oldgmc);
+            gmcNewGroupAux->append(newgmc);
+            aux->append(qMakePair(oldgmc, newgmc));
+            gmcAux->append(newgmc);
+        }
+
+        saveItemForCopy(gmcOldGroupAux, connGroup);
+        for (unsigned int k = 0; k < size; k++) {
+            group->addToGroup(gmcOldGroupAux->at(k));
+        }
+
+        for (unsigned int k = 0; k < static_cast<unsigned int>(connGroup->size()); k++) {
+            (*_portsCopies)->removeOne(connGroup->at(k));
+            (*_portsCopies)->append(connGroup->at(k));
+        }
+
+        QGraphicsItemGroup* newGroup = new QGraphicsItemGroup();
+        _graphicsView->getScene()->insertComponentGroup(newGroup, *gmcNewGroupAux);
+        gmcOldGroupAux->clear();
+        gmcNewGroupAux->clear();
+        groupAux->append(newGroup);
+        delete connGroup;
+    }
+
+    for (GraphicalConnection* conn : **_portsCopies) {
+        ModelComponent* source = conn->getSource()->component;
+        ModelComponent* dst = conn->getDestination()->component;
+
+        GraphicalComponentPort* sourcePort = nullptr;
+        GraphicalComponentPort* destinationPort = nullptr;
+        unsigned int portSourceConnection = 0;
+        unsigned int portDestinationConnection = 0;
+
+        GraphicalModelComponent* gmcSource = currentScene->findGraphicalModelComponent(source->getId());
+        GraphicalModelComponent* gmcDestination = currentScene->findGraphicalModelComponent(dst->getId());
+
+        for (GraphicalModelComponent* comp : **_gmcCopies) {
+            if (comp->getComponent()->getId() == source->getId()) {
+                sourcePort = conn->getSourceGraphicalPort();
+                portSourceConnection = conn->getPortSourceConnection();
+            }
+            if (comp->getComponent()->getId() == dst->getId()) {
+                destinationPort = conn->getDestinationGraphicalPort();
+                portDestinationConnection = conn->getPortDestinationConnection();
+            }
+        }
+
+        GraphicalModelComponent* gmcNewSource = nullptr;
+        GraphicalModelComponent* gmcNewDestination = nullptr;
+        for (const auto& pair : *aux) {
+            if (pair.first == gmcSource) {
+                gmcNewSource = pair.second;
+            }
+            if (pair.first == gmcDestination) {
+                gmcNewDestination = pair.second;
+            }
+        }
+
+        sourcePort = gmcNewSource->getGraphicalOutputPorts().at(portSourceConnection);
+        destinationPort = gmcNewDestination->getGraphicalInputPorts().at(portDestinationConnection);
+
+        GraphicalConnection* newConn = currentScene->addGraphicalConnection(sourcePort, destinationPort, portSourceConnection, portDestinationConnection);
+        _graphicsView->getScene()->clearPorts(newConn, gmcNewSource, gmcDestination);
+        portsAux->append(newConn);
+    }
+
+    for (QGraphicsItem* draw : **_drawCopy) {
+        if (AnimationCounter* animationCounter = dynamic_cast<AnimationCounter*>(draw)) {
+            AnimationCounter* copiedItem = new AnimationCounter();
+            copiedItem->setRect(0, 0, animationCounter->boundingRect().width(), animationCounter->boundingRect().height());
+            copiedItem->setPos(animationCounter->pos());
+            copiedItem->setCounter(animationCounter->getCounter());
+            copiedItem->setValue(animationCounter->getValue());
+            drawingAux->append(copiedItem);
+            continue;
+        }
+
+        if (AnimationVariable* animationVariable = dynamic_cast<AnimationVariable*>(draw)) {
+            AnimationVariable* copiedItem = new AnimationVariable();
+            copiedItem->setRect(0, 0, animationVariable->boundingRect().width(), animationVariable->boundingRect().height());
+            copiedItem->setPos(animationVariable->pos());
+            copiedItem->setVariable(animationVariable->getVariable());
+            copiedItem->setValue(animationVariable->getValue());
+            drawingAux->append(copiedItem);
+            continue;
+        }
+
+        if (QGraphicsRectItem* rectItem = dynamic_cast<QGraphicsRectItem*>(draw)) {
+            QGraphicsRectItem* copiedItem = new QGraphicsRectItem(rectItem->rect());
+            copiedItem->setPos(rectItem->pos());
+            copiedItem->setFlag(QGraphicsItem::ItemIsSelectable, true);
+            copiedItem->setFlag(QGraphicsItem::ItemIsMovable, true);
+            drawingAux->append(copiedItem);
+            continue;
+        }
+
+        if (QGraphicsEllipseItem* ellipseItem = dynamic_cast<QGraphicsEllipseItem*>(draw)) {
+            QGraphicsEllipseItem* copiedItem = new QGraphicsEllipseItem(ellipseItem->rect());
+            copiedItem->setPos(ellipseItem->pos());
+            copiedItem->setFlag(QGraphicsItem::ItemIsSelectable, true);
+            copiedItem->setFlag(QGraphicsItem::ItemIsMovable, true);
+            drawingAux->append(copiedItem);
+            continue;
+        }
+
+        if (QGraphicsPolygonItem* polygonItem = dynamic_cast<QGraphicsPolygonItem*>(draw)) {
+            QGraphicsPolygonItem* copiedItem = new QGraphicsPolygonItem(polygonItem->polygon());
+            copiedItem->setPos(polygonItem->pos());
+            copiedItem->setFlag(QGraphicsItem::ItemIsSelectable, true);
+            copiedItem->setFlag(QGraphicsItem::ItemIsMovable, true);
+            drawingAux->append(copiedItem);
+            continue;
+        }
+
+        if (QGraphicsLineItem* lineItem = dynamic_cast<QGraphicsLineItem*>(draw)) {
+            QGraphicsLineItem* copiedItem = new QGraphicsLineItem(lineItem->line());
+            copiedItem->setPos(lineItem->pos());
+            copiedItem->setFlag(QGraphicsItem::ItemIsSelectable, true);
+            copiedItem->setFlag(QGraphicsItem::ItemIsMovable, true);
+            drawingAux->append(copiedItem);
+            continue;
+        }
+    }
+
+    *_gmcCopies = gmcAux;
+    *_portsCopies = portsAux;
+    *_drawCopy = drawingAux;
+    *_groupCopy = groupAux;
+    delete aux;
+    delete gmcOldGroupAux;
+    delete gmcNewGroupAux;
+}

--- a/source/applications/gui/qt/GenesysQtGUI/controllers/EditCommandController.h
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/EditCommandController.h
@@ -1,0 +1,68 @@
+#ifndef EDITCOMMANDCONTROLLER_H
+#define EDITCOMMANDCONTROLLER_H
+
+#include <QList>
+#include <QGraphicsItem>
+#include <functional>
+
+class Simulator;
+class ModelGraphicsView;
+class GraphicalModelComponent;
+class GraphicalConnection;
+class QGraphicsItemGroup;
+
+// Phase 9 controller that centralizes edit/clipboard command orchestration.
+class EditCommandController {
+public:
+    // Inject only narrow dependencies required by edit command behavior.
+    EditCommandController(Simulator* simulator,
+                          ModelGraphicsView* graphicsView,
+                          std::function<void()> actualizeActions,
+                          bool* cut,
+                          QList<GraphicalModelComponent*>** gmcCopies,
+                          QList<GraphicalConnection*>** portsCopies,
+                          QList<QGraphicsItem*>** drawCopy,
+                          QList<QGraphicsItemGroup*>** groupCopy);
+
+    // Delegate undo command handling without changing scene undo semantics.
+    void onActionEditUndoTriggered() const;
+    // Delegate redo command handling without changing scene undo semantics.
+    void onActionEditRedoTriggered() const;
+    // Delegate cut command handling while preserving copy buffers.
+    void onActionEditCutTriggered() const;
+    // Delegate copy command handling while preserving copy buffers.
+    void onActionEditCopyTriggered() const;
+    // Delegate paste command handling while preserving copy buffers.
+    void onActionEditPasteTriggered() const;
+    // Delegate delete command handling while preserving undo integration.
+    void onActionEditDeleteTriggered() const;
+    // Delegate group command handling through scene grouping APIs.
+    void onActionEditGroupTriggered() const;
+    // Delegate ungroup command handling through scene grouping APIs.
+    void onActionEditUngroupTriggered() const;
+    // Delegate view-group command handling through scene grouping APIs.
+    void onActionViewGroupTriggered() const;
+    // Delegate view-ungroup command handling through scene grouping APIs.
+    void onActionViewUngroupTriggered() const;
+
+    // Keep clipboard filtering helper behavior used by copy/cut workflows.
+    void saveItemForCopy(QList<GraphicalModelComponent*>* gmcList, QList<GraphicalConnection*>* connList) const;
+    // Keep deep-copy helper behavior used by paste workflows.
+    void helpCopy() const;
+
+private:
+    // Resolve current scene from the injected graphics view.
+    class ModelGraphicsScene* scene() const;
+
+private:
+    Simulator* _simulator;
+    ModelGraphicsView* _graphicsView;
+    std::function<void()> _actualizeActions;
+    bool* _cut;
+    QList<GraphicalModelComponent*>** _gmcCopies;
+    QList<GraphicalConnection*>** _portsCopies;
+    QList<QGraphicsItem*>** _drawCopy;
+    QList<QGraphicsItemGroup*>** _groupCopy;
+};
+
+#endif // EDITCOMMANDCONTROLLER_H

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
@@ -23,6 +23,8 @@
 #include "controllers/ModelLifecycleController.h"
 // Add Phase 8 controller include for simulation-command orchestration.
 #include "controllers/SimulationCommandController.h"
+// Add Phase 9 controller include for edit-command orchestration.
+#include "controllers/EditCommandController.h"
 #include "services/ModelLanguageSynchronizer.h"
 #include "services/GraphvizModelExporter.h"
 #include "services/CppModelExporter.h"
@@ -287,6 +289,16 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
         [this]() { _actualizeActions(); },
         [this]() { return _check(false); },
         [this]() { return _setSimulationModelBasedOnText(); });
+    // Initialize the Phase 9 edit-command controller after scene and copy-buffer dependencies are available.
+    _editCommandController = std::make_unique<EditCommandController>(
+        simulator,
+        ui->graphicsView,
+        [this]() { _actualizeActions(); },
+        &_cut,
+        &_gmc_copies,
+        &_ports_copies,
+        &_draw_copy,
+        &_group_copy);
 
     // Initialize the Phase 7 model-lifecycle controller after simulator/UI/callback dependencies are ready.
     _modelLifecycleController = std::make_unique<ModelLifecycleController>(
@@ -417,32 +429,9 @@ void MainWindow::_onPropertyEditorModelChanged() {
 
 
 void::MainWindow::saveItemForCopy(QList<GraphicalModelComponent*> * gmcList, QList<GraphicalConnection*> * connList) {
-    foreach (GraphicalConnection *conn, *connList) {
-        ModelComponent * source = conn->getSource()->component;
-        ModelComponent * dst = conn->getDestination()->component;
-
-        GraphicalModelComponent * sourceSelected = nullptr;
-        GraphicalModelComponent * dstSelected = nullptr;
-        foreach (GraphicalModelComponent * comp, *gmcList) {
-
-            if (source != nullptr) {
-
-                if (comp->getComponent()->getId() == source->getId()) {
-                    sourceSelected = comp;
-                }
-            }
-
-            if (dst != nullptr) {
-
-                if (comp->getComponent()->getId() == dst->getId()) {
-                    dstSelected = comp;
-                }
-            }
-        }
-
-        if (sourceSelected == nullptr || dstSelected == nullptr) {
-            connList->removeOne(conn);
-        }
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 9 refactor.
+    if (_editCommandController != nullptr) {
+        _editCommandController->saveItemForCopy(gmcList, connList);
     }
 }
 
@@ -739,269 +728,10 @@ void MainWindow::_showMessageNotImplemented(){
 
 
 void MainWindow::_helpCopy() {
-    // Pega a cena
-    ModelGraphicsScene *scene = (ModelGraphicsScene *)(ui->graphicsView->getScene());
-
-    QList<COPY*> * aux = new QList<COPY *>();
-    QList<GraphicalModelComponent *> *gmc_aux  = new QList<GraphicalModelComponent*>();
-    QList<GraphicalModelComponent *> *gmc_old_group_aux  = new QList<GraphicalModelComponent*>();
-    QList<GraphicalModelComponent *> *gmc_new_group_aux  = new QList<GraphicalModelComponent*>();
-    QList<GraphicalConnection *> *ports_aux = new QList<GraphicalConnection*>();
-    QList<QGraphicsItem *> *drawing_aux = new QList<QGraphicsItem*>();
-    QList<QGraphicsItemGroup *> *group_aux = new QList<QGraphicsItemGroup*>();
-
-    // Adicionando todos os componentes antes
-    foreach (GraphicalModelComponent * gmc , *_gmc_copies) {
-
-        if (gmc->group())
-            continue;
-
-        // Componente
-        ModelComponent * previousComponent = gmc->getComponent();
-
-        // Adiciona o componente no modelo
-        simulator->getModelManager()->current()->getComponentManager()->insert(previousComponent);
-
-        // Nome do plugin para a copia do componente
-        std::string pluginname = previousComponent->getClassname();
-
-        // Plugin para a copia do novo component
-        Plugin* plugin = simulator->getPluginManager()->find(pluginname);
-
-        // Ajustando a posicao da copia
-        //@TODO: Modificar para por onde o mouse clicou
-        QPointF position = gmc->pos();
-
-        // Copiando a cor
-        QColor color = gmc->getColor();
-
-        // Componente de Copia ou Recorte
-        ModelComponent * component  = (ModelComponent*) plugin->newInstance(simulator->getModelManager()->current());
-
-
-        GraphicalModelComponent* newgmc = new GraphicalModelComponent(plugin, component, position, color);
-        // Adiciona o componente graficamente
-        GraphicalModelComponent * oldgmc = scene->findGraphicalModelComponent(previousComponent->getId());
-
-        COPY * temp = new COPY();
-        temp->old = oldgmc;
-        temp->copy = newgmc;
-        aux->append(temp);
-        gmc_aux->append(newgmc);
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 9 refactor.
+    if (_editCommandController != nullptr) {
+        _editCommandController->helpCopy();
     }
-
-    // Adicionando todos os componentes antes
-    foreach (QGraphicsItemGroup *group , *_group_copy) {
-        QList<GraphicalConnection*> * connGroup = new QList<GraphicalConnection*>();
-
-        unsigned int size = group->childItems().size();
-
-        for (unsigned int i = 0; i < (unsigned int) size; i++) {
-            GraphicalModelComponent *gmc = dynamic_cast<GraphicalModelComponent *>(group->childItems().at(0));
-
-            // remove do grupo para tratar o componente como um componente individual
-            group->removeFromGroup(gmc);
-
-            // Componente
-            ModelComponent * previousComponent = gmc->getComponent();
-
-            // Adiciona o componente no modelo
-            simulator->getModelManager()->current()->getComponentManager()->insert(previousComponent);
-
-            // Nome do plugin para a copia do componente
-            std::string pluginname = previousComponent->getClassname();
-
-            // Plugin para a copia do novo component
-            Plugin* plugin = simulator->getPluginManager()->find(pluginname);
-
-            // Ajustando a posicao da copia
-            //@TODO: Modificar para por onde o mouse clicou
-            QPointF position = gmc->pos();
-
-            // Copiando a cor
-            QColor color = gmc->getColor();
-
-            // Componente de Copia ou Recorte
-            ModelComponent * component  = (ModelComponent*) plugin->newInstance(simulator->getModelManager()->current());
-
-            GraphicalModelComponent* newgmc = new GraphicalModelComponent(plugin, component, position, color);
-            // Adiciona o componente graficamente
-            GraphicalModelComponent * oldgmc = scene->findGraphicalModelComponent(previousComponent->getId());
-
-            if (!oldgmc->getGraphicalInputPorts().empty() && !oldgmc->getGraphicalInputPorts().at(0)->getConnections()->empty()) {
-                connGroup->removeOne(oldgmc->getGraphicalInputPorts().at(0)->getConnections()->at(0));
-                connGroup->append(oldgmc->getGraphicalInputPorts().at(0)->getConnections()->at(0));
-            }
-
-            for (int j = 0; j < oldgmc->getGraphicalOutputPorts().size(); ++j) {
-                GraphicalComponentPort *port = oldgmc->getGraphicalOutputPorts().at(j);
-
-                if (!port->getConnections()->empty()) {
-                    connGroup->removeOne(port->getConnections()->at(0));
-                    connGroup->append(port->getConnections()->at(0));
-                }
-            }
-
-            gmc_old_group_aux->append(oldgmc);
-            gmc_new_group_aux->append(newgmc);
-            COPY * temp = new COPY();
-            temp->old = oldgmc;
-            temp->copy = newgmc;
-            aux->append(temp);
-            gmc_aux->append(newgmc);
-        }
-
-        saveItemForCopy(gmc_old_group_aux, connGroup);
-
-        // volta os itens no grupo
-        for (unsigned int k = 0; k < size; k++) {
-            group->addToGroup(gmc_old_group_aux->at(k));
-        }
-
-        for (unsigned int k = 0; k < (unsigned int) connGroup->size(); k++) {
-            _ports_copies->removeOne(connGroup->at(k));
-            _ports_copies->append(connGroup->at(k));
-        }
-
-        QGraphicsItemGroup *newGroup = new QGraphicsItemGroup();
-
-        ui->graphicsView->getScene()->insertComponentGroup(newGroup, *gmc_new_group_aux);
-
-        gmc_old_group_aux->clear();
-        gmc_new_group_aux->clear();
-        group_aux->append(newGroup);
-    }
-
-    // Adicionando as conexões (e seus respectivos componentes)
-    foreach (GraphicalConnection * conn, *_ports_copies) {
-
-        ModelComponent * source = conn->getSource()->component;
-        ModelComponent * dst = conn->getDestination()->component;
-
-        GraphicalComponentPort* sourcePort = nullptr;
-        GraphicalComponentPort* destinationPort = nullptr;
-
-        unsigned int portSourceConnection = 0;
-        unsigned int portDestinationConnection = 0;
-
-        // Ajustando a posicao da copia
-        //@TODO: Modificar para por onde o mouse clicou
-        GraphicalModelComponent * gmcSource = scene->findGraphicalModelComponent(source->getId());
-        GraphicalModelComponent * gmcDestination = scene->findGraphicalModelComponent(dst->getId());
-
-        foreach (GraphicalModelComponent * comp, *_gmc_copies) {
-
-            if (comp->getComponent()->getId() == source->getId()) {
-                sourcePort = conn->getSourceGraphicalPort();
-                portSourceConnection = conn->getPortSourceConnection();
-
-            }
-
-            if (comp->getComponent()->getId() == dst->getId()) {
-                destinationPort = conn->getDestinationGraphicalPort();
-                portDestinationConnection = conn->getPortDestinationConnection();
-            }
-        }
-
-        GraphicalModelComponent * gmcNewSource;
-        GraphicalModelComponent * gmcNewDestination;
-
-        foreach (COPY * c, *aux) {
-
-            if (c->old == gmcSource) gmcNewSource = c->copy;
-            if (c->old == gmcDestination) gmcNewDestination = c->copy;
-
-        }
-
-        // Cria GraphicalComponentPort para gmc source
-        sourcePort = gmcNewSource->getGraphicalOutputPorts().at(portSourceConnection);
-
-        // Cria GraphicalComponentPort para gmc destination
-        destinationPort = gmcNewDestination->getGraphicalInputPorts().at(portDestinationConnection);
-
-        // Conecta os componente graficamente e no modelo
-        GraphicalConnection * newConn = scene->addGraphicalConnection(sourcePort, destinationPort, portSourceConnection, portDestinationConnection);
-
-        ui->graphicsView->getScene()->clearPorts(newConn, gmcNewSource, gmcDestination);
-
-        ports_aux->append(newConn);
-    }
-
-    //Adicionando os desenhos
-    foreach(QGraphicsItem * draw, *_draw_copy) {
-        AnimationCounter *animationCounter = dynamic_cast<AnimationCounter*>(draw);
-        if (animationCounter) {
-            AnimationCounter *copiedItem;
-            copiedItem = new AnimationCounter();
-            copiedItem->setRect(0, 0, animationCounter->boundingRect().width(), animationCounter->boundingRect().height());
-            copiedItem->setPos(animationCounter->pos());
-            copiedItem->setCounter(animationCounter->getCounter());
-            copiedItem->setValue(animationCounter->getValue());
-            drawing_aux->append(copiedItem);
-            continue;
-        }
-
-        AnimationVariable *animationVariable = dynamic_cast<AnimationVariable*>(draw);
-        if (animationVariable) {
-            AnimationVariable *copiedItem;
-            copiedItem = new AnimationVariable();
-            copiedItem->setRect(0, 0, animationVariable->boundingRect().width(), animationVariable->boundingRect().height());
-            copiedItem->setPos(animationVariable->pos());
-            copiedItem->setVariable(animationVariable->getVariable());
-            copiedItem->setValue(animationVariable->getValue());
-            drawing_aux->append(copiedItem);
-            continue;
-        }
-
-        QGraphicsRectItem* rectItem = dynamic_cast<QGraphicsRectItem*>(draw);
-        if (rectItem) {
-            QGraphicsRectItem *copiedItem;
-            copiedItem = new QGraphicsRectItem(rectItem->rect());
-            copiedItem->setPos(rectItem->pos());
-            copiedItem->setFlag(QGraphicsItem::ItemIsSelectable, true);
-            copiedItem->setFlag(QGraphicsItem::ItemIsMovable, true);
-            drawing_aux->append(copiedItem);
-            continue;
-        }
-
-        QGraphicsEllipseItem* ellipseItem = dynamic_cast<QGraphicsEllipseItem*>(draw);
-        if (ellipseItem) {
-            QGraphicsEllipseItem *copiedItem;
-            copiedItem = new QGraphicsEllipseItem(ellipseItem->rect());
-            copiedItem->setPos(ellipseItem->pos());
-            copiedItem->setFlag(QGraphicsItem::ItemIsSelectable, true);
-            copiedItem->setFlag(QGraphicsItem::ItemIsMovable, true);
-            drawing_aux->append(copiedItem);
-            continue;
-        }
-
-        QGraphicsPolygonItem* polygonItem = dynamic_cast<QGraphicsPolygonItem*>(draw);
-        if (polygonItem) {
-            QGraphicsPolygonItem *copiedItem;
-            copiedItem = new QGraphicsPolygonItem(polygonItem->polygon());
-            copiedItem->setPos(polygonItem->pos());
-            copiedItem->setFlag(QGraphicsItem::ItemIsSelectable, true);
-            copiedItem->setFlag(QGraphicsItem::ItemIsMovable, true);
-            drawing_aux->append(copiedItem);
-            continue;
-        }
-
-        QGraphicsLineItem *lineItem = dynamic_cast<QGraphicsLineItem*>(draw);
-        if (lineItem) {
-            QGraphicsLineItem *copiedItem;
-            copiedItem = new QGraphicsLineItem(lineItem->line());
-            copiedItem->setPos(lineItem->pos());
-            copiedItem->setFlag(QGraphicsItem::ItemIsSelectable, true);
-            copiedItem->setFlag(QGraphicsItem::ItemIsMovable, true);
-            drawing_aux->append(copiedItem);
-            continue;
-        }
-    }
-
-    _gmc_copies = gmc_aux;
-    _ports_copies = ports_aux;
-    _draw_copy = drawing_aux;
-    _group_copy = group_aux;
 }
 
 

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.h
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.h
@@ -37,6 +37,7 @@ class PluginCatalogController;
 class PropertyEditorController;
 class ModelLifecycleController;
 class SimulationCommandController;
+class EditCommandController;
 
 /**
  * @brief Main Qt window of Genesys GUI.
@@ -284,6 +285,8 @@ private: // interface and model main elements to join
 	Ui::MainWindow *ui;
 	Simulator* simulator;
     std::unique_ptr<class SimulationController> _simulationController;
+    // Add the Phase 9 edit-command controller owned by MainWindow.
+    std::unique_ptr<EditCommandController> _editCommandController;
     // Add the Phase 8 simulation-command controller owned by MainWindow.
     std::unique_ptr<SimulationCommandController> _simulationCommandController;
     // Phase-1 services keep model-representation logic outside MainWindow while wrappers remain stable.

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow_controller.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow_controller.cpp
@@ -8,6 +8,8 @@
 #include "controllers/ModelLifecycleController.h"
 // Include the Phase 8 controller interface required by simulation-command compatibility wrappers.
 #include "controllers/SimulationCommandController.h"
+// Include the Phase 9 controller interface required by edit-command compatibility wrappers.
+#include "controllers/EditCommandController.h"
 
 #include "dialogs/dialogBreakpoint.h"
 #include "dialogs/Dialogmodelinformation.h"
@@ -16,9 +18,6 @@
 #include "dialogs/dialogsystempreferences.h"
 #include "dialogs/DialogFind.h"
 #include "controllers/SimulationController.h"
-
-#include "actions/DeleteUndoCommand.h"
-#include "actions/PasteUndoCommand.h"
 
 // std
 #include <string>
@@ -168,15 +167,17 @@ void MainWindow::on_actionAboutGetInvolved_triggered() {
 }
 
 void MainWindow::on_actionEditUndo_triggered() {
-    if (ui->graphicsView->getScene()->getUndoStack()) {
-        ui->graphicsView->getScene()->getUndoStack()->undo();
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 9 refactor.
+    if (_editCommandController != nullptr) {
+        _editCommandController->onActionEditUndoTriggered();
     }
 }
 
 
 void MainWindow::on_actionEditRedo_triggered() {
-    if (ui->graphicsView->getScene()->getUndoStack()) {
-        ui->graphicsView->getScene()->getUndoStack()->redo();
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 9 refactor.
+    if (_editCommandController != nullptr) {
+        _editCommandController->onActionEditRedoTriggered();
     }
 }
 
@@ -343,159 +344,23 @@ void MainWindow::on_actionEditReplace_triggered() {
 
 
 void MainWindow::on_actionEditCut_triggered() {
-    _gmc_copies->clear();
-    _ports_copies->clear();
-    _group_copy->clear();
-    _draw_copy->clear();
-
-    QList<QGraphicsItem *> selecteds =  ui->graphicsView->scene()->selectedItems();
-
-    // Verifica se tem itens selecionados
-    if (selecteds.size() > 0) {
-
-        // Pega a cena
-        ModelGraphicsScene *scene = (ModelGraphicsScene *)(ui->graphicsView->getScene());
-
-        // Seta o cut
-        _cut = true;
-
-        // Adiciona na lista de cópias (conexões, componentes e desenhos)
-        foreach (QGraphicsItem *item , ui->graphicsView->scene()->selectedItems()) {
-            QList<GraphicalModelComponent*> groupComponents  = QList<GraphicalModelComponent*>();
-            QList<GraphicalConnection*> * connGroup = new QList<GraphicalConnection*>();
-
-            // Tenta transformar em um componente gráfico de modelo
-            if (GraphicalModelComponent *gmc = dynamic_cast<GraphicalModelComponent*>(item)) {
-                // Adiciona em uma lista de cópias de componentes
-                _gmc_copies->append(gmc);
-            }
-            else if (QGraphicsItemGroup *group = dynamic_cast<QGraphicsItemGroup*>(item)) {
-                for (int i = 0; i < group->childItems().size(); i++) {
-                    GraphicalModelComponent * component = dynamic_cast<GraphicalModelComponent *>(group->childItems().at(i));
-
-                    if (!component->getGraphicalInputPorts().empty() && !component->getGraphicalInputPorts().at(0)->getConnections()->empty()) {
-                        for (int j = 0; j < component->getGraphicalInputPorts().at(0)->getConnections()->size(); ++j) {
-                            connGroup->append(component->getGraphicalInputPorts().at(0)->getConnections()->at(j));
-                        }
-                    }
-
-                    for (int j = 0; j < component->getGraphicalOutputPorts().size(); ++j) {
-                        GraphicalComponentPort *port = component->getGraphicalOutputPorts().at(j);
-
-                        if (!port->getConnections()->empty()) {
-                            connGroup->append(port->getConnections()->at(0));
-                        }
-                    }
-
-                    _gmc_copies->append(component);
-                    groupComponents.append(component);
-                }
-                saveItemForCopy(&groupComponents, connGroup);
-
-                _group_copy->append(group);
-                ui->graphicsView->getScene()->insertComponentGroup(group, groupComponents);
-                for (unsigned int k = 0; k < (unsigned int) connGroup->size(); k++) {
-                    _ports_copies->append(connGroup->at(k));
-                }
-            } else if (GraphicalConnection *port = dynamic_cast<GraphicalConnection*>(item)) {
-                _ports_copies->append(port);
-            } else {
-                _draw_copy->append(item);
-            }
-
-            delete connGroup;
-        }
-
-        // Removendo as conexoes do modelo e graficamente
-        // Só não é removido a conexão quando todos os itens estão selecionados
-        // (2x componentes e a conexão (similar ao arena)
-        saveItemForCopy(_gmc_copies, _ports_copies);
-
-        QUndoCommand *deleteUndoCommand = new DeleteUndoCommand(selecteds, scene);
-        scene->getUndoStack()->push(deleteUndoCommand);
-
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 9 refactor.
+    if (_editCommandController != nullptr) {
+        _editCommandController->onActionEditCutTriggered();
     }
 }
 
 void MainWindow::on_actionEditCopy_triggered() {
-    _gmc_copies->clear();
-    _ports_copies->clear();
-    _group_copy->clear();
-    _draw_copy->clear();
-
-    QList<QGraphicsItem*> selected = ui->graphicsView->scene()->selectedItems();
-    QList<GraphicalModelComponent *> gmc_copies_copy = QList<GraphicalModelComponent *>();
-
-    // verifica se tem itens selecionados
-    if (selected.size() > 0) {
-
-        // seta o cut
-        _cut = false;
-
-        // adiciona na lista de cópias (conexões, componentes e desenhos)
-        foreach (QGraphicsItem *item , ui->graphicsView->scene()->selectedItems()) {
-            // verifica se é um componente gráfico
-            if (GraphicalModelComponent *gmc = dynamic_cast<GraphicalModelComponent*>(item)) {
-                // Adiciona em uma lista de cópias de componentes
-                gmc->setSelected(false);
-                _gmc_copies->append(gmc);
-                gmc_copies_copy.append(gmc);
-            }
-            // verifica se é uma conexão gráfica
-            else if (GraphicalConnection *conn = dynamic_cast<GraphicalConnection*>(item)) {
-                conn->setSelected(false);
-                _ports_copies->append(conn);
-            }
-            // verifica se é um grupo
-            else if (QGraphicsItemGroup *group = dynamic_cast<QGraphicsItemGroup*>(item)) {
-                group->setSelected(false);
-                _group_copy->append(group);
-
-                for (int i = 0; i < group->childItems().size(); i++) {
-                    GraphicalModelComponent * component = dynamic_cast<GraphicalModelComponent *>(group->childItems().at(i));
-
-                    gmc_copies_copy.append(component);
-                }
-            }
-            // se não for nenhum deles é um desenho na tela
-            else {
-                item->setSelected(false);
-                _draw_copy->append(item);
-            }
-        }
-
-        // removendo as conexões em que os seus componentes não foram selecionados
-        saveItemForCopy(&gmc_copies_copy, _ports_copies);
-
-        // limpa a lista auxiliar
-        gmc_copies_copy.clear();
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 9 refactor.
+    if (_editCommandController != nullptr) {
+        _editCommandController->onActionEditCopyTriggered();
     }
-
 }
 
 void MainWindow::on_actionEditPaste_triggered() {
-
-    // se tiver componente copiados
-    if (_gmc_copies->size() > 0 || _draw_copy->size() > 0 || _group_copy->size() > 0) {
-
-        // pega a cena
-        ModelGraphicsScene *scene = (ModelGraphicsScene *)(ui->graphicsView->getScene());
-
-        // se não for ação de recorte chama o auxiliar do copy
-        if (!_cut) {
-            _helpCopy();
-        }
-
-        // cola na cena o que foi copiado
-        QUndoCommand *pasteUndoCommand = new PasteUndoCommand(_gmc_copies, _ports_copies, _group_copy, _draw_copy, scene);
-        scene->getUndoStack()->push(pasteUndoCommand);
-
-        // limpa todas as listas
-        _gmc_copies->clear();
-        _ports_copies->clear();
-        _draw_copy->clear();
-        _group_copy->clear();
-        _cut = false;
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 9 refactor.
+    if (_editCommandController != nullptr) {
+        _editCommandController->onActionEditPasteTriggered();
     }
 }
 
@@ -650,15 +515,10 @@ void MainWindow::on_actionAnimateStation_triggered() {
 
 void MainWindow::on_actionEditDelete_triggered()
 {
-    QList<QGraphicsItem *> selecteds = ui->graphicsView->scene()->selectedItems();
-    if (selecteds.isEmpty()) {
-        return;
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 9 refactor.
+    if (_editCommandController != nullptr) {
+        _editCommandController->onActionEditDeleteTriggered();
     }
-
-    ModelGraphicsScene *scene = ui->graphicsView->getScene();
-    QUndoCommand *deleteUndoCommand = new DeleteUndoCommand(selecteds, scene);
-    scene->getUndoStack()->push(deleteUndoCommand);
-    _actualizeActions();
 }
 
 
@@ -761,13 +621,19 @@ void MainWindow::on_actionAnimateStatistics_triggered()
 
 void MainWindow::on_actionEditGroup_triggered()
 {
-    on_actionViewGroup_triggered();
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 9 refactor.
+    if (_editCommandController != nullptr) {
+        _editCommandController->onActionEditGroupTriggered();
+    }
 }
 
 
 void MainWindow::on_actionEditUngroup_triggered()
 {
-    on_actionViewUngroup_triggered();
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 9 refactor.
+    if (_editCommandController != nullptr) {
+        _editCommandController->onActionEditUngroupTriggered();
+    }
 }
 
 
@@ -1148,15 +1014,19 @@ void MainWindow::on_actionShowSnap_triggered()
 
 void MainWindow::on_actionViewGroup_triggered()
 {
-    ModelGraphicsScene* scene = (ModelGraphicsScene*) (ui->graphicsView->scene());
-    scene->groupComponents(false);
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 9 refactor.
+    if (_editCommandController != nullptr) {
+        _editCommandController->onActionViewGroupTriggered();
+    }
 }
 
 
 void MainWindow::on_actionViewUngroup_triggered()
 {
-    ModelGraphicsScene* scene = (ModelGraphicsScene*) (ui->graphicsView->scene());
-    scene->ungroupComponents();
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 9 refactor.
+    if (_editCommandController != nullptr) {
+        _editCommandController->onActionViewUngroupTriggered();
+    }
 }
 
 void MainWindow::on_actionArranjeLeft_triggered()


### PR DESCRIPTION
### Motivation
- Reduce `MainWindow` responsibility by extracting edit/clipboard/undo-redo/group-delete orchestration into a dedicated controller while preserving existing behavior.
- Centralize cut/copy/paste/delete/undo/redo/group/ungroup and related clipboard helpers to make future refactors safer and easier.
- Preserve existing public slot signatures and keep thin compatibility wrappers in `MainWindow` for an incremental migration that stops at Phase 9.

### Description
- Added a new Phase 9 controller `EditCommandController` implemented in `controllers/EditCommandController.h/.cpp` that owns undo/redo, cut/copy/paste, delete, group/ungroup, `saveItemForCopy(...)` and `helpCopy()` logic, preserving prior undo-stack and copy-buffer semantics.
- Added `_editCommandController` as a `std::unique_ptr<EditCommandController>` member of `MainWindow` and initialize it with narrow dependencies (simulator, `ModelGraphicsView*`, an `_actualizeActions` callback and the existing copy/cut buffer pointers).
- Replaced the real implementations of Phase 9 methods in `mainwindow_controller.cpp` with thin delegating wrappers that call the new controller, and replaced `MainWindow::saveItemForCopy(...)` and `MainWindow::_helpCopy()` with wrappers delegating into the controller.
- Updated `GenesysQtGUI.pro` to include the new controller source and header so it is compiled and linked.
- All added and modified code regions include short, English comments explaining the change as required by the Phase 9 commenting policy, and the work intentionally stops at Phase 9 (no Phase 10+ refactors included).

### Testing
- Ran `git diff --check` to validate whitespace/patch issues; result was OK.
- Verified repository status with `git status --short` to ensure changes were committed; working-tree is clean after commit.
- Attempted to checkout branch `WiP20261` but it is not present in the local clone, so branch-specific checkout was not performed (this is an environment limitation, not a code change failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d58e25f8b88321be94776d3d82c9a3)