### PR TITLE
Phase 10: Extract scene/view tool commands into SceneToolController

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/GenesysQtGUI.pro
+++ b/source/applications/gui/qt/GenesysQtGUI/GenesysQtGUI.pro
@@ -255,6 +255,8 @@ SOURCES += \
     controllers/SimulationCommandController.cpp \
     # Phase-9 GUI refactor controller for edit-command responsibilities.
     controllers/EditCommandController.cpp \
+    # Phase-10 GUI refactor controller for scene/view/drawing responsibilities.
+    controllers/SceneToolController.cpp \
     # Phase-1 GUI refactor services for model representations.
     services/ModelLanguageSynchronizer.cpp \
     services/GraphvizModelExporter.cpp \
@@ -586,6 +588,8 @@ HEADERS += \
     controllers/SimulationCommandController.h \
     # Phase-9 GUI refactor controller header for edit-command responsibilities.
     controllers/EditCommandController.h \
+    # Phase-10 GUI refactor controller header for scene/view/drawing responsibilities.
+    controllers/SceneToolController.h \
     # Phase-1 GUI refactor service headers.
     services/ModelLanguageSynchronizer.h \
     services/GraphvizModelExporter.h \

--- a/source/applications/gui/qt/GenesysQtGUI/controllers/SceneToolController.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/SceneToolController.cpp
@@ -1,0 +1,422 @@
+#include "SceneToolController.h"
+
+#include "../ui_mainwindow.h"
+#include "../TraitsGUI.h"
+#include "../graphicals/ModelGraphicsView.h"
+#include "../graphicals/ModelGraphicsScene.h"
+#include "../graphicals/GraphicalModelComponent.h"
+#include "../animations/AnimationTransition.h"
+
+#include <QGraphicsItem>
+#include <QSignalBlocker>
+#include <Qt>
+
+// Store only narrow collaborators needed for Phase 10 scene-tool orchestration.
+SceneToolController::SceneToolController(ModelGraphicsView* graphicsView,
+                                         Ui::MainWindow* ui,
+                                         std::function<ModelGraphicsScene*()> currentScene,
+                                         std::function<bool()> createModelImage,
+                                         std::function<void()> unselectDrawIcons,
+                                         std::function<bool()> checkSelectedDrawIcons,
+                                         std::function<void(double)> gentleZoom,
+                                         std::function<void()> actualizeActions,
+                                         std::function<void()> actualizeTabPanes,
+                                         int& zoomValue,
+                                         bool& firstClickShowConnection)
+    : _graphicsView(graphicsView),
+      _ui(ui),
+      _currentScene(std::move(currentScene)),
+      _createModelImage(std::move(createModelImage)),
+      _unselectDrawIcons(std::move(unselectDrawIcons)),
+      _checkSelectedDrawIcons(std::move(checkSelectedDrawIcons)),
+      _gentleZoom(std::move(gentleZoom)),
+      _actualizeActions(std::move(actualizeActions)),
+      _actualizeTabPanes(std::move(actualizeTabPanes)),
+      _zoomValue(zoomValue),
+      _firstClickShowConnection(firstClickShowConnection) {
+}
+
+// Preserve deterministic action-to-scene grid synchronization.
+void SceneToolController::onActionShowGridTriggered() {
+    ModelGraphicsScene* scene = _currentScene();
+    if (scene != nullptr) {
+        scene->setGridVisible(_ui->actionShowGrid->isChecked());
+    }
+}
+
+// Preserve ruler state synchronization between QAction and graphics view backend.
+void SceneToolController::onActionShowRuleTriggered() {
+    const bool requestedVisible = _ui->actionShowRule->isChecked();
+    _graphicsView->setRuleVisible(requestedVisible);
+    _ui->actionShowRule->setChecked(_graphicsView->isRuleVisible());
+}
+
+// Preserve guides state synchronization between QAction and graphics view backend.
+void SceneToolController::onActionShowGuidesTriggered() {
+    const bool requestedVisible = _ui->actionShowGuides->isChecked();
+    _graphicsView->setGuidesVisible(requestedVisible);
+    _ui->actionShowGuides->setChecked(_graphicsView->isGuidesVisible());
+}
+
+// Preserve deterministic snap-to-grid synchronization from QAction to scene.
+void SceneToolController::onActionShowSnapTriggered() {
+    ModelGraphicsScene* scene = _currentScene();
+    if (scene != nullptr) {
+        scene->setSnapToGrid(_ui->actionShowSnap->isChecked());
+    }
+}
+
+// Preserve zoom-in command behavior through the graphical zoom slider.
+void SceneToolController::onActionZoomInTriggered() {
+    const int value = _ui->horizontalSlider_ZoomGraphical->value();
+    _ui->horizontalSlider_ZoomGraphical->setValue(value + TraitsGUI<GMainWindow>::zoomButtonChange);
+}
+
+// Preserve zoom-out command behavior through the graphical zoom slider.
+void SceneToolController::onActionZoomOutTriggered() {
+    const int value = _ui->horizontalSlider_ZoomGraphical->value();
+    _ui->horizontalSlider_ZoomGraphical->setValue(value - TraitsGUI<GMainWindow>::zoomButtonChange);
+}
+
+// Preserve zoom-all fit behavior and reset the slider baseline coherently.
+void SceneToolController::onActionZoomAllTriggered() {
+    ModelGraphicsScene* scene = _currentScene();
+    if (scene == nullptr || scene->items().isEmpty()) {
+        return;
+    }
+
+    const QRectF bounds = scene->itemsBoundingRect();
+    if (!bounds.isValid() || bounds.isEmpty()) {
+        return;
+    }
+
+    _graphicsView->resetTransform();
+    _graphicsView->fitInView(bounds.adjusted(-20.0, -20.0, 20.0, 20.0), Qt::KeepAspectRatio);
+    {
+        QSignalBlocker blocker(_ui->horizontalSlider_ZoomGraphical);
+        _zoomValue = _ui->horizontalSlider_ZoomGraphical->maximum() / 2;
+        _ui->horizontalSlider_ZoomGraphical->setValue(_zoomValue);
+    }
+    _graphicsView->centerOn(bounds.center());
+}
+
+// Preserve graphical slider zoom delta behavior and gentle zoom scaling.
+void SceneToolController::onHorizontalSliderZoomGraphicalValueChanged(int value) {
+    const double factor = (value - _zoomValue) * 0.002;
+    _zoomValue = value;
+    _gentleZoom(1.0 + factor);
+}
+
+// Preserve line-drawing tool activation and cursor semantics.
+void SceneToolController::onActionDrawLineTriggered() {
+    ModelGraphicsScene* scene = _currentScene();
+    if (scene == nullptr) {
+        return;
+    }
+
+    if (!_checkSelectedDrawIcons() && _ui->actionDrawLine->isChecked()) {
+        _graphicsView->setCursor(Qt::SizeHorCursor);
+        _ui->actionDrawLine->setChecked(true);
+        scene->setAction(_ui->actionDrawLine);
+        scene->setDrawingMode(ModelGraphicsScene::DrawingMode::LINE);
+    } else {
+        _unselectDrawIcons();
+    }
+}
+
+// Preserve rectangle-drawing tool activation and cursor semantics.
+void SceneToolController::onActionDrawRectangleTriggered() {
+    ModelGraphicsScene* scene = _currentScene();
+    if (scene == nullptr) {
+        return;
+    }
+
+    if (!_checkSelectedDrawIcons() && _ui->actionDrawRectangle->isChecked()) {
+        _graphicsView->setCursor(Qt::CrossCursor);
+        _ui->actionDrawRectangle->setChecked(true);
+        scene->setAction(_ui->actionDrawRectangle);
+        scene->setDrawingMode(ModelGraphicsScene::DrawingMode::RECTANGLE);
+    } else {
+        _unselectDrawIcons();
+    }
+}
+
+// Preserve ellipse-drawing tool activation and cursor semantics.
+void SceneToolController::onActionDrawEllipseTriggered() {
+    ModelGraphicsScene* scene = _currentScene();
+    if (scene == nullptr) {
+        return;
+    }
+
+    if (!_checkSelectedDrawIcons() && _ui->actionDrawEllipse->isChecked()) {
+        _graphicsView->setCursor(Qt::CrossCursor);
+        _ui->actionDrawEllipse->setChecked(true);
+        scene->setAction(_ui->actionDrawEllipse);
+        scene->setDrawingMode(ModelGraphicsScene::DrawingMode::ELLIPSE);
+    } else {
+        _unselectDrawIcons();
+    }
+}
+
+// Preserve text-drawing tool activation semantics.
+void SceneToolController::onActionDrawTextTriggered() {
+    ModelGraphicsScene* scene = _currentScene();
+    if (scene == nullptr) {
+        return;
+    }
+
+    if (!_checkSelectedDrawIcons() && _ui->actionDrawText->isChecked()) {
+        _ui->actionDrawText->setChecked(true);
+        scene->setAction(_ui->actionDrawText);
+        scene->setDrawingMode(ModelGraphicsScene::DrawingMode::TEXT);
+    } else {
+        _unselectDrawIcons();
+    }
+}
+
+// Preserve polygon-drawing tool activation and cursor semantics.
+void SceneToolController::onActionDrawPoligonTriggered() {
+    ModelGraphicsScene* scene = _currentScene();
+    if (scene == nullptr) {
+        return;
+    }
+
+    if (!_checkSelectedDrawIcons() && _ui->actionDrawPoligon->isChecked()) {
+        _graphicsView->setCursor(Qt::ArrowCursor);
+        _ui->actionDrawPoligon->setChecked(true);
+        scene->setAction(_ui->actionDrawPoligon);
+        scene->setDrawingMode(ModelGraphicsScene::DrawingMode::POLYGON);
+    } else {
+        _unselectDrawIcons();
+    }
+}
+
+// Preserve simulated-time animation tool activation behavior.
+void SceneToolController::onActionAnimateSimulatedTimeTriggered() {
+    ModelGraphicsScene* scene = _currentScene();
+    if (scene == nullptr) {
+        return;
+    }
+
+    if (!_checkSelectedDrawIcons() && _ui->actionAnimateSimulatedTime->isChecked()) {
+        _graphicsView->setCursor(Qt::CrossCursor);
+        scene->setAction(_ui->actionAnimateSimulatedTime);
+        scene->drawingTimer();
+    } else {
+        _unselectDrawIcons();
+    }
+}
+
+// Preserve variable animation tool activation behavior.
+void SceneToolController::onActionAnimateVariableTriggered() {
+    ModelGraphicsScene* scene = _currentScene();
+    if (scene == nullptr) {
+        return;
+    }
+
+    if (!_checkSelectedDrawIcons() && _ui->actionAnimateVariable->isChecked()) {
+        _graphicsView->setCursor(Qt::CrossCursor);
+        scene->setAction(_ui->actionAnimateVariable);
+        scene->drawingVariable();
+    } else {
+        _unselectDrawIcons();
+    }
+}
+
+// Preserve counter animation tool activation behavior.
+void SceneToolController::onActionAnimateCounterTriggered() {
+    ModelGraphicsScene* scene = _currentScene();
+    if (scene == nullptr) {
+        return;
+    }
+
+    if (!_checkSelectedDrawIcons() && _ui->actionAnimateCounter->isChecked()) {
+        _graphicsView->setCursor(Qt::CrossCursor);
+        scene->setAction(_ui->actionAnimateCounter);
+        scene->drawingCounter();
+    } else {
+        _unselectDrawIcons();
+    }
+}
+
+// Preserve connect-tool activation through the existing graphics-view flow.
+void SceneToolController::onActionConnectTriggered() {
+    _graphicsView->beginConnection();
+}
+
+// Preserve left arrange command semantics.
+void SceneToolController::onActionArranjeLeftTriggered() {
+    ModelGraphicsScene* scene = _currentScene();
+    if (scene != nullptr) {
+        scene->arranjeModels(0);
+    }
+}
+
+// Preserve right arrange command semantics.
+void SceneToolController::onActionArranjeRightTriggered() {
+    ModelGraphicsScene* scene = _currentScene();
+    if (scene != nullptr) {
+        scene->arranjeModels(1);
+    }
+}
+
+// Preserve top arrange command semantics.
+void SceneToolController::onActionArranjeTopTriggered() {
+    ModelGraphicsScene* scene = _currentScene();
+    if (scene != nullptr) {
+        scene->arranjeModels(2);
+    }
+}
+
+// Preserve bottom arrange command semantics.
+void SceneToolController::onActionArranjeBototmTriggered() {
+    ModelGraphicsScene* scene = _currentScene();
+    if (scene != nullptr) {
+        scene->arranjeModels(3);
+    }
+}
+
+// Preserve center arrange command semantics.
+void SceneToolController::onActionArranjeCenterTriggered() {
+    ModelGraphicsScene* scene = _currentScene();
+    if (scene != nullptr) {
+        scene->arranjeModels(4);
+    }
+}
+
+// Preserve middle arrange command semantics.
+void SceneToolController::onActionArranjeMiddleTriggered() {
+    ModelGraphicsScene* scene = _currentScene();
+    if (scene != nullptr) {
+        scene->arranjeModels(5);
+    }
+}
+
+// Preserve graphical simulation visibility toggle and animation running state.
+void SceneToolController::onActionActivateGraphicalSimulationTriggered() {
+    bool visivible = true;
+
+    if (!_ui->actionActivateGraphicalSimulation->isChecked()) {
+        AnimationTransition::setRunning(false);
+        visivible = false;
+    } else {
+        AnimationTransition::setRunning(true);
+    }
+
+    ModelGraphicsScene* scene = _currentScene();
+    if (scene == nullptr) {
+        return;
+    }
+
+    QList<QGraphicsItem*>* componentes = scene->getGraphicalModelComponents();
+    for (QGraphicsItem* item : *componentes) {
+        if (GraphicalModelComponent* component = dynamic_cast<GraphicalModelComponent*>(item)) {
+            component->visivibleImageQueue(visivible);
+        }
+    }
+}
+
+// Preserve animation speed slider conversion to execution time value.
+void SceneToolController::onHorizontalSliderAnimationSpeedValueChanged(int value) {
+    const double newValue = static_cast<double>(value) / 2.0;
+    AnimationTransition::setTimeExecution(newValue);
+}
+
+// Preserve diagram visibility logic and effective QAction re-synchronization.
+void SceneToolController::onActionDiagramsTriggered() {
+    ModelGraphicsScene* scene = _currentScene();
+    if (scene == nullptr) {
+        return;
+    }
+
+    if (_ui->actionDiagrams->isChecked()) {
+        if (!scene->existDiagram()) {
+            scene->createDiagrams();
+        }
+        scene->showDiagrams();
+    } else {
+        if (scene->existDiagram()) {
+            scene->hideDiagrams();
+        }
+    }
+
+    const bool diagramsVisible = scene->existDiagram() && scene->visibleDiagram();
+    if (_ui->actionDiagrams->isChecked() != diagramsVisible) {
+        _ui->actionDiagrams->setChecked(diagramsVisible);
+    }
+}
+
+// Preserve select-all semantics by selecting every scene item.
+void SceneToolController::onActionSelectAllTriggered() {
+    ModelGraphicsScene* scene = _currentScene();
+    if (scene == nullptr) {
+        return;
+    }
+
+    const QList<QGraphicsItem*> itemsToScene = scene->items();
+    for (QGraphicsItem* item : itemsToScene) {
+        item->setSelected(true);
+    }
+}
+
+// Preserve action-checkbox synchronization for internals image visibility.
+void SceneToolController::onActionShowInternalElementsTriggered() {
+    const bool checked = _ui->actionShowInternalElements->isChecked();
+    if (_ui->checkBox_ShowInternals->isChecked() != checked) {
+        _ui->checkBox_ShowInternals->setChecked(checked);
+    } else {
+        _createModelImage();
+    }
+}
+
+// Preserve action-checkbox synchronization for attached-elements image visibility.
+void SceneToolController::onActionShowAttachedElementsTriggered() {
+    const bool checked = _ui->actionShowAttachedElements->isChecked();
+    if (_ui->checkBox_ShowElements->isChecked() != checked) {
+        _ui->checkBox_ShowElements->setChecked(checked);
+    } else {
+        _createModelImage();
+    }
+}
+
+// Preserve checkbox-to-action synchronization for attached-elements visibility.
+void SceneToolController::onCheckBoxShowElementsStateChanged(int arg1) {
+    _ui->actionShowAttachedElements->setChecked(arg1 == Qt::Checked);
+    _createModelImage();
+}
+
+// Preserve checkbox-to-action synchronization for internals visibility.
+void SceneToolController::onCheckBoxShowInternalsStateChanged(int arg1) {
+    _ui->actionShowInternalElements->setChecked(arg1 == Qt::Checked);
+    _createModelImage();
+}
+
+// Preserve recursive image-toggle behavior by regenerating model image.
+void SceneToolController::onCheckBoxShowRecursiveStateChanged(int arg1) {
+    Q_UNUSED(arg1)
+    _createModelImage();
+}
+
+// Preserve levels image-toggle behavior by regenerating model image.
+void SceneToolController::onCheckBoxShowLevelsStateChanged(int arg1) {
+    Q_UNUSED(arg1)
+    _createModelImage();
+}
+
+// Preserve legacy connect-step toggle semantics and first-click synchronization.
+void SceneToolController::onActionGModelShowConnectTriggered() {
+    ModelGraphicsScene* scene = _currentScene();
+    if (scene == nullptr) {
+        return;
+    }
+
+    if (!_ui->actionGModelShowConnect->isChecked() && !_firstClickShowConnection) {
+        _ui->actionGModelShowConnect->setChecked(false);
+        scene->setConnectingStep(0);
+        _graphicsView->setCursor(Qt::ArrowCursor);
+    } else {
+        _ui->actionGModelShowConnect->setChecked(true);
+        scene->setConnectingStep(1);
+        _firstClickShowConnection = false;
+    }
+}

--- a/source/applications/gui/qt/GenesysQtGUI/controllers/SceneToolController.h
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/SceneToolController.h
@@ -1,0 +1,78 @@
+#ifndef SCENETOOLCONTROLLER_H
+#define SCENETOOLCONTROLLER_H
+
+#include <functional>
+
+class ModelGraphicsView;
+class ModelGraphicsScene;
+
+namespace Ui {
+class MainWindow;
+}
+
+// Move scene/view/drawing command orchestration into a dedicated Phase 10 controller.
+class SceneToolController {
+public:
+    // Inject only narrow dependencies required by scene and tool command handlers.
+    SceneToolController(ModelGraphicsView* graphicsView,
+                        Ui::MainWindow* ui,
+                        std::function<ModelGraphicsScene*()> currentScene,
+                        std::function<bool()> createModelImage,
+                        std::function<void()> unselectDrawIcons,
+                        std::function<bool()> checkSelectedDrawIcons,
+                        std::function<void(double)> gentleZoom,
+                        std::function<void()> actualizeActions,
+                        std::function<void()> actualizeTabPanes,
+                        int& zoomValue,
+                        bool& firstClickShowConnection);
+
+    void onActionShowGridTriggered();
+    void onActionShowRuleTriggered();
+    void onActionShowGuidesTriggered();
+    void onActionShowSnapTriggered();
+    void onActionZoomInTriggered();
+    void onActionZoomOutTriggered();
+    void onActionZoomAllTriggered();
+    void onHorizontalSliderZoomGraphicalValueChanged(int value);
+    void onActionDrawLineTriggered();
+    void onActionDrawRectangleTriggered();
+    void onActionDrawEllipseTriggered();
+    void onActionDrawTextTriggered();
+    void onActionDrawPoligonTriggered();
+    void onActionAnimateSimulatedTimeTriggered();
+    void onActionAnimateVariableTriggered();
+    void onActionAnimateCounterTriggered();
+    void onActionConnectTriggered();
+    void onActionArranjeLeftTriggered();
+    void onActionArranjeRightTriggered();
+    void onActionArranjeTopTriggered();
+    void onActionArranjeBototmTriggered();
+    void onActionArranjeCenterTriggered();
+    void onActionArranjeMiddleTriggered();
+    void onActionActivateGraphicalSimulationTriggered();
+    void onHorizontalSliderAnimationSpeedValueChanged(int value);
+    void onActionDiagramsTriggered();
+    void onActionSelectAllTriggered();
+    void onActionShowInternalElementsTriggered();
+    void onActionShowAttachedElementsTriggered();
+    void onCheckBoxShowElementsStateChanged(int arg1);
+    void onCheckBoxShowInternalsStateChanged(int arg1);
+    void onCheckBoxShowRecursiveStateChanged(int arg1);
+    void onCheckBoxShowLevelsStateChanged(int arg1);
+    void onActionGModelShowConnectTriggered();
+
+private:
+    ModelGraphicsView* _graphicsView;
+    Ui::MainWindow* _ui;
+    std::function<ModelGraphicsScene*()> _currentScene;
+    std::function<bool()> _createModelImage;
+    std::function<void()> _unselectDrawIcons;
+    std::function<bool()> _checkSelectedDrawIcons;
+    std::function<void(double)> _gentleZoom;
+    std::function<void()> _actualizeActions;
+    std::function<void()> _actualizeTabPanes;
+    int& _zoomValue;
+    bool& _firstClickShowConnection;
+};
+
+#endif // SCENETOOLCONTROLLER_H

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
@@ -25,6 +25,8 @@
 #include "controllers/SimulationCommandController.h"
 // Add Phase 9 controller include for edit-command orchestration.
 #include "controllers/EditCommandController.h"
+// Add Phase 10 controller include for scene/view/drawing command orchestration.
+#include "controllers/SceneToolController.h"
 #include "services/ModelLanguageSynchronizer.h"
 #include "services/GraphvizModelExporter.h"
 #include "services/CppModelExporter.h"
@@ -299,6 +301,20 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
         &_ports_copies,
         &_draw_copy,
         &_group_copy);
+
+    // Initialize the Phase 10 scene-tool controller after scene/view widgets and callbacks are ready.
+    _sceneToolController = std::make_unique<SceneToolController>(
+        ui->graphicsView,
+        ui,
+        [this]() { return ui->graphicsView->getScene(); },
+        [this]() { return _createModelImage(); },
+        [this]() { unselectDrawIcons(); },
+        [this]() { return checkSelectedDrawIcons(); },
+        [this](double factor) { _gentle_zoom(factor); },
+        [this]() { _actualizeActions(); },
+        [this]() { _actualizeTabPanes(); },
+        _zoomValue,
+        _firstClickShowConnection);
 
     // Initialize the Phase 7 model-lifecycle controller after simulator/UI/callback dependencies are ready.
     _modelLifecycleController = std::make_unique<ModelLifecycleController>(

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.h
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.h
@@ -38,6 +38,7 @@ class PropertyEditorController;
 class ModelLifecycleController;
 class SimulationCommandController;
 class EditCommandController;
+class SceneToolController;
 
 /**
  * @brief Main Qt window of Genesys GUI.
@@ -287,6 +288,8 @@ private: // interface and model main elements to join
     std::unique_ptr<class SimulationController> _simulationController;
     // Add the Phase 9 edit-command controller owned by MainWindow.
     std::unique_ptr<EditCommandController> _editCommandController;
+    // Add the Phase 10 scene-tool controller owned by MainWindow.
+    std::unique_ptr<SceneToolController> _sceneToolController;
     // Add the Phase 8 simulation-command controller owned by MainWindow.
     std::unique_ptr<SimulationCommandController> _simulationCommandController;
     // Phase-1 services keep model-representation logic outside MainWindow while wrappers remain stable.

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow_controller.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow_controller.cpp
@@ -10,6 +10,8 @@
 #include "controllers/SimulationCommandController.h"
 // Include the Phase 9 controller interface required by edit-command compatibility wrappers.
 #include "controllers/EditCommandController.h"
+// Include the Phase 10 controller interface required by scene-tool compatibility wrappers.
+#include "controllers/SceneToolController.h"
 
 #include "dialogs/dialogBreakpoint.h"
 #include "dialogs/Dialogmodelinformation.h"
@@ -366,127 +368,87 @@ void MainWindow::on_actionEditPaste_triggered() {
 
 
 void MainWindow::on_actionShowGrid_triggered() {
-    // Aplica o estado de grid da action diretamente na cena para evitar inversão por toggle.
-    ui->graphicsView->getScene()->setGridVisible(ui->actionShowGrid->isChecked());
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    if (_sceneToolController != nullptr) {
+        _sceneToolController->onActionShowGridTriggered();
+    }
 }
 
 
 void MainWindow::on_actionShowRule_triggered() {
-    // Applies the requested ruler state and then mirrors the effective backend state into the QAction.
-    const bool requestedVisible = ui->actionShowRule->isChecked();
-    ui->graphicsView->setRuleVisible(requestedVisible);
-    ui->actionShowRule->setChecked(ui->graphicsView->isRuleVisible());
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    if (_sceneToolController != nullptr) {
+        _sceneToolController->onActionShowRuleTriggered();
+    }
 }
 
 
 void MainWindow::on_actionShowGuides_triggered() {
-    // Applies the requested guides state and then mirrors the effective backend state into the QAction.
-    const bool requestedVisible = ui->actionShowGuides->isChecked();
-    ui->graphicsView->setGuidesVisible(requestedVisible);
-    ui->actionShowGuides->setChecked(ui->graphicsView->isGuidesVisible());
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    if (_sceneToolController != nullptr) {
+        _sceneToolController->onActionShowGuidesTriggered();
+    }
 }
 
 
 void MainWindow::on_actionZoom_In_triggered() {
-    int value = ui->horizontalSlider_ZoomGraphical->value();
-    ui->horizontalSlider_ZoomGraphical->setValue(value+TraitsGUI<GMainWindow>::zoomButtonChange);
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    if (_sceneToolController != nullptr) {
+        _sceneToolController->onActionZoomInTriggered();
+    }
 }
 
 
 void MainWindow::on_actionZoom_Out_triggered() {
-    int value = ui->horizontalSlider_ZoomGraphical->value();
-    ui->horizontalSlider_ZoomGraphical->setValue(value-TraitsGUI<GMainWindow>::zoomButtonChange);
-
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    if (_sceneToolController != nullptr) {
+        _sceneToolController->onActionZoomOutTriggered();
+    }
 }
 
 
 void MainWindow::on_actionZoom_All_triggered() {
-    ModelGraphicsScene* scene = ui->graphicsView->getScene();
-    if (scene == nullptr || scene->items().isEmpty()) {
-        return;
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    if (_sceneToolController != nullptr) {
+        _sceneToolController->onActionZoomAllTriggered();
     }
-
-    const QRectF bounds = scene->itemsBoundingRect();
-    if (!bounds.isValid() || bounds.isEmpty()) {
-        return;
-    }
-
-    ui->graphicsView->resetTransform();
-    ui->graphicsView->fitInView(bounds.adjusted(-20.0, -20.0, 20.0, 20.0), Qt::KeepAspectRatio);
-    {
-        QSignalBlocker blocker(ui->horizontalSlider_ZoomGraphical);
-        _zoomValue = ui->horizontalSlider_ZoomGraphical->maximum() / 2;
-        ui->horizontalSlider_ZoomGraphical->setValue(_zoomValue);
-    }
-    ui->graphicsView->centerOn(bounds.center());
 }
 
 
 void MainWindow::on_actionDrawLine_triggered() {
-    ModelGraphicsScene* scene = ui->graphicsView->getScene();
-    if (!checkSelectedDrawIcons() && ui->actionDrawLine->isChecked()) {
-        ui->graphicsView->setCursor(Qt::SizeHorCursor);
-        ui->actionDrawLine->setChecked(true);
-        // Ative a ferramenta de desenho de linha
-        scene->setAction(ui->actionDrawLine);
-        scene->setDrawingMode(ModelGraphicsScene::DrawingMode::LINE); // Enumeração que representa o modo de desenho de linha
-    } else {
-        unselectDrawIcons();
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    if (_sceneToolController != nullptr) {
+        _sceneToolController->onActionDrawLineTriggered();
     }
 }
 
 
 void MainWindow::on_actionDrawRectangle_triggered() {
-    ModelGraphicsScene* scene = ui->graphicsView->getScene();
-    // Ative a ferramenta de desenho de retangulo
-    if (!checkSelectedDrawIcons() && ui->actionDrawRectangle->isChecked()) {
-        ui->graphicsView->setCursor(Qt::CrossCursor);
-        ui->actionDrawRectangle->setChecked(true);
-        scene->setAction(ui->actionDrawRectangle);
-        scene->setDrawingMode(ModelGraphicsScene::DrawingMode::RECTANGLE);
-    } else {
-        unselectDrawIcons();
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    if (_sceneToolController != nullptr) {
+        _sceneToolController->onActionDrawRectangleTriggered();
     }
 }
 
 
 void MainWindow::on_actionDrawEllipse_triggered() {
-    ModelGraphicsScene* scene = ui->graphicsView->getScene();
-    // Ative a ferramenta de desenho de ellipse
-    if (!checkSelectedDrawIcons() && ui->actionDrawEllipse->isChecked()) {
-        ui->graphicsView->setCursor(Qt::CrossCursor);
-        ui->actionDrawEllipse->setChecked(true);
-        scene->setAction(ui->actionDrawEllipse);
-        scene->setDrawingMode(ModelGraphicsScene::DrawingMode::ELLIPSE);
-    } else {
-        unselectDrawIcons();
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    if (_sceneToolController != nullptr) {
+        _sceneToolController->onActionDrawEllipseTriggered();
     }
 }
 
-void MainWindow::on_actionDrawText_triggered()
-{
-    ModelGraphicsScene* scene = ui->graphicsView->getScene();
-    if (!checkSelectedDrawIcons() && ui->actionDrawText->isChecked()) {
-        ui->actionDrawText->setChecked(true);
-        scene->setAction(ui->actionDrawText);
-        // Ative a ferramenta de desenho do texto
-        scene->setDrawingMode(ModelGraphicsScene::DrawingMode::TEXT);
-    } else {
-        unselectDrawIcons();
+void MainWindow::on_actionDrawText_triggered() {
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    if (_sceneToolController != nullptr) {
+        _sceneToolController->onActionDrawTextTriggered();
     }
 }
 
-void MainWindow::on_actionDrawPoligon_triggered()
-{
-    ModelGraphicsScene* scene = ui->graphicsView->getScene();
-    if (!checkSelectedDrawIcons() && ui->actionDrawPoligon->isChecked()) {
-        ui->graphicsView->setCursor(Qt::ArrowCursor);
-        ui->actionDrawPoligon->setChecked(true);
-        scene->setAction(ui->actionDrawPoligon);
-        // Ative a ferramenta de desenho do polygon
-        scene->setDrawingMode(ModelGraphicsScene::DrawingMode::POLYGON);
-    } else {
-        unselectDrawIcons();
+void MainWindow::on_actionDrawPoligon_triggered() {
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    if (_sceneToolController != nullptr) {
+        _sceneToolController->onActionDrawPoligonTriggered();
     }
 }
 
@@ -563,35 +525,24 @@ void MainWindow::on_actionAlignLeft_triggered()
     _showMessageNotImplemented();
 }
 
-void MainWindow::on_actionAnimateCounter_triggered()
-{
-    if (!checkSelectedDrawIcons() && ui->actionAnimateCounter->isChecked()) {
-        ui->graphicsView->setCursor(Qt::CrossCursor);
-        myScene()->setAction(ui->actionAnimateCounter);
-        myScene()->drawingCounter();
-    } else {
-        unselectDrawIcons();
+void MainWindow::on_actionAnimateCounter_triggered() {
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    if (_sceneToolController != nullptr) {
+        _sceneToolController->onActionAnimateCounterTriggered();
     }
 }
 
 void MainWindow::on_actionAnimateVariable_triggered() {
-    if (!checkSelectedDrawIcons() && ui->actionAnimateVariable->isChecked()) {
-        ui->graphicsView->setCursor(Qt::CrossCursor);
-        myScene()->setAction(ui->actionAnimateVariable);
-        myScene()->drawingVariable();
-    } else {
-        unselectDrawIcons();
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    if (_sceneToolController != nullptr) {
+        _sceneToolController->onActionAnimateVariableTriggered();
     }
 }
 
-void MainWindow::on_actionAnimateSimulatedTime_triggered()
-{
-    if (!checkSelectedDrawIcons() && ui->actionAnimateSimulatedTime->isChecked()) {
-        ui->graphicsView->setCursor(Qt::CrossCursor);
-        myScene()->setAction(ui->actionAnimateSimulatedTime);
-        myScene()->drawingTimer();
-    } else {
-        unselectDrawIcons();
+void MainWindow::on_actionAnimateSimulatedTime_triggered() {
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    if (_sceneToolController != nullptr) {
+        _sceneToolController->onActionAnimateSimulatedTimeTriggered();
     }
 }
 
@@ -1005,11 +956,11 @@ void MainWindow::on_treeWidgetDataDefnitions_itemChanged(QTreeWidgetItem *item, 
 }
 
 
-void MainWindow::on_actionShowSnap_triggered()
-{
-    ModelGraphicsScene* scene = (ModelGraphicsScene*) (ui->graphicsView->scene());
-    // Sincroniza o snap com o estado checkado da action de forma determinística.
-    scene->setSnapToGrid(ui->actionShowSnap->isChecked());
+void MainWindow::on_actionShowSnap_triggered() {
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    if (_sceneToolController != nullptr) {
+        _sceneToolController->onActionShowSnapTriggered();
+    }
 }
 
 void MainWindow::on_actionViewGroup_triggered()
@@ -1029,57 +980,57 @@ void MainWindow::on_actionViewUngroup_triggered()
     }
 }
 
-void MainWindow::on_actionArranjeLeft_triggered()
-{
-    ModelGraphicsScene* scene = (ModelGraphicsScene*) (ui->graphicsView->scene());
-    scene->arranjeModels(0);
+void MainWindow::on_actionArranjeLeft_triggered() {
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    if (_sceneToolController != nullptr) {
+        _sceneToolController->onActionArranjeLeftTriggered();
+    }
 }
 
 
-void MainWindow::on_actionArranjeCenter_triggered()
-{
-    ModelGraphicsScene* scene = (ModelGraphicsScene*) (ui->graphicsView->scene());
-    scene->arranjeModels(4);
+void MainWindow::on_actionArranjeCenter_triggered() {
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    if (_sceneToolController != nullptr) {
+        _sceneToolController->onActionArranjeCenterTriggered();
+    }
 }
 
 
-void MainWindow::on_actionArranjeRight_triggered()
-{
-    ModelGraphicsScene* scene = (ModelGraphicsScene*) (ui->graphicsView->scene());
-    scene->arranjeModels(1);
+void MainWindow::on_actionArranjeRight_triggered() {
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    if (_sceneToolController != nullptr) {
+        _sceneToolController->onActionArranjeRightTriggered();
+    }
 }
 
 
-void MainWindow::on_actionArranjeTop_triggered()
-{
-    ModelGraphicsScene* scene = (ModelGraphicsScene*) (ui->graphicsView->scene());
-    scene->arranjeModels(2);
+void MainWindow::on_actionArranjeTop_triggered() {
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    if (_sceneToolController != nullptr) {
+        _sceneToolController->onActionArranjeTopTriggered();
+    }
 }
 
 
-void MainWindow::on_actionArranjeMiddle_triggered()
-{
-    ModelGraphicsScene* scene = (ModelGraphicsScene*) (ui->graphicsView->scene());
-    scene->arranjeModels(5);
+void MainWindow::on_actionArranjeMiddle_triggered() {
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    if (_sceneToolController != nullptr) {
+        _sceneToolController->onActionArranjeMiddleTriggered();
+    }
 }
 
 
-void MainWindow::on_actionArranjeBototm_triggered()
-{
-    ModelGraphicsScene* scene = (ModelGraphicsScene*) (ui->graphicsView->scene());
-    scene->arranjeModels(3);
+void MainWindow::on_actionArranjeBototm_triggered() {
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    if (_sceneToolController != nullptr) {
+        _sceneToolController->onActionArranjeBototmTriggered();
+    }
 }
 
-void MainWindow::on_actionGModelShowConnect_triggered()
-{
-    if (!ui->actionGModelShowConnect->isChecked() && !_firstClickShowConnection) {
-        ui->actionGModelShowConnect->setChecked(false);
-        ui->graphicsView->getScene()->setConnectingStep(0);
-        ui->graphicsView->setCursor(Qt::ArrowCursor);
-    } else {
-        ui->actionGModelShowConnect->setChecked(true);
-        ui->graphicsView->getScene()->setConnectingStep(1);
-        _firstClickShowConnection = false;
+void MainWindow::on_actionGModelShowConnect_triggered() {
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    if (_sceneToolController != nullptr) {
+        _sceneToolController->onActionGModelShowConnectTriggered();
     }
 }
 
@@ -1095,63 +1046,34 @@ void MainWindow::on_actionSimulatorsPluginManager_triggered()
 //}
 
 
-void MainWindow::on_actionActivateGraphicalSimulation_triggered()
-{
-    bool visivible = true;
-
-    if (!ui->actionActivateGraphicalSimulation->isChecked()) {
-        AnimationTransition::setRunning(false);
-        visivible = false;
-    } else {
-        AnimationTransition::setRunning(true);
-    }
-
-    // Esconde ou exibe animação de fila
-    QList<QGraphicsItem *> *componentes = myScene()->getGraphicalModelComponents();
-
-    for (QGraphicsItem* item : *componentes) {
-        if (GraphicalModelComponent *component = dynamic_cast<GraphicalModelComponent *>(item)) {
-            component->visivibleImageQueue(visivible);
-        }
+void MainWindow::on_actionActivateGraphicalSimulation_triggered() {
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    if (_sceneToolController != nullptr) {
+        _sceneToolController->onActionActivateGraphicalSimulationTriggered();
     }
 }
 
 
-void MainWindow::on_horizontalSliderAnimationSpeed_valueChanged(int value)
-{
-    double newValue = ((double) value) / 2;
-
-    AnimationTransition::setTimeExecution(newValue);
-}
-
-
-void MainWindow::on_actionDiagrams_triggered()
-{
-    // Uses the active scene as the single source of truth for persisted diagram state.
-    ModelGraphicsScene* scene = (ModelGraphicsScene*) (ui->graphicsView->scene());
-    if (ui->actionDiagrams->isChecked()) {
-        // Creates diagram structures on demand when load restored diagrams=1 but none exist yet.
-        if (!scene->existDiagram()) scene->createDiagrams();
-        // Shows diagrams only after creation to fully restore persisted visibility.
-        scene->showDiagrams();
-    } else {
-        // Hides diagrams only when they already exist to avoid side effects during load.
-        if (scene->existDiagram()) scene->hideDiagrams();
-    }
-    // Re-syncs QAction with effective visibility to keep UI and scene flags coherent.
-    const bool diagramsVisible = scene->existDiagram() && scene->visibleDiagram();
-    if (ui->actionDiagrams->isChecked() != diagramsVisible) {
-        ui->actionDiagrams->setChecked(diagramsVisible);
+void MainWindow::on_horizontalSliderAnimationSpeed_valueChanged(int value) {
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    if (_sceneToolController != nullptr) {
+        _sceneToolController->onHorizontalSliderAnimationSpeedValueChanged(value);
     }
 }
 
 
-void MainWindow::on_actionSelectAll_triggered()
-{
-    QList<QGraphicsItem *> itensToScene = myScene()->items();
+void MainWindow::on_actionDiagrams_triggered() {
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    if (_sceneToolController != nullptr) {
+        _sceneToolController->onActionDiagramsTriggered();
+    }
+}
 
-    foreach (QGraphicsItem* item, itensToScene) {
-        item->setSelected(true);
+
+void MainWindow::on_actionSelectAll_triggered() {
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    if (_sceneToolController != nullptr) {
+        _sceneToolController->onActionSelectAllTriggered();
     }
 }
 
@@ -1215,13 +1137,17 @@ void MainWindow::on_tabWidget_Model_tabBarClicked(int index) {
 }
 
 void MainWindow::on_checkBox_ShowElements_stateChanged(int arg1) {
-    ui->actionShowAttachedElements->setChecked(arg1 == Qt::Checked);
-    bool result = _createModelImage();
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    if (_sceneToolController != nullptr) {
+        _sceneToolController->onCheckBoxShowElementsStateChanged(arg1);
+    }
 }
 
 void MainWindow::on_checkBox_ShowInternals_stateChanged(int arg1) {
-    ui->actionShowInternalElements->setChecked(arg1 == Qt::Checked);
-    bool result = _createModelImage();
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    if (_sceneToolController != nullptr) {
+        _sceneToolController->onCheckBoxShowInternalsStateChanged(arg1);
+    }
 }
 
 void MainWindow::on_horizontalSlider_Zoom_valueChanged(int value) {
@@ -1243,11 +1169,17 @@ void MainWindow::on_horizontalSlider_Zoom_valueChanged(int value) {
 }
 
 void MainWindow::on_checkBox_ShowRecursive_stateChanged(int arg1) {
-    bool result = _createModelImage();
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    if (_sceneToolController != nullptr) {
+        _sceneToolController->onCheckBoxShowRecursiveStateChanged(arg1);
+    }
 }
 
 void MainWindow::on_checkBox_ShowLevels_stateChanged(int arg1) {
-    bool result = _createModelImage();
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    if (_sceneToolController != nullptr) {
+        _sceneToolController->onCheckBoxShowLevelsStateChanged(arg1);
+    }
 }
 
 void MainWindow::on_tabWidget_Debug_currentChanged(int index) {
@@ -1374,13 +1306,17 @@ void MainWindow::on_graphicsView_rubberBandChanged(const QRect &viewportRect, co
 }
 
 void MainWindow::on_horizontalSlider_ZoomGraphical_valueChanged(int value) {
-    double factor = (value - _zoomValue)*0.002;
-    _zoomValue = value;
-    _gentle_zoom(1.0 + factor);
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    if (_sceneToolController != nullptr) {
+        _sceneToolController->onHorizontalSliderZoomGraphicalValueChanged(value);
+    }
 }
 
 void MainWindow::on_actionConnect_triggered() {
-    ((ModelGraphicsView*) ui->graphicsView)->beginConnection();
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    if (_sceneToolController != nullptr) {
+        _sceneToolController->onActionConnectTriggered();
+    }
 }
 
 void MainWindow::on_pushButton_Export_clicked() {
@@ -1469,20 +1405,16 @@ void MainWindow::on_actionGModelComponentBreakpoint_triggered() {
 }
 
 void MainWindow::on_actionShowInternalElements_triggered() {
-    const bool checked = ui->actionShowInternalElements->isChecked();
-    if (ui->checkBox_ShowInternals->isChecked() != checked) {
-        ui->checkBox_ShowInternals->setChecked(checked);
-    } else {
-        _createModelImage();
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    if (_sceneToolController != nullptr) {
+        _sceneToolController->onActionShowInternalElementsTriggered();
     }
 }
 
 void MainWindow::on_actionShowAttachedElements_triggered() {
-    const bool checked = ui->actionShowAttachedElements->isChecked();
-    if (ui->checkBox_ShowElements->isChecked() != checked) {
-        ui->checkBox_ShowElements->setChecked(checked);
-    } else {
-        _createModelImage();
+    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    if (_sceneToolController != nullptr) {
+        _sceneToolController->onActionShowAttachedElementsTriggered();
     }
 }
 


### PR DESCRIPTION
### Motivation
- Reduce MainWindow coupling by extracting scene/view/drawing/visualization command orchestration into a dedicated Phase 10 controller while preserving existing behavior and slot signatures.
- Consolidate grid/ruler/guides/snap, zoom, drawing tools, animation insertion, connect, arrange/align, diagram toggles, select-all, graphical simulation toggle, animation speed and model-image toggles out of `MainWindow` to enable incremental refactor safety.

### Description
- Added `controllers/SceneToolController.h` and `controllers/SceneToolController.cpp` implementing one public method per moved slot and using narrow constructor dependencies (graphics view, `Ui::MainWindow*`, scene getter, image/toolbar callbacks, gentle zoom, references to `_zoomValue` and `_firstClickShowConnection`).
- Moved the real implementations of the Phase 10 handlers from `mainwindow_controller.cpp` into `SceneToolController` preserving cursor changes, action checked-state synchronization, `_zoomValue` semantics, diagram logic, animation speed behavior, select-all semantics, and connect-step first-click semantics.
- Added `std::unique_ptr<SceneToolController> _sceneToolController;` to `MainWindow`, initialized it in the `MainWindow` constructor (after view/scene/actions/widgets are ready) with narrow callbacks/state references, and kept all original `MainWindow` slot signatures as thin compatibility wrappers that delegate to the controller.
- Updated `GenesysQtGUI.pro` to include the new controller source/header files and added short English comments immediately above created/modified code regions in the Phase 10 scope.

### Testing
- Ran `git diff --check` to verify no whitespace/conflict markers, which succeeded.
- Verified repository status with `git status --short` and inspected the commit with `git show --name-only` after committing the change, which succeeded and produced a single commit for Phase 10.
- Did not run a full project build or GUI runtime tests in this run (no compile/link verification was performed).

Notes: compatibility wrappers remain in `MainWindow` intentionally for an incremental migration; work intentionally stopped at Phase 10.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d590baf37c83219170a2902e5bf5ab)