### PR TITLE
Phase 12: finalize MainWindow consolidation and wrapper hygiene

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
@@ -11,7 +11,7 @@
 #include "TraitsGUI.h"
 #include "graphicals/GraphicalConnection.h"
 #include "controllers/SimulationController.h"
-// Add dedicated controllers progressively during incremental GUI refactors.
+// Keep explicit controller includes to make MainWindow composition-root wiring clear.
 #include "controllers/ModelInspectorController.h"
 #include "controllers/TraceConsoleController.h"
 #include "controllers/SimulationEventController.h"
@@ -53,7 +53,6 @@
 #include <QMessageBox>
 #include <QTextStream>
 #include <QFileDialog>
-#include <QGraphicsScene>
 #include <QDateTime>
 #include <QEventLoop>
 #include <QTemporaryFile>
@@ -62,7 +61,6 @@
 #include <QPropertyAnimation>
 // #include <qt5/QtWidgets/qgraphicsitem.h>
 #include <QtWidgets/qgraphicsitem.h>
-#include <QGraphicsScene>
 //#include <QDesktopWidget> //removed from qt6
 #include <QScreen>
 #include <QDebug>
@@ -466,7 +464,7 @@ void MainWindow::_onPropertyEditorModelChanged() {
 
 
 void::MainWindow::saveItemForCopy(QList<GraphicalModelComponent*> * gmcList, QList<GraphicalConnection*> * connList) {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 9 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 9 refactor.
     if (_editCommandController != nullptr) {
         _editCommandController->saveItemForCopy(gmcList, connList);
     }
@@ -765,7 +763,7 @@ void MainWindow::_showMessageNotImplemented(){
 
 
 void MainWindow::_helpCopy() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 9 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 9 refactor.
     if (_editCommandController != nullptr) {
         _editCommandController->helpCopy();
     }

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.h
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.h
@@ -44,9 +44,7 @@ class DialogUtilityController;
 /**
  * @brief Main Qt window of Genesys GUI.
  *
- * Aggregates user interactions, graphical model edition and kernel integration.
- *
- * @todo Continue decomposing this class into dedicated controllers to reduce coupling.
+ * Acts as the final composition root and compatibility façade for extracted controllers/services.
  */
 class MainWindow : public QMainWindow {
 	Q_OBJECT
@@ -286,16 +284,9 @@ private: //???
 private: // interface and model main elements to join
 	Ui::MainWindow *ui;
 	Simulator* simulator;
+    // Keep core simulation command gateway owned by MainWindow composition root.
     std::unique_ptr<class SimulationController> _simulationController;
-    // Add the Phase 9 edit-command controller owned by MainWindow.
-    std::unique_ptr<EditCommandController> _editCommandController;
-    // Add the Phase 10 scene-tool controller owned by MainWindow.
-    std::unique_ptr<SceneToolController> _sceneToolController;
-    // Add the Phase 11 dialog-utility controller owned by MainWindow.
-    std::unique_ptr<DialogUtilityController> _dialogUtilityController;
-    // Add the Phase 8 simulation-command controller owned by MainWindow.
-    std::unique_ptr<SimulationCommandController> _simulationCommandController;
-    // Phase-1 services keep model-representation logic outside MainWindow while wrappers remain stable.
+    // Keep phase-ordered services to make composition dependencies explicit in Phase 12.
     // Synchronize textual model language with the kernel model manager.
     std::unique_ptr<ModelLanguageSynchronizer> _modelLanguageSynchronizer;
     // Generate Graphviz DOT and rendered model images for the GUI pane.
@@ -306,6 +297,7 @@ private: // interface and model main elements to join
     std::unique_ptr<GraphicalModelSerializer> _graphicalModelSerializer;
     // Rebuild graphical components and links through the Phase 2 builder service.
     std::unique_ptr<GraphicalModelBuilder> _graphicalModelBuilder;
+    // Keep phase-ordered controllers to preserve the final compatibility façade surface.
     // Add the Phase 3 model-inspector controller owned by MainWindow.
     std::unique_ptr<ModelInspectorController> _modelInspectorController;
     // Add the Phase 4 trace controller owned by MainWindow.
@@ -318,6 +310,14 @@ private: // interface and model main elements to join
     std::unique_ptr<PropertyEditorController> _propertyEditorController;
     // Add the Phase 7 model-lifecycle controller owned by MainWindow.
     std::unique_ptr<ModelLifecycleController> _modelLifecycleController;
+    // Add the Phase 8 simulation-command controller owned by MainWindow.
+    std::unique_ptr<SimulationCommandController> _simulationCommandController;
+    // Add the Phase 9 edit-command controller owned by MainWindow.
+    std::unique_ptr<EditCommandController> _editCommandController;
+    // Add the Phase 10 scene-tool controller owned by MainWindow.
+    std::unique_ptr<SceneToolController> _sceneToolController;
+    // Add the Phase 11 dialog-utility controller owned by MainWindow.
+    std::unique_ptr<DialogUtilityController> _dialogUtilityController;
 	PropertyEditorGenesys* propertyGenesys;
     std::map<SimulationControl*, DataComponentProperty*>* propertyList;
     std::map<SimulationControl*, DataComponentEditor*>* propertyEditorUI;

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow_controller.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow_controller.cpp
@@ -46,7 +46,6 @@
 #include <QPropertyAnimation>
 // #include <qt5/QtWidgets/qgraphicsitem.h>
 #include <QtWidgets/qgraphicsitem.h>
-#include <QGraphicsScene>
 //#include <QDesktopWidget> //removed from qt6
 #include <QScreen>
 #include <QDebug>
@@ -83,71 +82,56 @@
 //  menu actions
 // -------------------------------------------------
 
+// Keep this slot documentation aligned with the final wrapper-only architecture.
 /**
- * @brief Stops the active simulation execution.
- *
- * Guarded by SimulationController to avoid dereferencing null model/simulation.
- *
- * @todo Move command execution details (animation flags + console command) into SimulationController.
+ * @brief Stops the active simulation execution through the simulation command controller.
  */
 void MainWindow::on_actionSimulationStop_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 8 refactor.
+    // Keep this wrapper as part of the final compatibility façade.
     if (_simulationCommandController != nullptr) {
         _simulationCommandController->onActionSimulationStopTriggered();
     }
 }
 
+// Keep this slot documentation aligned with the final wrapper-only architecture.
 /**
- * @brief Starts simulation after readiness validation.
- *
- * Preconditions:
- * - Current model/simulation must exist;
- * - Model may be checked when needed;
- * - Textual model representation must be synchronized.
- *
- * @todo Replace lambda callbacks by explicit command objects for better unit testing.
+ * @brief Starts simulation after readiness validation through the simulation command controller.
  */
 void MainWindow::on_actionSimulationStart_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 8 refactor.
+    // Keep this wrapper as part of the final compatibility façade.
     if (_simulationCommandController != nullptr) {
         _simulationCommandController->onActionSimulationStartTriggered(_modelCheked);
     }
 }
 
+// Keep this slot documentation aligned with the final wrapper-only architecture.
 /**
- * @brief Executes one simulation step after readiness validation.
- *
- * Uses the same precondition pipeline as start command.
- *
- * @todo Consolidate duplicated animation-toggle code between start and step.
+ * @brief Executes one simulation step after readiness validation through the simulation command controller.
  */
 void MainWindow::on_actionSimulationStep_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 8 refactor.
+    // Keep this wrapper as part of the final compatibility façade.
     if (_simulationCommandController != nullptr) {
         _simulationCommandController->onActionSimulationStepTriggered(_modelCheked);
     }
 }
 
+// Keep this slot documentation aligned with the final wrapper-only architecture.
 /**
- * @brief Pauses running simulation.
- *
- * @todo Add explicit feedback when pause is requested in invalid state.
+ * @brief Pauses running simulation through the simulation command controller.
  */
 void MainWindow::on_actionSimulationPause_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 8 refactor.
+    // Keep this wrapper as part of the final compatibility façade.
     if (_simulationCommandController != nullptr) {
         _simulationCommandController->onActionSimulationPauseTriggered();
     }
 }
 
+// Keep this slot documentation aligned with the final wrapper-only architecture.
 /**
- * @brief Resumes simulation execution after readiness validation.
- *
- * @todo Introduce a dedicated `resume()` API in kernel side when available
- *       to avoid semantic coupling with `start()`.
+ * @brief Resumes simulation execution after readiness validation through the simulation command controller.
  */
 void MainWindow::on_actionSimulationResume_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 8 refactor.
+    // Keep this wrapper as part of the final compatibility façade.
     if (_simulationCommandController != nullptr) {
         _simulationCommandController->onActionSimulationResumeTriggered(_modelCheked);
     }
@@ -155,7 +139,7 @@ void MainWindow::on_actionSimulationResume_triggered() {
 
 
 void MainWindow::on_actionAboutAbout_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 11 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 11 refactor.
     if (_dialogUtilityController != nullptr) {
         _dialogUtilityController->onActionAboutAboutTriggered();
     }
@@ -163,7 +147,7 @@ void MainWindow::on_actionAboutAbout_triggered() {
 
 
 void MainWindow::on_actionAboutLicence_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 11 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 11 refactor.
     if (_dialogUtilityController != nullptr) {
         _dialogUtilityController->onActionAboutLicenceTriggered();
     }
@@ -171,7 +155,7 @@ void MainWindow::on_actionAboutLicence_triggered() {
 
 
 void MainWindow::on_actionAboutGetInvolved_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 11 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 11 refactor.
     if (_dialogUtilityController != nullptr) {
         _dialogUtilityController->onActionAboutGetInvolvedTriggered();
     }
@@ -179,7 +163,7 @@ void MainWindow::on_actionAboutGetInvolved_triggered() {
 
 
 void MainWindow::on_actionEditUndo_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 9 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 9 refactor.
     if (_editCommandController != nullptr) {
         _editCommandController->onActionEditUndoTriggered();
     }
@@ -187,7 +171,7 @@ void MainWindow::on_actionEditUndo_triggered() {
 
 
 void MainWindow::on_actionEditRedo_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 9 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 9 refactor.
     if (_editCommandController != nullptr) {
         _editCommandController->onActionEditRedoTriggered();
     }
@@ -195,7 +179,7 @@ void MainWindow::on_actionEditRedo_triggered() {
 
 
 void MainWindow::on_actionEditFind_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 11 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 11 refactor.
     if (_dialogUtilityController != nullptr) {
         _dialogUtilityController->onActionEditFindTriggered();
     }
@@ -207,7 +191,7 @@ void MainWindow::on_actionEditFind_triggered() {
 //     _showMessageNotImplemented();
 // }
 void MainWindow::on_actionEditReplace_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 11 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 11 refactor.
     if (_dialogUtilityController != nullptr) {
         _dialogUtilityController->onActionEditReplaceTriggered();
     }
@@ -216,21 +200,21 @@ void MainWindow::on_actionEditReplace_triggered() {
 
 
 void MainWindow::on_actionEditCut_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 9 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 9 refactor.
     if (_editCommandController != nullptr) {
         _editCommandController->onActionEditCutTriggered();
     }
 }
 
 void MainWindow::on_actionEditCopy_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 9 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 9 refactor.
     if (_editCommandController != nullptr) {
         _editCommandController->onActionEditCopyTriggered();
     }
 }
 
 void MainWindow::on_actionEditPaste_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 9 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 9 refactor.
     if (_editCommandController != nullptr) {
         _editCommandController->onActionEditPasteTriggered();
     }
@@ -238,7 +222,7 @@ void MainWindow::on_actionEditPaste_triggered() {
 
 
 void MainWindow::on_actionShowGrid_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 10 refactor.
     if (_sceneToolController != nullptr) {
         _sceneToolController->onActionShowGridTriggered();
     }
@@ -246,7 +230,7 @@ void MainWindow::on_actionShowGrid_triggered() {
 
 
 void MainWindow::on_actionShowRule_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 10 refactor.
     if (_sceneToolController != nullptr) {
         _sceneToolController->onActionShowRuleTriggered();
     }
@@ -254,7 +238,7 @@ void MainWindow::on_actionShowRule_triggered() {
 
 
 void MainWindow::on_actionShowGuides_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 10 refactor.
     if (_sceneToolController != nullptr) {
         _sceneToolController->onActionShowGuidesTriggered();
     }
@@ -262,7 +246,7 @@ void MainWindow::on_actionShowGuides_triggered() {
 
 
 void MainWindow::on_actionZoom_In_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 10 refactor.
     if (_sceneToolController != nullptr) {
         _sceneToolController->onActionZoomInTriggered();
     }
@@ -270,7 +254,7 @@ void MainWindow::on_actionZoom_In_triggered() {
 
 
 void MainWindow::on_actionZoom_Out_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 10 refactor.
     if (_sceneToolController != nullptr) {
         _sceneToolController->onActionZoomOutTriggered();
     }
@@ -278,7 +262,7 @@ void MainWindow::on_actionZoom_Out_triggered() {
 
 
 void MainWindow::on_actionZoom_All_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 10 refactor.
     if (_sceneToolController != nullptr) {
         _sceneToolController->onActionZoomAllTriggered();
     }
@@ -286,7 +270,7 @@ void MainWindow::on_actionZoom_All_triggered() {
 
 
 void MainWindow::on_actionDrawLine_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 10 refactor.
     if (_sceneToolController != nullptr) {
         _sceneToolController->onActionDrawLineTriggered();
     }
@@ -294,7 +278,7 @@ void MainWindow::on_actionDrawLine_triggered() {
 
 
 void MainWindow::on_actionDrawRectangle_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 10 refactor.
     if (_sceneToolController != nullptr) {
         _sceneToolController->onActionDrawRectangleTriggered();
     }
@@ -302,21 +286,21 @@ void MainWindow::on_actionDrawRectangle_triggered() {
 
 
 void MainWindow::on_actionDrawEllipse_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 10 refactor.
     if (_sceneToolController != nullptr) {
         _sceneToolController->onActionDrawEllipseTriggered();
     }
 }
 
 void MainWindow::on_actionDrawText_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 10 refactor.
     if (_sceneToolController != nullptr) {
         _sceneToolController->onActionDrawTextTriggered();
     }
 }
 
 void MainWindow::on_actionDrawPoligon_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 10 refactor.
     if (_sceneToolController != nullptr) {
         _sceneToolController->onActionDrawPoligonTriggered();
     }
@@ -347,7 +331,7 @@ void MainWindow::on_actionAnimateStation_triggered() {
 
 void MainWindow::on_actionEditDelete_triggered()
 {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 9 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 9 refactor.
     if (_editCommandController != nullptr) {
         _editCommandController->onActionEditDeleteTriggered();
     }
@@ -355,7 +339,7 @@ void MainWindow::on_actionEditDelete_triggered()
 
 
 void MainWindow::on_actionSimulatorPreferences_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 11 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 11 refactor.
     if (_dialogUtilityController != nullptr) {
         _dialogUtilityController->onActionSimulatorPreferencesTriggered();
     }
@@ -398,21 +382,21 @@ void MainWindow::on_actionAlignLeft_triggered()
 }
 
 void MainWindow::on_actionAnimateCounter_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 10 refactor.
     if (_sceneToolController != nullptr) {
         _sceneToolController->onActionAnimateCounterTriggered();
     }
 }
 
 void MainWindow::on_actionAnimateVariable_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 10 refactor.
     if (_sceneToolController != nullptr) {
         _sceneToolController->onActionAnimateVariableTriggered();
     }
 }
 
 void MainWindow::on_actionAnimateSimulatedTime_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 10 refactor.
     if (_sceneToolController != nullptr) {
         _sceneToolController->onActionAnimateSimulatedTimeTriggered();
     }
@@ -444,7 +428,7 @@ void MainWindow::on_actionAnimateStatistics_triggered()
 
 void MainWindow::on_actionEditGroup_triggered()
 {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 9 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 9 refactor.
     if (_editCommandController != nullptr) {
         _editCommandController->onActionEditGroupTriggered();
     }
@@ -453,7 +437,7 @@ void MainWindow::on_actionEditGroup_triggered()
 
 void MainWindow::on_actionEditUngroup_triggered()
 {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 9 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 9 refactor.
     if (_editCommandController != nullptr) {
         _editCommandController->onActionEditUngroupTriggered();
     }
@@ -461,7 +445,7 @@ void MainWindow::on_actionEditUngroup_triggered()
 
 
 void MainWindow::on_actionToolsParserGrammarChecker_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 11 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 11 refactor.
     if (_dialogUtilityController != nullptr) {
         _dialogUtilityController->onActionToolsParserGrammarCheckerTriggered();
     }
@@ -477,7 +461,7 @@ void MainWindow::on_actionToolsExperimentation_triggered()
 
 
 void MainWindow::on_actionToolsOptimizator_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 11 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 11 refactor.
     if (_dialogUtilityController != nullptr) {
         _dialogUtilityController->onActionToolsOptimizatorTriggered();
     }
@@ -486,7 +470,7 @@ void MainWindow::on_actionToolsOptimizator_triggered() {
 
 
 void MainWindow::on_actionToolsDataAnalyzer_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 11 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 11 refactor.
     if (_dialogUtilityController != nullptr) {
         _dialogUtilityController->onActionToolsDataAnalyzerTriggered();
     }
@@ -501,7 +485,7 @@ void MainWindow::on_actionAnimatePlot_triggered()
 
 
 void MainWindow::on_actionViewConfigure_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 11 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 11 refactor.
     if (_dialogUtilityController != nullptr) {
         _dialogUtilityController->onActionViewConfigureTriggered();
     }
@@ -516,20 +500,20 @@ void MainWindow::on_actionViewConfigure_triggered() {
 
 
 void MainWindow::on_actionModelNew_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 7 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 7 refactor.
     _modelLifecycleController->onActionModelNewTriggered();
 }
 
 void MainWindow::on_actionModelOpen_triggered()
 {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 7 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 7 refactor.
     _modelLifecycleController->onActionModelOpenTriggered();
 }
 
 
 void MainWindow::on_actionModelSave_triggered()
 {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 7 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 7 refactor.
     _modelLifecycleController->onActionModelSaveTriggered();
 }
 
@@ -537,63 +521,63 @@ void MainWindow::on_actionModelSave_triggered()
 
 void MainWindow::on_actionModelClose_triggered()
 {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 7 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 7 refactor.
     _modelLifecycleController->onActionModelCloseTriggered();
 }
 
 
 void MainWindow::on_actionModelInformation_triggered()
 {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 7 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 7 refactor.
     _modelLifecycleController->onActionModelInformationTriggered();
 }
 
 
 void MainWindow::on_actionModelCheck_triggered()
 {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 7 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 7 refactor.
     _modelLifecycleController->onActionModelCheckTriggered();
 }
 
 void MainWindow::on_actionSimulatorExit_triggered()
 {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 7 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 7 refactor.
     _modelLifecycleController->onActionSimulatorExitTriggered();
 }
 
 bool MainWindow::_hasPendingModelChanges() const {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 7 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 7 refactor.
     return _modelLifecycleController->hasPendingModelChanges();
 }
 
 bool MainWindow::_confirmApplicationExit() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 7 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 7 refactor.
     return _modelLifecycleController->confirmApplicationExit();
 }
 
 
 void MainWindow::on_actionSimulationConfigure_triggered()
 {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 7 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 7 refactor.
     _modelLifecycleController->onActionSimulationConfigureTriggered();
 }
 
 
 void MainWindow::on_treeWidgetDataDefnitions_itemDoubleClicked(QTreeWidgetItem *item, int column)
 {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 3 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 3 refactor.
     _modelInspectorController->beginDataDefinitionNameEdit(item, column);
 }
 
 void MainWindow::on_treeWidgetDataDefnitions_itemChanged(QTreeWidgetItem *item, int column)
 {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 3 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 3 refactor.
     _modelInspectorController->applyDataDefinitionNameChange(item, column);
 }
 
 
 void MainWindow::on_actionShowSnap_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 10 refactor.
     if (_sceneToolController != nullptr) {
         _sceneToolController->onActionShowSnapTriggered();
     }
@@ -601,7 +585,7 @@ void MainWindow::on_actionShowSnap_triggered() {
 
 void MainWindow::on_actionViewGroup_triggered()
 {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 9 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 9 refactor.
     if (_editCommandController != nullptr) {
         _editCommandController->onActionViewGroupTriggered();
     }
@@ -610,14 +594,14 @@ void MainWindow::on_actionViewGroup_triggered()
 
 void MainWindow::on_actionViewUngroup_triggered()
 {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 9 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 9 refactor.
     if (_editCommandController != nullptr) {
         _editCommandController->onActionViewUngroupTriggered();
     }
 }
 
 void MainWindow::on_actionArranjeLeft_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 10 refactor.
     if (_sceneToolController != nullptr) {
         _sceneToolController->onActionArranjeLeftTriggered();
     }
@@ -625,7 +609,7 @@ void MainWindow::on_actionArranjeLeft_triggered() {
 
 
 void MainWindow::on_actionArranjeCenter_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 10 refactor.
     if (_sceneToolController != nullptr) {
         _sceneToolController->onActionArranjeCenterTriggered();
     }
@@ -633,7 +617,7 @@ void MainWindow::on_actionArranjeCenter_triggered() {
 
 
 void MainWindow::on_actionArranjeRight_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 10 refactor.
     if (_sceneToolController != nullptr) {
         _sceneToolController->onActionArranjeRightTriggered();
     }
@@ -641,7 +625,7 @@ void MainWindow::on_actionArranjeRight_triggered() {
 
 
 void MainWindow::on_actionArranjeTop_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 10 refactor.
     if (_sceneToolController != nullptr) {
         _sceneToolController->onActionArranjeTopTriggered();
     }
@@ -649,7 +633,7 @@ void MainWindow::on_actionArranjeTop_triggered() {
 
 
 void MainWindow::on_actionArranjeMiddle_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 10 refactor.
     if (_sceneToolController != nullptr) {
         _sceneToolController->onActionArranjeMiddleTriggered();
     }
@@ -657,21 +641,21 @@ void MainWindow::on_actionArranjeMiddle_triggered() {
 
 
 void MainWindow::on_actionArranjeBototm_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 10 refactor.
     if (_sceneToolController != nullptr) {
         _sceneToolController->onActionArranjeBototmTriggered();
     }
 }
 
 void MainWindow::on_actionGModelShowConnect_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 10 refactor.
     if (_sceneToolController != nullptr) {
         _sceneToolController->onActionGModelShowConnectTriggered();
     }
 }
 
 void MainWindow::on_actionSimulatorsPluginManager_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 11 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 11 refactor.
     if (_dialogUtilityController != nullptr) {
         _dialogUtilityController->onActionSimulatorsPluginManagerTriggered();
     }
@@ -685,7 +669,7 @@ void MainWindow::on_actionSimulatorsPluginManager_triggered() {
 
 
 void MainWindow::on_actionActivateGraphicalSimulation_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 10 refactor.
     if (_sceneToolController != nullptr) {
         _sceneToolController->onActionActivateGraphicalSimulationTriggered();
     }
@@ -693,7 +677,7 @@ void MainWindow::on_actionActivateGraphicalSimulation_triggered() {
 
 
 void MainWindow::on_horizontalSliderAnimationSpeed_valueChanged(int value) {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 10 refactor.
     if (_sceneToolController != nullptr) {
         _sceneToolController->onHorizontalSliderAnimationSpeedValueChanged(value);
     }
@@ -701,7 +685,7 @@ void MainWindow::on_horizontalSliderAnimationSpeed_valueChanged(int value) {
 
 
 void MainWindow::on_actionDiagrams_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 10 refactor.
     if (_sceneToolController != nullptr) {
         _sceneToolController->onActionDiagramsTriggered();
     }
@@ -709,14 +693,14 @@ void MainWindow::on_actionDiagrams_triggered() {
 
 
 void MainWindow::on_actionSelectAll_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 10 refactor.
     if (_sceneToolController != nullptr) {
         _sceneToolController->onActionSelectAllTriggered();
     }
 }
 
 void MainWindow::on_actionParallelization_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 11 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 11 refactor.
     if (_dialogUtilityController != nullptr) {
         _dialogUtilityController->onActionParallelizationTriggered();
     }
@@ -739,14 +723,14 @@ void MainWindow::on_tabWidget_Model_tabBarClicked(int index) {
 }
 
 void MainWindow::on_checkBox_ShowElements_stateChanged(int arg1) {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 10 refactor.
     if (_sceneToolController != nullptr) {
         _sceneToolController->onCheckBoxShowElementsStateChanged(arg1);
     }
 }
 
 void MainWindow::on_checkBox_ShowInternals_stateChanged(int arg1) {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 10 refactor.
     if (_sceneToolController != nullptr) {
         _sceneToolController->onCheckBoxShowInternalsStateChanged(arg1);
     }
@@ -771,14 +755,14 @@ void MainWindow::on_horizontalSlider_Zoom_valueChanged(int value) {
 }
 
 void MainWindow::on_checkBox_ShowRecursive_stateChanged(int arg1) {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 10 refactor.
     if (_sceneToolController != nullptr) {
         _sceneToolController->onCheckBoxShowRecursiveStateChanged(arg1);
     }
 }
 
 void MainWindow::on_checkBox_ShowLevels_stateChanged(int arg1) {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 10 refactor.
     if (_sceneToolController != nullptr) {
         _sceneToolController->onCheckBoxShowLevelsStateChanged(arg1);
     }
@@ -789,7 +773,7 @@ void MainWindow::on_tabWidget_Debug_currentChanged(int index) {
 }
 
 void MainWindow::on_pushButton_Breakpoint_Insert_clicked() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 11 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 11 refactor.
     if (_dialogUtilityController != nullptr) {
         _dialogUtilityController->onPushButtonBreakpointInsertClicked();
     }
@@ -797,7 +781,7 @@ void MainWindow::on_pushButton_Breakpoint_Insert_clicked() {
 
 
 void MainWindow::on_pushButton_Breakpoint_Remove_clicked() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 11 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 11 refactor.
     if (_dialogUtilityController != nullptr) {
         _dialogUtilityController->onPushButtonBreakpointRemoveClicked();
     }
@@ -812,7 +796,7 @@ void MainWindow::on_tabWidgetCentral_tabBarClicked(int index) {
 }
 
 void MainWindow::on_treeWidget_Plugins_itemDoubleClicked(QTreeWidgetItem *item, int column) {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 5 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 5 refactor.
     _pluginCatalogController->handlePluginItemDoubleClicked(item, column);
 }
 
@@ -835,21 +819,21 @@ void MainWindow::on_graphicsView_rubberBandChanged(const QRect &viewportRect, co
 }
 
 void MainWindow::on_horizontalSlider_ZoomGraphical_valueChanged(int value) {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 10 refactor.
     if (_sceneToolController != nullptr) {
         _sceneToolController->onHorizontalSliderZoomGraphicalValueChanged(value);
     }
 }
 
 void MainWindow::on_actionConnect_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 10 refactor.
     if (_sceneToolController != nullptr) {
         _sceneToolController->onActionConnectTriggered();
     }
 }
 
 void MainWindow::on_pushButton_Export_clicked() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 11 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 11 refactor.
     if (_dialogUtilityController != nullptr) {
         _dialogUtilityController->onPushButtonExportClicked();
     }
@@ -885,26 +869,26 @@ void MainWindow::on_actionGModelComponentBreakpoint_triggered() {
 }
 
 void MainWindow::on_actionShowInternalElements_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 10 refactor.
     if (_sceneToolController != nullptr) {
         _sceneToolController->onActionShowInternalElementsTriggered();
     }
 }
 
 void MainWindow::on_actionShowAttachedElements_triggered() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 10 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 10 refactor.
     if (_sceneToolController != nullptr) {
         _sceneToolController->onActionShowAttachedElementsTriggered();
     }
 }
 
 void MainWindow::on_treeWidgetComponents_itemSelectionChanged() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 3 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 3 refactor.
     _modelInspectorController->syncSelectedComponentTreeItemToScene();
 }
 
 void MainWindow::on_treeWidget_Plugins_itemClicked(QTreeWidgetItem *item, int column) {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 5 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 5 refactor.
     _pluginCatalogController->handlePluginItemClicked(item, column);
 }
 

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow_modelrepresentations.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow_modelrepresentations.cpp
@@ -22,7 +22,6 @@
 #include <QMessageBox>
 #include <QTextStream>
 #include <QFileDialog>
-#include <QGraphicsScene>
 #include <QDateTime>
 #include <QEventLoop>
 #include <QTemporaryFile>
@@ -31,7 +30,6 @@
 #include <QPropertyAnimation>
 // #include <qt5/QtWidgets/qgraphicsitem.h>
 #include <QtWidgets/qgraphicsitem.h>
-#include <QGraphicsScene>
 //#include <QDesktopWidget> //removed from qt6
 #include <QScreen>
 #include <QDebug>
@@ -42,7 +40,7 @@
 #include <QUrl>
 
 void MainWindow::_actualizeModelSimLanguage() {
-    // This wrapper delegates model-language synchronization to a dedicated phase-1 service.
+    // Keep this wrapper as part of the final compatibility façade for model-language synchronization.
     _modelLanguageSynchronizer->actualizeModelSimLanguage();
 }
 
@@ -57,32 +55,32 @@ void MainWindow::_clearModelEditors() {
 }
 
 bool MainWindow::_setSimulationModelBasedOnText() {
-    // This wrapper delegates text-to-model synchronization while keeping MainWindow as temporary API surface.
+    // Keep this wrapper as part of the final compatibility façade for text-to-model synchronization.
     return _modelLanguageSynchronizer->setSimulationModelBasedOnText();
 }
 
 std::string MainWindow::_adjustDotName(std::string name) {
-    // This wrapper delegates DOT-name normalization to the phase-1 Graphviz service.
+    // Keep this wrapper as part of the final compatibility façade for Graphviz naming.
     return _graphvizModelExporter->adjustDotName(std::move(name));
 }
 
 void MainWindow::_insertTextInDot(std::string text, unsigned int compLevel, unsigned int compRank, std::map<unsigned int, std::map<unsigned int, std::list<std::string>*>*>* dotmap, bool isNode) {
-    // This wrapper delegates ranked DOT insertion to the phase-1 Graphviz service.
+    // Keep this wrapper as part of the final compatibility façade for Graphviz dot insertion.
     _graphvizModelExporter->insertTextInDot(std::move(text), compLevel, compRank, dotmap, isNode);
 }
 
 void MainWindow::_recursiveCreateModelGraphicPicture(ModelDataDefinition* componentOrData, std::list<ModelDataDefinition*>* visited, std::map<unsigned int, std::map<unsigned int, std::list<std::string>*>*>* dotmap) {
-    // This wrapper delegates recursive DOT generation to the phase-1 Graphviz service.
+    // Keep this wrapper as part of the final compatibility façade for recursive Graphviz generation.
     _graphvizModelExporter->recursiveCreateModelGraphicPicture(componentOrData, visited, dotmap);
 }
 
 std::string MainWindow::_addCppCodeLine(std::string line, unsigned int indent) {
-    // This wrapper delegates C++ line formatting to the phase-1 exporter service.
+    // Keep this wrapper as part of the final compatibility façade for C++ code formatting.
     return _cppModelExporter->addCppCodeLine(line, indent);
 }
 
 void MainWindow::_actualizeModelCppCode() {
-    // This wrapper delegates full C++ code export rendering to the phase-1 exporter service.
+    // Keep this wrapper as part of the final compatibility façade for C++ code export.
     _cppModelExporter->actualizeModelCppCode();
 }
 
@@ -96,7 +94,7 @@ void MainWindow::setGraphicalModelHasChanged(bool graphicalModelHasChanged) {
 }
 
 bool MainWindow::_createModelImage() {
-    // This wrapper delegates model diagram image creation to the phase-1 Graphviz service.
+    // Keep this wrapper as part of the final compatibility façade for model image creation.
     return _graphvizModelExporter->createModelImage();
 }
 
@@ -104,29 +102,29 @@ bool MainWindow::_createModelImage() {
 
 bool MainWindow::_saveTextModel(QFile *saveFile, QString data)
 {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 2 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 2 refactor.
     return _graphicalModelSerializer->saveTextModel(saveFile, data);
 }
 
 bool MainWindow::_saveGraphicalModel(QString filename)
 {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 2 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 2 refactor.
     return _graphicalModelSerializer->saveGraphicalModel(filename);
 }
 
 Model *MainWindow::_loadGraphicalModel(std::string filename) {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 2 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 2 refactor.
     return _graphicalModelSerializer->loadGraphicalModel(filename);
 }
 
 
 void MainWindow::_recursivalyGenerateGraphicalModelFromModel(ModelComponent* component, List<ModelComponent*>* visited, std::map<ModelComponent*,GraphicalModelComponent*>* map, int *x, int *y, int *ymax, int sequenceInLine) {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 2 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 2 refactor.
     _graphicalModelBuilder->recursivalyGenerateGraphicalModelFromModel(component, visited, map, x, y, ymax, sequenceInLine);
 }
 
 void MainWindow::_actualizeModelComponents(bool force) {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 3 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 3 refactor.
     _modelInspectorController->actualizeModelComponents(force);
 }
 
@@ -137,7 +135,7 @@ void MainWindow::_actualizeModelTextHasChanged(bool hasChanged) {
 }
 
 void MainWindow::_actualizeModelDataDefinitions(bool force) {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 3 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 3 refactor.
     _modelInspectorController->actualizeModelDataDefinitions(force);
 }
 
@@ -149,7 +147,7 @@ void MainWindow::_actualizeGraphicalModel(SimulationEvent * re) {
 }
 
 void MainWindow::_generateGraphicalModelFromModel() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 2 refactor.
+    // Keep this wrapper as part of the final compatibility façade from Phase 2 refactor.
     _graphicalModelBuilder->generateGraphicalModelFromModel();
 }
 

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow_scene.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow_scene.cpp
@@ -5,36 +5,38 @@
 
 //-----------------------------------------
 
+// Keep this scene callback local to MainWindow because it updates direct UI status widgets.
 /**
- * @brief Atualiza label de coordenadas com posição atual do mouse na cena.
- * @param mouseEvent Evento de mouse recebido da cena gráfica.
+ * @brief Updates the coordinate label with the current scene mouse position.
+ * @param mouseEvent Mouse event received from the graphical scene.
  */
 void MainWindow::_onSceneMouseEvent(QGraphicsSceneMouseEvent* mouseEvent) {
     QPointF pos = mouseEvent->scenePos();
     ui->labelMousePos->setText(QString::fromStdString("<" + std::to_string((int) pos.x()) + "," + std::to_string((int) pos.y()) + ">"));
 }
 
+// Keep this scene callback local to MainWindow because it bridges wheel events to existing slider state.
 /**
- * @brief Aumenta zoom da visualização gráfica via slider principal.
+ * @brief Increases graphical view zoom through the main slider.
  */
 void MainWindow::_onSceneWheelInEvent() {
     int value = ui->horizontalSlider_ZoomGraphical->value();
     ui->horizontalSlider_ZoomGraphical->setValue(value + TraitsGUI<GMainWindow>::zoomButtonChange);
 }
 
+// Keep this scene callback local to MainWindow because it bridges wheel events to existing slider state.
 /**
- * @brief Reduz zoom da visualização gráfica via slider principal.
+ * @brief Decreases graphical view zoom through the main slider.
  */
 void MainWindow::_onSceneWheelOutEvent() {
     int value = ui->horizontalSlider_ZoomGraphical->value();
     ui->horizontalSlider_ZoomGraphical->setValue(value - TraitsGUI<GMainWindow>::zoomButtonChange);
 }
 
+// Keep this scene callback as a compatibility façade entry-point for tab updates.
 /**
- * @brief Atualiza painéis dependentes quando o modelo gráfico muda.
- * @param event Evento de alteração gráfica (não utilizado diretamente neste handler).
- *
- * @todo Evoluir para atualização incremental por tipo de evento para reduzir custo.
+ * @brief Refreshes dependent panes when the graphical model changes.
+ * @param event Graphical change event (currently unused by this compatibility wrapper).
  */
 void MainWindow::_onSceneGraphicalModelEvent(const GraphicalModelEvent& /*event*/) {
     _actualizeTabPanes();
@@ -42,18 +44,17 @@ void MainWindow::_onSceneGraphicalModelEvent(const GraphicalModelEvent& /*event*
 
 //-----------------------------------------
 
+// Keep this slot in MainWindow because it centralizes action-state synchronization.
 /**
- * @brief Slot de notificação de alteração da cena (redo/undo e ações de edição).
- * @param region Regiões invalidadas da cena.
+ * @brief Scene-change notification slot (undo/redo and edit action synchronization).
+ * @param region Invalidated scene regions.
  */
 void MainWindow::sceneChanged(const QList<QRectF> &region) {
     if (_shuttingDown || ui == nullptr || ui->graphicsView == nullptr || ui->graphicsView->getScene() == nullptr) {
         return;
     }
     Q_UNUSED(region);
-    /**
-     * Bloco 1: sincroniza estado de undo/redo e flags de alteração textual.
-     */
+    // Synchronize undo/redo state and textual model dirty flag.
     bool canUndo = ui->graphicsView->getScene()->getUndoStack()->canUndo();
     bool canRedo = ui->graphicsView->getScene()->getUndoStack()->canRedo();
 
@@ -64,23 +65,20 @@ void MainWindow::sceneChanged(const QList<QRectF> &region) {
 
     ui->graphicsView->scene()->update();
 
-    /**
-     * Bloco 2: habilita/desabilita ações de edição conforme itens/copias disponíveis.
-     */
+    // Refresh edit-action enablement based on current selection and copy buffers.
     _actualizeActions();
 
-    /**
-     * Bloco 3: atualiza estado visual final da cena.
-     */
+    // Finalize visual state refresh for connection tool and scene update.
     if (ui->graphicsView->getScene()->connectingStep() == 0)
         ui->actionGModelShowConnect->setChecked(false);
 
     ui->graphicsView->scene()->update();
 }
 
+// Keep this helper local to MainWindow because it contributes to centralized action-state logic.
 /**
- * @brief Verifica se há itens relevantes na cena para habilitar operações de edição.
- * @return true se houver componentes/desenhos/animações no modelo gráfico.
+ * @brief Checks whether the scene has relevant items to enable edit operations.
+ * @return true when components/drawings/animations exist in the graphical model.
  */
 bool MainWindow::_checkItemsScene() {
     bool res = false;
@@ -105,10 +103,11 @@ void MainWindow::sceneFocusItemChanged(QGraphicsItem *newFocusItem, QGraphicsIte
 }
 //void sceneRectChanged(const QRectF &rect){}
 
+// Keep this wrapper as part of the final compatibility façade for property editor synchronization.
 /**
- * @brief Slot quando seleção de itens da cena muda.
+ * @brief Slot called when scene selection changes.
  *
- * Atualiza o Property Editor para um único componente selecionado e limpa em caso contrário.
+ * Updates property editor state according to current selection.
  */
 void MainWindow::sceneSelectionChanged() {
     // Keep this wrapper for compatibility during the incremental Phase 6 refactor.

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow_simulator.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow_simulator.cpp
@@ -12,23 +12,31 @@
 //-------------------------
 
 void MainWindow::_simulatorTraceHandler(TraceEvent e) {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 4 refactor.
-    _traceConsoleController->simulatorTraceHandler(e);
+    // Keep this compatibility wrapper in the final façade and guard shutdown-time calls.
+    if (_traceConsoleController != nullptr) {
+        _traceConsoleController->simulatorTraceHandler(e);
+    }
 }
 
 void MainWindow::_simulatorTraceErrorHandler(TraceErrorEvent e) {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 4 refactor.
-    _traceConsoleController->simulatorTraceErrorHandler(e);
+    // Keep this compatibility wrapper in the final façade and guard shutdown-time calls.
+    if (_traceConsoleController != nullptr) {
+        _traceConsoleController->simulatorTraceErrorHandler(e);
+    }
 }
 
 void MainWindow::_simulatorTraceSimulationHandler(TraceSimulationEvent e) {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 4 refactor.
-    _traceConsoleController->simulatorTraceSimulationHandler(e);
+    // Keep this compatibility wrapper in the final façade and guard shutdown-time calls.
+    if (_traceConsoleController != nullptr) {
+        _traceConsoleController->simulatorTraceSimulationHandler(e);
+    }
 }
 
 void MainWindow::_simulatorTraceReportsHandler(TraceEvent e) {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 4 refactor.
-    _traceConsoleController->simulatorTraceReportsHandler(e);
+    // Keep this compatibility wrapper in the final façade and guard shutdown-time calls.
+    if (_traceConsoleController != nullptr) {
+        _traceConsoleController->simulatorTraceReportsHandler(e);
+    }
 }
 
 //
@@ -36,64 +44,88 @@ void MainWindow::_simulatorTraceReportsHandler(TraceEvent e) {
 //
 
 void MainWindow::_onModelCheckSuccessHandler(ModelEvent* re) {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 4 refactor.
-    _simulationEventController->onModelCheckSuccessHandler(re);
+    // Keep this compatibility wrapper in the final façade and guard shutdown-time calls.
+    if (_simulationEventController != nullptr) {
+        _simulationEventController->onModelCheckSuccessHandler(re);
+    }
 }
 
 void MainWindow::_onReplicationStartHandler(SimulationEvent * re) {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 4 refactor.
-    _simulationEventController->onReplicationStartHandler(re);
+    // Keep this compatibility wrapper in the final façade and guard shutdown-time calls.
+    if (_simulationEventController != nullptr) {
+        _simulationEventController->onReplicationStartHandler(re);
+    }
 }
 
 void MainWindow::_onSimulationStartHandler(SimulationEvent * re) {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 4 refactor.
-    _simulationEventController->onSimulationStartHandler(re);
+    // Keep this compatibility wrapper in the final façade and guard shutdown-time calls.
+    if (_simulationEventController != nullptr) {
+        _simulationEventController->onSimulationStartHandler(re);
+    }
 }
 
 void MainWindow::_onSimulationPausedHandler(SimulationEvent * re) {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 4 refactor.
-    _simulationEventController->onSimulationPausedHandler(re);
+    // Keep this compatibility wrapper in the final façade and guard shutdown-time calls.
+    if (_simulationEventController != nullptr) {
+        _simulationEventController->onSimulationPausedHandler(re);
+    }
 }
 
 void MainWindow::_onSimulationResumeHandler(SimulationEvent * re) {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 4 refactor.
-    _simulationEventController->onSimulationResumeHandler(re);
+    // Keep this compatibility wrapper in the final façade and guard shutdown-time calls.
+    if (_simulationEventController != nullptr) {
+        _simulationEventController->onSimulationResumeHandler(re);
+    }
 }
 
 void MainWindow::_onSimulationEndHandler(SimulationEvent * re) {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 4 refactor.
-    _simulationEventController->onSimulationEndHandler(re);
+    // Keep this compatibility wrapper in the final façade and guard shutdown-time calls.
+    if (_simulationEventController != nullptr) {
+        _simulationEventController->onSimulationEndHandler(re);
+    }
 }
 
 void MainWindow::_onProcessEventHandler(SimulationEvent * re) {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 4 refactor.
-    _simulationEventController->onProcessEventHandler(re);
+    // Keep this compatibility wrapper in the final façade and guard shutdown-time calls.
+    if (_simulationEventController != nullptr) {
+        _simulationEventController->onProcessEventHandler(re);
+    }
 }
 
 void MainWindow::_onEntityCreateHandler(SimulationEvent* re) {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 4 refactor.
-    _simulationEventController->onEntityCreateHandler(re);
+    // Keep this compatibility wrapper in the final façade and guard shutdown-time calls.
+    if (_simulationEventController != nullptr) {
+        _simulationEventController->onEntityCreateHandler(re);
+    }
 }
 
 void MainWindow::_onEntityRemoveHandler(SimulationEvent* re) {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 4 refactor.
-    _simulationEventController->onEntityRemoveHandler(re);
+    // Keep this compatibility wrapper in the final façade and guard shutdown-time calls.
+    if (_simulationEventController != nullptr) {
+        _simulationEventController->onEntityRemoveHandler(re);
+    }
 }
 
 void MainWindow::_onMoveEntityEvent(SimulationEvent *re) {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 4 refactor.
-    _simulationEventController->onMoveEntityEvent(re);
+    // Keep this compatibility wrapper in the final façade and guard shutdown-time calls.
+    if (_simulationEventController != nullptr) {
+        _simulationEventController->onMoveEntityEvent(re);
+    }
 }
 
 void MainWindow::_onAfterProcessEvent(SimulationEvent *re) {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 4 refactor.
-    _simulationEventController->onAfterProcessEvent(re);
+    // Keep this compatibility wrapper in the final façade and guard shutdown-time calls.
+    if (_simulationEventController != nullptr) {
+        _simulationEventController->onAfterProcessEvent(re);
+    }
 }
 
 
 void MainWindow::_setOnEventHandlers() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 4 refactor.
-    _simulationEventController->setOnEventHandlers(this);
+    // Keep this compatibility wrapper in the final façade and guard shutdown-time calls.
+    if (_simulationEventController != nullptr) {
+        _simulationEventController->setOnEventHandlers(this);
+    }
 }
 
 
@@ -102,11 +134,15 @@ void MainWindow::_setOnEventHandlers() {
 //-------------------------
 
 void MainWindow::_insertPluginUI(Plugin * plugin) {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 5 refactor.
-    _pluginCatalogController->insertPluginUI(plugin);
+    // Keep this compatibility wrapper in the final façade and guard shutdown-time calls.
+    if (_pluginCatalogController != nullptr) {
+        _pluginCatalogController->insertPluginUI(plugin);
+    }
 }
 
 void MainWindow::_insertFakePlugins() {
-    // Keep this wrapper temporarily for compatibility during the incremental Phase 5 refactor.
-    _pluginCatalogController->insertFakePlugins();
+    // Keep this compatibility wrapper in the final façade and guard shutdown-time calls.
+    if (_pluginCatalogController != nullptr) {
+        _pluginCatalogController->insertFakePlugins();
+    }
 }


### PR DESCRIPTION
### Motivation
- Finalize Phase 12: consolidate MainWindow as the composition root and compatibility façade after prior phase extractions, performing cleanup and stabilization only. 
- Remove stale comments, tidy includes/forward declarations, and ensure controller/service ownership and initialization order are explicit and coherent without introducing new domains or behaviors.

### Description
- Grouped and documented controller/service ownership in `mainwindow.h` and adjusted class-level wording to state `MainWindow` is the final composition root/compatibility façade. 
- Standardized wrapper comments across `mainwindow_controller.cpp`, `mainwindow_scene.cpp`, `mainwindow_simulator.cpp`, and `mainwindow_modelrepresentations.cpp` to reflect the final compatibility façade intent and removed stale "incremental/todo" phrasing. 
- Removed duplicate/unused `QGraphicsScene` includes from translation units and cleaned a few include lists for compile hygiene. 
- Added small defensive null-guards in simulator/event/plugin wrapper delegates to avoid shutdown-time dereferences while preserving behavior. 
- No new controllers/services were created; compatibility wrappers were preserved; I intentionally stopped at Phase 12 and mark the refactor plan complete.

### Testing
- Ran repository checks: `git diff --check` (no trailing-whitespace/patch errors), `git status --short`, and `git show --stat --oneline HEAD`; all succeeded. 
- Committed changes locally with a single message reflecting Phase 12 work. 
- No full build or automated unit test suite was executed in this environment, so compilation was not validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d59ccd0f5c8321a64489c66615dc7f)