### PR TITLE
docs: add final post-refactor validation report

### DIFF
--- a/docs/post-refactor-validation-report.md
+++ b/docs/post-refactor-validation-report.md
@@ -1,0 +1,44 @@
+# Final post-refactor validation report
+
+## Branch used
+- `work` (current branch).
+- `WiP20261` does **not** exist locally or as `origin/WiP20261` in this environment, so validation was executed on `work` as required.
+
+## Build system path used
+- Qt GUI build entrypoint discovered in `source/applications/gui/qt/GenesysQtGUI/GenesysQtGUI.pro` and `source/applications/gui/qt/GenesysQtGUI/build_qtgui.sh` (qmake-driven).
+- CMake GUI target also explicitly requires qmake (`find_program(... qmake6 qmake-qt5 qmake)` + fatal error if absent).
+
+## Build commands executed
+- `cd source/applications/gui/qt/GenesysQtGUI && ./build_qtgui.sh --config Debug --build-dir build/validation-debug --jobs 2`
+- `cmake -S . -B build/validation-cmake -DGENESYS_BUILD_GUI_APPLICATION=ON`
+
+## Runtime / diagnostic commands executed
+- `command -v qmake6 || command -v qmake`
+- `command -v gdb || true; command -v valgrind || true; command -v xvfb-run || true`
+- Runtime launch commands were not executable because no GUI binary could be produced (build blocker at qmake discovery).
+
+## What was validated successfully
+- Repository/branch validation was completed; fallback branch policy applied correctly (`work` used because `WiP20261` missing).
+- Build path discovery was completed and grounded in repo build files (qmake is mandatory for GUI path).
+- Clean build attempt was executed and blocker captured with exact error text (`qmake not found`).
+
+## Issues found
+- **Environment blocker**: Qt `qmake` toolchain is missing.
+  - `build_qtgui.sh` exits early when `qmake` is unavailable (`command -v` check + `exit 1`).
+  - CMake GUI configuration also fails for the same reason by design (`message(FATAL_ERROR ...)`).
+- Because of this blocker, the following mandatory runtime validations could not be executed: GUI launch, model create/open, plugin catalog interaction, insertion flows, Property Editor crash path, simulation controls, save/open cycle, diagram generation.
+
+## Fixes applied
+- No source-code fix was applied, because no build/runtime defect in project code could be reached before the external toolchain blocker.
+- No project source-code fix was committed during the validation run because execution was blocked before runtime validation.
+
+## Remaining limitations
+- Missing `qmake` prevents any Qt GUI binary from being built.
+- Missing runtime diagnostics tools (`gdb`, `valgrind`, `xvfb-run`) further limit crash-path automation in this container.
+- Property Editor crash path could not be exercised due to absence of runnable GUI binary.
+
+## Final status
+- [ ] VALIDATED
+- [ ] VALIDATED WITH FIXES
+- [ ] PARTIALLY VALIDATED
+- [x] BLOCKED


### PR DESCRIPTION
### Motivation
- Persist the final post-refactor validation findings and the environment blocker details so follow-up triage and environment setup are reproducible.

### Description
- Added `docs/post-refactor-validation-report.md` containing the branch fallback, discovered GUI build path, exact build/diagnostic commands executed, blocker analysis, and final blocked status checklist.
- Clarified the "Fixes applied" wording to state that no project source-code fix was made during the validation run because runtime validation was blocked.
- This is a documentation-only change and does not modify source-code or runtime behavior.

### Testing
- Ran `cd source/applications/gui/qt/GenesysQtGUI && ./build_qtgui.sh --config Debug --build-dir build/validation-debug --jobs 2`, which failed early with `qmake not found` and blocked the build.
- Ran `cmake -S . -B build/validation-cmake -DGENESYS_BUILD_GUI_APPLICATION=ON`, which is configured to fatal-error when `qmake` is missing and therefore failed as expected given the environment.
- Executed environment checks `command -v qmake6 || command -v qmake` and `command -v gdb || true; command -v valgrind || true; command -v xvfb-run || true`, which confirmed the absence of `qmake` and the limited availability of runtime diagnostic tools and reported their findings successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5a4c5487c83218f859ffb40e915b3)