### PR TITLE
Stabilize Enter commit flow in Property Editor and defer heavy refresh safely

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/controllers/PropertyEditorController.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/PropertyEditorController.cpp
@@ -7,6 +7,8 @@
 
 #include <QGraphicsItem>
 #include <QDebug>
+#include <QTimer>
+#include <QPointer>
 
 // Build the Phase 6 controller with narrow dependencies for property-editor orchestration.
 PropertyEditorController::PropertyEditorController(
@@ -48,9 +50,26 @@ void PropertyEditorController::clearPropertyEditorSelection() const {
     _propertyBrowser->clearCurrentlyConnectedObject();
 }
 
+bool PropertyEditorController::isPostCommitPipelineActive() const {
+    const bool propertyEditorBusy = (_propertyBrowser != nullptr) && _propertyBrowser->isCommitPipelineBusy();
+    return propertyEditorBusy || _isGlobalRefreshQueued || _isGlobalRefreshRunning || _pendingGlobalRefresh;
+}
+
 // Preserve legacy single-selection behavior while moving orchestration out of MainWindow.
 void PropertyEditorController::sceneSelectionChanged() const {
     if (_graphicsView == nullptr || _propertyBrowser == nullptr) {
+        return;
+    }
+
+    if (isPostCommitPipelineActive()) {
+        qInfo() << "[PropertyEditorController] sceneSelectionChanged deferred because post-commit pipeline is active";
+        if (!_isDeferredSelectionSyncScheduled) {
+            _isDeferredSelectionSyncScheduled = true;
+            QTimer::singleShot(0, [this]() {
+                _isDeferredSelectionSyncScheduled = false;
+                this->sceneSelectionChanged();
+            });
+        }
         return;
     }
 
@@ -82,44 +101,88 @@ void PropertyEditorController::sceneSelectionChanged() const {
 
 // Preserve the existing post-edit cascade while preventing stale scene pointer reuse.
 void PropertyEditorController::onPropertyEditorModelChanged() const {
-    qInfo() << "[PropertyEditorController] onPropertyEditorModelChanged enter";
-    if (_actualizeModelSimLanguage) {
-        _actualizeModelSimLanguage();
-    }
-    if (_actualizeModelComponents) {
-        _actualizeModelComponents(true);
-    }
-    if (_actualizeModelDataDefinitions) {
-        _actualizeModelDataDefinitions(true);
-    }
-    if (_actualizeModelCppCode) {
-        _actualizeModelCppCode();
-    }
-    if (_createModelImage) {
-        _createModelImage();
-    }
-    if (_actualizeTabPanes) {
-        _actualizeTabPanes();
-    }
-
-    ModelGraphicsScene* scene = (_graphicsView != nullptr) ? _graphicsView->getScene() : nullptr;
-    if (scene == nullptr) {
-        qWarning() << "Skipping property-editor scene refresh because scene is null";
+    qInfo() << "[PropertyEditorController] onPropertyEditorModelChanged request. queued=" << _isGlobalRefreshQueued
+            << " running=" << _isGlobalRefreshRunning << " pending=" << _pendingGlobalRefresh;
+    _pendingGlobalRefresh = true;
+    if (_isGlobalRefreshRunning || _isGlobalRefreshQueued) {
         return;
     }
 
-    scene->actualizeDiagramArrows();
-    scene->update();
+    _isGlobalRefreshQueued = true;
+    QTimer::singleShot(0, [this]() {
+        _isGlobalRefreshQueued = false;
+        _runGlobalRefresh();
+    });
+}
 
-    if (scene->existDiagram()) {
-        const bool wasVisible = scene->visibleDiagram();
-        scene->destroyDiagram();
-        scene->createDiagrams();
-        if (wasVisible) {
-            scene->showDiagrams();
-        } else {
-            scene->hideDiagrams();
-        }
+void PropertyEditorController::_runGlobalRefresh() const {
+    if (_isGlobalRefreshRunning) {
+        _pendingGlobalRefresh = true;
+        qInfo() << "[PropertyEditorController] _runGlobalRefresh skipped because refresh is already running";
+        return;
     }
-    qInfo() << "[PropertyEditorController] onPropertyEditorModelChanged exit";
+
+    if (_propertyBrowser != nullptr && _propertyBrowser->isCommitPipelineBusy()) {
+        qInfo() << "[PropertyEditorController] _runGlobalRefresh deferred because property editor is still stabilizing";
+        if (!_isGlobalRefreshQueued) {
+            _isGlobalRefreshQueued = true;
+            QTimer::singleShot(0, [this]() {
+                _isGlobalRefreshQueued = false;
+                _runGlobalRefresh();
+            });
+        }
+        return;
+    }
+
+    _isGlobalRefreshRunning = true;
+    do {
+        _pendingGlobalRefresh = false;
+        qInfo() << "[PropertyEditorController] _runGlobalRefresh enter";
+
+        if (_actualizeModelSimLanguage) {
+            _actualizeModelSimLanguage();
+        }
+        if (_actualizeModelComponents) {
+            _actualizeModelComponents(true);
+        }
+        if (_actualizeModelDataDefinitions) {
+            _actualizeModelDataDefinitions(true);
+        }
+        if (_actualizeModelCppCode) {
+            _actualizeModelCppCode();
+        }
+        if (_createModelImage) {
+            _createModelImage();
+        }
+        if (_actualizeTabPanes) {
+            _actualizeTabPanes();
+        }
+
+        ModelGraphicsScene* scene = (_graphicsView != nullptr) ? _graphicsView->getScene() : nullptr;
+        if (scene == nullptr) {
+            qWarning() << "[PropertyEditorController] Skipping scene refresh because scene is null";
+        } else {
+            scene->actualizeDiagramArrows();
+            scene->update();
+
+            if (scene->existDiagram()) {
+                const bool wasVisible = scene->visibleDiagram();
+                QPointer<ModelGraphicsScene> guardedScene(scene);
+                QTimer::singleShot(0, [guardedScene, wasVisible]() {
+                    if (guardedScene.isNull()) {
+                        return;
+                    }
+                    guardedScene->destroyDiagram();
+                    guardedScene->createDiagrams();
+                    if (wasVisible) {
+                        guardedScene->showDiagrams();
+                    } else {
+                        guardedScene->hideDiagrams();
+                    }
+                });
+            }
+        }
+        qInfo() << "[PropertyEditorController] _runGlobalRefresh exit";
+    } while (_pendingGlobalRefresh);
+    _isGlobalRefreshRunning = false;
 }

--- a/source/applications/gui/qt/GenesysQtGUI/controllers/PropertyEditorController.h
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/PropertyEditorController.h
@@ -36,6 +36,8 @@ public:
     void onPropertyEditorModelChanged() const;
     // Clear property editor selection and bindings defensively.
     void clearPropertyEditorSelection() const;
+    // Report whether post-commit stabilization/refresh is still running or queued.
+    bool isPostCommitPipelineActive() const;
 
 private:
     // Keep direct access to the property browser used by this controller.
@@ -56,6 +58,15 @@ private:
     std::function<bool()> _createModelImage;
     std::function<void()> _actualizeTabPanes;
     std::function<void()> _actualizeActions;
+
+    // Coalesce and serialize heavy refresh requests after property commits.
+    mutable bool _isGlobalRefreshQueued = false;
+    mutable bool _isGlobalRefreshRunning = false;
+    mutable bool _pendingGlobalRefresh = false;
+    // Coalesce deferred selection synchronization while commit/refresh is active.
+    mutable bool _isDeferredSelectionSyncScheduled = false;
+
+    void _runGlobalRefresh() const;
 };
 
 #endif // PROPERTYEDITORCONTROLLER_H

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
@@ -463,6 +463,8 @@ void MainWindow::_onPropertyEditorModelChanged() {
             if (_propertyEditorController == nullptr) {
                 return;
             }
+            qInfo() << "[MainWindow] property-editor pipeline active before controller callback="
+                    << _propertyEditorController->isPostCommitPipelineActive();
             qInfo() << "[MainWindow] executing deferred property-editor model-changed handling";
             _propertyEditorController->onPropertyEditorModelChanged();
         }, Qt::QueuedConnection);

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow_scene.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow_scene.cpp
@@ -125,6 +125,9 @@ void MainWindow::sceneSelectionChanged() {
         qInfo() << "[MainWindow] sceneSelectionChanged exit early";
         return;
     }
+    if (_propertyEditorController->isPostCommitPipelineActive()) {
+        qInfo() << "[MainWindow] sceneSelectionChanged observed active post-commit pipeline; selection sync will be deferred";
+    }
     _propertyEditorController->sceneSelectionChanged();
     qInfo() << "[MainWindow] sceneSelectionChanged exit";
 }

--- a/source/applications/gui/qt/GenesysQtGUI/propertyeditor/ObjectPropertyBrowser.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/propertyeditor/ObjectPropertyBrowser.cpp
@@ -73,6 +73,7 @@ void ObjectPropertyBrowser::_clearAll() {
     _bindings.clear();
     _enumNames.clear();
     _pendingCommittedProperties.clear();
+    _pendingCommittedValues.clear();
 
     delete _variantFactory;
     delete _enumFactory;
@@ -130,6 +131,15 @@ void ObjectPropertyBrowser::clearCurrentlyConnectedObject() {
 
 void ObjectPropertyBrowser::setModelChangedCallback(ModelChangedCallback callback) {
     _modelChangedCallback = std::move(callback);
+}
+
+bool ObjectPropertyBrowser::isCommitPipelineBusy() const {
+    return _isRebuildingProperties
+        || _isNotifyingModelChange
+        || _pendingRebuild
+        || _isDeferredRebuildScheduled
+        || _isDeferredModelChangedScheduled
+        || !_pendingCommittedProperties.isEmpty();
 }
 
 void ObjectPropertyBrowser::setActiveObject(
@@ -205,15 +215,30 @@ void ObjectPropertyBrowser::_scheduleDeferredModelChangedCallback() {
 
     _isDeferredModelChangedScheduled = true;
     QMetaObject::invokeMethod(this, [this]() {
-        qInfo() << "[PropertyEditor] executing deferred model-changed callback";
+        qInfo() << "[PropertyEditor] executing deferred model-changed callback. rebuildScheduled="
+                << _isDeferredRebuildScheduled << " rebuilding=" << _isRebuildingProperties
+                << " pendingRebuild=" << _pendingRebuild;
         _isDeferredModelChangedScheduled = false;
+        if (_isRebuildingProperties || _pendingRebuild || _isDeferredRebuildScheduled) {
+            qInfo() << "[PropertyEditor] deferring model-changed callback until rebuild stabilizes";
+            _scheduleDeferredModelChangedCallback();
+            return;
+        }
         if (!_hasValidActiveBindingContext()) {
             qWarning() << "[PropertyEditor] Deferred model-changed callback canceled due to invalid binding context";
             return;
         }
-        if (_modelChangedCallback) {
-            _modelChangedCallback();
-        }
+        QMetaObject::invokeMethod(this, [this]() {
+            if (_isRebuildingProperties || _pendingRebuild || _isDeferredRebuildScheduled) {
+                qInfo() << "[PropertyEditor] model-changed callback postponed one more turn due to pending rebuild";
+                _scheduleDeferredModelChangedCallback();
+                return;
+            }
+            if (_modelChangedCallback) {
+                qInfo() << "[PropertyEditor] invoking model-changed callback after local rebuild stabilization";
+                _modelChangedCallback();
+            }
+        }, Qt::QueuedConnection);
     }, Qt::QueuedConnection);
 }
 
@@ -615,6 +640,9 @@ bool ObjectPropertyBrowser::_requiresCommitConfirmation(const Binding& binding) 
 }
 
 bool ObjectPropertyBrowser::_applyVariantChange(QtProperty* property, const QVariant& value, bool committed) {
+    qInfo() << "[PropertyEditor] _applyVariantChange property="
+            << (property != nullptr ? property->propertyName() : QString("<null>"))
+            << " committed=" << committed;
     auto it = _bindings.find(property);
     if (it == _bindings.end()) {
         qInfo() << "[PropertyEditor] variant apply ignored due to missing binding";
@@ -689,10 +717,26 @@ void ObjectPropertyBrowser::onVariantEditorCommitted(QtProperty* property) {
         return;
     }
 
+    const QVariant pendingValue = _variantManager->value(property);
     _pendingCommittedProperties.insert(property);
+    _pendingCommittedValues.insert(property, pendingValue);
     qInfo() << "[PropertyEditor] editor commit received for" << property->propertyName();
-    _applyVariantChange(property, _variantManager->value(property), true);
-    _pendingCommittedProperties.remove(property);
+    QMetaObject::invokeMethod(this, [this, property]() {
+        if (!_pendingCommittedProperties.contains(property)) {
+            return;
+        }
+        if (!_hasValidActiveBindingContext(property)) {
+            qWarning() << "[PropertyEditor] queued commit aborted due to invalid binding context";
+            _pendingCommittedProperties.remove(property);
+            _pendingCommittedValues.remove(property);
+            return;
+        }
+        const QVariant committedValue = _pendingCommittedValues.value(property, _variantManager->value(property));
+        qInfo() << "[PropertyEditor] queued commit apply for" << property->propertyName();
+        _pendingCommittedProperties.remove(property);
+        _pendingCommittedValues.remove(property);
+        _applyVariantChange(property, committedValue, true);
+    }, Qt::QueuedConnection);
 }
 
 void ObjectPropertyBrowser::valueChanged(QtProperty *property, const QVariant &value) {
@@ -718,10 +762,17 @@ void ObjectPropertyBrowser::valueChanged(QtProperty *property, const QVariant &v
         return;
     }
 
-    _applyVariantChange(property, value, committed || !requiresCommit);
     if (committed) {
+        const QVariant pendingValue = _pendingCommittedValues.value(property);
+        if (pendingValue.isValid() && pendingValue != value) {
+            qInfo() << "[PropertyEditor] valueChanged waiting for committed value for" << property->propertyName();
+            return;
+        }
         _pendingCommittedProperties.remove(property);
+        _pendingCommittedValues.remove(property);
     }
+
+    _applyVariantChange(property, value, committed || !requiresCommit);
     qInfo() << "[PropertyEditor] valueChanged exit";
 }
 

--- a/source/applications/gui/qt/GenesysQtGUI/propertyeditor/ObjectPropertyBrowser.h
+++ b/source/applications/gui/qt/GenesysQtGUI/propertyeditor/ObjectPropertyBrowser.h
@@ -46,6 +46,7 @@ public:
 
     void clearCurrentlyConnectedObject();
     void setModelChangedCallback(ModelChangedCallback callback);
+    bool isCommitPipelineBusy() const;
 
 private:
     struct Binding {
@@ -124,6 +125,7 @@ private:
     QMap<QtProperty*, Binding> _bindings;
     QMap<QtProperty*, QStringList> _enumNames;
     QSet<QtProperty*> _pendingCommittedProperties;
+    QMap<QtProperty*, QVariant> _pendingCommittedValues;
     ModelChangedCallback _modelChangedCallback;
 
 private:


### PR DESCRIPTION
### Motivation
- Fix crashes triggered when the user confirms an edit with Enter by stabilizing the commit path and avoiding reentrant/global refresh while the editor widget is fragile. 
- Preserve the recent behavior that stops per-keystroke global refresh while ensuring a single, safe model mutation on real confirmation. 
- Prevent race conditions between the Property Editor, scene/selection updates and the heavyweight global refresh cascade that previously led to SIGSEGV. 

### Description
- Make commit handling idempotent and queued in `ObjectPropertyBrowser` by tracking pending committed properties plus their committed values in `QSet`/`QMap` (`_pendingCommittedProperties`, `_pendingCommittedValues`) and applying the confirmed value from a queued `Qt::QueuedConnection` callback so the model is mutated exactly once on Enter. (changes in `source/applications/gui/qt/GenesysQtGUI/propertyeditor/ObjectPropertyBrowser.h` and `.../ObjectPropertyBrowser.cpp`).
- Split the post-commit pipeline into Stage A (local commit + safe property-tree rebuild via `_scheduleDeferredRebuild()` / `_rebuildPropertiesGuarded()`) and Stage B (heavy global refresh) by deferring the `ModelChangedCallback` until the property tree has stabilized and by re-queuing the model-changed callback one turn later when needed, ensuring Stage B does not run while the property editor is rebuilding. (changes in `ObjectPropertyBrowser.cpp`).
- Harden `PropertyEditorController::onPropertyEditorModelChanged()` to coalesce and serialize heavy global refreshes with `_isGlobalRefreshQueued`, `_isGlobalRefreshRunning`, `_pendingGlobalRefresh`, and `_runGlobalRefresh()` so the controller waits for `ObjectPropertyBrowser::isCommitPipelineBusy()` before running heavy work, and defer the heaviest diagram regeneration via `QTimer::singleShot` with a `QPointer` guard to avoid stale scene access. (changes in `source/applications/gui/qt/GenesysQtGUI/controllers/PropertyEditorController.*`).
- Defer selection-driven rebinding during a post-commit pipeline by exposing `isCommitPipelineBusy()` on the browser and using it in `PropertyEditorController::sceneSelectionChanged()` and `MainWindow::sceneSelectionChanged()` to schedule a zero-delay retry instead of running during stabilization. (changes in `ObjectPropertyBrowser.*`, `PropertyEditorController.*`, `mainwindow_scene.cpp`, and `mainwindow.cpp`).
- Add focused temporary logging at key points to allow tracing: commit detection and queued-apply, `_applyVariantChange(..., committed)`, deferred rebuild scheduling/execution, deferred model-changed callback scheduling/execution, controller queue/run state, and selection deferral traces. (logs added in `ObjectPropertyBrowser.cpp`, `PropertyEditorController.cpp`, `mainwindow.cpp`, `mainwindow_scene.cpp`).
- Files changed: `source/applications/gui/qt/GenesysQtGUI/propertyeditor/ObjectPropertyBrowser.h`, `.../ObjectPropertyBrowser.cpp`, `source/applications/gui/qt/GenesysQtGUI/controllers/PropertyEditorController.h`, `.../PropertyEditorController.cpp`, `source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp`, and `source/applications/gui/qt/GenesysQtGUI/mainwindow_scene.cpp`.
- Root causes fixed: overlapping commit paths (`editingFinished`/`valueChanged`) that could both attempt model mutation; immediate scheduling/execution of the heavyweight global refresh while the property-editor commit/rebuild was still in-flight; and unguarded diagram/scene operations accessing now-stale pointers causing SIGSEGV.
- Summary of separation/guards/coalescing added: local commit is applied only from the queued commit pipeline using `_pendingCommittedValues` and a queued apply; property-tree rebuild is guarded by `_isRebuildingProperties` and `_scheduleDeferredRebuild()`; model-changed callback execution is deferred and retried until rebuild is stable; `PropertyEditorController` queues and coalesces heavy refreshes with `_isGlobalRefreshQueued/_isGlobalRefreshRunning/_pendingGlobalRefresh`; selection sync is deferred via `_isDeferredSelectionSyncScheduled`; diagram recreation uses `QPointer` and a delayed invocation to avoid stale scene access. 

### Testing
- Ran configuration: `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug`, which completed successfully. 
- Ran build: `cmake --build build -j2`; the build progressed through compilation and most targets, but the full build failed in an existing smoke-test link step (`genesys_smoke_simulator_start`) with unresolved `SinkModelComponent` symbols that are unrelated to these GUI changes. 
- No GUI runtime crash reproduction was observed in the automated build logs because GUI runtime validation is interactive; the automated checks above show the code compiles through the GUI changes and the failure is in an unrelated linker step. 

Notes for reviewers: the change focuses strictly on event ordering and runtime safety (deferred/queued commit finalization, staged rebuild + deferred global refresh, selection/scene guard), keeps the per-keystroke no-refresh behavior intact, and adds temporary logs to help validate that a confirmed Enter commit is applied once and that Stage B runs only after Stage A stabilizes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5b8f7f4d48321a45d5d5bbde1b941)