### PR TITLE
Fix List<T> copy semantics and destructor; add unit tests

### DIFF
--- a/source/kernel/util/List.h
+++ b/source/kernel/util/List.h
@@ -37,8 +37,9 @@ public:
 	/*! \brief Creates an empty list and positions the internal iterator at the beginning. */
 	List();
 	/*! \brief Creates a copy of the source list. */
-	List(List<T> &origin);
-	virtual ~List() = default;
+	List(const List<T>& origin);
+	List<T>& operator=(const List<T>& origin);
+	virtual ~List();
 public: // direct access to list
 	/*! \brief Returns the number of stored elements. */
 	unsigned int size();
@@ -104,9 +105,25 @@ List<T>::List() {
 }
 
 template <typename T>
-List<T>::List(List<T> &origin) {
-	_list = new std::list<T>(origin);
-	_it = _list->begin(); // todo: check. end()? 2210
+List<T>::List(const List<T>& origin) {
+	_list = new std::list<T>(*origin._list);
+	_sortFunc = origin._sortFunc;
+	_it = _list->begin();
+}
+
+template <typename T>
+List<T>& List<T>::operator=(const List<T>& origin) {
+	if (this != &origin) {
+		*_list = *origin._list;
+		_sortFunc = origin._sortFunc;
+		_it = _list->begin();
+	}
+	return *this;
+}
+
+template <typename T>
+List<T>::~List() {
+	delete _list;
 }
 
 template <typename T>

--- a/source/tests/unit/test_util.cpp
+++ b/source/tests/unit/test_util.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include "kernel/util/Util.h"
+#include "kernel/util/List.h"
 
 TEST(UtilTest, DirSeparatorMatchesPlatformExpectation) {
 #ifdef __linux__
@@ -16,4 +17,37 @@ TEST(UtilTest, TimeUnitConvertSecondToMinute) {
         Util::TimeUnitConvert(Util::TimeUnit::second, Util::TimeUnit::minute),
         1.0 / 60.0
     );
+}
+
+TEST(ListTest, CopyConstructorCreatesIndependentContainerState) {
+    int a = 1;
+    int b = 2;
+    int c = 3;
+
+    List<int*> original;
+    original.insert(&a);
+    original.insert(&b);
+
+    List<int*> copy(original);
+    copy.insert(&c);
+
+    EXPECT_EQ(original.size(), 2u);
+    EXPECT_EQ(copy.size(), 3u);
+}
+
+TEST(ListTest, CopyAssignmentCreatesIndependentContainerState) {
+    int a = 1;
+    int b = 2;
+    int c = 3;
+
+    List<int*> original;
+    original.insert(&a);
+
+    List<int*> assigned;
+    assigned.insert(&b);
+    assigned = original;
+    assigned.insert(&c);
+
+    EXPECT_EQ(original.size(), 1u);
+    EXPECT_EQ(assigned.size(), 2u);
 }


### PR DESCRIPTION
### Motivation
- The `List<T>` wrapper allocated its internal `_list` with `new` but used a defaulted destructor, lacked a proper const copy constructor and copy-assignment operator, causing incorrect copying and a memory-management gap.
- Add minimal unit coverage for `List<T>` to prevent regressions and validate independent container state after copy/assignment.

### Description
- Changed class declaration in `source/kernel/util/List.h` to use `List(const List<T>&)`, add `List<T>& operator=(const List<T>&)`, and declare an explicit `~List()`.
- Implemented the copy constructor to deep-copy `*origin._list`, copy `_sortFunc`, and reset `_it` as requested, implemented copy-assignment with self-assignment guard copying the internal list and `_sortFunc`, and implemented `~List()` to `delete _list`.
- Added two unit tests in `source/tests/unit/test_util.cpp` (included `kernel/util/List.h`) to verify that copy construction and copy assignment produce independent container state.
- No other APIs were changed and `source/tests/unit/CMakeLists.txt` was left untouched.

### Testing
- Configured and built tests with `cmake --preset tests-kernel-unit` and `cmake --build build/tests-kernel-unit --target genesys_test_util`, which completed successfully.
- Ran the test executable `./build/tests-kernel-unit/source/tests/unit/genesys_test_util` and observed all tests pass: 4 tests run, 4 passed (including the two new `ListTest` cases).
- No further CMake changes were necessary and the changes were committed on branch `WiP20261`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6e9b21da48321a78215f2c93a5c46)