### PR TITLE
Fix defensive event-check and drawing/connection counters in ModelGraphicsScene

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
@@ -720,7 +720,7 @@ bool ModelGraphicsScene::connectDestination(GraphicalConnection* connection, Gra
         }
 
         // diz que o componente de destino tem mais uma porta de saida ocupada
-        dst->setOcupiedInputPorts(dst->getOcupiedOutputPorts() + 1);
+        dst->setOcupiedInputPorts(dst->getOcupiedInputPorts() + 1);
 
         return true;
     }
@@ -840,7 +840,7 @@ void ModelGraphicsScene::addDrawing(QGraphicsItem * item, bool notify) {
     isAnimation = addDrawingAnimation(item);
 
     if (!isAnimation)
-        isGeometry = removeDrawingGeometry(item);
+        isGeometry = addDrawingGeometry(item);
 
     if (isAnimation || isGeometry) {
         addItem(item);
@@ -1798,13 +1798,26 @@ void ModelGraphicsScene::arranjeModels(int direction) {
 //-------------------------
 
 bool ModelGraphicsScene::checkIgnoreEvent() {
-    if (_simulator->getModelManager()->current()->getSimulation()) {
-        if (_simulator->getModelManager()->current()->getSimulation()->isRunning()) {
-            return true;
-        } else {
-            return false;
-        }
+    if (_simulator == nullptr) {
+        return false;
     }
+
+    auto* modelManager = _simulator->getModelManager();
+    if (modelManager == nullptr) {
+        return false;
+    }
+
+    auto* currentModel = modelManager->current();
+    if (currentModel == nullptr) {
+        return false;
+    }
+
+    auto* simulation = currentModel->getSimulation();
+    if (simulation == nullptr) {
+        return false;
+    }
+
+    return simulation->isRunning();
 }
 void ModelGraphicsScene::mousePressEvent(QGraphicsSceneMouseEvent *mouseEvent) {
     if (checkIgnoreEvent()) {


### PR DESCRIPTION
### Motivation
- Eliminate undefined behavior where `checkIgnoreEvent()` could exit without returning a value and harden the check against null simulator/model/simulation pointers.
- Fix a logical error in `addDrawing()` where the geometry add-path incorrectly called `removeDrawingGeometry()` during addition.
- Fix a counter bug in `connectDestination()` where input-port occupancy was updated using the output-port counter.

### Description
- Replaced `ModelGraphicsScene::checkIgnoreEvent()` with a fully defensive implementation that returns `false` if `_simulator` is null, if `_simulator->getModelManager()` is null, if `current()` is null, or if `getSimulation()` is null, otherwise returning `simulation->isRunning()`; change located in `source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp`.
- In `addDrawing(QGraphicsItem * item, bool notify)` changed the single line so that when an item is not an animation it calls `addDrawingGeometry(item)` instead of `removeDrawingGeometry(item)`.
- In `connectDestination(GraphicalConnection* connection, GraphicalModelComponent *destination)` changed the single line that updates occupied input ports to use `dst->getOcupiedInputPorts() + 1` instead of `dst->getOcupiedOutputPorts() + 1`.
- All edits are limited to `ModelGraphicsScene.cpp` and touch exactly the three requested locations with no other semantic or header changes.

### Testing
- Verified the resulting diff is limited to `source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp` and includes only the three targeted changes via `git diff` and `rg` checks; these checks succeeded.
- Committed the change locally with `git commit` (commit recorded as part of the workflow); commit succeeded.
- Attempted to build the GUI using the repository qmake flow (`qmake ... && make`), but the environment lacks Qt tooling and `qmake` is not installed, causing the build attempt to fail with `qmake: command not found`, so no binary or runtime GUI tests were executed.
- No automated unit tests were run in this environment due to the missing Qt build toolchain.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6e9c28ff08321b6ee39f198907c10)