### PR TITLE
Harden AnimationTransition lifecycle and fix transition leaks

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/animations/AnimationTransition.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/animations/AnimationTransition.cpp
@@ -16,8 +16,13 @@ bool AnimationTransition::_running = true; // Define um valor inicial para o run
 
 AnimationTransition::AnimationTransition(ModelGraphicsScene* myScene, ModelComponent* graphicalStartComponent, ModelComponent* graphicalEndComponent, bool viewSimulation) :
     _myScene(myScene),
+    // Initialize potentially deferred members to safe defaults for early-return paths.
+    _graphicalStartComponent(nullptr),
     _graphicalEndComponent(nullptr),
+    _graphicalConnection(nullptr),
     _imageAnimation(nullptr),
+    _portNumber(0),
+    _currentProgress(0.0),
     _viewSimulation(viewSimulation){
 
     // Pega o componente gráfico de início e fim da animação
@@ -128,8 +133,15 @@ void AnimationTransition::setRunning(bool running) {
 
 // Outros
 void AnimationTransition::startAnimation() {
-    // Adiciona a imagem na cena
-    _myScene->addItem(_imageAnimation);
+    // Guard against partially constructed transitions before interacting with scene/image pointers.
+    if (_myScene == nullptr || _imageAnimation == nullptr) {
+        return;
+    }
+
+    // Add the animation image only if it is not already in this scene.
+    if (_imageAnimation->scene() != _myScene) {
+        _myScene->addItem(_imageAnimation);
+    }
 
     // Atualiza a cena
     _myScene->update();
@@ -139,20 +151,24 @@ void AnimationTransition::startAnimation() {
 }
 
 void AnimationTransition::stopAnimation() {
-    // Remove a imagem na cena
-    _myScene->removeItem(_imageAnimation);
+    // Stop only when running/paused and cleanup scene state without simulating normal completion.
+    if (state() != QAbstractAnimation::Stopped) {
+        stop();
+    }
 
-    // Para a animação
-    stop();
-
-    // Atualiza a cena
-    _myScene->update();
-
-    // Emite o sinal de encerramento de animação (caso opte por encerrar por essa função)
-    emit finished();
+    // Remove image only when both pointers are valid and image belongs to this scene.
+    if (_myScene != nullptr && _imageAnimation != nullptr && _imageAnimation->scene() == _myScene) {
+        _myScene->removeItem(_imageAnimation);
+        _myScene->update();
+    }
 }
 
 void AnimationTransition::restartAnimation() {
+    // Guard resume against missing image or invalid animation duration.
+    if (_imageAnimation == nullptr || duration() <= 0) {
+        return;
+    }
+
     // Configura o progresso
     setCurrentTime(_currentProgress * duration());
 
@@ -256,13 +272,17 @@ void AnimationTransition::connectFinishedSignal() {
 }
 
 void AnimationTransition::onAnimationFinished() {
-    // Adiciona animação de fila se for o caso
-    if(_graphicalEndComponent != nullptr)
+    // Only notify queue insertion when both scene and destination component are valid.
+    if (_myScene != nullptr && _graphicalEndComponent != nullptr)
         _myScene->animateQueueInsert(_graphicalEndComponent->getComponent(), _viewSimulation);
 
-    // Remove o item da cena
-    _myScene->removeItem(_imageAnimation);
+    // Remove image only when it is valid and still attached to this scene.
+    if (_myScene != nullptr && _imageAnimation != nullptr && _imageAnimation->scene() == _myScene) {
+        _myScene->removeItem(_imageAnimation);
+    }
 
-    // Atualiza a cena
-    _myScene->update();
+    // Update scene only when scene pointer is valid.
+    if (_myScene != nullptr) {
+        _myScene->update();
+    }
 }

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
@@ -1219,7 +1219,10 @@ void ModelGraphicsScene::animateTransition(ModelComponent *source, ModelComponen
     if (animationTransition->getGraphicalStartComponent() != nullptr && animationTransition->getGraphicalEndComponent() != nullptr && viewSimulation) {
         runAnimateTransition(animationTransition, event);
     } else {
+        // Ensure invalid/non-visible transition is fully cleaned up to avoid leaks.
         animationTransition->stopAnimation();
+        delete animationTransition;
+        return;
     }
 }
 
@@ -1245,6 +1248,11 @@ void ModelGraphicsScene::runAnimateTransition(AnimationTransition *animationTran
     loop.exec();
 
     _animationsTransition->removeOne(animationTransition);
+
+    // Keep paused transitions alive for resume flow; cleanup all others.
+    if (animationTransition->state() != QAbstractAnimation::Paused) {
+        animationTransition->deleteLater();
+    }
 }
 
 void ModelGraphicsScene::handleAnimationStateChanged(QAbstractAnimation::State newState, QEventLoop* loop, Event* event, AnimationTransition* animationTransition) {


### PR DESCRIPTION
### Motivation
- Prevent accidental side-effects from `AnimationTransition` destruction by removing code paths that could trigger normal completion logic during cleanup.
- Fix confirmed memory leaks when transitions are created but not shown or after normal completion.
- Make animation lifecycle methods defensive against partially-constructed state to avoid null-dereference crashes.

### Description
- Hardened `AnimationTransition` constructor initializer list by explicitly initializing `_graphicalStartComponent`, `_graphicalConnection`, `_portNumber`, and `_currentProgress` to safe defaults (`nullptr`, `0`, `0.0`).
- Made `startAnimation()` defensive by returning early if `_myScene` or `_imageAnimation` is `nullptr`, and only adding the image to the scene if it is not already attached to the same scene.
- Rewrote `stopAnimation()` to be cleanup-only: it no longer emits `finished()`, stops the animation only if not already `Stopped`, and removes the image from the scene only when pointers and scene ownership are valid.
- Added guards to `restartAnimation()` to return early when `_imageAnimation` is `nullptr` or `duration() <= 0`.
- Hardened `onAnimationFinished()` to call `animateQueueInsert`, remove the image, and call `update()` only when the relevant pointers and scene ownership are valid.
- Fixed leak in `ModelGraphicsScene::animateTransition()` by calling `stopAnimation()` then `delete animationTransition;` and returning on the invalid/non-visible branch.
- Fixed leak in `ModelGraphicsScene::runAnimateTransition()` by calling `_animationsTransition->removeOne(animationTransition);` and scheduling `animationTransition->deleteLater()` when the transition state is not `Paused` to preserve paused/resume semantics.
- Changes are restricted to `source/applications/gui/qt/GenesysQtGUI/animations/AnimationTransition.cpp` and `source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp` only, with short English comments added above altered blocks.

### Testing
- Performed code inspection and `git diff` to verify the intended edits were applied to the two target files only and that new comments are present.
- Verified by inspection that `stopAnimation()` no longer contains `emit finished();` and that invalid branch in `animateTransition()` now deletes the `AnimationTransition` instance.
- Verified by inspection that `runAnimateTransition()` performs conditional cleanup via `deleteLater()` when the transition is not `Paused`.
- Attempted to build the GUI with `cd source/applications/gui/qt/GenesysQtGUI && ./build_qtgui.sh --config Debug`, which failed in this environment due to missing `qmake` (`qmake not found. Set QMAKE_EXECUTABLE or add qmake to PATH.`), so runtime build/tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6ee53e0008321b7542b7cecfa89a0)