### PR TITLE
Fix paused-animation ownership and cleanup in GUI

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/controllers/SimulationEventController.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/SimulationEventController.cpp
@@ -24,6 +24,41 @@
 #include <string>
 #include <utility>
 
+namespace {
+// Release one paused-animation list and optionally destroy its animations.
+static void cleanupPausedAnimationList(QList<AnimationTransition*>* pausedAnimations, bool destroyAnimations) {
+    if (!pausedAnimations) {
+        return;
+    }
+
+    if (destroyAnimations) {
+        for (AnimationTransition* animation : *pausedAnimations) {
+            if (animation) {
+                animation->stopAnimation();
+                delete animation;
+            }
+        }
+    }
+
+    pausedAnimations->clear();
+    delete pausedAnimations;
+}
+
+// Release all paused-animation lists in the map and then clear the map keys.
+static void cleanupPausedAnimationMap(QMap<Event*, QList<AnimationTransition*>*>* pausedAnimationsMap,
+                                      bool destroyAnimations) {
+    if (!pausedAnimationsMap) {
+        return;
+    }
+
+    for (auto it = pausedAnimationsMap->begin(); it != pausedAnimationsMap->end(); ++it) {
+        cleanupPausedAnimationList(it.value(), destroyAnimations);
+    }
+
+    pausedAnimationsMap->clear();
+}
+} // namespace
+
 // Build the simulation-event controller with narrow simulator/view/widget dependencies.
 SimulationEventController::SimulationEventController(Simulator* simulator,
                                                      ModelGraphicsScene* scene,
@@ -119,20 +154,22 @@ void SimulationEventController::onSimulationPausedHandler(SimulationEvent* re) c
 void SimulationEventController::onSimulationResumeHandler(SimulationEvent* re) const {
     _callbacks.actualizeActions();
 
-    if (_scene->getAnimationPaused()) {
-        if (!_scene->getAnimationPaused()->empty()) {
-            QList<AnimationTransition*>* animationPaused =
-                _scene->getAnimationPaused()->value(re->getCurrentEvent());
-
-            if (animationPaused) {
-                if (!animationPaused->empty()) {
-                    for (AnimationTransition* animation : *animationPaused) {
-                        _scene->runAnimateTransition(animation, re->getCurrentEvent(), true);
+    // Resume only the current-event paused animations and release that owned list.
+    QMap<Event*, QList<AnimationTransition*>*>* pausedAnimationsMap = _scene->getAnimationPaused();
+    Event* currentEvent = re ? re->getCurrentEvent() : nullptr;
+    if (pausedAnimationsMap && !pausedAnimationsMap->empty() && currentEvent) {
+        auto it = pausedAnimationsMap->find(currentEvent);
+        if (it != pausedAnimationsMap->end()) {
+            QList<AnimationTransition*>* pausedAnimations = it.value();
+            if (pausedAnimations) {
+                for (AnimationTransition* animation : *pausedAnimations) {
+                    if (animation) {
+                        _scene->runAnimateTransition(animation, currentEvent, true);
                     }
-                    animationPaused->clear();
                 }
             }
-            _scene->getAnimationPaused()->clear();
+            cleanupPausedAnimationList(pausedAnimations, false);
+            pausedAnimationsMap->remove(currentEvent);
         }
     }
 
@@ -142,7 +179,8 @@ void SimulationEventController::onSimulationResumeHandler(SimulationEvent* re) c
 // Preserve simulation-end cleanup, tab switch and model-check flag reset behavior.
 void SimulationEventController::onSimulationEndHandler(SimulationEvent* re) const {
     Q_UNUSED(re)
-    _scene->getAnimationPaused()->clear();
+    // Destroy all paused-animation lists and remaining paused animations before ending.
+    cleanupPausedAnimationMap(_scene->getAnimationPaused(), true);
     _callbacks.actualizeActions();
     _centralTabWidget->setCurrentIndex(_tabCentralReportsIndex);
     for (unsigned int i = 0; i < 50; i++) {

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
@@ -1335,12 +1335,30 @@ void ModelGraphicsScene::clearAnimations() {
 }
 
 void ModelGraphicsScene::clearAnimationsTransition() {
-    // Limpa lista de animações de transição
+    // Keep cleaning active transition animations owned by the transition list.
     if (_animationsTransition) {
         for (unsigned int i = 0; i < (unsigned int) _animationsTransition->size(); i++) {
             delete _animationsTransition->at(i);
         }
         _animationsTransition->clear();
+    }
+
+    // Release paused transition lists and destroy remaining paused animations.
+    if (_animationPaused) {
+        for (auto it = _animationPaused->begin(); it != _animationPaused->end(); ++it) {
+            QList<AnimationTransition*>* pausedAnimations = it.value();
+            if (pausedAnimations) {
+                for (AnimationTransition* animation : *pausedAnimations) {
+                    if (animation) {
+                        animation->stopAnimation();
+                        delete animation;
+                    }
+                }
+                pausedAnimations->clear();
+                delete pausedAnimations;
+            }
+        }
+        _animationPaused->clear();
     }
 }
 


### PR DESCRIPTION
### Motivation
- Prevent memory leaks and unsafe ownership of heap-allocated `QList<AnimationTransition*>*` stored in `_animationPaused` and ensure paused animations are properly stopped/deleted on end.
- Avoid the previous global `clear()` behavior on resume/end that caused lost ownership and potential leaks or double-free risks.

### Description
- Added local helpers in an anonymous namespace in `SimulationEventController.cpp`: `cleanupPausedAnimationList(...)` and `cleanupPausedAnimationMap(...)` to centralize safe destruction of paused lists and (optionally) their animations.
- Reworked `onSimulationResumeHandler()` to resume only the paused list for `re->getCurrentEvent()`, call `runAnimateTransition(...)` for each resumed animation, then delete the owned list and remove only that key from the map (no global `clear()` anymore). A short English comment was added above the changed block.
- Reworked `onSimulationEndHandler()` to call the helper to explicitly destroy all paused lists and remaining paused animations before continuing the existing end flow; kept the rest of the handler semantics intact and added a short comment.
- Extended `ModelGraphicsScene::clearAnimationsTransition()` to also iterate `_animationPaused`, call `stopAnimation()` and `delete` on remaining paused `AnimationTransition` objects, delete each heap-allocated `QList`, and clear the map; a short English comment was added above this change.

### Testing
- Performed automated repository /diff inspections with `git status`, `git diff` and file dumps (`sed`/`nl`) and confirmed the diff is limited to the two allowed files and contains the intended helpers and handler changes.
- Ran quick static checks (`rg`/file searches) to confirm modified functions (`onSimulationResumeHandler`, `onSimulationEndHandler`, `clearAnimationsTransition`) reflect the new logic; inspections confirmed that heap-allocated lists are deleted and the resume path no longer does a blind map `clear()`.
- Attempted to build the GUI toolchain but `qmake`/`qmake6` was not available in this environment, so a compile/run of the GUI could not be executed.
- No automated unit tests were run or available for these GUI flows in this environment; behavior was validated by careful code inspection only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6f0551f408321b63ff8bcd1bb00b7)