### PR TITLE
Phase 2A: fix Model ownership, Event lifecycle and manager container cleanup

### DIFF
--- a/source/kernel/simulator/ComponentManager.cpp
+++ b/source/kernel/simulator/ComponentManager.cpp
@@ -26,6 +26,12 @@ ComponentManager::ComponentManager(Model* model) {
 	});
 }
 
+// Releases the heap-allocated container that tracks components; component ownership is handled by Model.
+ComponentManager::~ComponentManager() {
+	delete _components;
+	_components = nullptr;
+}
+
 bool ComponentManager::insert(ModelComponent* comp) {
 	if (_components->find(comp) == _components->list()->end()) {
 		_components->insert(comp);

--- a/source/kernel/simulator/ComponentManager.h
+++ b/source/kernel/simulator/ComponentManager.h
@@ -30,7 +30,7 @@ class ComponentManager {
 public:
 	/*! \brief Creates a component manager attached to a model. */
 	ComponentManager(Model* model);
-	virtual ~ComponentManager() = default;
+	virtual ~ComponentManager();
 public:
 	/*!
 	 * \brief insert

--- a/source/kernel/simulator/Model.cpp
+++ b/source/kernel/simulator/Model.cpp
@@ -101,6 +101,44 @@ Model::Model(Simulator* simulator, unsigned int level) {
 
 }
 
+// Explicitly destroys model-owned runtime and manager infrastructure in a safe order.
+Model::~Model() {
+	// Releases pending heap events owned by the model calendar before managers are destroyed.
+	_destroyFutureEvents();
+	// Releases transient entity instances still alive in the model runtime list.
+	_destroyTransientEntities();
+	// Releases remaining components while letting component destructors update manager state.
+	_destroyComponents();
+	// Releases non-entity model data definitions that were not already released by components.
+	_destroyModelDataDefinitions();
+
+	// Destroys runtime services owned by Model (non-owned pointers are intentionally not deleted).
+	delete _simulation;
+	_simulation = nullptr;
+	delete _modelPersistence;
+	_modelPersistence = nullptr;
+	delete _modelChecker;
+	_modelChecker = nullptr;
+	delete _parser;
+	_parser = nullptr;
+
+	// Destroys infrastructure containers owned by Model after contained objects were released.
+	delete _futureEvents;
+	_futureEvents = nullptr;
+	delete _controls;
+	_controls = nullptr;
+	delete _responses;
+	_responses = nullptr;
+	delete _componentManager;
+	_componentManager = nullptr;
+	delete _modeldataManager;
+	_modeldataManager = nullptr;
+	delete _eventManager;
+	_eventManager = nullptr;
+	delete _modelInfo;
+	_modelInfo = nullptr;
+}
+
 void Model::sendEntityToComponent(Entity* entity, Connection* connection, double timeDelay) {
 	this->sendEntityToComponent(entity, connection->component, timeDelay, connection->channel.portNumber);
 }
@@ -296,13 +334,86 @@ void Model::_showSimulationResponses() const {
 }
 
 void Model::clear() {
-	this->_componentManager->clear();
-	this->_modeldataManager->clear();
-	this->_futureEvents->clear();
+	// Clears and destroys pending runtime events to avoid leaking queued Event objects.
+	_destroyFutureEvents();
+	// Clears and destroys transient entities that may still exist between runs.
+	_destroyTransientEntities();
+	// Clears and destroys components currently owned by the model.
+	_destroyComponents();
+	// Clears and destroys remaining non-entity data definitions tracked by the model.
+	_destroyModelDataDefinitions();
 	Util::ResetAllIds();
 	//this->_simulation->clear();  // @TODO clear method
 	//this->_modelInfo->clear(); // @TODO clear method
 	//Util::ResetAllIds(); // @TODO: To implement
+}
+
+// Iterates over the future event list and deletes each pending heap-allocated event.
+void Model::_destroyFutureEvents() {
+	if (_futureEvents == nullptr) {
+		return;
+	}
+	while (!_futureEvents->empty()) {
+		Event* event = _futureEvents->front();
+		_futureEvents->pop_front();
+		delete event;
+	}
+}
+
+// Iterates over the live entity list and deletes each transient heap-allocated entity.
+void Model::_destroyTransientEntities() {
+	if (_modeldataManager == nullptr) {
+		return;
+	}
+	List<ModelDataDefinition*>* entities = _modeldataManager->getDataDefinitionList(Util::TypeOf<Entity>());
+	while (entities != nullptr && !entities->empty()) {
+		ModelDataDefinition* data = entities->front();
+		Entity* entity = dynamic_cast<Entity*>(data);
+		if (entity == nullptr) {
+			entities->pop_front();
+			continue;
+		}
+		delete entity;
+	}
+}
+
+// Iterates over remaining components and deletes them so their destructors keep manager state consistent.
+void Model::_destroyComponents() {
+	if (_componentManager == nullptr) {
+		return;
+	}
+	while (_componentManager->getNumberOfComponents() > 0) {
+		ModelComponent* component = _componentManager->front();
+		if (component == nullptr) {
+			break;
+		}
+		delete component;
+	}
+}
+
+// Iteratively deletes non-entity data definitions without assuming stable collections during destruction.
+void Model::_destroyModelDataDefinitions() {
+	if (_modeldataManager == nullptr) {
+		return;
+	}
+	bool hasPendingNonEntity = true;
+	while (hasPendingNonEntity) {
+		hasPendingNonEntity = false;
+		std::list<std::string>* types = _modeldataManager->getDataDefinitionClassnames();
+		for (const std::string& type : *types) {
+			if (type == Util::TypeOf<Entity>()) {
+				continue;
+			}
+			List<ModelDataDefinition*>* datadefs = _modeldataManager->getDataDefinitionList(type);
+			if (datadefs != nullptr && !datadefs->empty()) {
+				hasPendingNonEntity = true;
+				ModelDataDefinition* data = datadefs->front();
+				delete data;
+				break;
+			}
+		}
+		delete types;
+	}
 }
 
 void Model::_createModelInternalElements() {

--- a/source/kernel/simulator/Model.h
+++ b/source/kernel/simulator/Model.h
@@ -42,7 +42,7 @@ class Simulator;
 class Model {
 public:
 	Model(Simulator* simulator, unsigned int level = 0);
-	virtual ~Model() = default;
+	virtual ~Model();
 public: // model control
 	//void showReports();
 	/*!
@@ -239,6 +239,10 @@ private:
 	void _showSimulationControls() const;
 	void _showSimulationResponses() const;
 	void _createModelInternalElements();
+	void _destroyFutureEvents();
+	void _destroyTransientEntities();
+	void _destroyComponents();
+	void _destroyModelDataDefinitions();
 private:
 	bool _hasChanged = false;
     //bool _isChecked = false; // @TODO: Not implemented yet. First, _hasChanged should be trustful
@@ -269,4 +273,3 @@ private: // no public access (no gets / sets)
 };
 //namespace\\}
 #endif /* SIMULATIONMODEL_H */
-

--- a/source/kernel/simulator/ModelDataManager.cpp
+++ b/source/kernel/simulator/ModelDataManager.cpp
@@ -22,6 +22,18 @@ ModelDataManager::ModelDataManager(Model* model) {
 	_datadefinitions = new std::map<std::string, List<ModelDataDefinition*>*>();
 }
 
+// Releases per-type list containers and the map container itself; Model owns pointed data objects lifecycle.
+ModelDataManager::~ModelDataManager() {
+	if (_datadefinitions == nullptr) {
+		return;
+	}
+	for (auto& pair : *_datadefinitions) {
+		delete pair.second;
+	}
+	delete _datadefinitions;
+	_datadefinitions = nullptr;
+}
+
 bool ModelDataManager::insert(ModelDataDefinition * anElement) {
 	std::string datadefinitionTypename = anElement->getClassname();
 	return insert(datadefinitionTypename, anElement);
@@ -89,6 +101,10 @@ bool ModelDataManager::check(std::string datadefinitionTypename, ModelDataDefini
 
 void ModelDataManager::clear() {
 	_hasChanged = true;
+	// Deletes list containers before clearing the map to avoid leaking heap-allocated per-type lists.
+	for (auto& pair : *this->_datadefinitions) {
+		delete pair.second;
+	}
 	this->_datadefinitions->clear();
 }
 

--- a/source/kernel/simulator/ModelDataManager.h
+++ b/source/kernel/simulator/ModelDataManager.h
@@ -32,7 +32,7 @@ class ModelDataManager {
 public:
 	/*! \brief Creates a data manager attached to \p model. */
 	ModelDataManager(Model* model);
-	virtual ~ModelDataManager() = default;
+	virtual ~ModelDataManager();
 public:
 	/*!
 	 * \brief insert

--- a/source/kernel/simulator/ModelManager.cpp
+++ b/source/kernel/simulator/ModelManager.cpp
@@ -32,6 +32,10 @@ ModelManager::~ModelManager() {
 		for (Model* model : *_models->list()) {
 			delete model;
 		}
+		// Releases a detached current model that is not tracked by the manager list.
+		if (_currentModel != nullptr && _models->find(_currentModel) == _models->list()->end()) {
+			delete _currentModel;
+		}
 		delete _models;
 		_models = nullptr;
 	}
@@ -39,6 +43,10 @@ ModelManager::~ModelManager() {
 }
 
 Model* ModelManager::newModel() {
+	// Prevents leaking a previously created current model that was never inserted into _models.
+	if (_currentModel != nullptr && _models->find(_currentModel) == _models->list()->end()) {
+		delete _currentModel;
+	}
 	_currentModel = new Model(_simulator);
 	return _currentModel;
 }

--- a/source/kernel/simulator/ModelSimulation.cpp
+++ b/source/kernel/simulator/ModelSimulation.cpp
@@ -362,8 +362,24 @@ void ModelSimulation::_initReplication() {
 	TraceManager* tm = _model->getTracer();
 	tm->traceSimulation(this, TraceManager::Level::L5_event, ""); //@TODO L5 and L2??
 	tm->traceSimulation(this, TraceManager::Level::L2_results, "Replication "+std::to_string(_currentReplicationNumber)+" of "+std::to_string(_numberOfReplications)+" is starting.");
-	_model->getFutureEvents()->clear();
-	_model->getDataManager()->getDataDefinitionList("Entity")->clear();
+	// Destroys pending events before resetting replication state to avoid leaking queued heap events.
+	while (!_model->getFutureEvents()->empty()) {
+		Event* event = _model->getFutureEvents()->front();
+		_model->getFutureEvents()->pop_front();
+		delete event;
+	}
+	// Destroys transient entities before clearing per-replication runtime data.
+	List<ModelDataDefinition*>* entities = _model->getDataManager()->getDataDefinitionList(Util::TypeOf<Entity>());
+	while (!entities->empty()) {
+		ModelDataDefinition* data = entities->front();
+		Entity* entity = dynamic_cast<Entity*>(data);
+		if (entity == nullptr) {
+			entities->pop_front();
+			continue;
+		}
+		// Delegates entity release to Model because Entity destruction is restricted to model ownership paths.
+		_model->removeEntity(entity);
+	}
 	_simulatedTime = 0.0;
 	// init all components between replications
 	Util::IncIndent();
@@ -424,13 +440,15 @@ void ModelSimulation::_stepSimulation() {
 	auto simulationEvent = _createSimulationEvent();
 	_model->getOnEventManager()->NotifyReplicationStepHandlers(simulationEvent.get());
 	Event* nextEvent = _model->getFutureEvents()->front();
-	_model->getFutureEvents()->pop_front();
 	if (_warmUpPeriod>0.0)
 		_checkWarmUpTime(nextEvent);
 	if (nextEvent->getTime()<=_replicationLength*_replicationTimeScaleFactorToBase) {
 		if (_checkBreakpointAt(nextEvent)) {
+			// Keeps the event in the queue when a breakpoint pauses execution before processing.
 			this->_pauseRequested = true;
 		} else {
+			// Removes the event from the queue only when it will actually be processed.
+			_model->getFutureEvents()->pop_front();
 			if (nextEvent->getTime()>_simulatedTime)
 				_model->getTracer()->traceSimulation(this, TraceManager::Level::L8_detailed, "");
 			_model->getTracer()->traceSimulation(this, TraceManager::Level::L5_event, "Event {"+nextEvent->show()+"}");
@@ -449,12 +467,18 @@ void ModelSimulation::_stepSimulation() {
 			}
 			auto afterProcessEvent = _createSimulationEvent();
 			_model->getOnEventManager()->NotifyAfterProcessEventHandlers(afterProcessEvent.get());
+			// Deletes processed events only after after-process notifications to preserve observer access.
+			delete nextEvent;
+			_currentEvent = nullptr;
 			if (_pauseOnEvent) {
 				_pauseRequested = true;
 			}
 			Util::DecIndent();
 		}
 	} else {
+		// Removes and destroys out-of-window events to keep event lifecycle ownership consistent.
+		_model->getFutureEvents()->pop_front();
+		delete nextEvent;
 		this->_simulatedTime = _replicationLength * _replicationTimeScaleFactorToBase; ////nextEvent->getTime(); // just to advance time to beyond simulatedTime
 	}
 }

--- a/source/kernel/simulator/OnEventManager.cpp
+++ b/source/kernel/simulator/OnEventManager.cpp
@@ -18,6 +18,43 @@
 OnEventManager::OnEventManager() {
 }
 
+// Releases all heap-allocated listener containers while preserving handler registration semantics.
+OnEventManager::~OnEventManager() {
+	delete _onModelCheckSuccessHandlers;
+	delete _onModelLoadHandlers;
+	delete _onModelSaveHandlers;
+	delete _onReplicationStartHandlers;
+	delete _onReplicationStepHandlers;
+	delete _onReplicationEndHandlers;
+	delete _onProcessEventHandlers;
+	delete _onAfterProcessEventHandlers;
+	delete _onEntityCreateHandlers;
+	delete _onEntityMoveHandlers;
+	delete _onEntityRemoveHandlers;
+	delete _onSimulationStartHandlers;
+	delete _onSimulationPausedHandlers;
+	delete _onSimulationResumeHandlers;
+	delete _onSimulationEndHandlers;
+	delete _onBreakpointHandlers;
+
+	delete _onModelCheckSuccessHandlerMethods;
+	delete _onModelLoadHandlerMethods;
+	delete _onModelSaveHandlerMethods;
+	delete _onReplicationStartHandlerMethods;
+	delete _onReplicationStepHandlerMethods;
+	delete _onReplicationEndHandlerMethods;
+	delete _onProcessEventHandlerMethods;
+	delete _onAfterProcessEventHandlerMethods;
+	delete _onEntityCreateHandlerMethods;
+	delete _onEntityMoveHandlerMethods;
+	delete _onEntityRemoveHandlerMethods;
+	delete _onSimulationStartHandlerMethods;
+	delete _onSimulationPausedHandlerMethods;
+	delete _onSimulationResumeHandlerMethods;
+	delete _onSimulationEndHandlerMethods;
+	delete _onBreakpointHandlerMethods;
+}
+
 void OnEventManager::_addOnHandler(List<simulationEventHandler>* list, simulationEventHandler EventHandler) {
 	if (list->find(EventHandler) == list->list()->end())
 		list->insert(EventHandler);

--- a/source/kernel/simulator/OnEventManager.h
+++ b/source/kernel/simulator/OnEventManager.h
@@ -187,7 +187,7 @@ typedef std::function<void(SimulationEvent*) > simulationEventHandlerMethod;
 class OnEventManager {
 public:
 	OnEventManager();
-	virtual ~OnEventManager() = default;
+	virtual ~OnEventManager();
 public: // event listeners (handlers)
 	void addOnModelCheckSucessHandler(modelEventHandler EventHandler);
 	void addOnModelLoadHandler(modelEventHandler EventHandler);
@@ -412,4 +412,3 @@ Private Sub VBA_Block_1_Fire()
 
 //namespace\\}
 #endif /* ONEVENTMANAGER_H */
-

--- a/source/tests/unit/test_simulator_runtime.cpp
+++ b/source/tests/unit/test_simulator_runtime.cpp
@@ -78,3 +78,17 @@ TEST(SimulatorRuntimeTest, SimulationStartHandlerReceivesInitializedStateSnapsho
     EXPECT_FALSE(observer.paused);
     EXPECT_EQ(observer.replication, 1u);
 }
+
+// Ensures creating a new current model repeatedly keeps runtime usable and updates current() consistently.
+TEST(SimulatorRuntimeTest, NewModelCanBeCalledMultipleTimesAndUpdatesCurrentModel) {
+    Simulator simulator;
+
+    Model* first = simulator.getModelManager()->newModel();
+    ASSERT_NE(first, nullptr);
+
+    Model* second = simulator.getModelManager()->newModel();
+    ASSERT_NE(second, nullptr);
+
+    EXPECT_EQ(simulator.getModelManager()->current(), second);
+    EXPECT_NO_THROW(second->getSimulation()->start());
+}

--- a/source/tests/unit/test_simulator_support.cpp
+++ b/source/tests/unit/test_simulator_support.cpp
@@ -34,6 +34,9 @@ Model::Model(Simulator* simulator, unsigned int level) {
     (void)level;
 }
 
+// Provides a trivial out-of-line destructor for the test double after Model gained an explicit virtual destructor.
+Model::~Model() = default;
+
 bool Model::save(std::string filename) {
     (void)filename;
     return true;
@@ -440,4 +443,3 @@ TEST(SimulatorSupportTest, LegacyPropertyBaseCanCoexistWithKernelPropertyBaseAli
     SimulationResponse* response = &control;
     EXPECT_NE(response, nullptr);
 }
-

--- a/source/tests/unit/test_support_modelmanager.cpp
+++ b/source/tests/unit/test_support_modelmanager.cpp
@@ -19,6 +19,9 @@ Model::Model(Simulator* simulator, unsigned int level) {
     ++g_model_constructions;
 }
 
+// Provides a trivial out-of-line destructor for the test double after Model gained an explicit virtual destructor.
+Model::~Model() = default;
+
 bool Model::save(std::string filename) {
     (void)filename;
     ++g_model_saves;


### PR DESCRIPTION
### Motivation
- Eliminate several ownership/lifecycle leaks where `Model` and runtime objects allocated with `new` were not being destroyed correctly. 
- Ensure events are not lost at breakpoints and are released after observers finish accessing them.
- Close a leak where a transient `_currentModel` could be created but never inserted into `_models` and thus never deleted.
- Free immediate heap-allocated container objects in managers to avoid leaking small infrastructure containers.

### Description
- Made `Model` explicitly destructible by replacing the defaulted destructor with `virtual ~Model()` and added private helpers `_destroyFutureEvents()`, `_destroyTransientEntities()`, `_destroyComponents()` and `_destroyModelDataDefinitions()` to tear down owned state in a safe order.
- Implemented `Model::~Model()` to call the helpers and then delete owned runtime services and container objects while preserving non-owned pointers like `_parentSimulator` and `_traceManager`.
- Reworked `Model::clear()` to destroy pending future `Event` objects, transient `Entity` instances, remaining `ModelComponent` objects and non-entity model data definitions before resetting IDs.
- Fixed `ModelSimulation::_stepSimulation()` to observe the next event without removing it for breakpoint checks, remove it only when actually processing, and delete the processed `Event*` only after `NotifyAfterProcessEventHandlers(...)`; also ensured out-of-window events are removed and deleted.
- Fixed `ModelSimulation::_initReplication()` to explicitly destroy pending future events and transient entities (delegating entity deletion via `Model::removeEntity`) instead of only clearing pointer lists.
- Prevented leaking a detached current model in `ModelManager` by deleting an existing `_currentModel` that is not in `_models` in `newModel()` and by deleting such a detached `_currentModel` in the `ModelManager` destructor.
- Added explicit destructors for `ComponentManager`, `ModelDataManager` and `OnEventManager` that free their heap-allocated container objects while leaving object-delete semantics of domain objects centralized in `Model`.
- Added a small unit test to `test_simulator_runtime.cpp` exercising repeated `newModel()` usage and adjusted test doubles in support tests to provide an out-of-line `Model::~Model()` symbol now that `Model` has an explicit virtual destructor.

### Testing
- Configured the build with `cmake --preset tests-kernel-unit` and built the test targets with `cmake --build --preset tests-kernel-unit-run --target genesys_test_simulator_runtime genesys_test_simulator_support genesys_test_support_modelmanager` which completed successfully.
- Executed the focused unit tests with `ctest --test-dir build/tests-kernel-unit --output-on-failure -R 'SimulatorRuntimeTest|SimulatorSupportTest|SupportModelManagerClassTest'` and all selected unit tests passed (100% for the executed suites).
- Attempted to run the smoke build via `cmake --preset tests-smoke` and `cmake --build --preset tests-smoke --target genesys_smoke_simulator_start`, but the smoke target failed at link time due to an unresolved `SinkModelComponent` symbol that is outside the scope of this Phase 2A change.
- Summary: unit test targets built and ran successfully; smoke target build failed due to an unrelated linking issue.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6eee11f248321b4c0d070a4f3c6f8)