### PR TITLE
Harden AnimationTransition creation path with null/geometry guards

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/animations/AnimationTransition.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/animations/AnimationTransition.cpp
@@ -25,9 +25,19 @@ AnimationTransition::AnimationTransition(ModelGraphicsScene* myScene, ModelCompo
     _currentProgress(0.0),
     _viewSimulation(viewSimulation){
 
+    // Abort construction when required input pointers are missing.
+    if (_myScene == nullptr || graphicalStartComponent == nullptr || graphicalEndComponent == nullptr) {
+        return;
+    }
+
     // Pega o componente gráfico de início e fim da animação
     _graphicalStartComponent = _myScene->findGraphicalModelComponent(graphicalStartComponent->getId());
     _graphicalEndComponent = _myScene->findGraphicalModelComponent(graphicalEndComponent->getId());
+
+    // Stop setup when either graphical endpoint is not present in the scene.
+    if (_graphicalStartComponent == nullptr || _graphicalEndComponent == nullptr) {
+        return;
+    }
 
     if (_graphicalStartComponent && !_graphicalStartComponent->getGraphicalOutputPorts().empty()) {
         QList<GraphicalComponentPort *> startComponentOutputPorts = _graphicalStartComponent->getGraphicalOutputPorts();
@@ -38,24 +48,34 @@ AnimationTransition::AnimationTransition(ModelGraphicsScene* myScene, ModelCompo
             if (!startComponentOutputPorts.at(i)->getConnections()->empty()) {
                 if (startComponentOutputPorts.at(i)->getConnections()->at(0)->getDestination()->component->getId() == _graphicalEndComponent->getComponent()->getId()) {
                     connection = startComponentOutputPorts.at(i)->getConnections()->at(0);
+                    _graphicalConnection = connection;
                     _portNumber = i;
                     break;
                 }
             }
         }
 
-        // Pega o componente de destino do evento/animação de transição
-        ModelComponent *destinationComponent;
+        // Abort when no matching graphical connection is found for this transition.
         if (connection == nullptr) {
             _graphicalEndComponent = nullptr;
+            _graphicalConnection = nullptr;
             return;
         }
 
+        // Pega o componente de destino do evento/animação de transição
+        ModelComponent *destinationComponent;
         destinationComponent = connection->getDestination()->component;
         _graphicalEndComponent = _myScene->findGraphicalModelComponent(destinationComponent->getId());
 
         // Pega os pontos na tela em que a animação deve ocorrer
         QList<QPointF> pointsConnection = connection->getPoints();
+
+        // Abort transition setup when the connection geometry does not provide the required points.
+        if (pointsConnection.size() < 4) {
+            _graphicalEndComponent = nullptr;
+            _graphicalConnection = nullptr;
+            return;
+        }
 
         // Tamanho para imagem
         const int imageWidth = 50;

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
@@ -1213,6 +1213,11 @@ bool ModelGraphicsScene::getSnapToGrid() {
 }
 
 void ModelGraphicsScene::animateTransition(ModelComponent *source, ModelComponent *destination, bool viewSimulation, Event *event) {
+    // Skip transition creation when source or destination is missing.
+    if (source == nullptr || destination == nullptr) {
+        return;
+    }
+
     // Cria a animação
     AnimationTransition *animationTransition = new AnimationTransition(this, source, destination, viewSimulation);
 


### PR DESCRIPTION
### Motivation

- Prevent crashes caused by null dereferences and out-of-bounds access during creation/configuration of `AnimationTransition` when scene/components/connections/geometry are missing or invalid.  
- Implement minimal defensive checks exactly in the path that constructs and configures the transition so runtime animation creation is safe.

### Description

- Added an early guard in `ModelGraphicsScene::animateTransition()` to skip creating a transition when `source` or `destination` is `nullptr` and included a short English comment above the check.  
- Hardened `AnimationTransition` constructor with an early return if `myScene`, `graphicalStartComponent`, or `graphicalEndComponent` are `nullptr`, and added a short English comment above this guard.  
- Validated the scene-resolved `_graphicalStartComponent` and `_graphicalEndComponent` immediately after resolution and returned early if either is missing, with an English comment above the validation.  
- Assigned the found connection to `_graphicalConnection` when matched, invalidated both `_graphicalEndComponent` and `_graphicalConnection` and returned when no connection is found, and added a geometry size check (`pointsConnection.size() < 4`) that invalidates state and returns before indexing connection points; each modified area has a short English comment above it.

### Testing

- Ran a CMake configure at the repository root (`cmake -S . -B build`) which completed successfully and confirmed general project configuration.  
- Attempted the GUI configure (`cmake -S source/applications/gui/qt/GenesysQtGUI -B build-qtgui`) which failed because `qmake` was not found in `PATH`, so GUI compilation could not be executed in this environment.  
- Verified by code inspection and `git diff` that dereferences of input parameters and `_graphicalEndComponent` are now guarded and that `pointsConnection` is no longer indexed without checking `size() >= 4`, and committed the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6f4de4c248321bf44485779f82398)