### PR TITLE
Stabilize GenesysQtGUI resume selection for paused animations

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/controllers/SimulationEventController.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/SimulationEventController.cpp
@@ -25,6 +25,27 @@
 #include <utility>
 
 namespace {
+// Select and detach the paused-animation list that can be safely resumed.
+static QList<AnimationTransition*>* takePausedAnimationListForResume(
+    QMap<Event*, QList<AnimationTransition*>*>* pausedAnimationsMap,
+    Event* currentEvent) {
+    if (!pausedAnimationsMap || pausedAnimationsMap->empty()) {
+        return nullptr;
+    }
+
+    if (currentEvent && pausedAnimationsMap->contains(currentEvent)) {
+        return pausedAnimationsMap->take(currentEvent);
+    }
+
+    if (pausedAnimationsMap->size() == 1) {
+        auto it = pausedAnimationsMap->begin();
+        Event* onlyKey = it.key();
+        return pausedAnimationsMap->take(onlyKey);
+    }
+
+    return nullptr;
+}
+
 // Release one paused-animation list and optionally destroy its animations.
 static void cleanupPausedAnimationList(QList<AnimationTransition*>* pausedAnimations, bool destroyAnimations) {
     if (!pausedAnimations) {
@@ -155,20 +176,19 @@ void SimulationEventController::onSimulationPausedHandler(SimulationEvent* re) c
 void SimulationEventController::onSimulationResumeHandler(SimulationEvent* re) const {
     _callbacks.actualizeActions();
 
-    // Detach the current-event paused list before resuming to isolate re-paused animations.
+    // Resume only a deterministically selected paused list detached from the map.
     QMap<Event*, QList<AnimationTransition*>*>* pausedAnimationsMap = _scene->getAnimationPaused();
     Event* currentEvent = re ? re->getCurrentEvent() : nullptr;
-    if (pausedAnimationsMap && !pausedAnimationsMap->empty() && currentEvent) {
-        QList<AnimationTransition*>* pausedAnimations = pausedAnimationsMap->take(currentEvent);
-        if (pausedAnimations) {
-            // Resume each detached transition using the same event context.
-            for (AnimationTransition* animation : *pausedAnimations) {
-                if (animation) {
-                    _scene->runAnimateTransition(animation, currentEvent, true);
-                }
+    QList<AnimationTransition*>* pausedAnimations =
+        takePausedAnimationListForResume(pausedAnimationsMap, currentEvent);
+    if (pausedAnimations) {
+        // Replay each paused transition with the current resume event context.
+        for (AnimationTransition* animation : *pausedAnimations) {
+            if (animation) {
+                _scene->runAnimateTransition(animation, currentEvent, true);
             }
-            cleanupPausedAnimationList(pausedAnimations, false);
         }
+        cleanupPausedAnimationList(pausedAnimations, false);
     }
 
     QCoreApplication::processEvents();


### PR DESCRIPTION
### Motivation
- `onSimulationResumeHandler()` previously depended on `SimulationEvent::getCurrentEvent()` to `take()` a paused-animation list, which fails when `currentEvent` is null or no longer a valid map key.
- Provide a local, conservative rule to select and detach the correct paused list for resume without changing `_animationPaused` structure or making arbitrary choices when ambiguous.

### Description
- Added a local helper `takePausedAnimationListForResume(QMap<Event*, QList<AnimationTransition*>*>*, Event*)` in the anonymous namespace that returns `nullptr` for null/empty maps, `take(currentEvent)` when present, returns the single list if the map has exactly one entry, and returns `nullptr` if ambiguous.
- Reworked `SimulationEventController::onSimulationResumeHandler(SimulationEvent* re) const` to call the helper, iterate the detached list and call `_scene->runAnimateTransition(animation, currentEvent, true)` for each non-null animation, then call `cleanupPausedAnimationList(pausedAnimations, false)`; the list is removed from the map by the helper before iteration.
- Added short English comments immediately above the helper and the modified resume logic as required, and preserved conservative behavior when multiple paused lists exist.

### Testing
- Ran CMake configure for non-GUI build: `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` which completed successfully (configuration files generated).
- Attempted GUI configure: `cmake -S . -B build-gui -DGENESYS_BUILD_GUI_APPLICATION=ON` which failed because `qmake` is not available in `PATH` in this environment, so GUI compile could not be executed.
- Performed automated inspection commands (`git diff`, `rg`, `cmake` runs) to verify the patch scope and that the helper detaches the list via `take(...)`, supports single-entry fallback, and preserves conservative no-op behavior on ambiguity; these checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6f72807dc8321951b1fa6cb2053c8)