### PR TITLE
Fix ownership teardown for ConnectionManager, ModelComponent, Entity, ModelDataDefinition and ModelSimulation controls

### DIFF
--- a/source/kernel/simulator/ConnectionManager.cpp
+++ b/source/kernel/simulator/ConnectionManager.cpp
@@ -18,6 +18,15 @@
 ConnectionManager::ConnectionManager() {
 }
 
+ConnectionManager::~ConnectionManager() {
+	// Destroy every owned connection before deleting the backing port map.
+	for (std::pair<const unsigned int, Connection*>& connectionPair : *_nextConnections) {
+		delete connectionPair.second;
+	}
+	delete _nextConnections;
+	_nextConnections = nullptr;
+}
+
 unsigned int ConnectionManager::size() {
 	return _nextConnections->size();
 }
@@ -45,14 +54,23 @@ void ConnectionManager::insert(Connection* connection) {
 }
 
 void ConnectionManager::insertAtPort(unsigned int port, Connection* connection) {
+	// Replace an existing port connection and release the previous owned object.
+	std::map<unsigned int, Connection*>::iterator it = _nextConnections->find(port);
+	if (it != _nextConnections->end()) {
+		if (it->second != connection) {
+			delete it->second;
+		}
+		it->second = connection;
+		return;
+	}
 	_nextConnections->insert({port, connection});
 }
 
 void ConnectionManager::remove(Connection* connection) {
+	// Remove and destroy the matched owned connection to keep teardown complete.
 	for (std::map<unsigned int, Connection*>::iterator it = _nextConnections->begin(); it != _nextConnections->end(); it++) {
 		if ((*it).second == connection) {
-			// TODO(genesys|connection-manager|ownership): Confirm the ownership policy for Connection*.
-			// If ConnectionManager owns the connection, removal should also destroy the object to avoid leaks.
+			delete (*it).second;
 			_nextConnections->erase(it);
 			return;
 		}
@@ -60,9 +78,12 @@ void ConnectionManager::remove(Connection* connection) {
 }
 
 void ConnectionManager::removeAtPort(unsigned int port) {
-		// TODO(genesys|connection-manager|ownership): Investigate whether removeAtPort should also destroy
-	// the Connection associated with the removed port.
-	_nextConnections->erase(port);
+	// Remove and destroy the owned connection bound to the informed output port.
+	std::map<unsigned int, Connection*>::iterator it = _nextConnections->find(port);
+	if (it != _nextConnections->end()) {
+		delete it->second;
+		_nextConnections->erase(it);
+	}
 }
 
 //------------------

--- a/source/kernel/simulator/ConnectionManager.h
+++ b/source/kernel/simulator/ConnectionManager.h
@@ -52,7 +52,7 @@ class ConnectionManager {
 public:
 	/*! \brief Creates an empty connection manager with zero constraints. */
 	ConnectionManager();
-	virtual ~ConnectionManager() = default;
+	virtual ~ConnectionManager();
 public:
 	/*!
 	 * \brief size

--- a/source/kernel/simulator/Entity.cpp
+++ b/source/kernel/simulator/Entity.cpp
@@ -28,6 +28,16 @@ Entity::Entity(Model* model, std::string name, bool insertIntoModel) : ModelData
 	}
 }
 
+Entity::~Entity() {
+	// Release each per-attribute value map owned by this entity instance.
+	for (std::map<std::string, double>* attributeMap : *_attributeValues->list()) {
+		delete attributeMap;
+	}
+	// Release the container that tracks all attribute maps created for this entity.
+	delete _attributeValues;
+	_attributeValues = nullptr;
+}
+
 void Entity::setEntityTypeName(std::string entityTypeName) {
 	EntityType* entitytype = dynamic_cast<EntityType*> (_parentModel->getDataManager()->getDataDefinition(Util::TypeOf<EntityType>(), entityTypeName));
 	if (entitytype != nullptr) {

--- a/source/kernel/simulator/Entity.h
+++ b/source/kernel/simulator/Entity.h
@@ -77,7 +77,7 @@ class Entity : public ModelDataDefinition {
 private: // no one can create or destry entities directlly. This can be done one throught friend class Model
 	/*! \brief Creates an entity instance (restricted to \c Model friend). */
 	Entity(Model* model, std::string name = "", bool insertIntoModel = true);
-	virtual ~Entity() = default;
+	virtual ~Entity();
 	// friend Entity* Model::createEntity(std::string name, bool insertIntoModel); // It would be better, but Model is not known at this point of compilaton
 	friend class Model;
 public:

--- a/source/kernel/simulator/ModelComponent.cpp
+++ b/source/kernel/simulator/ModelComponent.cpp
@@ -26,7 +26,11 @@ ModelComponent::ModelComponent(Model* model, std::string componentTypename, std:
 }
 
 ModelComponent::~ModelComponent() {
+	// Keep manager bookkeeping consistent before releasing owned connection resources.
     _parentModel->getComponentManager()->remove(this);
+	// Release the connection manager owned by this component instance.
+	delete _connections;
+	_connections = nullptr;
 }
 
 

--- a/source/kernel/simulator/ModelDataDefinition.cpp
+++ b/source/kernel/simulator/ModelDataDefinition.cpp
@@ -73,9 +73,35 @@ void ModelDataDefinition::setModelLevel(unsigned int _modelLevel) {
 //}
 
 ModelDataDefinition::~ModelDataDefinition() {
-	////trace(TraceManager::Level::L9_mostDetailed, "Removing Element \"" + this->_name + "\" from the model");
+	// Release all owned internal modeldata definitions registered by this model element.
 	_internalDataClear();
+	// Keep model registry consistent by removing this modeldata from the manager first.
 	_parentModel->getDataManager()->remove(this);
+	// Detach and destroy owned SimulationControl properties tracked by this model element.
+	if (_properties != nullptr) {
+		for (SimulationControl* property : *_properties->list()) {
+			if (property == nullptr) {
+				continue;
+			}
+			_parentModel->getControls()->remove(property);
+			SimulationResponse* response = dynamic_cast<SimulationResponse*>(property);
+			if (response != nullptr) {
+				_parentModel->getResponses()->remove(response);
+			}
+			delete property;
+		}
+		delete _properties;
+		_properties = nullptr;
+	}
+	// Destroy the internal-data registry container after its owned contents are cleared.
+	delete _internalData;
+	_internalData = nullptr;
+	// Clear and destroy the attached-data registry without deleting referenced external objects.
+	if (_attachedData != nullptr) {
+		_attachedData->clear();
+		delete _attachedData;
+		_attachedData = nullptr;
+	}
 }
 
 void ModelDataDefinition::_internalDataClear() {

--- a/source/kernel/simulator/ModelSimulation.cpp
+++ b/source/kernel/simulator/ModelSimulation.cpp
@@ -32,35 +32,55 @@ ModelSimulation::ModelSimulation(Model* model) {
 		return a->getId()<b->getId();
 	});
 	_simulationReporter = new TraitsKernel<SimulationReporter_if>::Implementation(this, model, this->_cstatsAndCountersSimulation);
-	// controls
-	//@TODO Add ReplicationLength, getReplicationLengthTimeUnit, getReplicationBaseTimeUnit, warmUpPeriod, ...
-	_model->getControls()->insert(new SimulationControlTimeUnit(
-					 std::bind(&ModelSimulation::getReplicationBaseTimeUnit, this),
-					 std::bind(&ModelSimulation::setReplicationReportBaseTimeUnit, this, std::placeholders::_1),
-					 Util::TypeOf<ModelSimulation>(), "ModelSimulation", "ReplicationBaseTimeUnit"));
-	_model->getControls()->insert(new SimulationControlTimeUnit(
-					 std::bind(&ModelSimulation::getReplicationLengthTimeUnit, this),
-					 std::bind(&ModelSimulation::setReplicationLengthTimeUnit, this, std::placeholders::_1),
-					 Util::TypeOf<ModelSimulation>(), "ModelSimulation", "ReplicationLengthTimeUnit"));
-	_model->getControls()->insert(new SimulationControlTimeUnit(
-					 std::bind(&ModelSimulation::getWarmUpPeriodTimeUnit, this),
-					 std::bind(&ModelSimulation::setWarmUpPeriodTimeUnit, this, std::placeholders::_1),
-					 Util::TypeOf<ModelSimulation>(), "ModelSimulation", "WarmUpPeriodTimeUnit"));
-	_model->getControls()->insert(new SimulationControlDouble(
-					 std::bind(&ModelSimulation::getWarmUpPeriod, this),
-					 std::bind(&ModelSimulation::setWarmUpPeriod, this, std::placeholders::_1, Util::TimeUnit::unknown),
-					 Util::TypeOf<ModelSimulation>(), "ModelSimulation", "WarmUpPeriod"));
-	_model->getControls()->insert(new SimulationControlUInt(
-					 std::bind(&ModelSimulation::getNumberOfReplications, this),
-					 std::bind(&ModelSimulation::setNumberOfReplications, this, std::placeholders::_1),
-					 Util::TypeOf<ModelSimulation>(), "ModelSimulation", "NumberOfReplications"));
-	_model->getControls()->insert(new SimulationControlString(
-					 std::bind(&ModelSimulation::getTerminatingCondition, this),
-					 std::bind(&ModelSimulation::setTerminatingCondition, this, std::placeholders::_1),
-					 Util::TypeOf<ModelSimulation>(), "ModelSimulation", "TerminatingCondition"));
+	// Create and register the base simulation controls while tracking their ownership locally.
+	SimulationControl* replicationBaseTimeUnit = new SimulationControlTimeUnit(
+			 std::bind(&ModelSimulation::getReplicationBaseTimeUnit, this),
+			 std::bind(&ModelSimulation::setReplicationReportBaseTimeUnit, this, std::placeholders::_1),
+			 Util::TypeOf<ModelSimulation>(), "ModelSimulation", "ReplicationBaseTimeUnit");
+	_model->getControls()->insert(replicationBaseTimeUnit);
+	_ownedControls->insert(replicationBaseTimeUnit);
+	SimulationControl* replicationLengthTimeUnit = new SimulationControlTimeUnit(
+			 std::bind(&ModelSimulation::getReplicationLengthTimeUnit, this),
+			 std::bind(&ModelSimulation::setReplicationLengthTimeUnit, this, std::placeholders::_1),
+			 Util::TypeOf<ModelSimulation>(), "ModelSimulation", "ReplicationLengthTimeUnit");
+	_model->getControls()->insert(replicationLengthTimeUnit);
+	_ownedControls->insert(replicationLengthTimeUnit);
+	SimulationControl* warmUpPeriodTimeUnit = new SimulationControlTimeUnit(
+			 std::bind(&ModelSimulation::getWarmUpPeriodTimeUnit, this),
+			 std::bind(&ModelSimulation::setWarmUpPeriodTimeUnit, this, std::placeholders::_1),
+			 Util::TypeOf<ModelSimulation>(), "ModelSimulation", "WarmUpPeriodTimeUnit");
+	_model->getControls()->insert(warmUpPeriodTimeUnit);
+	_ownedControls->insert(warmUpPeriodTimeUnit);
+	SimulationControl* warmUpPeriod = new SimulationControlDouble(
+			 std::bind(&ModelSimulation::getWarmUpPeriod, this),
+			 std::bind(&ModelSimulation::setWarmUpPeriod, this, std::placeholders::_1, Util::TimeUnit::unknown),
+			 Util::TypeOf<ModelSimulation>(), "ModelSimulation", "WarmUpPeriod");
+	_model->getControls()->insert(warmUpPeriod);
+	_ownedControls->insert(warmUpPeriod);
+	SimulationControl* numberOfReplications = new SimulationControlUInt(
+			 std::bind(&ModelSimulation::getNumberOfReplications, this),
+			 std::bind(&ModelSimulation::setNumberOfReplications, this, std::placeholders::_1),
+			 Util::TypeOf<ModelSimulation>(), "ModelSimulation", "NumberOfReplications");
+	_model->getControls()->insert(numberOfReplications);
+	_ownedControls->insert(numberOfReplications);
+	SimulationControl* terminatingCondition = new SimulationControlString(
+			 std::bind(&ModelSimulation::getTerminatingCondition, this),
+			 std::bind(&ModelSimulation::setTerminatingCondition, this, std::placeholders::_1),
+			 Util::TypeOf<ModelSimulation>(), "ModelSimulation", "TerminatingCondition");
+	_model->getControls()->insert(terminatingCondition);
+	_ownedControls->insert(terminatingCondition);
 }
 
 ModelSimulation::~ModelSimulation() {
+	// Remove and destroy only the base controls explicitly created by this simulation object.
+	if (_ownedControls != nullptr) {
+		for (SimulationControl* control : *_ownedControls->list()) {
+			_model->getControls()->remove(control);
+			delete control;
+		}
+		delete _ownedControls;
+		_ownedControls = nullptr;
+	}
 	if (_cstatsAndCountersSimulation != nullptr) {
 		for (ModelDataDefinition* data : *_cstatsAndCountersSimulation->list()) {
 			delete data;

--- a/source/kernel/simulator/ModelSimulation.h
+++ b/source/kernel/simulator/ModelSimulation.h
@@ -16,6 +16,7 @@
 
 #include <chrono>
 #include <memory>
+#include "SimulationControlAndResponse.h"
 #include "Event.h"
 #include "Entity.h"
 #include "ModelInfo.h"
@@ -194,6 +195,7 @@ private:
 	ModelInfo* _info;
 	SimulationReporter_if* _simulationReporter;
 	bool _ownsSimulationReporter = true;
+	List<SimulationControl*>* _ownedControls = new List<SimulationControl*>();
 	//@TODO Change List below to a MAP, associating every CstatOuCounter in the replication to the equivalent in the simulation
 	List<ModelDataDefinition*>* _cstatsAndCountersSimulation = new List<ModelDataDefinition*>();
 	std::map<ModelDataDefinition*, ModelDataDefinition*>* _cstatsAndCountersMapSimulation = new std::map<ModelDataDefinition*, ModelDataDefinition*>();

--- a/source/tests/unit/test_simulator_runtime.cpp
+++ b/source/tests/unit/test_simulator_runtime.cpp
@@ -92,3 +92,16 @@ TEST(SimulatorRuntimeTest, NewModelCanBeCalledMultipleTimesAndUpdatesCurrentMode
     EXPECT_EQ(simulator.getModelManager()->current(), second);
     EXPECT_NO_THROW(second->getSimulation()->start());
 }
+
+TEST(SimulatorRuntimeTest, ModelClearPreservesBaseSimulationControlsCount) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+    // Capture the baseline controls created by ModelSimulation and ensure clear() keeps them available.
+    const unsigned int controlsBefore = model->getControls()->size();
+    ASSERT_GT(controlsBefore, 0u);
+
+    model->clear();
+
+    EXPECT_EQ(model->getControls()->size(), controlsBefore);
+}

--- a/source/tests/unit/test_support_connectionmanager.cpp
+++ b/source/tests/unit/test_support_connectionmanager.cpp
@@ -29,3 +29,16 @@ TEST(SupportConnectionManagerClassTest, RemoveAtPortClearsInsertedConnection) {
     EXPECT_EQ(manager.size(), 0u);
     EXPECT_EQ(manager.getConnectionAtPort(0), nullptr);
 }
+
+TEST(SupportConnectionManagerClassTest, InsertAtPortReplacesExistingConnectionWithoutGrowingSize) {
+    ConnectionManager manager;
+    // Build two raw connections to validate replacement and ownership in the same port.
+    Connection* first = new Connection{nullptr, {0, ""}};
+    Connection* second = new Connection{nullptr, {0, ""}};
+
+    manager.insertAtPort(0, first);
+    manager.insertAtPort(0, second);
+
+    EXPECT_EQ(manager.size(), 1u);
+    EXPECT_EQ(manager.getConnectionAtPort(0), second);
+}


### PR DESCRIPTION
### Motivation
- Remove clear leaks and incomplete teardowns for unequivocal owners in core simulator classes to avoid memory leaks at model teardown. 
- Implement explicit ownership lifecycle where objects were clearly owned (connections, attribute maps, internal data and base controls) while keeping scope restricted and avoiding broad refactors.

### Description
- `ConnectionManager`: added explicit destructor that deletes remaining `Connection*` and the backing map, updated `insertAtPort` to delete replaced connection, and updated `remove`/`removeAtPort` to delete removed connections. 
- `ModelComponent`: ensure component is removed from `ComponentManager` and then delete the owned `_connections` `ConnectionManager` and null it. 
- `Entity`: changed defaulted destructor to explicit destructor that deletes each `std::map<std::string,double>*` stored in `_attributeValues` and then deletes the `_attributeValues` container. 
- `ModelDataDefinition`: extended destructor to call `_internalDataClear()`, remove this object from the `DataManager`, unregister and delete owned `_properties` (`SimulationControl*`), delete `_internalData` container, and clear/delete `_attachedData` without deleting referenced external objects. 
- `ModelSimulation`: added `_ownedControls` container, register each base `SimulationControl*` created in the constructor into `_ownedControls` and `model->getControls()`, and in the destructor remove them from the model and `delete` them. 
- Tests: added `InsertAtPortReplacesExistingConnectionWithoutGrowingSize` in `test_support_connectionmanager.cpp` and `ModelClearPreservesBaseSimulationControlsCount` in `test_simulator_runtime.cpp` to validate replacement ownership and that `model->clear()` preserves base controls count.

### Testing
- Configured tests with `cmake --preset tests-unit` and built the affected targets with `cmake --build --preset tests-unit --target genesys_test_support_connectionmanager genesys_test_simulator_runtime genesys_test_simulator_support` which completed successfully. 
- Executed the test binaries `./genesys_test_support_connectionmanager`, `./genesys_test_simulator_runtime` and `./genesys_test_simulator_support` from `build/tests-unit/source/tests/unit` and all executed tests passed including the two new unit tests. 
- No additional changes to `CMakeLists.txt` were necessary and the build/test run produced no failures for the modified units.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6f54eec748321870662846c91d991)