### PR TITLE
Disconnect temporary Qt connections in runAnimateTransition to avoid callback accumulation

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
@@ -1242,15 +1242,21 @@ void ModelGraphicsScene::runAnimateTransition(AnimationTransition *animationTran
 
     // Cria um loop de eventos para aguardar a conclusão da animação
     QEventLoop loop;
-    connect(animationTransition, &AnimationTransition::finished, &loop, &QEventLoop::quit);
+    // Store temporary finished connection to disconnect it after this loop execution.
+    QMetaObject::Connection finishedConnection = connect(animationTransition, &AnimationTransition::finished, &loop, &QEventLoop::quit);
 
     // Conecta o sinal de stateChanged para sair do loop quando a animação for pausada
-    connect(animationTransition, &QAbstractAnimation::stateChanged, [this, &loop, event, animationTransition](QAbstractAnimation::State newState, QAbstractAnimation::State oldState) {
+    // Store temporary stateChanged connection to avoid callback accumulation across resumes.
+    QMetaObject::Connection stateChangedConnection = connect(animationTransition, &QAbstractAnimation::stateChanged, [this, &loop, event, animationTransition](QAbstractAnimation::State newState, QAbstractAnimation::State oldState) {
         handleAnimationStateChanged(newState, &loop, event, animationTransition);
     });
 
     // Aguarda a conclusão da animação sem bloquear o restante do código
     loop.exec();
+
+    // Explicitly disconnect temporary local connections created for this run only.
+    QObject::disconnect(finishedConnection);
+    QObject::disconnect(stateChangedConnection);
 
     _animationsTransition->removeOne(animationTransition);
 


### PR DESCRIPTION
### Motivation
- Prevent accumulation of ephemeral Qt signal connections created inside `ModelGraphicsScene::runAnimateTransition()` that cause duplicated callbacks and erratic pause/resume behavior.
- Ensure each invocation of the event-loop-driven animation run does not leave lingering `finished` or `stateChanged` handlers registered on the animation object.

### Description
- Capture the `finished` connection return value in a `QMetaObject::Connection finishedConnection` local variable and the `stateChanged` connection in `QMetaObject::Connection stateChangedConnection` local variable. 
- After `loop.exec()` returns, explicitly call `QObject::disconnect(finishedConnection)` and `QObject::disconnect(stateChangedConnection)` to remove those temporary handlers. 
- Add short, precise English comments immediately above each altered code block to explain the change. 
- Changes are restricted to `source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp` and the rest of the method logic (append/start/restart/event loop/remove/deleteLater) is left intact.

### Testing
- Verified by code inspection and `git diff` that the two `connect(...)` calls were replaced with `QMetaObject::Connection` locals and that `QObject::disconnect(...)` is invoked after `loop.exec()`; this confirms the intended programmatic effect. 
- Ran repository checks (`git status`, file listings, targeted `sed`/`rg` lookups) and confirmed only the intended file was modified and committed. 
- Attempted to run `qmake --version` to trigger a GUI build, but the environment lacks the Qt toolchain (`qmake: command not found`), so no compile or runtime tests were executed. 
- Commit was created locally with the change; no runtime regressions were validated due to the missing Qt build tools.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6f8ea3d2c832182fc1c22bc0b971c)