### PR TITLE
Fix local QEventLoop arming order in runAnimateTransition

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
@@ -1234,22 +1234,22 @@ void ModelGraphicsScene::animateTransition(ModelComponent *source, ModelComponen
 void ModelGraphicsScene::runAnimateTransition(AnimationTransition *animationTransition, Event *event, bool restart) {
     _animationsTransition->append(animationTransition);
 
-    // Inicia ou reinicia a animação
+    // Create the local event loop before starting the animation to avoid missing early signals.
+    QEventLoop loop;
+
+    // Store temporary finished connection to disconnect it after this loop execution.
+    QMetaObject::Connection finishedConnection = connect(animationTransition, &AnimationTransition::finished, &loop, &QEventLoop::quit);
+
+    // Connect state changes before start/restart so pause transitions are observed from the beginning.
+    QMetaObject::Connection stateChangedConnection = connect(animationTransition, &QAbstractAnimation::stateChanged, [this, &loop, event, animationTransition](QAbstractAnimation::State newState, QAbstractAnimation::State oldState) {
+        handleAnimationStateChanged(newState, &loop, event, animationTransition);
+    });
+
+    // Start or restart only after wiring temporary loop exit connections.
     if (restart)
         animationTransition->restartAnimation();
     else
         animationTransition->startAnimation();
-
-    // Cria um loop de eventos para aguardar a conclusão da animação
-    QEventLoop loop;
-    // Store temporary finished connection to disconnect it after this loop execution.
-    QMetaObject::Connection finishedConnection = connect(animationTransition, &AnimationTransition::finished, &loop, &QEventLoop::quit);
-
-    // Conecta o sinal de stateChanged para sair do loop quando a animação for pausada
-    // Store temporary stateChanged connection to avoid callback accumulation across resumes.
-    QMetaObject::Connection stateChangedConnection = connect(animationTransition, &QAbstractAnimation::stateChanged, [this, &loop, event, animationTransition](QAbstractAnimation::State newState, QAbstractAnimation::State oldState) {
-        handleAnimationStateChanged(newState, &loop, event, animationTransition);
-    });
 
     // Aguarda a conclusão da animação sem bloquear o restante do código
     loop.exec();


### PR DESCRIPTION
### Motivation
- Prevent missed/late signals and race conditions by ensuring the local `QEventLoop` is armed before the animation can change state.
- The previous ordering started the animation before temporary `connect()`s were established, risking loss of `paused`/`finished` notifications.

### Description
- Reordered `ModelGraphicsScene::runAnimateTransition()` so the method now appends the transition, creates `QEventLoop loop`, connects `finished` and `stateChanged`, and only then calls `startAnimation()`/`restartAnimation()`.
- Preserved the explicit `QObject::disconnect(...)` calls after `loop.exec()` and left the lambda semantics for `stateChanged` unchanged.
- Added short, technical English comments immediately above each modified code block explaining the purpose of the change.
- Change scope restricted to `source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp` only.

### Testing
- Ran `cmake --preset debug` which configured the project (non-GUI parts) successfully in this environment.
- Attempted GUI configure with `cmake -S . -B build/gui -DGENESYS_BUILD_GUI_APPLICATION=ON ...` and it failed because `qmake`/Qt toolchain is not present in `PATH` in this environment (so no runtime GUI build/test was possible).
- Performed code inspection and `git diff` to verify the new ordering: `QEventLoop` and both `connect()` calls are created before the call to `startAnimation()`/`restartAnimation()`, and explicit disconnections remain after `loop.exec()`.
- Changes were committed with message `Fix event loop arming order in runAnimateTransition`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6fab8a2248321832c1f0bf607ff8a)