### PR TITLE
Phase 2C: align attached-data non-owner semantics and fix classnames snapshot leaks

### DIFF
--- a/source/kernel/simulator/CppSerializer.cpp
+++ b/source/kernel/simulator/CppSerializer.cpp
@@ -52,11 +52,14 @@ bool CppSerializer::dump(std::ostream& output) {
 
 	// do includes and separate defs/components
 	std::set<std::string> includes;
-	for (auto& klass : *_model->getDataManager()->getDataDefinitionClassnames()) {
+	// Free the temporary class-name snapshot after collecting include dependencies for persisted data definitions.
+	std::list<std::string>* dataDefinitionClassnames = _model->getDataManager()->getDataDefinitionClassnames();
+	for (auto& klass : *dataDefinitionClassnames) {
 		if (!typenames.count(klass)) continue;
 		datadefs.insert(klass);
 		includes.insert("plugins/data/" + klass + ".h");
 	}
+	delete dataDefinitionClassnames;
 	for (auto& comp : *_model->getComponentManager()->getAllComponents()) {
 		if (!typenames.count(comp->getClassname())) continue;
 		components.insert(comp->getClassname());

--- a/source/kernel/simulator/Model.cpp
+++ b/source/kernel/simulator/Model.cpp
@@ -284,6 +284,7 @@ void Model::_showElements() const {
 	{
 		std::string elementType;
 		ModelDataDefinition* modeldatum;
+		// Release the temporary class-name list returned by the manager after iterating through it.
 		std::list<std::string>* elementTypes = getDataManager()->getDataDefinitionClassnames();
 		for (std::list<std::string>::iterator typeIt = elementTypes->begin(); typeIt!=elementTypes->end(); typeIt++) {
 			elementType = (*typeIt);
@@ -298,6 +299,7 @@ void Model::_showElements() const {
 			}
 			Util::DecIndent();
 		}
+		delete elementTypes;
 	}
 	Util::DecIndent();
 }
@@ -431,10 +433,11 @@ void Model::_createModelInternalElements() {
 		}
 
 		std::list<ModelDataDefinition*>* modelElements;
-		unsigned int originalSize = getDataManager()->getDataDefinitionClassnames()->size(), pos = 1;
-		//for (std::list<std::string>::iterator itty = elements()->elementClassnames()->begin(); itty != elements()->elementClassnames()->end(); itty++) {
-		std::list<std::string>::iterator itty = getDataManager()->getDataDefinitionClassnames()->begin();
-		while (itty!=getDataManager()->getDataDefinitionClassnames()->end()&&pos<=originalSize) {
+		// Cache and explicitly free temporary class-name snapshots while handling possible dynamic type insertions.
+		std::list<std::string>* elementTypes = getDataManager()->getDataDefinitionClassnames();
+		unsigned int originalSize = elementTypes->size(), pos = 1;
+		std::list<std::string>::iterator itty = elementTypes->begin();
+		while (itty!=elementTypes->end()&&pos<=originalSize) {
 			//try {
 			modelElements = getDataManager()->getDataDefinitionList((*itty))->list();
 			//} catch (const std::exception& e) {
@@ -450,16 +453,24 @@ void Model::_createModelInternalElements() {
 				ModelDataDefinition::CreateInternalData((*itel));
 				Util::DecIndent();
 			}
-			if (originalSize==getDataManager()->getDataDefinitionClassnames()->size()) {
+			// Compare against a fresh snapshot size and free it immediately to avoid leaking manager-owned temporaries.
+			std::list<std::string>* currentTypes = getDataManager()->getDataDefinitionClassnames();
+			unsigned int currentSize = currentTypes->size();
+			delete currentTypes;
+			if (originalSize==currentSize) {
 				itty++;
 				pos++;
 			} else {
-				originalSize = getDataManager()->getDataDefinitionClassnames()->size();
-				itty = getDataManager()->getDataDefinitionClassnames()->begin();
+				// Refresh the cached snapshot after dynamic insertions so iteration restarts from a coherent list.
+				delete elementTypes;
+				elementTypes = getDataManager()->getDataDefinitionClassnames();
+				originalSize = elementTypes->size();
+				itty = elementTypes->begin();
 				pos = 1;
 				getTracer()->trace("Restarting to create internal elements (due to previous creations)", TraceManager::Level::L7_internal);
 			}
 		}
+		delete elementTypes;
 		Util::DecIndent();
 	}
 }

--- a/source/kernel/simulator/ModelCheckerDefaultImpl1.cpp
+++ b/source/kernel/simulator/ModelCheckerDefaultImpl1.cpp
@@ -147,6 +147,7 @@ bool ModelCheckerDefaultImpl1::checkSymbols() {
 				bool result;
 				ModelDataDefinition* modeldatum;
                 std::string errorMessage = "";
+				// Release the temporary type-name list after checking all data-definition symbols.
 				std::list<std::string>* elementTypes = _model->getDataManager()->getDataDefinitionClassnames();
 				for (std::list<std::string>::iterator typeIt = elementTypes->begin(); typeIt != elementTypes->end(); typeIt++) {
 					elementType = (*typeIt);
@@ -170,6 +171,7 @@ bool ModelCheckerDefaultImpl1::checkSymbols() {
 						Util::DecIndent();
 					}
 				}
+				delete elementTypes;
 			}
 			Util::DecIndent();
 		}
@@ -233,15 +235,20 @@ bool ModelCheckerDefaultImpl1::checkOrphaned() {
 	{
 		std::list<ModelDataDefinition*>* orphaned = new std::list<ModelDataDefinition*>();
 		// Start by including all elements as orphaned
-		for (std::string ddtypename : *_model->getDataManager()->getDataDefinitionClassnames()) {
+		// Hold and free a temporary snapshot of type names when enumerating initial orphan candidates.
+		std::list<std::string>* allTypes = _model->getDataManager()->getDataDefinitionClassnames();
+		for (std::string ddtypename : *allTypes) {
 			for (ModelDataDefinition* element : *_model->getDataManager()->getDataDefinitionList(ddtypename)->list()) {
 				orphaned->insert(orphaned->end(), element);
 			}
 		}
+		delete allTypes;
 		// now exclude all those are refered by someone.
 		ModelDataDefinition* mdd;
 		// ... by someone (ModelDataDefinition).
-		for (std::string ddtypename : *_model->getDataManager()->getDataDefinitionClassnames()) {
+		// Hold and free another snapshot because orphan pruning can trigger recursive checks with changed registries.
+		std::list<std::string>* referencedTypes = _model->getDataManager()->getDataDefinitionClassnames();
+		for (std::string ddtypename : *referencedTypes) {
 			for (ModelDataDefinition* element : *_model->getDataManager()->getDataDefinitionList(ddtypename)->list()) {
 				for (std::pair<std::string, ModelDataDefinition*> pairInternal : *element->getInternalData()) {
 					mdd = pairInternal.second;
@@ -255,6 +262,7 @@ bool ModelCheckerDefaultImpl1::checkOrphaned() {
 				}
 			}
 		}
+		delete referencedTypes;
 		// ... by someone (ModelComponent).
 		for (ModelComponent* component : *_model->getComponentManager()->getAllComponents()) {
 			for (std::pair<std::string, ModelDataDefinition*> pairInternal : *component->getInternalData()) {

--- a/source/kernel/simulator/ModelDataDefinition.cpp
+++ b/source/kernel/simulator/ModelDataDefinition.cpp
@@ -179,12 +179,10 @@ void ModelDataDefinition::_attachedDataInsert(std::string key, ModelDataDefiniti
 }
 
 void ModelDataDefinition::_attachedDataRemove(std::string key) {
-	//for (std::map<std::string, ModelDataDefinition*>::iterator it = _internelElements->begin(); it != _internelElements->end(); it++) {
+	// Remove only the non-owning attachment registry entry and keep the referenced object lifetime untouched.
 	std::map<std::string, ModelDataDefinition*>::iterator it = _attachedData->begin();
 	while (it != _attachedData->end()) {
 		if ((*it).first == key) {
-			this->_parentModel->getDataManager()->remove((*it).second);
-			delete ((*it).second); //->~ModelDataDefinition();
 			_attachedData->erase(it);
 			it = _attachedData->begin();
 		} else {

--- a/source/kernel/simulator/ModelDataManager.cpp
+++ b/source/kernel/simulator/ModelDataManager.cpp
@@ -207,6 +207,7 @@ int ModelDataManager::getRankOf(std::string datadefinitionTypename, std::string 
 }
 
 std::list<std::string>* ModelDataManager::getDataDefinitionClassnames() const {
+	// Build a heap snapshot of registered class names so callers can iterate safely over a stable copy.
 	std::list<std::string>* keys = new std::list<std::string>();
 	for (std::map<std::string, List<ModelDataDefinition*>*>::iterator it = _datadefinitions->begin(); it != _datadefinitions->end(); it++) {
 		keys->insert(keys->end(), (*it).first);

--- a/source/kernel/simulator/ModelDataManager.h
+++ b/source/kernel/simulator/ModelDataManager.h
@@ -116,7 +116,7 @@ public:
 	int getRankOf(std::string datadefinitionTypename, std::string name); //!< returns the position (1st position=0) of the modeldatum if found, or negative value if not found
 	/*!
 	 * \brief getDataDefinitionClassnames
-	 * \return
+	 * \return Heap-allocated list snapshot; caller must delete it after use.
 	 */
 	std::list<std::string>* getDataDefinitionClassnames() const;
 

--- a/source/kernel/simulator/ModelPersistenceDefaultImpl2.cpp
+++ b/source/kernel/simulator/ModelPersistenceDefaultImpl2.cpp
@@ -67,7 +67,9 @@ bool ModelPersistenceDefaultImpl2::save(std::string filename) {
 	// gather data definitions
 	const std::string counter = Util::TypeOf<Counter>();
 	const std::string statsCollector = Util::TypeOf<StatisticsCollector>();
-	for (auto& type : *_model->getDataManager()->getDataDefinitionClassnames()) {
+	// Release the temporary class-name snapshot allocated by the manager after serializing all eligible data definitions.
+	std::list<std::string>* dataDefinitionClassnames = _model->getDataManager()->getDataDefinitionClassnames();
+	for (auto& type : *dataDefinitionClassnames) {
 		if (type == statsCollector || type == counter) continue; // these don't need to be saved
 		_model->getTracer()->trace(TraceManager::Level::L9_mostDetailed, "Writing elements of type \"" + type + "\":");
 		Util::IncIndent();
@@ -82,6 +84,7 @@ bool ModelPersistenceDefaultImpl2::save(std::string filename) {
 		}
 		Util::DecIndent();
 	}
+	delete dataDefinitionClassnames;
 
 	// gather model components
 	_model->getTracer()->trace(TraceManager::Level::L9_mostDetailed, "Writing components:");

--- a/source/kernel/simulator/ModelSimulation.cpp
+++ b/source/kernel/simulator/ModelSimulation.cpp
@@ -412,6 +412,7 @@ void ModelSimulation::_initReplication() {
 			ModelComponent::InitBetweenReplications(*it);
 		}
 		// init all elements between replications
+		// Free the temporary list of data-definition class names once initialization across all types is done.
 		std::list<std::string>* elementTypes = _model->getDataManager()->getDataDefinitionClassnames();
 		for (std::string elementType : *elementTypes) {//std::list<std::string>::iterator typeIt = elementTypes->begin(); typeIt != elementTypes->end(); typeIt++) {
 			List<ModelDataDefinition*>* elements = _model->getDataManager()->getDataDefinitionList(elementType);
@@ -419,6 +420,7 @@ void ModelSimulation::_initReplication() {
 				ModelDataDefinition::InitBetweenReplications(modeldatum);
 			}
 		}
+		delete elementTypes;
 		//}
 		if (this->_initializeStatisticsBetweenReplications) {
 			_clearStatistics();

--- a/source/tests/unit/test_simulator_runtime.cpp
+++ b/source/tests/unit/test_simulator_runtime.cpp
@@ -2,6 +2,7 @@
 
 #include "kernel/simulator/Simulator.h"
 #include "kernel/simulator/Model.h"
+#include "kernel/simulator/ModelDataDefinition.h"
 
 namespace {
 struct SimulationStartObserver {
@@ -15,6 +16,21 @@ struct SimulationStartObserver {
         running = event->isRunning();
         paused = event->isPaused();
         replication = event->getCurrentReplicationNumber();
+    }
+};
+
+// Exposes protected attached-data hooks so unit tests can verify non-owning attachment semantics directly.
+class AttachedDataAccessProbe : public ModelDataDefinition {
+public:
+    AttachedDataAccessProbe(Model* model, const std::string& name)
+        : ModelDataDefinition(model, "AttachedDataAccessProbe", name, true) {}
+
+    void Attach(std::string key, ModelDataDefinition* data) {
+        _attachedDataInsert(key, data);
+    }
+
+    void Detach(std::string key) {
+        _attachedDataRemove(key);
     }
 };
 }
@@ -104,4 +120,22 @@ TEST(SimulatorRuntimeTest, ModelClearPreservesBaseSimulationControlsCount) {
     model->clear();
 
     EXPECT_EQ(model->getControls()->size(), controlsBefore);
+}
+
+TEST(SimulatorRuntimeTest, AttachedDataRemoveOnlyDetachesRegistryEntry) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    // Creates two managed model data objects and links one as a non-owning attachment of the other.
+    auto* owner = new AttachedDataAccessProbe(model, "Owner");
+    auto* attached = new AttachedDataAccessProbe(model, "Attached");
+    owner->Attach("Ref", attached);
+
+    // Detaches only the attachment mapping and verifies the attached object remains registered in the manager.
+    owner->Detach("Ref");
+    EXPECT_NE(model->getDataManager()->getDataDefinition("AttachedDataAccessProbe", "Attached"), nullptr);
+
+    delete owner;
+    delete attached;
 }


### PR DESCRIPTION
### Motivation
- Make `_attachedData` semantics internally consistent by treating it as a non-owning registry and avoid double-deletion of ModelDataDefinition instances. 
- Eliminate heap leaks caused by callers not freeing the temporary `std::list<std::string>*` returned by `ModelDataManager::getDataDefinitionClassnames()` inside kernel/simulator call sites.

### Description
- Aligned `_attachedDataRemove(std::string)` in `ModelDataDefinition` to only remove the registry entry and not call `ModelDataManager::remove` nor `delete` the referenced object. (preserves `_internalData` owner-like policy). 
- Updated kernel/simulator call sites to explicitly free snapshots returned by `getDataDefinitionClassnames()` after use to prevent leaks in iteration/loop code paths. 
- Documented the ownership expectation of `getDataDefinitionClassnames()` in `ModelDataManager.h` and added a clarifying comment in `ModelDataManager.cpp`. 
- Added a small focused Google Test that exercises the detach-only behavior using a test double `AttachedDataAccessProbe` in `source/tests/unit/test_simulator_runtime.cpp`. 
- Files changed: `ModelDataDefinition.cpp`, `Model.cpp`, `ModelSimulation.cpp`, `ModelCheckerDefaultImpl1.cpp`, `CppSerializer.cpp`, `ModelPersistenceDefaultImpl2.cpp`, `ModelDataManager.h`, `ModelDataManager.cpp`, and `source/tests/unit/test_simulator_runtime.cpp`.

### Testing
- Configured build with `cmake -S . -B build` and built the requested test targets `genesys_test_simulator_runtime` and `genesys_test_simulator_support` successfully. 
- Executed test binaries directly: `./build/source/tests/unit/genesys_test_simulator_runtime` (all tests passed, includes new detach-only test) and `./build/source/tests/unit/genesys_test_simulator_support` (all tests passed). 
- `ctest` did not discover tests in this environment so executables were run directly; both test binaries reported all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6f9ea0c1483218aeb357e4d4fcd2a)