### PR TITLE
Preserve resume key for paused animations in SimulationEventController

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/controllers/SimulationEventController.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/SimulationEventController.cpp
@@ -25,25 +25,25 @@
 #include <utility>
 
 namespace {
-// Select and detach the paused-animation list that can be safely resumed.
-static QList<AnimationTransition*>* takePausedAnimationListForResume(
+// Select and detach the paused-animation list together with its effective resume key.
+static std::pair<Event*, QList<AnimationTransition*>*> takePausedAnimationListForResume(
     QMap<Event*, QList<AnimationTransition*>*>* pausedAnimationsMap,
     Event* currentEvent) {
     if (!pausedAnimationsMap || pausedAnimationsMap->empty()) {
-        return nullptr;
+        return {nullptr, nullptr};
     }
 
     if (currentEvent && pausedAnimationsMap->contains(currentEvent)) {
-        return pausedAnimationsMap->take(currentEvent);
+        return {currentEvent, pausedAnimationsMap->take(currentEvent)};
     }
 
     if (pausedAnimationsMap->size() == 1) {
         auto it = pausedAnimationsMap->begin();
         Event* onlyKey = it.key();
-        return pausedAnimationsMap->take(onlyKey);
+        return {onlyKey, pausedAnimationsMap->take(onlyKey)};
     }
 
-    return nullptr;
+    return {nullptr, nullptr};
 }
 
 // Release one paused-animation list and optionally destroy its animations.
@@ -176,20 +176,19 @@ void SimulationEventController::onSimulationPausedHandler(SimulationEvent* re) c
 void SimulationEventController::onSimulationResumeHandler(SimulationEvent* re) const {
     _callbacks.actualizeActions();
 
-    // Resume only a deterministically selected paused list detached from the map.
+    // Resume detached paused animations using the same key selected from the paused map.
     QMap<Event*, QList<AnimationTransition*>*>* pausedAnimationsMap = _scene->getAnimationPaused();
     Event* currentEvent = re ? re->getCurrentEvent() : nullptr;
-    QList<AnimationTransition*>* pausedAnimations =
+    auto [resumeEventKey, pausedAnimations] =
         takePausedAnimationListForResume(pausedAnimationsMap, currentEvent);
     if (pausedAnimations) {
-        // Replay each paused transition with the current resume event context.
         for (AnimationTransition* animation : *pausedAnimations) {
             if (animation) {
-                _scene->runAnimateTransition(animation, currentEvent, true);
+                _scene->runAnimateTransition(animation, resumeEventKey, true);
             }
         }
-        cleanupPausedAnimationList(pausedAnimations, false);
     }
+    cleanupPausedAnimationList(pausedAnimations, false);
 
     QCoreApplication::processEvents();
 }


### PR DESCRIPTION
### Motivation
- Fix incorrect re-attachment key when resuming paused animations that were selected by fallback (single-entry) or when `currentEvent == nullptr`, which caused subsequent pauses to be stored under the wrong key.

### Description
- Replaced the local helper with a variant that returns both the effective resume key and the detached paused-animation list as `std::pair<Event*, QList<AnimationTransition*>*>`, preserving the original deterministic selection logic (null map/empty map => `{nullptr,nullptr}`, prefer `currentEvent` if present, fallback only when map has exactly one entry, ambiguous => `{nullptr,nullptr}`).
- Updated `onSimulationResumeHandler()` to use the `resumeEventKey` returned by the helper when calling `_scene->runAnimateTransition(animation, resumeEventKey, true)`, ensuring re-pauses will reattach to the same logical key.
- Kept `_callbacks.actualizeActions();` and always call `cleanupPausedAnimationList(pausedAnimations, false);` after resuming, and added short English comments directly above the changed code as required.
- Changes are restricted to `source/applications/gui/qt/GenesysQtGUI/controllers/SimulationEventController.cpp` only.

### Testing
- Ran CMake configure for the project (`cmake -S . -B build`) successfully to validate no basic compilation/configuration errors in non-GUI mode.
- Attempted to configure GUI build (`cmake -S . -B build-gui -DGENESYS_BUILD_GUI_APPLICATION=ON`) and it failed because `qmake` (Qt toolchain) is not available in PATH in the environment, preventing GUI build/run verification.
- Performed static inspection and `git diff` to confirm the helper now returns the key and `onSimulationResumeHandler()` passes `resumeEventKey` to `runAnimateTransition`; committed the change on branch `WiP20261`.
- No runtime GUI tests or unit tests were executed because the Qt/qmake toolchain is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6fd7326b083218f3cd372e85125b9)