### PR TITLE
Guard paused animation tracking against duplicates

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
@@ -1267,14 +1267,35 @@ void ModelGraphicsScene::runAnimateTransition(AnimationTransition *animationTran
 }
 
 void ModelGraphicsScene::handleAnimationStateChanged(QAbstractAnimation::State newState, QEventLoop* loop, Event* event, AnimationTransition* animationTransition) {
-    if (newState == QAbstractAnimation::Paused) {
-        if (!_animationPaused->contains(event)) {
-            QList<AnimationTransition *> *newList = new  QList<AnimationTransition *>();
-            _animationPaused->insert(event, newList);
-        }
-        _animationPaused->value(event)->append(animationTransition);
-        if (loop) loop->quit();
+    // Process only paused transitions and exit early for other states.
+    if (newState != QAbstractAnimation::Paused) {
+        return;
     }
+
+    // Protect map usage when paused storage is not available.
+    if (_animationPaused == nullptr) {
+        return;
+    }
+
+    // Ignore invalid transition pointers to avoid storing null entries.
+    if (animationTransition == nullptr) {
+        return;
+    }
+
+    // Ensure there is a paused-animation list for the current event key.
+    if (!_animationPaused->contains(event)) {
+        QList<AnimationTransition*>* newList = new QList<AnimationTransition*>();
+        _animationPaused->insert(event, newList);
+    }
+
+    // Append only when this transition is not already tracked for the event.
+    QList<AnimationTransition*>* pausedAnimations = _animationPaused->value(event);
+    if (pausedAnimations != nullptr && !pausedAnimations->contains(animationTransition)) {
+        pausedAnimations->append(animationTransition);
+    }
+
+    // Preserve local loop exit when the animation transitions to paused.
+    if (loop) loop->quit();
 }
 
 void ModelGraphicsScene::animateQueueInsert(ModelComponent *component, bool visivible) {


### PR DESCRIPTION
### Motivation
- Avoid adding the same `AnimationTransition*` multiple times to the paused list and add minimal defensive checks in `handleAnimationStateChanged()` to make pause handling idempotent and safe.

### Description
- Added early-return so only `QAbstractAnimation::Paused` state is processed and other states exit immediately.
- Added defensive checks to return early when `_animationPaused == nullptr` or `animationTransition == nullptr` to avoid touching the map with invalid pointers.
- Ensure a `QList<AnimationTransition*>` exists for the `event` key and insert it when missing, then append the transition only if the list does not already `contains(...)` the `animationTransition`.
- Preserved the existing local loop exit (`if (loop) loop->quit();`) semantics and added short English comments immediately above each modified block.

### Testing
- Attempted automated GUI build with the project script: `cd source/applications/gui/qt/GenesysQtGUI && ./build_qtgui.sh --config debug`, which failed in this environment because `qmake` was not found (`qmake not found. Set QMAKE_EXECUTABLE or add qmake to PATH.`).
- Performed static inspection and diffs confirming that `_animationPaused` is checked before use, `animationTransition` is checked before use, duplicates are prevented via `contains(...)`, `loop->quit()` is preserved, and only `ModelGraphicsScene.cpp` was modified (changes committed on branch `WiP20261`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d70050e78883218bb3eeb76ce1c9b0)