### PR TITLE
Implement deterministic ModelGraphicsScene destructor cleanup

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
@@ -76,7 +76,137 @@ ModelGraphicsScene::ModelGraphicsScene(qreal x, qreal y, qreal width, qreal heig
 ModelGraphicsScene::ModelGraphicsScene(const ModelGraphicsScene& orig) { // : QGraphicsScene(orig) {
 }
 
-ModelGraphicsScene::~ModelGraphicsScene() {}
+ModelGraphicsScene::~ModelGraphicsScene() {
+    // Release transient drawing items that may still be detached from normal commit flow.
+    if (_currentRectangle != nullptr) {
+        if (_currentRectangle->scene() == this) {
+            removeItem(_currentRectangle);
+        }
+        delete _currentRectangle;
+        _currentRectangle = nullptr;
+    }
+    if (_currentLine != nullptr) {
+        if (_currentLine->scene() == this) {
+            removeItem(_currentLine);
+        }
+        delete _currentLine;
+        _currentLine = nullptr;
+    }
+    if (_currentEllipse != nullptr) {
+        if (_currentEllipse->scene() == this) {
+            removeItem(_currentEllipse);
+        }
+        delete _currentEllipse;
+        _currentEllipse = nullptr;
+    }
+    if (_currentPolygon != nullptr) {
+        if (_currentPolygon->scene() == this) {
+            removeItem(_currentPolygon);
+        }
+        delete _currentPolygon;
+        _currentPolygon = nullptr;
+    }
+    if (_currentCounter != nullptr) {
+        if (_currentCounter->scene() == this) {
+            removeItem(_currentCounter);
+        }
+        delete _currentCounter;
+        _currentCounter = nullptr;
+    }
+    if (_currentVariable != nullptr) {
+        if (_currentVariable->scene() == this) {
+            removeItem(_currentVariable);
+        }
+        delete _currentVariable;
+        _currentVariable = nullptr;
+    }
+    if (_currentTimer != nullptr) {
+        if (_currentTimer->scene() == this) {
+            removeItem(_currentTimer);
+        }
+        delete _currentTimer;
+        _currentTimer = nullptr;
+    }
+
+    // Reuse the existing animation cleanup sequence before destroying animation containers.
+    clearAnimations();
+
+    // Clear and destroy grid line resources before releasing the grid container.
+    _grid.clear();
+    delete _grid.lines;
+    _grid.lines = nullptr;
+
+    // Reset lightweight auxiliary lists without forcing ownership deletion of scene-managed items.
+    if (_counters != nullptr) {
+        _counters->clear();
+    }
+    if (_variables != nullptr) {
+        _variables->clear();
+    }
+    if (_graphicalModelComponents != nullptr) {
+        _graphicalModelComponents->clear();
+    }
+    if (_graphicalModelDataDefinitions != nullptr) {
+        _graphicalModelDataDefinitions->clear();
+    }
+    if (_graphicalConnections != nullptr) {
+        _graphicalConnections->clear();
+    }
+    if (_graphicalDiagramConnections != nullptr) {
+        _graphicalDiagramConnections->clear();
+    }
+    if (_graphicalAssociations != nullptr) {
+        _graphicalAssociations->clear();
+    }
+    if (_graphicalGeometries != nullptr) {
+        _graphicalGeometries->clear();
+    }
+    if (_graphicalAnimations != nullptr) {
+        _graphicalAnimations->clear();
+    }
+    if (_graphicalEntities != nullptr) {
+        _graphicalEntities->clear();
+    }
+    if (_graphicalGroups != nullptr) {
+        _graphicalGroups->clear();
+    }
+
+    // Destroy heap-owning containers allocated by this scene and nullify their pointers.
+    delete _counters;
+    _counters = nullptr;
+    delete _variables;
+    _variables = nullptr;
+    delete _animationPaused;
+    _animationPaused = nullptr;
+    delete _imagesAnimation;
+    _imagesAnimation = nullptr;
+    delete _animationsTransition;
+    _animationsTransition = nullptr;
+    delete _animationsCounter;
+    _animationsCounter = nullptr;
+    delete _animationsVariable;
+    _animationsVariable = nullptr;
+    delete _animationsTimer;
+    _animationsTimer = nullptr;
+    delete _graphicalModelComponents;
+    _graphicalModelComponents = nullptr;
+    delete _graphicalModelDataDefinitions;
+    _graphicalModelDataDefinitions = nullptr;
+    delete _graphicalConnections;
+    _graphicalConnections = nullptr;
+    delete _graphicalDiagramConnections;
+    _graphicalDiagramConnections = nullptr;
+    delete _graphicalAssociations;
+    _graphicalAssociations = nullptr;
+    delete _graphicalGeometries;
+    _graphicalGeometries = nullptr;
+    delete _graphicalAnimations;
+    _graphicalAnimations = nullptr;
+    delete _graphicalEntities;
+    _graphicalEntities = nullptr;
+    delete _graphicalGroups;
+    _graphicalGroups = nullptr;
+}
 
 
 //-----------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- The `ModelGraphicsScene::~ModelGraphicsScene()` destructor was empty while the class owns several heap-allocated containers and transient drawing items, creating potential local leaks and dangling resources.
- Provide a conservative, deterministic cleanup sequence that frees transient drawing/editing items and destroys containers clearly owned by the scene without changing ownership semantics for scene-managed `QGraphicsItem`s.

### Description
- Implemented `ModelGraphicsScene::~ModelGraphicsScene()` to release transient drawing/editing items (`_currentRectangle`, `_currentLine`, `_currentEllipse`, `_currentPolygon`, `_currentCounter`, `_currentVariable`, `_currentTimer`) by removing from the scene when attached, deleting, and nulling pointers, with a short English comment above that block.
- Reused existing animation cleanup by calling `clearAnimations()` before destroying animation-related containers, with a short comment above that call.
- Cleared the grid via `_grid.clear()`, then explicitly `delete _grid.lines` and set `_grid.lines = nullptr`, with a short comment above.
- Performed light `clear()` on auxiliary non-owning containers (counters, variables and graphical lists) to avoid forcing deletion of scene-managed items, with a short comment above these clears.
- Explicitly `delete`-ed all heap-owning containers allocated by the scene (lists and maps listed in the task) and nulled their pointers, with a short comment above that block.
- All modifications were restricted to `source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp` and include the requested short comments in English immediately above altered blocks.

### Testing
- Attempted to build the GUI using the project script with `cd source/applications/gui/qt/GenesysQtGUI && ./build_qtgui.sh --config Debug`, but the build failed due to the environment missing `qmake` with the error: `qmake not found. Set QMAKE_EXECUTABLE or add qmake to PATH.` (no successful compile possible in this environment).
- Performed code inspection and diffs: confirmed the destructor is no longer empty, that `delete` calls are present for the listed heap-owned containers, that `_grid.lines` is deleted, and that transient drawing pointers are released and nulled; these checks succeeded by source diffs and greps.
- Committed the change locally with message `Implement deterministic ModelGraphicsScene destructor cleanup` and prepared PR metadata; no automated unit tests or runtime tests were executed due to missing Qt toolchain.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7079944e88321b44ab01e18685b33)