### PR TITLE
Stage 12: eliminate temporary local leaks in ModelGraphicsScene.cpp

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
@@ -34,6 +34,7 @@
 #include <QTreeWidget>
 #include <QMessageBox>
 #include <QUndoCommand>
+#include <memory>
 #include <string>
 #include <list>
 #include "graphicals/ModelGraphicsScene.h"
@@ -506,7 +507,8 @@ void ModelGraphicsScene::startTextEditing() {
 
 // limpa todo o modelo
 void ModelGraphicsScene::clearGraphicalModelComponents() {
-    QList<GraphicalModelComponent*> *componentsInModel = this->graphicalModelComponentItems();
+    // Own and automatically release the temporary component list returned by the scene query.
+    auto componentsInModel = std::unique_ptr<QList<GraphicalModelComponent*>>(this->graphicalModelComponentItems());
     GraphicalModelComponent *source;
     GraphicalModelComponent *destination;
 
@@ -881,7 +883,8 @@ void ModelGraphicsScene::redoConnections(GraphicalModelComponent *graphicalCompo
 
 
 void ModelGraphicsScene::saveDataDefinitions() {
-    QList<GraphicalModelComponent*> *components = this->graphicalModelComponentItems();
+    // Own and automatically release the temporary component list returned by the scene query.
+    auto components = std::unique_ptr<QList<GraphicalModelComponent*>>(this->graphicalModelComponentItems());
 
     for (GraphicalModelComponent* component : *components) {
         component->verifyQueue();
@@ -918,7 +921,8 @@ void ModelGraphicsScene::saveDataDefinitions() {
 }
 
 void ModelGraphicsScene::insertRestoredDataDefinitions(bool loaded) {
-    QList<GraphicalModelComponent*> *components = this->graphicalModelComponentItems();
+    // Own and automatically release the temporary component list returned by the scene query.
+    auto components = std::unique_ptr<QList<GraphicalModelComponent*>>(this->graphicalModelComponentItems());
     QList<GraphicalModelComponent*> *allComponentes = this->getAllComponents();
 
     if (!allComponentes->empty()) {
@@ -2746,16 +2750,15 @@ void ModelGraphicsScene::clearAnimationsValues() {
 void ModelGraphicsScene::setCounters() {
     Model* currentModel = _simulator->getModelManager()->current();
 
-    QList<ModelDataDefinition *> *counters = nullptr;
-
     if (currentModel) {
         _counters->clear();
 
         List<ModelDataDefinition *> *countersList = currentModel->getDataManager()->getDataDefinitionList(Util::TypeOf<Counter>());
 
-        counters = new QList<ModelDataDefinition *>(countersList->list()->begin(), countersList->list()->end());
+        // Build the temporary data-definition list on the stack to avoid heap leaks.
+        QList<ModelDataDefinition *> counters(countersList->list()->begin(), countersList->list()->end());
 
-        foreach(ModelDataDefinition *counter, *counters) {
+        foreach(ModelDataDefinition *counter, counters) {
             Counter *newCounter = dynamic_cast<Counter *>(counter);
 
             if (newCounter) {
@@ -2768,16 +2771,15 @@ void ModelGraphicsScene::setCounters() {
 void ModelGraphicsScene::setVariables() {
     Model* currentModel = _simulator->getModelManager()->current();
 
-    QList<ModelDataDefinition *> *variables = nullptr;
-
     if (currentModel) {
         _variables->clear();
 
         List<ModelDataDefinition *> *variablesList = currentModel->getDataManager()->getDataDefinitionList(Util::TypeOf<Variable>());
 
-        variables = new QList<ModelDataDefinition *>(variablesList->list()->begin(), variablesList->list()->end());
+        // Build the temporary data-definition list on the stack to avoid heap leaks.
+        QList<ModelDataDefinition *> variables(variablesList->list()->begin(), variablesList->list()->end());
 
-        foreach(ModelDataDefinition *variable, *variables) {
+        foreach(ModelDataDefinition *variable, variables) {
             Variable *newVariable = dynamic_cast<Variable *>(variable);
 
             if (newVariable) {


### PR DESCRIPTION
### Motivation
- Remove several local heap allocations that caused short-lived leaks inside `ModelGraphicsScene.cpp` without changing public APIs.
- Keep the function signature of `graphicalModelComponentItems()` unchanged while ensuring callers release the returned list.
- Replace unnecessary heap temporaries in `setCounters()` and `setVariables()` with stack-allocated containers to simplify ownership.

### Description
- Added `#include <memory>` and wrapped the raw lists returned by `graphicalModelComponentItems()` in `std::unique_ptr<QList<GraphicalModelComponent*>>` in `clearGraphicalModelComponents()`, `saveDataDefinitions()`, and `insertRestoredDataDefinitions()` to ensure RAII-based release of the temporary lists. A short English comment was added above each change. 
- Replaced `new QList<ModelDataDefinition*>(...)` temporaries with stack-allocated `QList<ModelDataDefinition*>` instances in `setCounters()` and `setVariables()` and added short English comments above those changes. 
- Changes are restricted to a single file: `source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp`, and no header or public signatures were modified.

### Testing
- Performed code inspection and diffs to verify ownership changes and that the three callers now own and automatically release the lists returned by `graphicalModelComponentItems()`. These checks succeeded.
- Attempted to run the provided GUI build script: `bash source/applications/gui/qt/GenesysQtGUI/build_qtgui.sh --config debug`, which failed in this environment with `qmake not found. Set QMAKE_EXECUTABLE or add qmake to PATH.` so a full build could not be executed here.
- No automated unit tests were executed in this environment due to the absence of the Qt/qmake toolchain; static change verification and runtime build attempt are the performed validations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d70aed754c8321b413df6ce2df7e72)