### PR TITLE
Add kernel lifecycle regression tests for Model, ModelManager and ConnectionManager

### DIFF
--- a/source/tests/unit/test_simulator_runtime.cpp
+++ b/source/tests/unit/test_simulator_runtime.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <algorithm>
 
 #include "kernel/simulator/Simulator.h"
 #include "kernel/simulator/Model.h"
@@ -32,6 +33,12 @@ public:
     void Detach(std::string key) {
         _attachedDataRemove(key);
     }
+};
+
+class SnapshotDataDefinitionProbe : public ModelDataDefinition {
+public:
+    SnapshotDataDefinitionProbe(Model* model, const std::string& name)
+        : ModelDataDefinition(model, "SnapshotDataDefinitionProbe", name, true) {}
 };
 }
 
@@ -120,6 +127,51 @@ TEST(SimulatorRuntimeTest, ModelClearPreservesBaseSimulationControlsCount) {
     model->clear();
 
     EXPECT_EQ(model->getControls()->size(), controlsBefore);
+}
+
+TEST(SimulatorRuntimeTest, ModelClearIsIdempotentAndKeepsRuntimeUsable) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    // Captures the runtime control baseline and validates clear() can run repeatedly without breaking infrastructure.
+    const unsigned int controlsBefore = model->getControls()->size();
+    ASSERT_GT(controlsBefore, 0u);
+
+    model->clear();
+    model->clear();
+
+    EXPECT_EQ(model->getControls()->size(), controlsBefore);
+    EXPECT_NE(model->getSimulation(), nullptr);
+    EXPECT_NE(model->getDataManager(), nullptr);
+    EXPECT_NE(model->getComponentManager(), nullptr);
+}
+
+TEST(SimulatorRuntimeTest, DataDefinitionClassnamesSnapshotIsReturnedByValue) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    auto* first = new SnapshotDataDefinitionProbe(model, "First");
+    auto* second = new SnapshotDataDefinitionProbe(model, "Second");
+
+    // Takes two independent snapshots and verifies local mutations never affect manager state or another snapshot instance.
+    auto names1 = model->getDataManager()->getDataDefinitionClassnames();
+    auto names2 = model->getDataManager()->getDataDefinitionClassnames();
+
+    const std::string expectedType = "SnapshotDataDefinitionProbe";
+    EXPECT_NE(std::find(names1.begin(), names1.end(), expectedType), names1.end());
+    EXPECT_NE(std::find(names2.begin(), names2.end(), expectedType), names2.end());
+
+    names1.clear();
+    EXPECT_TRUE(names1.empty());
+    EXPECT_NE(std::find(names2.begin(), names2.end(), expectedType), names2.end());
+
+    const auto namesFromManager = model->getDataManager()->getDataDefinitionClassnames();
+    EXPECT_NE(std::find(namesFromManager.begin(), namesFromManager.end(), expectedType), namesFromManager.end());
+
+    delete first;
+    delete second;
 }
 
 TEST(SimulatorRuntimeTest, AttachedDataRemoveOnlyDetachesRegistryEntry) {

--- a/source/tests/unit/test_support_connectionmanager.cpp
+++ b/source/tests/unit/test_support_connectionmanager.cpp
@@ -42,3 +42,30 @@ TEST(SupportConnectionManagerClassTest, InsertAtPortReplacesExistingConnectionWi
     EXPECT_EQ(manager.size(), 1u);
     EXPECT_EQ(manager.getConnectionAtPort(0), second);
 }
+
+TEST(SupportConnectionManagerClassTest, RemovingUnknownConnectionKeepsStateUnchanged) {
+    ConnectionManager manager;
+    Connection* inserted = new Connection{nullptr, {0, ""}};
+    Connection* neverInserted = new Connection{nullptr, {1, ""}};
+
+    // Inserts one connection and validates that removing an unknown pointer keeps the existing mapping intact.
+    manager.insertAtPort(0, inserted);
+    manager.remove(neverInserted);
+
+    EXPECT_EQ(manager.size(), 1u);
+    EXPECT_EQ(manager.getConnectionAtPort(0), inserted);
+
+    delete neverInserted;
+}
+
+TEST(SupportConnectionManagerClassTest, ReplaceSamePointerDoesNotChangeSize) {
+    ConnectionManager manager;
+    Connection* reused = new Connection{nullptr, {0, ""}};
+
+    // Reinserts the same pointer in the same port to validate the defensive no-growth replace path.
+    manager.insertAtPort(0, reused);
+    manager.insertAtPort(0, reused);
+
+    EXPECT_EQ(manager.size(), 1u);
+    EXPECT_EQ(manager.getConnectionAtPort(0), reused);
+}

--- a/source/tests/unit/test_support_modelmanager.cpp
+++ b/source/tests/unit/test_support_modelmanager.cpp
@@ -10,6 +10,7 @@ TraceManager* Simulator::getTraceManager() const {
 
 namespace {
 int g_model_constructions = 0;
+int g_model_destructions = 0;
 int g_model_saves = 0;
 }
 
@@ -19,8 +20,10 @@ Model::Model(Simulator* simulator, unsigned int level) {
     ++g_model_constructions;
 }
 
-// Provides a trivial out-of-line destructor for the test double after Model gained an explicit virtual destructor.
-Model::~Model() = default;
+// Tracks model destruction so tests can validate detached current-model lifecycle behavior in ModelManager.
+Model::~Model() {
+    ++g_model_destructions;
+}
 
 bool Model::save(std::string filename) {
     (void)filename;
@@ -34,6 +37,9 @@ bool Model::load(std::string filename) {
 }
 
 TEST(SupportModelManagerClassTest, NewModelSetsCurrentModel) {
+    // Resets lifecycle counters to keep this test independent from others.
+    g_model_constructions = 0;
+    g_model_destructions = 0;
     ModelManager manager(nullptr);
 
     Model* created = manager.newModel();
@@ -44,6 +50,9 @@ TEST(SupportModelManagerClassTest, NewModelSetsCurrentModel) {
 }
 
 TEST(SupportModelManagerClassTest, SaveModelDelegatesToCurrentModel) {
+    // Resets construction/save counters before exercising delegation.
+    g_model_constructions = 0;
+    g_model_saves = 0;
     ModelManager manager(nullptr);
     manager.newModel();
 
@@ -57,4 +66,34 @@ TEST(SupportModelManagerClassTest, SaveModelWithoutCurrentModelReturnsFalse) {
     ModelManager manager(nullptr);
 
     EXPECT_FALSE(manager.saveModel("dummy.gen"));
+}
+
+TEST(SupportModelManagerClassTest, NewModelReleasesPreviousDetachedCurrentModel) {
+    // Resets counters and verifies replacing a detached current model releases the previous allocation.
+    g_model_constructions = 0;
+    g_model_destructions = 0;
+    ModelManager manager(nullptr);
+
+    Model* first = manager.newModel();
+    Model* second = manager.newModel();
+
+    ASSERT_NE(first, nullptr);
+    ASSERT_NE(second, nullptr);
+    EXPECT_EQ(manager.current(), second);
+    EXPECT_EQ(g_model_constructions, 2);
+    EXPECT_EQ(g_model_destructions, 1);
+}
+
+TEST(SupportModelManagerClassTest, DestructorReleasesDetachedCurrentModel) {
+    // Ensures manager teardown releases a detached current model even when it was never inserted into _models.
+    g_model_constructions = 0;
+    g_model_destructions = 0;
+    {
+        ModelManager manager(nullptr);
+        Model* created = manager.newModel();
+        ASSERT_NE(created, nullptr);
+    }
+
+    EXPECT_EQ(g_model_constructions, 1);
+    EXPECT_EQ(g_model_destructions, 1);
 }


### PR DESCRIPTION
### Motivation
- Consolidate recent ownership/lifecycle fixes by adding focused unit/regression tests for kernel runtime behavior without changing production code.
- Prevent regressions in `Model::clear()`, `ModelManager` detached-current handling, `ConnectionManager` ownership paths, and `ModelDataManager` classname snapshot semantics.
- Keep scope strictly to kernel unit tests and preserve GUI/plugins/smart-pointer/namespace code.

### Description
- Added tests in `source/tests/unit/test_simulator_runtime.cpp` to validate `Model::clear()` is idempotent and preserves runtime managers, and to verify `ModelDataManager::getDataDefinitionClassnames()` returns independent snapshots by value using a small test double.
- Extended `source/tests/unit/test_support_modelmanager.cpp` with a destruction counter in the `Model` test-double and two regression tests asserting that `newModel()` releases a previously detached current model and that the `ModelManager` destructor releases a detached current model.
- Extended `source/tests/unit/test_support_connectionmanager.cpp` with tests ensuring removing an unknown `Connection*` leaves state unchanged and that replacing a port with the same pointer does not increase size.
- Kept changes limited to test files and added short technical comments immediately above each modified/added logical block per project style requirements; no production code, GUI, plugin, namespace or smart-pointer refactors were introduced.

### Testing
- Configured with `cmake --preset tests-kernel-unit` and built targets `genesys_test_simulator_runtime`, `genesys_test_support_modelmanager`, and `genesys_test_support_connectionmanager` successfully.
- Ran `./build/tests-kernel-unit/source/tests/unit/genesys_test_simulator_runtime` and observed all tests passing (10/10).
- Ran `./build/tests-kernel-unit/source/tests/unit/genesys_test_support_modelmanager` and `./build/tests-kernel-unit/source/tests/unit/genesys_test_support_connectionmanager` and observed all tests passing (5/5 and 6/6 respectively).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d70b302b508321baeabb4cab88bfa9)