### PR TITLE
Add kernel lifecycle/ownership regression unit tests

### DIFF
--- a/source/tests/unit/test_simulator_runtime.cpp
+++ b/source/tests/unit/test_simulator_runtime.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 
+#include <algorithm>
+
 #include "kernel/simulator/Simulator.h"
 #include "kernel/simulator/Model.h"
 #include "kernel/simulator/ModelDataDefinition.h"
@@ -32,6 +34,13 @@ public:
     void Detach(std::string key) {
         _attachedDataRemove(key);
     }
+};
+
+// Provides a minimal concrete data definition type to exercise manager class-name snapshot semantics.
+class DataDefinitionSnapshotProbe : public ModelDataDefinition {
+public:
+    DataDefinitionSnapshotProbe(Model* model, const std::string& name)
+        : ModelDataDefinition(model, "DataDefinitionSnapshotProbe", name, true) {}
 };
 }
 
@@ -120,6 +129,54 @@ TEST(SimulatorRuntimeTest, ModelClearPreservesBaseSimulationControlsCount) {
     model->clear();
 
     EXPECT_EQ(model->getControls()->size(), controlsBefore);
+}
+
+TEST(SimulatorRuntimeTest, ModelClearIsIdempotentAndKeepsRuntimeUsable) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    // Captures baseline simulation controls and validates clear() can run twice without invalidating core runtime managers.
+    const unsigned int controlsBefore = model->getControls()->size();
+    ASSERT_GT(controlsBefore, 0u);
+
+    model->clear();
+    model->clear();
+
+    EXPECT_EQ(model->getControls()->size(), controlsBefore);
+    EXPECT_NE(model->getSimulation(), nullptr);
+    EXPECT_NE(model->getDataManager(), nullptr);
+    EXPECT_NE(model->getComponentManager(), nullptr);
+}
+
+TEST(SimulatorRuntimeTest, DataDefinitionClassnamesSnapshotIsReturnedByValue) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    // Creates managed data definitions so the manager registry exposes at least one class name for snapshot checks.
+    auto* first = new DataDefinitionSnapshotProbe(model, "SnapshotA");
+    auto* second = new DataDefinitionSnapshotProbe(model, "SnapshotB");
+    (void)second;
+
+    // Captures independent snapshots and verifies mutating one local copy does not affect manager state or another snapshot.
+    auto names1 = model->getDataManager()->getDataDefinitionClassnames();
+    auto names2 = model->getDataManager()->getDataDefinitionClassnames();
+    ASSERT_FALSE(names1.empty());
+    ASSERT_FALSE(names2.empty());
+    EXPECT_NE(std::find(names1.begin(), names1.end(), "DataDefinitionSnapshotProbe"), names1.end());
+    EXPECT_NE(std::find(names2.begin(), names2.end(), "DataDefinitionSnapshotProbe"), names2.end());
+
+    names1.remove("DataDefinitionSnapshotProbe");
+
+    EXPECT_EQ(std::find(names1.begin(), names1.end(), "DataDefinitionSnapshotProbe"), names1.end());
+    EXPECT_NE(std::find(names2.begin(), names2.end(), "DataDefinitionSnapshotProbe"), names2.end());
+    auto names3 = model->getDataManager()->getDataDefinitionClassnames();
+    EXPECT_NE(std::find(names3.begin(), names3.end(), "DataDefinitionSnapshotProbe"), names3.end());
+
+    // Explicitly releases test-owned instances to keep teardown deterministic inside this test body.
+    delete first;
+    delete second;
 }
 
 TEST(SimulatorRuntimeTest, AttachedDataRemoveOnlyDetachesRegistryEntry) {

--- a/source/tests/unit/test_support_connectionmanager.cpp
+++ b/source/tests/unit/test_support_connectionmanager.cpp
@@ -42,3 +42,31 @@ TEST(SupportConnectionManagerClassTest, InsertAtPortReplacesExistingConnectionWi
     EXPECT_EQ(manager.size(), 1u);
     EXPECT_EQ(manager.getConnectionAtPort(0), second);
 }
+
+TEST(SupportConnectionManagerClassTest, RemovingUnknownConnectionKeepsStateUnchanged) {
+    ConnectionManager manager;
+    // Allocates distinct raw connections to validate remove(Connection*) leaves state intact when pointer is unknown.
+    Connection* inserted = new Connection{nullptr, {0, ""}};
+    Connection* unknown = new Connection{nullptr, {0, ""}};
+
+    manager.insertAtPort(0, inserted);
+    manager.remove(unknown);
+
+    EXPECT_EQ(manager.size(), 1u);
+    EXPECT_EQ(manager.getConnectionAtPort(0), inserted);
+
+    // Releases the pointer never handed over to manager ownership to avoid leaking test memory.
+    delete unknown;
+}
+
+TEST(SupportConnectionManagerClassTest, ReplaceSamePointerDoesNotChangeSize) {
+    ConnectionManager manager;
+    // Reuses the same pointer at the same port to assert defensive replacement logic keeps a single owned entry.
+    Connection* shared = new Connection{nullptr, {0, ""}};
+
+    manager.insertAtPort(0, shared);
+    manager.insertAtPort(0, shared);
+
+    EXPECT_EQ(manager.size(), 1u);
+    EXPECT_EQ(manager.getConnectionAtPort(0), shared);
+}

--- a/source/tests/unit/test_support_modelmanager.cpp
+++ b/source/tests/unit/test_support_modelmanager.cpp
@@ -10,6 +10,7 @@ TraceManager* Simulator::getTraceManager() const {
 
 namespace {
 int g_model_constructions = 0;
+int g_model_destructions = 0;
 int g_model_saves = 0;
 }
 
@@ -19,8 +20,10 @@ Model::Model(Simulator* simulator, unsigned int level) {
     ++g_model_constructions;
 }
 
-// Provides a trivial out-of-line destructor for the test double after Model gained an explicit virtual destructor.
-Model::~Model() = default;
+// Tracks destruction events so tests can validate detached current-model lifecycle handling in ModelManager.
+Model::~Model() {
+    ++g_model_destructions;
+}
 
 bool Model::save(std::string filename) {
     (void)filename;
@@ -34,6 +37,10 @@ bool Model::load(std::string filename) {
 }
 
 TEST(SupportModelManagerClassTest, NewModelSetsCurrentModel) {
+    // Resets test counters to keep this scenario isolated from previous test side effects.
+    g_model_constructions = 0;
+    g_model_destructions = 0;
+    g_model_saves = 0;
     ModelManager manager(nullptr);
 
     Model* created = manager.newModel();
@@ -44,6 +51,10 @@ TEST(SupportModelManagerClassTest, NewModelSetsCurrentModel) {
 }
 
 TEST(SupportModelManagerClassTest, SaveModelDelegatesToCurrentModel) {
+    // Resets test counters to keep this scenario isolated from previous test side effects.
+    g_model_constructions = 0;
+    g_model_destructions = 0;
+    g_model_saves = 0;
     ModelManager manager(nullptr);
     manager.newModel();
 
@@ -54,7 +65,45 @@ TEST(SupportModelManagerClassTest, SaveModelDelegatesToCurrentModel) {
 }
 
 TEST(SupportModelManagerClassTest, SaveModelWithoutCurrentModelReturnsFalse) {
+    // Resets test counters to keep this scenario isolated from previous test side effects.
+    g_model_constructions = 0;
+    g_model_destructions = 0;
+    g_model_saves = 0;
     ModelManager manager(nullptr);
 
     EXPECT_FALSE(manager.saveModel("dummy.gen"));
+}
+
+TEST(SupportModelManagerClassTest, NewModelReleasesPreviousDetachedCurrentModel) {
+    // Resets lifecycle counters and validates replacing detached current model deletes the previous instance.
+    g_model_constructions = 0;
+    g_model_destructions = 0;
+    g_model_saves = 0;
+
+    ModelManager manager(nullptr);
+    Model* first = manager.newModel();
+    Model* second = manager.newModel();
+
+    ASSERT_NE(first, nullptr);
+    ASSERT_NE(second, nullptr);
+    EXPECT_EQ(manager.current(), second);
+    EXPECT_EQ(g_model_constructions, 2);
+    EXPECT_EQ(g_model_destructions, 1);
+}
+
+TEST(SupportModelManagerClassTest, DestructorReleasesDetachedCurrentModel) {
+    // Ensures manager teardown deletes a detached current model that was never inserted into the internal list.
+    g_model_constructions = 0;
+    g_model_destructions = 0;
+    g_model_saves = 0;
+
+    {
+        ModelManager manager(nullptr);
+        Model* current = manager.newModel();
+        ASSERT_NE(current, nullptr);
+        EXPECT_EQ(g_model_constructions, 1);
+        EXPECT_EQ(g_model_destructions, 0);
+    }
+
+    EXPECT_EQ(g_model_destructions, 1);
 }


### PR DESCRIPTION
### Motivation
- Consolidate recent ownership/lifecycle fixes by adding lightweight regression tests that exercise kernel runtime behaviors without touching GUI or production refactors.
- Ensure `Model::clear()` is safe to call repeatedly and does not invalidate core runtime managers.
- Verify `ModelManager` releases a detached `_currentModel` both when replaced and at destruction to prevent leaks.
- Cover defensive branches in `ConnectionManager` and assert `ModelDataManager::getDataDefinitionClassnames()` returns independent snapshots by value.

### Description
- Added tests in `source/tests/unit/test_simulator_runtime.cpp` for `Model::clear()` idempotency and for snapshot-by-value behavior of `ModelDataManager::getDataDefinitionClassnames()`, including a small test double `DataDefinitionSnapshotProbe` to exercise the manager registry.
- Extended `source/tests/unit/test_support_modelmanager.cpp` with a destruction counter and two lifecycle regression tests: `NewModelReleasesPreviousDetachedCurrentModel` and `DestructorReleasesDetachedCurrentModel`, and reset counters per test for isolation.
- Added two defensive tests to `source/tests/unit/test_support_connectionmanager.cpp`: `RemovingUnknownConnectionKeepsStateUnchanged` and `ReplaceSamePointerDoesNotChangeSize`, with explicit cleanup of non-owned pointers to avoid leaks in tests.
- All changes are confined to unit tests and include short English comments immediately above modified blocks explaining their intent, as required by test-style constraints.

### Testing
- Configured and generated build files with `cmake --preset tests-kernel-unit` and built the kernel unit test targets successfully.
- Built the specific test executables with `cmake --build build/tests-kernel-unit --target genesys_test_simulator_runtime genesys_test_support_modelmanager genesys_test_support_connectionmanager` and completed linking without errors.
- Ran the test binaries directly (`./build/tests-kernel-unit/source/tests/unit/genesys_test_simulator_runtime`, `./build/tests-kernel-unit/source/tests/unit/genesys_test_support_modelmanager`, and `./build/tests-kernel-unit/source/tests/unit/genesys_test_support_connectionmanager`) and all tests passed.
- No production source files were modified; only unit tests were added/updated to lock regressions in place.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d70bf487348321b3a18e000d74fb7a)