### PR TITLE
GUI: remove implicit heap ownership from ModelGraphicsScene component list API

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
@@ -507,13 +507,13 @@ void ModelGraphicsScene::startTextEditing() {
 
 // limpa todo o modelo
 void ModelGraphicsScene::clearGraphicalModelComponents() {
-    // Own and automatically release the temporary component list returned by the scene query.
-    auto componentsInModel = std::unique_ptr<QList<GraphicalModelComponent*>>(this->graphicalModelComponentItems());
+    // Get model components by value to avoid temporary heap ownership.
+    QList<GraphicalModelComponent*> componentsInModel = this->graphicalModelComponentItems();
     GraphicalModelComponent *source;
     GraphicalModelComponent *destination;
 
-    for (unsigned int x = 0; x < (unsigned int) componentsInModel->size(); x++){
-        GraphicalModelComponent *gmc = componentsInModel->at(x);
+    for (unsigned int x = 0; x < (unsigned int) componentsInModel.size(); x++){
+        GraphicalModelComponent *gmc = componentsInModel.at(x);
         removeComponentInModel(gmc);
     }
 
@@ -883,10 +883,10 @@ void ModelGraphicsScene::redoConnections(GraphicalModelComponent *graphicalCompo
 
 
 void ModelGraphicsScene::saveDataDefinitions() {
-    // Own and automatically release the temporary component list returned by the scene query.
-    auto components = std::unique_ptr<QList<GraphicalModelComponent*>>(this->graphicalModelComponentItems());
+    // Get model components by value to avoid temporary heap ownership.
+    QList<GraphicalModelComponent*> components = this->graphicalModelComponentItems();
 
-    for (GraphicalModelComponent* component : *components) {
+    for (GraphicalModelComponent* component : components) {
         component->verifyQueue();
 
         if (component->getInternalData()->empty() || component->getAttachedData()->empty()) {
@@ -921,13 +921,13 @@ void ModelGraphicsScene::saveDataDefinitions() {
 }
 
 void ModelGraphicsScene::insertRestoredDataDefinitions(bool loaded) {
-    // Own and automatically release the temporary component list returned by the scene query.
-    auto components = std::unique_ptr<QList<GraphicalModelComponent*>>(this->graphicalModelComponentItems());
+    // Get model components by value to avoid temporary heap ownership.
+    QList<GraphicalModelComponent*> components = this->graphicalModelComponentItems();
     QList<GraphicalModelComponent*> *allComponentes = this->getAllComponents();
 
     if (!allComponentes->empty()) {
         for (GraphicalModelComponent* component : *allComponentes) {
-            if (!components->contains(component)) {
+            if (!components.contains(component)) {
                 if (component->getEntityType() == nullptr) {
                     SourceModelComponent *isSrc = dynamic_cast<SourceModelComponent *>(component->getComponent());
 
@@ -941,8 +941,8 @@ void ModelGraphicsScene::insertRestoredDataDefinitions(bool loaded) {
         }
     }
 
-    if (!components->empty()) {
-        for (GraphicalModelComponent* component : *components) {
+    if (!components.empty()) {
+        for (GraphicalModelComponent* component : components) {
             for (ModelDataDefinition* dataInternal : *component->getInternalData()) {
                 _simulator->getModelManager()->current()->getDataManager()->insert(dataInternal);
             }
@@ -2709,12 +2709,13 @@ void ModelGraphicsScene::clearDrawingMode() {
     _drawingMode = ModelGraphicsScene::NONE;
     ((QGraphicsView*)this->parent())->setCursor(Qt::ArrowCursor);
 }
-QList<GraphicalModelComponent*>* ModelGraphicsScene::graphicalModelComponentItems(){
-    QList<GraphicalModelComponent*>* list = new QList<GraphicalModelComponent*>();
+// Build and return a temporary component list by value.
+QList<GraphicalModelComponent*> ModelGraphicsScene::graphicalModelComponentItems(){
+    QList<GraphicalModelComponent*> list;
     for(QGraphicsItem* item: this->items()) {
         GraphicalModelComponent* gmc = dynamic_cast<GraphicalModelComponent*>(item);
         if (gmc != nullptr) {
-            list->append(gmc);
+            list.append(gmc);
         }
     }
     return list;

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.h
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.h
@@ -136,7 +136,8 @@ public: // editing graphic model
     void ungroupComponents(bool notify = false);
     void ungroupModelComponents(QGraphicsItemGroup *group);
     void notifyGraphicalModelChange(GraphicalModelEvent::EventType eventType, GraphicalModelEvent::EventObjectType eventObjectType, QGraphicsItem *item);
-    QList<GraphicalModelComponent*>* graphicalModelComponentItems();
+    // Return model component items by value to avoid heap ownership transfer.
+    QList<GraphicalModelComponent*> graphicalModelComponentItems();
     GraphicalModelComponent* findGraphicalModelComponent(Util::identification id);
 public:
     struct GRID {


### PR DESCRIPTION
### Motivation
- Eliminate an API that returned a heap-allocated `QList<GraphicalModelComponent*>*` which transferred implicit ownership to callers and risked leaks. 
- Replace temporary heap allocations used for short-lived lists with automatic (stack) storage to make ownership explicit and safer. 

### Description
- Changed the declaration `QList<GraphicalModelComponent*>* graphicalModelComponentItems()` to `QList<GraphicalModelComponent*> graphicalModelComponentItems()` in `ModelGraphicsScene.h` and added a short English comment above the declaration. 
- Reimplemented `ModelGraphicsScene::graphicalModelComponentItems()` to build a local `QList<GraphicalModelComponent*>` and return it by value, removing the `new QList<...>` usage and adding a short English comment above the implementation. 
- Updated local callers in `ModelGraphicsScene.cpp` to use the returned list by value instead of owning pointers, specifically in `clearGraphicalModelComponents()`, `saveDataDefinitions()`, and `insertRestoredDataDefinitions()`, and added short English comments above each adjusted snippet. 
- Ensured `setCounters()` and `setVariables()` use automatic temporary `QList<ModelDataDefinition*>` constructed from the kernel container iterators (no `new`), preserving original logic and intent; limited changes to only the two target files. 

### Testing
- Verified code changes via repository inspection commands including `rg` and file previews to confirm signature, implementation, and caller updates succeeded. 
- Committed the changes locally (`git commit`) and confirmed the diff touched only `ModelGraphicsScene.h` and `ModelGraphicsScene.cpp`. 
- Attempted to build the GUI with `./build_qtgui.sh --config debug`, but the build could not run in this environment because `qmake` is not available in `PATH`, so no compile was performed in this runner. 
- No automated unit tests were executed in this environment; static/grep-based verification succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7126fd41083219efe61f14f6ca659)