### PR TITLE
GUI: initialize ModelGraphicsScene member pointers in-class

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.h
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.h
@@ -263,7 +263,8 @@ private:
     std::map<SimulationControl*, DataComponentEditor*>* _propertyEditorUI = nullptr;
     std::map<SimulationControl*, ComboBoxEnum*>* _propertyBox = nullptr;
     QTreeWidgetItem* _objectBeingDragged = nullptr;
-    QWidget* _parentWidget;
+    // Initialize the parent widget pointer to a known null state.
+    QWidget* _parentWidget = nullptr;
     QList<GraphicalModelComponent*> _allGraphicalModelComponents;
     QList<GraphicalConnection*> _allGraphicalConnections;
     QList<GraphicalModelDataDefinition*> _allGraphicalModelDataDefinitions;
@@ -288,11 +289,16 @@ private:
     unsigned short _connectingStep = 0; //0:nothing, 1:waiting click on source or destination, 2: click on source, 3: click on destination
     bool _controlIsPressed = false;
     bool _snapToGrid = false;
-    GraphicalComponentPort* _sourceGraphicalComponentPort;
-    GraphicalComponentPort* _destinationGraphicalComponentPort;
-    AnimationCounter *_currentCounter;
-    AnimationVariable *_currentVariable;
-    AnimationTimer *_currentTimer;
+    // Initialize the source port pointer before connection drawing starts.
+    GraphicalComponentPort* _sourceGraphicalComponentPort = nullptr;
+    // Initialize the destination port pointer before connection drawing starts.
+    GraphicalComponentPort* _destinationGraphicalComponentPort = nullptr;
+    // Initialize the current counter drawing pointer to avoid indeterminate access.
+    AnimationCounter *_currentCounter = nullptr;
+    // Initialize the current variable drawing pointer to avoid indeterminate access.
+    AnimationVariable *_currentVariable = nullptr;
+    // Initialize the current timer drawing pointer to avoid indeterminate access.
+    AnimationTimer *_currentTimer = nullptr;
     QMap<Event *, QList<AnimationTransition *> *> *_animationPaused = new QMap<Event *, QList<AnimationTransition *> *>();
 
 private:


### PR DESCRIPTION
### Motivation
- Ensure deterministic initial state for `ModelGraphicsScene` by explicitly initializing several member pointer fields to `nullptr` to remove lifecycle/order dependencies.

### Description
- Add in-class `nullptr` initialization and short English comments above each declaration for `_parentWidget`, `_sourceGraphicalComponentPort`, `_destinationGraphicalComponentPort`, `_currentCounter`, `_currentVariable`, and `_currentTimer` in `source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.h` and do not modify other logic or files.

### Testing
- Attempted to build the GUI with `./build_qtgui.sh --config Debug`, which failed because `qmake` is not available in the environment (`qmake not found`), so no compile or runtime tests could be performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d71ef1cc20832195213ce6d0ba5565)