### PR TITLE
[KERNEL/TESTS] Add lifecycle coverage for multi-child internal data and response-registered owned property

### DIFF
--- a/source/tests/unit/test_simulator_runtime.cpp
+++ b/source/tests/unit/test_simulator_runtime.cpp
@@ -322,6 +322,26 @@ TEST(SimulatorRuntimeTest, ModelDataDefinitionDestructorDeletesOwnedInternalData
     EXPECT_EQ(g_countingChildProbeDestructorCount, 1u);
 }
 
+TEST(SimulatorRuntimeTest, ModelDataDefinitionDestructorDeletesMultipleOwnedInternalDataChildren) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    g_countingChildProbeDestructorCount = 0;
+
+    auto* owner = new LifecycleModelDataDefinitionProbe(model, "OwnerWithMultipleChildren");
+    auto* childA = new CountingChildDataDefinitionProbe(model, "OwnedChildA");
+    auto* childB = new CountingChildDataDefinitionProbe(model, "OwnedChildB");
+
+    // Declares two owned internal data children so owner teardown must delete both instances.
+    owner->AttachInternalData("childA", childA);
+    owner->AttachInternalData("childB", childB);
+
+    delete owner;
+
+    EXPECT_EQ(g_countingChildProbeDestructorCount, 2u);
+}
+
 TEST(SimulatorRuntimeTest, ModelDataDefinitionDestructorDoesNotDeleteAttachedDataTarget) {
     Simulator simulator;
     Model* model = simulator.getModelManager()->newModel();
@@ -338,4 +358,33 @@ TEST(SimulatorRuntimeTest, ModelDataDefinitionDestructorDoesNotDeleteAttachedDat
     EXPECT_NE(model->getDataManager()->getDataDefinition("LifecycleModelDataDefinitionProbe", "AttachedTarget"), nullptr);
 
     delete attached;
+}
+
+TEST(SimulatorRuntimeTest, ModelDataDefinitionDestructorRemovesOwnedPropertyAlsoRegisteredAsResponse) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    g_countingControlProbeDestructorCount = 0;
+    const unsigned int controlsBefore = model->getControls()->size();
+    const unsigned int responsesBefore = model->getResponses()->size();
+
+    auto* owner = new LifecycleModelDataDefinitionProbe(model, "OwnerControlAndResponse");
+    const unsigned int controlsAfterOwnerConstruction = model->getControls()->size();
+    const unsigned int responsesAfterOwnerConstruction = model->getResponses()->size();
+
+    auto* ownedProperty = new CountingSimulationControlProbe(owner->getName(), "OwnedControlAndResponse");
+    // Registers the same owned property in controls and responses so destructor cleanup must remove both references.
+    model->getControls()->insert(ownedProperty);
+    model->getResponses()->insert(static_cast<SimulationResponse*>(ownedProperty));
+    owner->AttachOwnedProperty(ownedProperty);
+
+    EXPECT_EQ(model->getControls()->size(), controlsAfterOwnerConstruction + 1);
+    EXPECT_EQ(model->getResponses()->size(), responsesAfterOwnerConstruction + 1);
+
+    delete owner;
+
+    EXPECT_EQ(model->getControls()->size(), controlsBefore);
+    EXPECT_EQ(model->getResponses()->size(), responsesBefore);
+    EXPECT_EQ(g_countingControlProbeDestructorCount, 1u);
 }


### PR DESCRIPTION
### Motivation
- Close two remaining lifecycle coverage gaps in `ModelDataDefinition`: multiple owned children in `_internalData` and an owned property also registered in `model->getResponses()`.
- Keep changes minimal and restricted to unit tests to avoid touching production code and prevent regressions.
- Reuse existing test doubles and infrastructure already present in `test_simulator_runtime.cpp` to keep tests small and focused.

### Description
- Added test `ModelDataDefinitionDestructorDeletesMultipleOwnedInternalDataChildren` which creates an owner and two owned internal children, attaches both under different keys, deletes the owner and expects both children to be destroyed.
- Added test `ModelDataDefinitionDestructorRemovesOwnedPropertyAlsoRegisteredAsResponse` which registers an owned `CountingSimulationControlProbe` in both `model->getControls()` and `model->getResponses()`, attaches it to an owner, deletes the owner and asserts both collections are restored and the property is destroyed exactly once.
- All changes made in a single test file: `source/tests/unit/test_simulator_runtime.cpp`, with short technical comments immediately above the altered logical blocks as required by style rules.
- No production files were modified; tests reuse `CountingSimulationControlProbe`, `LifecycleModelDataDefinitionProbe`, and `CountingChildDataDefinitionProbe` already present in the test suite.

### Testing
- Configured and generated build files with `cmake -S . -B build` successfully.
- Built the specific test target with `cmake --build build --target genesys_test_simulator_runtime -j4` successfully.
- Ran the test binary `./build/source/tests/unit/genesys_test_simulator_runtime` and observed: 17 tests run, 17 passed, 0 failed (including the two new tests).
- The new tests exercise destructor cleanup semantics for multiple internal children and for an owned property that is also present in the model responses collection.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d72110b2508321a1ef468d62ef01b5)