### PR TITLE
TOOLS/FITTER-3: promote default Fitter trait binding to FitterDefaultImpl

### DIFF
--- a/source/tools/ARCHITECTURE_tools.md
+++ b/source/tools/ARCHITECTURE_tools.md
@@ -21,7 +21,7 @@ The `tools` package provides domain-support services for statistical analysis an
 
 ### Fitting
 - Preserve legacy fitting API.
-- Transition from dummy implementation to a concrete default implementation in phased manner (FITTER-1 delivered baseline behavior, and FITTER-2 added functional Beta and Weibull fitting in `FitterDefaultImpl`, still without changing default trait binding).
+- Transition from dummy implementation to a concrete default implementation in phased manner (FITTER-1 delivered baseline behavior, FITTER-2 added functional Beta and Weibull fitting in `FitterDefaultImpl`, and FITTER-3 promotes `TraitsTools<Fitter_if>` to `FitterDefaultImpl`).
 
 ### Hypothesis testing
 - Maintain current contract and refine implementation completeness, especially two-population methods.
@@ -44,7 +44,7 @@ The `tools` package provides domain-support services for statistical analysis an
 ## 4. Legacy compatibility strategy
 
 - Do not break existing public signatures in this phase.
-- Preserve current trait selections to avoid runtime and build regressions.
+- Preserve compatibility by keeping legacy classes available while promoting only validated trait selections.
 - Add new abstractions as header-only contracts until implementations are mature.
 
 ## 5. Planned migration order
@@ -57,7 +57,8 @@ The `tools` package provides domain-support services for statistical analysis an
 
 ## 6. Stability notes and non-goals for this phase
 
-- FITTER-2 consolidates additional fitting algorithms in `FitterDefaultImpl` (beta and weibull) on top of FITTER-1 families, while keeping trait defaults unchanged (`TraitsTools<Fitter_if>` still points to `FitterDummyImpl`).
+- FITTER-2 consolidated additional fitting algorithms in `FitterDefaultImpl` (beta and weibull) on top of FITTER-1 families; FITTER-3 now switches the default trait binding so `TraitsTools<Fitter_if>` points to `FitterDefaultImpl`.
+- `FitterDummyImpl` is intentionally preserved as a legacy/documental placeholder and is no longer the default fitter binding.
 - No full completion of hypothesis-testing theory coverage.
 - No numerical refactor of legacy solver internals.
 - No cross-package behavior changes outside `source/tools`.

--- a/source/tools/README_tools.md
+++ b/source/tools/README_tools.md
@@ -16,7 +16,7 @@ The `source/tools` package hosts statistical and numerical support abstractions 
 ## 3. Current limitations
 
 - Fitting baseline was expanded in FITTER-2: `FitterDefaultImpl` now also provides functional Beta (scaled) and Weibull fitting, still preserving controlled-failure behavior when constraints are not met.
-- Traits still keep `FitterDummyImpl` as the default binding in this phase for compatibility.
+- `FitterDummyImpl` is preserved as a legacy placeholder/documental implementation, but it is no longer the default trait binding after FITTER-3.
 - Some hypothesis-testing paths, especially two-population paths, remain partially consolidated.
 - Distribution APIs are static utilities, not yet an OO hierarchy with reusable distribution objects.
 - Solver abstraction conflates quadrature and ODE-like concerns.
@@ -24,7 +24,7 @@ The `source/tools` package hosts statistical and numerical support abstractions 
 ## 4. Planned evolution
 
 - Introduce cohesive interfaces for dataset, distributions, quadrature, root finding, and ODE solving.
-- Promote `FitterDefaultImpl` from structural placeholder to complete fitting implementation.
+- Continue hardening `FitterDefaultImpl` as the promoted default fitting implementation.
 - Evolve traits coverage to include newly stabilized abstractions.
 - Keep legacy interfaces during migration to avoid behavior breaks.
 
@@ -34,7 +34,7 @@ The `source/tools` package hosts statistical and numerical support abstractions 
 
 ## 6. Current status by topic
 
-- **Fitting**: interface defined; `FitterDefaultImpl` is functional for uniform/triangular/normal/exponential/erlang/beta/weibull with binary dataset loading and SSE-CDF comparison, but production trait binding remains on `FitterDummyImpl`.
+- **Fitting**: interface defined; `FitterDefaultImpl` is functional for uniform/triangular/normal/exponential/erlang/beta/weibull with binary dataset loading and SSE-CDF comparison and is now the default `TraitsTools<Fitter_if>` binding (FITTER-3). `FitterDummyImpl` remains available as legacy placeholder.
 - **Hypothesis testing**: functional baseline exists in `HypothesisTesterDefaultImpl1`, with known partial areas.
 - **Probability distributions**: mathematical static base and inverse façade available, with internal numeric dependencies.
 - **Numerical solvers**: legacy `Solver_if` + `SolverDefaultImpl1` remain the compatible baseline.

--- a/source/tools/TraitsTools.h
+++ b/source/tools/TraitsTools.h
@@ -17,7 +17,7 @@
 #include "SolverDefaultImpl1.h"
 #include "HypothesisTesterDefaultImpl1.h"
 #include "HypothesisTester_if.h"
-#include "FitterDummyImpl.h"
+#include "FitterDefaultImpl.h"
 #include "Fitter_if.h"
 
 /**
@@ -59,7 +59,7 @@ template <> struct TraitsTools<HypothesisTester_if> {
  *  Configure the Fitter to be used
  */
 template <> struct TraitsTools<Fitter_if> {
-	typedef FitterDummyImpl Implementation;
+	typedef FitterDefaultImpl Implementation;
 };
 
 #endif /* TRAITSTOOLS_H */


### PR DESCRIPTION
### Motivation
- Promote the functional fitter implementation so trait-based consumers obtain the working `FitterDefaultImpl` instead of the legacy stub. 
- Preserve `FitterDummyImpl` as a documented legacy placeholder to keep binary/source compatibility. 
- Keep the change strictly local to the `source/tools` package and avoid cross-package or build-system modifications. 

### Description
- Updated `source/tools/TraitsTools.h` to include `FitterDefaultImpl.h` and changed `TraitsTools<Fitter_if>::Implementation` from `FitterDummyImpl` to `FitterDefaultImpl`. 
- Kept `FitterDummyImpl` sources unchanged and available under `source/tools` as a preserved legacy class. 
- Modified `source/tools/README_tools.md` and `source/tools/ARCHITECTURE_tools.md` to document that `FitterDefaultImpl` is now the default binding and that `FitterDummyImpl` remains as a legacy/documental placeholder. 
- All edits were confined to `source/tools` and are limited to small include/typedef and documentation updates. 

### Testing
- Ran repository checks with `git status --short --branch` and `git diff --name-only` to verify the working tree and changed files, which succeeded. 
- Compiled a minimal translation unit that `#include`s `source/tools/TraitsTools.h` and instantiates `TraitsTools<Fitter_if>::Implementation` while calling `setDataFilename` and `getDataFilename`, which compiled successfully with `g++`. 
- Built and ran a temporary functional driver that generated a binary `double` datafile and exercised `fitNormal` and `fitAll` via the trait-instantiated fitter by linking `source/tools/ProbabilityDistributionBase.cpp` and `source/tools/SolverDefaultImpl1.cpp`; the run completed successfully and printed `impl_type` showing the promoted `FitterDefaultImpl` and returned a `fitAll` result (`name=normal`). 
- All automated compilation and execution checks reported success for the minimal validations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d721af059883218354e23fa748fc70)