### PR TITLE
Fix ASan UAF in List::remove and add Simulator dtor to satisfy RTTI in support tests

### DIFF
--- a/source/kernel/util/List.h
+++ b/source/kernel/util/List.h
@@ -176,10 +176,9 @@ void List<T>::pop_front() {
 
 template <typename T>
 void List<T>::remove(T element) {
+	// Reset the internal cursor after erasure to avoid dereferencing a stale iterator during recursive removals.
 	_list->remove(element);
-	if ((*_it) == element) { /*  @TODO: +: check this */
-		_it = _list->begin(); // if it points to the removed modeldatum, then changes to begin
-	}
+	_it = _list->begin();
 }
 
 template <typename T>

--- a/source/tests/unit/test_support_modelmanager.cpp
+++ b/source/tests/unit/test_support_modelmanager.cpp
@@ -4,6 +4,9 @@
 #include "kernel/simulator/Simulator.h"
 #include "kernel/simulator/TraceManager.h"
 
+// Provide an out-of-line virtual destructor definition so RTTI symbols are available when linking support-only tests.
+Simulator::~Simulator() = default;
+
 TraceManager* Simulator::getTraceManager() const {
     return nullptr;
 }


### PR DESCRIPTION
### Motivation
- Address an AddressSanitizer-detected heap-use-after-free in `List<T>::remove` that caused crashes during kernel unit tests.
- Resolve a linker/RTTI failure when building the support-only `genesys_test_support_modelmanager` test under sanitizer builds by providing a minimal out-of-line `Simulator` destructor.

### Description
- Reset the internal cursor safely after element erasure in `source/kernel/util/List.h` to avoid dereferencing a stale iterator during recursive/multi-step removals, with a short English comment placed immediately above the changed block.
- Add an out-of-line `Simulator::~Simulator() = default;` in `source/tests/unit/test_support_modelmanager.cpp` to materialize RTTI/typeinfo/vtable symbols needed by the support test binary, with a short English comment above that addition.
- Changes are intentionally minimal and limited to the test/kernel scope permitted by the validation step; no GUI, namespace, or broad refactors were performed.

### Testing
- Configured and built with `tests-kernel-unit`, `asan`, and `ubsan` presets using the repository's presets and Ninja generator.
- Built targets: `genesys_test_simulator_runtime`, `genesys_test_support_modelmanager`, `genesys_test_support_connectionmanager`.
- Normal build: all three binaries built and executed successfully; `genesys_test_simulator_runtime` passed `17/17`, `genesys_test_support_modelmanager` passed `5/5`, `genesys_test_support_connectionmanager` passed `6/6`.
- ASan build: compilation succeeded; the original UAF on `List.h` no longer occurs during `genesys_test_simulator_runtime` execution; however, LeakSanitizer reports kernel/plugin registration leaks remain under ASan default leak detection.
- ASan runtime workaround: `ASAN_OPTIONS=detect_leaks=0 ./build/asan/source/tests/unit/genesys_test_simulator_runtime` runs and all tests pass functionally after the UAF fix.
- UBSan build and execution: all three priority binaries built and ran successfully with no UBSan reports.

Files changed:
- `source/kernel/util/List.h` (reset internal iterator after removal; added short English comment above changed block)
- `source/tests/unit/test_support_modelmanager.cpp` (added `Simulator::~Simulator() = default;` and short English comment)

Notes and next steps:
- The UAF was remediated with a minimal, safe change; LeakSanitizer output in the runtime target indicates remaining lifecycle/leak issues (plugin/registration paths) that require a focused follow-up phase.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7262c0d308321bf65bdcf5ce96f9d)