### PR TITLE
Handle invalid probability parameters as recoverable errors

### DIFF
--- a/source/kernel/simulator/ParserDefaultImpl2.cpp
+++ b/source/kernel/simulator/ParserDefaultImpl2.cpp
@@ -12,6 +12,7 @@
  */
 
 #include "ParserDefaultImpl2.h"
+#include <exception>
 
 //using namespace GenesysKernel;
 
@@ -27,10 +28,28 @@ double ParserDefaultImpl2::parse(const std::string expression) { // may throw ex
 		if (res == 0) {
 			return _wrapper.getResult();
 		} else {
-			throw std::string("Error parsing expression \"" + expression + "\"");
+			std::string msg = _wrapper.getErrorMessage();
+			if (msg.empty()) {
+				msg = "Error parsing expression \"" + expression + "\"";
+			}
+			throw std::string(msg);
 		}
-	} catch (std::string e) {
+	} catch (const std::string& e) {
 		_model->getTracer()->traceError(e);
+		return _wrapper.getResult();
+	} catch (const std::exception& e) {
+		std::string msg = _wrapper.getErrorMessage();
+		if (msg.empty()) {
+			msg = e.what();
+		}
+		_model->getTracer()->traceError(msg);
+		return _wrapper.getResult();
+	} catch (...) {
+		std::string msg = _wrapper.getErrorMessage();
+		if (msg.empty()) {
+			msg = "Unknown parser error";
+		}
+		_model->getTracer()->traceError(msg);
 		return _wrapper.getResult();
 	}
 }
@@ -45,7 +64,14 @@ double ParserDefaultImpl2::parse(const std::string expression, bool& success, st
 	int res = -1;
 	try {
 		res = _wrapper.parse_str(expression);
+	} catch (const std::string& e) {
+		errorMessage = !_wrapper.getErrorMessage().empty() ? _wrapper.getErrorMessage() : e;
+		res = -1;
+	} catch (const std::exception& e) {
+		errorMessage = !_wrapper.getErrorMessage().empty() ? _wrapper.getErrorMessage() : std::string(e.what());
+		res = -1;
 	} catch (...) {
+		errorMessage = !_wrapper.getErrorMessage().empty() ? _wrapper.getErrorMessage() : "Unknown parser error";
 		res = -1;
 	}
 	if (res == 0) {
@@ -53,7 +79,12 @@ double ParserDefaultImpl2::parse(const std::string expression, bool& success, st
 		return _wrapper.getResult();
 	} else {
         success = false;
-        errorMessage = _wrapper.getErrorMessage();
+        if (errorMessage.empty()) {
+        	errorMessage = _wrapper.getErrorMessage();
+        }
+        if (errorMessage.empty()) {
+        	errorMessage = "Error parsing expression \"" + expression + "\"";
+        }
 		return _wrapper.getResult();
 	}
 }

--- a/source/kernel/statistics/SamplerDefaultImpl1.cpp
+++ b/source/kernel/statistics/SamplerDefaultImpl1.cpp
@@ -16,6 +16,7 @@
 #include <cmath>
 #include <complex>
 #include <random>
+#include <stdexcept>
 
 #include "SamplerDefaultImpl1.h"
 
@@ -87,17 +88,23 @@ double SamplerDefaultImpl1::random() {
 }
 
 double SamplerDefaultImpl1::sampleUniform(double min, double max) {
-	assert(min <= max);
+	if (min > max) {
+		throw std::invalid_argument("unif requires min <= max");
+	}
 	return min + (max - min) * random();
 }
 
 double SamplerDefaultImpl1::sampleExponential(double mean, double offset) {
-	assert(mean >= 0.0);
+	if (mean < 0.0) {
+		throw std::invalid_argument("expo requires mean >= 0");
+	}
 	return offset + mean * (-std::log(randomOpen01(*this)));
 }
 
 double SamplerDefaultImpl1::sampleErlang(double mean, int M, double offset) {
-	assert((mean >= 0.0) && (M > 0));
+	if (mean < 0.0 || M <= 0) {
+		throw std::invalid_argument("erla requires mean >= 0 and M > 0");
+	}
 	double P = 1.0;
 	for (int i = 0; i < M; i++) {
 		P *= randomOpen01(*this);
@@ -106,7 +113,9 @@ double SamplerDefaultImpl1::sampleErlang(double mean, int M, double offset) {
 }
 
 double SamplerDefaultImpl1::sampleNormal(double mean, double stddev) {
-	assert(stddev >= 0.0);
+	if (stddev < 0.0) {
+		throw std::invalid_argument("norm requires stddev >= 0");
+	}
 	double z;
 	if (_normalflag) {
 		z = _lastnormal;
@@ -123,15 +132,21 @@ double SamplerDefaultImpl1::sampleNormal(double mean, double stddev) {
 }
 
 double SamplerDefaultImpl1::sampleLogNormal(double mean, double stddev, double offset) {
-	assert(mean > 0.0);
-	assert(stddev >= 0.0);
+	if (mean <= 0.0) {
+		throw std::invalid_argument("logn requires mean > 0");
+	}
+	if (stddev < 0.0) {
+		throw std::invalid_argument("logn requires stddev >= 0");
+	}
 	const double dispersionNorm = std::log((stddev * stddev) / (mean * mean) + 1.0);
 	const double meanNorm = std::log(mean) - 0.5 * dispersionNorm;
 	return offset + std::exp(sampleNormal(meanNorm, std::sqrt(dispersionNorm)));
 }
 
 double SamplerDefaultImpl1::sampleTriangular(double min, double mode, double max) {
-	assert(!((min > mode) || (max < mode) || (min > max)));
+	if ((min > mode) || (max < mode) || (min > max)) {
+		throw std::invalid_argument("tria requires min <= mode <= max");
+	}
 	const double part1 = mode - min;
 	const double part2 = max - mode;
 	const double full = max - min;
@@ -217,8 +232,9 @@ double SamplerDefaultImpl1::sampleGamma(double mean, double alpha) {
  */
 
 double SamplerDefaultImpl1::sampleGamma(double alpha, double beta, double offset) {
-	assert(alpha > 0.0);
-	assert(beta > 0.0);
+	if (alpha <= 0.0 || beta <= 0.0) {
+		throw std::invalid_argument("gamm requires alpha > 0 and beta > 0");
+	}
 
 	if (alpha < 1.0) {
 		const double g = sampleGamma(alpha + 1.0, beta);
@@ -250,13 +266,20 @@ double SamplerDefaultImpl1::sampleGamma(double alpha, double beta, double offset
 }
 
 double SamplerDefaultImpl1::sampleBeta(double alpha, double beta, double infLimit, double supLimit) {
-	assert(infLimit <= supLimit);
+	if (alpha <= 0.0 || beta <= 0.0) {
+		throw std::invalid_argument("beta requires alpha > 0 and beta > 0");
+	}
+	if (infLimit > supLimit) {
+		throw std::invalid_argument("beta requires infLimit <= supLimit");
+	}
 	double X = sampleBeta(alpha, beta);
 	return infLimit + (supLimit - infLimit) * X;
 }
 
 double SamplerDefaultImpl1::sampleWeibull(double alpha, double scale) {
-	assert(!((alpha <= 0.0) || (scale <= 0.0)));
+	if ((alpha <= 0.0) || (scale <= 0.0)) {
+		throw std::invalid_argument("weib requires alpha > 0 and scale > 0");
+	}
 	return std::exp(std::log(scale * (-std::log(randomOpen01(*this)))) / alpha);
 }
 
@@ -298,8 +321,9 @@ double SamplerDefaultImpl1::sampleGumbell(double mode, double scale) {
 }
 
 double SamplerDefaultImpl1::sampleBeta(double alpha, double beta) {
-	assert(alpha > 0.0);
-	assert(beta > 0.0);
+	if (alpha <= 0.0 || beta <= 0.0) {
+		throw std::invalid_argument("beta requires alpha > 0 and beta > 0");
+	}
 	const double x = sampleGamma(alpha, 1.0);
 	const double y = sampleGamma(beta, 1.0);
 	return x / (x + y);

--- a/source/parser/Genesys++-driver.cpp
+++ b/source/parser/Genesys++-driver.cpp
@@ -1,4 +1,5 @@
 #include <string>
+#include <exception>
 #include "Genesys++-driver.h"
 //#include "../Traits.h"
 
@@ -37,7 +38,36 @@ int genesyspp_driver::parse_file(const std::string &f) {
 	setErrorMessage("");
 	scan_begin_file();
 	yy::genesyspp_parser parser(*this);
-	int res = parser.parse();
+	int res = -1;
+	try {
+		res = parser.parse();
+	} catch (const std::string& e) {
+		setErrorMessage(e);
+		setResult(-1);
+		scan_end_file();
+		if (throwsException) {
+			throw std::string(e);
+		}
+		return res;
+	} catch (const std::exception& e) {
+		const std::string message = e.what();
+		setErrorMessage(message);
+		setResult(-1);
+		scan_end_file();
+		if (throwsException) {
+			throw std::string(message);
+		}
+		return res;
+	} catch (...) {
+		const std::string message = "Unknown parser error";
+		setErrorMessage(message);
+		setResult(-1);
+		scan_end_file();
+		if (throwsException) {
+			throw std::string(message);
+		}
+		return res;
+	}
 	scan_end_file();
 	return res;
 }
@@ -48,7 +78,36 @@ int genesyspp_driver::parse_str(const std::string &str) {
 	setErrorMessage("");
 	scan_begin_str();
 	yy::genesyspp_parser parser(*this);
-	int res = parser.parse();
+	int res = -1;
+	try {
+		res = parser.parse();
+	} catch (const std::string& e) {
+		setErrorMessage(e);
+		setResult(-1);
+		scan_end_str();
+		if (throwsException) {
+			throw std::string(e);
+		}
+		return res;
+	} catch (const std::exception& e) {
+		const std::string message = e.what();
+		setErrorMessage(message);
+		setResult(-1);
+		scan_end_str();
+		if (throwsException) {
+			throw std::string(message);
+		}
+		return res;
+	} catch (...) {
+		const std::string message = "Unknown parser error";
+		setErrorMessage(message);
+		setResult(-1);
+		scan_end_str();
+		if (throwsException) {
+			throw std::string(message);
+		}
+		return res;
+	}
 	scan_end_str();
 	return res;
 }

--- a/source/parser/parserBisonFlex/bisonparser.yy
+++ b/source/parser/parserBisonFlex/bisonparser.yy
@@ -61,6 +61,20 @@
 %code
 {
 # include "Genesys++-driver.h"
+# include <exception>
+
+namespace {
+
+std::string buildProbError(const std::string& functionName, const std::string& details) {
+	return std::string("Error evaluating ") + functionName + ": " + details;
+}
+
+void failProbFunction(genesyspp_driver& driver, const std::string& message) {
+	driver.setErrorMessage(message);
+	driver.setResult(-1);
+}
+
+}
 
 }
 
@@ -401,16 +415,196 @@ mathFunction:
     ;
 
 probFunction:
-	  fRND1					     { $$.valor = driver.getSampler()->sampleUniform(0.0,1.0);}
-	| fEXPO  "(" expression ")"  { $$.valor = driver.getSampler()->sampleExponential($3.valor);}
-	| fNORM  "(" expression "," expression ")"  { $$.valor = driver.getSampler()->sampleNormal($3.valor,$5.valor);}
-	| fUNIF  "(" expression "," expression ")"  { $$.valor = driver.getSampler()->sampleUniform($3.valor,$5.valor);}
-	| fWEIB  "(" expression "," expression ")"  { $$.valor = driver.getSampler()->sampleWeibull($3.valor,$5.valor);}
-	| fLOGN  "(" expression "," expression ")"  { $$.valor = driver.getSampler()->sampleLogNormal($3.valor,$5.valor);}
-	| fGAMM  "(" expression "," expression ")"  { $$.valor = driver.getSampler()->sampleGamma($3.valor,$5.valor);}
-	| fERLA  "(" expression "," expression ")"  { $$.valor = driver.getSampler()->sampleErlang($3.valor,$5.valor);}
-	| fTRIA  "(" expression "," expression "," expression ")"   { $$.valor = driver.getSampler()->sampleTriangular($3.valor,$5.valor,$7.valor);}
-	| fBETA  "(" expression "," expression "," expression "," expression ")"  { $$.valor = driver.getSampler()->sampleBeta($3.valor,$5.valor,$7.valor,$9.valor);}
+	  fRND1					     {
+		try { $$.valor = driver.getSampler()->sampleUniform(0.0,1.0); }
+		catch (const std::exception& e) {
+			std::string msg = buildProbError("rnd", e.what());
+			failProbFunction(driver, msg);
+			if (driver.getThrowsException()) throw std::string(msg);
+			YYERROR;
+		} catch (const std::string& e) {
+			std::string msg = buildProbError("rnd", e);
+			failProbFunction(driver, msg);
+			if (driver.getThrowsException()) throw std::string(msg);
+			YYERROR;
+		} catch (...) {
+			std::string msg = "Error evaluating rnd: unknown error";
+			failProbFunction(driver, msg);
+			if (driver.getThrowsException()) throw std::string(msg);
+			YYERROR;
+		}
+	}
+	| fEXPO  "(" expression ")"  {
+		try { $$.valor = driver.getSampler()->sampleExponential($3.valor); }
+		catch (const std::exception& e) {
+			std::string msg = buildProbError("expo", e.what());
+			failProbFunction(driver, msg);
+			if (driver.getThrowsException()) throw std::string(msg);
+			YYERROR;
+		} catch (const std::string& e) {
+			std::string msg = buildProbError("expo", e);
+			failProbFunction(driver, msg);
+			if (driver.getThrowsException()) throw std::string(msg);
+			YYERROR;
+		} catch (...) {
+			std::string msg = "Error evaluating expo: unknown error";
+			failProbFunction(driver, msg);
+			if (driver.getThrowsException()) throw std::string(msg);
+			YYERROR;
+		}
+	}
+	| fNORM  "(" expression "," expression ")"  {
+		try { $$.valor = driver.getSampler()->sampleNormal($3.valor,$5.valor); }
+		catch (const std::exception& e) {
+			std::string msg = buildProbError("norm", e.what());
+			failProbFunction(driver, msg);
+			if (driver.getThrowsException()) throw std::string(msg);
+			YYERROR;
+		} catch (const std::string& e) {
+			std::string msg = buildProbError("norm", e);
+			failProbFunction(driver, msg);
+			if (driver.getThrowsException()) throw std::string(msg);
+			YYERROR;
+		} catch (...) {
+			std::string msg = "Error evaluating norm: unknown error";
+			failProbFunction(driver, msg);
+			if (driver.getThrowsException()) throw std::string(msg);
+			YYERROR;
+		}
+	}
+	| fUNIF  "(" expression "," expression ")"  {
+		try { $$.valor = driver.getSampler()->sampleUniform($3.valor,$5.valor); }
+		catch (const std::exception& e) {
+			std::string msg = buildProbError("unif", e.what());
+			failProbFunction(driver, msg);
+			if (driver.getThrowsException()) throw std::string(msg);
+			YYERROR;
+		} catch (const std::string& e) {
+			std::string msg = buildProbError("unif", e);
+			failProbFunction(driver, msg);
+			if (driver.getThrowsException()) throw std::string(msg);
+			YYERROR;
+		} catch (...) {
+			std::string msg = "Error evaluating unif: unknown error";
+			failProbFunction(driver, msg);
+			if (driver.getThrowsException()) throw std::string(msg);
+			YYERROR;
+		}
+	}
+	| fWEIB  "(" expression "," expression ")"  {
+		try { $$.valor = driver.getSampler()->sampleWeibull($3.valor,$5.valor); }
+		catch (const std::exception& e) {
+			std::string msg = buildProbError("weib", e.what());
+			failProbFunction(driver, msg);
+			if (driver.getThrowsException()) throw std::string(msg);
+			YYERROR;
+		} catch (const std::string& e) {
+			std::string msg = buildProbError("weib", e);
+			failProbFunction(driver, msg);
+			if (driver.getThrowsException()) throw std::string(msg);
+			YYERROR;
+		} catch (...) {
+			std::string msg = "Error evaluating weib: unknown error";
+			failProbFunction(driver, msg);
+			if (driver.getThrowsException()) throw std::string(msg);
+			YYERROR;
+		}
+	}
+	| fLOGN  "(" expression "," expression ")"  {
+		try { $$.valor = driver.getSampler()->sampleLogNormal($3.valor,$5.valor); }
+		catch (const std::exception& e) {
+			std::string msg = buildProbError("logn", e.what());
+			failProbFunction(driver, msg);
+			if (driver.getThrowsException()) throw std::string(msg);
+			YYERROR;
+		} catch (const std::string& e) {
+			std::string msg = buildProbError("logn", e);
+			failProbFunction(driver, msg);
+			if (driver.getThrowsException()) throw std::string(msg);
+			YYERROR;
+		} catch (...) {
+			std::string msg = "Error evaluating logn: unknown error";
+			failProbFunction(driver, msg);
+			if (driver.getThrowsException()) throw std::string(msg);
+			YYERROR;
+		}
+	}
+	| fGAMM  "(" expression "," expression ")"  {
+		try { $$.valor = driver.getSampler()->sampleGamma($3.valor,$5.valor); }
+		catch (const std::exception& e) {
+			std::string msg = buildProbError("gamm", e.what());
+			failProbFunction(driver, msg);
+			if (driver.getThrowsException()) throw std::string(msg);
+			YYERROR;
+		} catch (const std::string& e) {
+			std::string msg = buildProbError("gamm", e);
+			failProbFunction(driver, msg);
+			if (driver.getThrowsException()) throw std::string(msg);
+			YYERROR;
+		} catch (...) {
+			std::string msg = "Error evaluating gamm: unknown error";
+			failProbFunction(driver, msg);
+			if (driver.getThrowsException()) throw std::string(msg);
+			YYERROR;
+		}
+	}
+	| fERLA  "(" expression "," expression ")"  {
+		try { $$.valor = driver.getSampler()->sampleErlang($3.valor,$5.valor); }
+		catch (const std::exception& e) {
+			std::string msg = buildProbError("erla", e.what());
+			failProbFunction(driver, msg);
+			if (driver.getThrowsException()) throw std::string(msg);
+			YYERROR;
+		} catch (const std::string& e) {
+			std::string msg = buildProbError("erla", e);
+			failProbFunction(driver, msg);
+			if (driver.getThrowsException()) throw std::string(msg);
+			YYERROR;
+		} catch (...) {
+			std::string msg = "Error evaluating erla: unknown error";
+			failProbFunction(driver, msg);
+			if (driver.getThrowsException()) throw std::string(msg);
+			YYERROR;
+		}
+	}
+	| fTRIA  "(" expression "," expression "," expression ")"   {
+		try { $$.valor = driver.getSampler()->sampleTriangular($3.valor,$5.valor,$7.valor); }
+		catch (const std::exception& e) {
+			std::string msg = buildProbError("tria", e.what());
+			failProbFunction(driver, msg);
+			if (driver.getThrowsException()) throw std::string(msg);
+			YYERROR;
+		} catch (const std::string& e) {
+			std::string msg = buildProbError("tria", e);
+			failProbFunction(driver, msg);
+			if (driver.getThrowsException()) throw std::string(msg);
+			YYERROR;
+		} catch (...) {
+			std::string msg = "Error evaluating tria: unknown error";
+			failProbFunction(driver, msg);
+			if (driver.getThrowsException()) throw std::string(msg);
+			YYERROR;
+		}
+	}
+	| fBETA  "(" expression "," expression "," expression "," expression ")"  {
+		try { $$.valor = driver.getSampler()->sampleBeta($3.valor,$5.valor,$7.valor,$9.valor); }
+		catch (const std::exception& e) {
+			std::string msg = buildProbError("beta", e.what());
+			failProbFunction(driver, msg);
+			if (driver.getThrowsException()) throw std::string(msg);
+			YYERROR;
+		} catch (const std::string& e) {
+			std::string msg = buildProbError("beta", e);
+			failProbFunction(driver, msg);
+			if (driver.getThrowsException()) throw std::string(msg);
+			YYERROR;
+		} catch (...) {
+			std::string msg = "Error evaluating beta: unknown error";
+			failProbFunction(driver, msg);
+			if (driver.getThrowsException()) throw std::string(msg);
+			YYERROR;
+		}
+	}
 	| fDISC  "(" listaparm ")"                  { $$.valor = driver.getSampler()->sampleDiscrete(0,0); /*@TODO: NOT IMPLEMENTED YET*/ }
     ;
 


### PR DESCRIPTION
### Motivation
- Prevent simulator crashes caused by user-supplied invalid parameters to probabilistic functions (e.g. `unif(1,0.8)`, `tria(3,2,1)`, `weib(-1,2)`), converting fatal `assert` aborts into recoverable errors.
- Apply the chosen Alternative A: validate in the sampler, translate/capture in the parser, and contain in the driver/wrapper so callers always receive a useful error message.

### Description
- Replaced user-input `assert(...)` checks with runtime validation that throws `std::invalid_argument` and short technical messages in `SamplerDefaultImpl1` for these functions: `sampleUniform`, `sampleExponential`, `sampleErlang`, `sampleNormal`, `sampleLogNormal`, `sampleTriangular`, `sampleGamma`, both `sampleBeta` overloads, and `sampleWeibull` (file: `source/kernel/statistics/SamplerDefaultImpl1.cpp`).
- Added a small helper and `try/catch` translation in the Bison `probFunction` actions so sampler exceptions are converted to contextual parser errors via `driver.setErrorMessage(...)`, `driver.setResult(-1)`, conditional `throw std::string(...)` when `driver.getThrowsException()` is true, and `YYERROR` otherwise (file: `source/parser/parserBisonFlex/bisonparser.yy`).
- Hardened the parser driver by wrapping `parser.parse()` in `genesyspp_driver::parse_file` and `::parse_str` with `try/catch` for `const std::string&`, `const std::exception&`, and `...` to set `errorMessage`/`result=-1`, run `scan_end_*()`, and optionally rethrow to preserve existing `throwsException` semantics (file: `source/parser/Genesys++-driver.cpp`).
- Improved wrapper handling in `ParserDefaultImpl2` to also catch `std::exception` and `...`, prefer messages from `_wrapper.getErrorMessage()` before falling back to generic messages, and return controlled results and `success=false` where applicable (file: `source/kernel/simulator/ParserDefaultImpl2.cpp`).

### Testing
- Repository / branch checks: created and worked on branch `WiP20261` and verified changes with `git status --short --branch` and `git diff --name-only`.
- Build attempts: ran `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` (configure succeeded) and tried `cmake --build` on parser/test targets; a full integration run failed due to an unrelated pre-existing plugin/bootstrap issue (`PluginConnectorDummyBootstrap.cpp`) outside the patch scope, so full integration tests were not completed.
- Functional validation: compiled and ran a small local test program linking `SamplerDefaultImpl1` that exercised the required cases and observed:
  - Valid: `unif(0.8,1.0)`, `tria(1,2,3)`, `expo(2.0)` executed successfully.
  - Invalid: `unif(1,0.8)`, `tria(3,2,1)`, `weib(-1,2)` raised recoverable exceptions with the new specific messages (e.g. `"unif requires min <= max"`, `"tria requires min <= mode <= max"`, `"weib requires alpha > 0 and scale > 0"`) and did not abort the process.
- Result: behavior meets the requirement that invalid user parameters produce recoverable, contextual errors instead of fatal `assert` aborts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8122b42e88321af35d7734586ff15)