### PR TITLE
Add regression tests for parser->sampler probabilistic validation behavior

### DIFF
--- a/source/tests/unit/test_parser_expressions.cpp
+++ b/source/tests/unit/test_parser_expressions.cpp
@@ -1,7 +1,10 @@
+#include <cmath>
 #include <gtest/gtest.h>
 
 #include "kernel/simulator/Model.h"
 #include "kernel/simulator/Simulator.h"
+#include "kernel/statistics/SamplerDefaultImpl1.h"
+#include "parser/Genesys++-driver.h"
 
 class ParserExpressionsTest : public ::testing::Test {
 protected:
@@ -35,4 +38,95 @@ TEST_F(ParserExpressionsTest, MathFunctionsRoundTruncFracAndSqrt) {
     EXPECT_DOUBLE_EQ(model->parseExpression("trunc(3.9)"), 3.0);
     EXPECT_DOUBLE_EQ(model->parseExpression("frac(3.9)"), 0.9);
     EXPECT_DOUBLE_EQ(model->parseExpression("sqrt(9)"), 3.0);
+}
+
+TEST_F(ParserExpressionsTest, ProbabilisticFunctionsValidExpressionsWithThrowsExceptionTrue) {
+    bool success = false;
+    std::string errorMessage;
+
+    const double unifValue = model->parseExpression("unif(0.8,1.0)", success, errorMessage);
+    EXPECT_TRUE(success);
+    EXPECT_TRUE(errorMessage.empty());
+    EXPECT_TRUE(std::isfinite(unifValue));
+    EXPECT_GE(unifValue, 0.8);
+    EXPECT_LE(unifValue, 1.0);
+
+    errorMessage.clear();
+    const double triaValue = model->parseExpression("tria(1,2,3)", success, errorMessage);
+    EXPECT_TRUE(success);
+    EXPECT_TRUE(errorMessage.empty());
+    EXPECT_TRUE(std::isfinite(triaValue));
+    EXPECT_GE(triaValue, 1.0);
+    EXPECT_LE(triaValue, 3.0);
+
+    errorMessage.clear();
+    const double expoValue = model->parseExpression("expo(2.0)", success, errorMessage);
+    EXPECT_TRUE(success);
+    EXPECT_TRUE(errorMessage.empty());
+    EXPECT_TRUE(std::isfinite(expoValue));
+    EXPECT_GE(expoValue, 0.0);
+}
+
+TEST_F(ParserExpressionsTest, ProbabilisticFunctionsInvalidExpressionsAreRecoverableWithThrowsExceptionTrue) {
+    bool success = true;
+    std::string errorMessage;
+
+    (void) model->parseExpression("unif(1,0.8)", success, errorMessage);
+    EXPECT_FALSE(success);
+    EXPECT_FALSE(errorMessage.empty());
+    EXPECT_NE(errorMessage.find("unif"), std::string::npos);
+
+    errorMessage.clear();
+    (void) model->parseExpression("tria(3,2,1)", success, errorMessage);
+    EXPECT_FALSE(success);
+    EXPECT_FALSE(errorMessage.empty());
+    EXPECT_NE(errorMessage.find("tria"), std::string::npos);
+
+    errorMessage.clear();
+    (void) model->parseExpression("weib(-1,2)", success, errorMessage);
+    EXPECT_FALSE(success);
+    EXPECT_FALSE(errorMessage.empty());
+    EXPECT_NE(errorMessage.find("weib"), std::string::npos);
+}
+
+TEST(ParserDriverThrowsFalseTest, ProbabilisticFunctionsRecoverWithoutThrowing) {
+    SamplerDefaultImpl1 sampler;
+    genesyspp_driver driver(nullptr, &sampler, false);
+
+    EXPECT_NO_THROW({
+        const int parseResult = driver.parse_str("unif(0.8,1.0)");
+        EXPECT_EQ(parseResult, 0);
+        EXPECT_TRUE(driver.getErrorMessage().empty());
+        const double value = driver.getResult();
+        EXPECT_TRUE(std::isfinite(value));
+        EXPECT_GE(value, 0.8);
+        EXPECT_LE(value, 1.0);
+    });
+
+    EXPECT_NO_THROW({
+        const int parseResult = driver.parse_str("unif(1,0.8)");
+        EXPECT_NE(parseResult, 0);
+        EXPECT_EQ(driver.getResult(), -1.0);
+        const std::string message = driver.getErrorMessage();
+        EXPECT_FALSE(message.empty());
+        EXPECT_NE(message.find("unif"), std::string::npos);
+    });
+
+    EXPECT_NO_THROW({
+        const int parseResult = driver.parse_str("tria(3,2,1)");
+        EXPECT_NE(parseResult, 0);
+        EXPECT_EQ(driver.getResult(), -1.0);
+        const std::string message = driver.getErrorMessage();
+        EXPECT_FALSE(message.empty());
+        EXPECT_NE(message.find("tria"), std::string::npos);
+    });
+
+    EXPECT_NO_THROW({
+        const int parseResult = driver.parse_str("weib(-1,2)");
+        EXPECT_NE(parseResult, 0);
+        EXPECT_EQ(driver.getResult(), -1.0);
+        const std::string message = driver.getErrorMessage();
+        EXPECT_FALSE(message.empty());
+        EXPECT_NE(message.find("weib"), std::string::npos);
+    });
 }


### PR DESCRIPTION
### Motivation
- Provide a minimal, reproducible regression suite that verifies probabilistic expression handling across the path `user -> parser -> sampler`, ensuring valid expressions evaluate, invalid expressions are recoverable and produce useful messages, and behavior is consistent for `throwsException=true` and `throwsException=false`.

### Description
- Added focused unit tests in `source/tests/unit/test_parser_expressions.cpp` that exercise valid probabilistic expressions (`unif(0.8,1.0)`, `tria(1,2,3)`, `expo(2.0)`) and assert success, finiteness and plausible ranges using `Model::parseExpression(..., success, errorMessage)`.
- Added invalid-case assertions for `unif(1,0.8)`, `tria(3,2,1)`, and `weib(-1,2)` that verify failures are recoverable and that `errorMessage` is non-empty and mentions the function name.
- Added a direct driver-level test using `genesyspp_driver` with `throwsException=false` that validates the parser does not throw, sets `result == -1.0` on error, returns a non-zero parse result, and populates `errorMessage` for invalid inputs.
- No runtime/parser/sampler implementation files were modified; changes are limited to the single test file and include the necessary sampler/driver headers.

### Testing
- Ran `git checkout -b WiP20261` and committed the test changes as the branch used for this work, and verified `git status`/`git diff --name-only` to confirm only the test file changed.
- Confirmed by inspection that `SamplerDefaultImpl1.cpp` throws semantic `std::invalid_argument` on invalid parameters and that `bisonparser.yy`, `Genesys++-driver.cpp` and `ParserDefaultImpl2.cpp` contain the expected error capture/translation/propagation logic used by the tests.
- Configured the build with `cmake --preset tests-kernel-unit` which completed successfully, but an attempt to build the test target with `cmake --build build/tests-kernel-unit --target genesys_test_parser_expressions` failed due to an out-of-scope compilation error: `fatal error: PluginConnectorDummyImpl1.h: No such file or directory` in `PluginConnectorDummyBootstrap.cpp`, so the new tests could not be executed in this environment.
- No automated tests were run to completion because the unrelated plugin connector include error blocked the build; the test binary was added and is ready to run once the external build issue is resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8190a428c83218d698c5bd963e79d)