### PR TITLE
GUI R2: deterministic AnimationTransition teardown in runtime and terminal cleanup

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/controllers/SimulationEventController.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/SimulationEventController.cpp
@@ -53,11 +53,12 @@ static void cleanupPausedAnimationList(QList<AnimationTransition*>* pausedAnimat
     }
 
     if (destroyAnimations) {
-        // Stop each paused transition and schedule Qt-safe destruction.
+        // Stop each paused transition before deterministic terminal destruction.
         for (AnimationTransition* animation : *pausedAnimations) {
             if (animation) {
                 animation->stopAnimation();
-                animation->deleteLater();
+                // Destroy paused transitions immediately in terminal cleanup paths.
+                delete animation;
             }
         }
     }

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
@@ -1391,6 +1391,9 @@ void ModelGraphicsScene::runAnimateTransition(AnimationTransition *animationTran
     // Store temporary finished connection to disconnect it after this loop execution.
     QMetaObject::Connection finishedConnection = connect(animationTransition, &AnimationTransition::finished, &loop, &QEventLoop::quit);
 
+    // Ensure the local loop exits if the transition is destroyed during execution.
+    QMetaObject::Connection destroyedConnection = connect(animationTransition, &QObject::destroyed, &loop, &QEventLoop::quit);
+
     // Connect state changes before start/restart so pause transitions are observed from the beginning.
     QMetaObject::Connection stateChangedConnection = connect(animationTransition, &QAbstractAnimation::stateChanged, [this, &loop, event, animationTransition](QAbstractAnimation::State newState, QAbstractAnimation::State oldState) {
         handleAnimationStateChanged(newState, &loop, event, animationTransition);
@@ -1407,13 +1410,14 @@ void ModelGraphicsScene::runAnimateTransition(AnimationTransition *animationTran
 
     // Explicitly disconnect temporary local connections created for this run only.
     QObject::disconnect(finishedConnection);
+    QObject::disconnect(destroyedConnection);
     QObject::disconnect(stateChangedConnection);
 
     _animationsTransition->removeOne(animationTransition);
 
-    // Keep paused transitions alive for resume flow; cleanup all others.
+    // Destroy non-paused transitions immediately after loop completion and list removal.
     if (animationTransition->state() != QAbstractAnimation::Paused) {
-        animationTransition->deleteLater();
+        delete animationTransition;
     }
 }
 
@@ -1531,11 +1535,12 @@ void ModelGraphicsScene::clearAnimationsTransition() {
         for (auto it = _animationPaused->begin(); it != _animationPaused->end(); ++it) {
             QList<AnimationTransition*>* pausedAnimations = it.value();
             if (pausedAnimations) {
-                // Stop each paused transition and defer QObject deletion through Qt.
+                // Stop each paused transition before terminal destruction.
                 for (AnimationTransition* animation : *pausedAnimations) {
                     if (animation) {
                         animation->stopAnimation();
-                        animation->deleteLater();
+                        // Destroy paused transitions deterministically during terminal scene cleanup.
+                        delete animation;
                     }
                 }
                 pausedAnimations->clear();


### PR DESCRIPTION
### Motivation
- Make destruction of `AnimationTransition` deterministic in terminal/teardown paths while preserving pause/resume semantics.
- Ensure a local `QEventLoop` inside `runAnimateTransition()` exits safely if the transition is destroyed by another path.
- Reduce reliance on asynchronous `deleteLater()` for terminal cleanup to avoid nondeterministic lifecycles during simulation runtime and shutdown.

### Description
- Added a temporary connection from `animationTransition`'s `destroyed(QObject*)` signal to the local `QEventLoop::quit()` in `ModelGraphicsScene::runAnimateTransition()` and disconnected it after `loop.exec()` returns. 
- After disconnecting temporary connections and removing the transition from `_animationsTransition`, replaced `animationTransition->deleteLater()` with immediate `delete animationTransition` for non-paused terminal cleanup in `runAnimateTransition()`.
- Replaced `animation->deleteLater()` with `delete animation` inside the destructive branch of `cleanupPausedAnimationList()` in `SimulationEventController.cpp` while keeping `animation->stopAnimation()`.
- Replaced `animation->deleteLater()` with `delete animation` for paused transitions in the terminal cleanup path of `ModelGraphicsScene::clearAnimationsTransition()` while keeping `animation->stopAnimation()` and leaving other function semantics unchanged.
- Included short, precise English comments immediately above each changed code region and kept modifications strictly limited to the two target files.

### Testing
- Ran CMake configure and attempted to build the GUI target with `cmake -S . -B build && cmake --build build --target GenesysQtGUI -j2`, which failed because the `GenesysQtGUI` target was not generated in this environment. (Expected: GUI target unavailable.)
- Attempted to enable GUI via `cmake -S . -B build-gui -DGENESYS_BUILD_GUI=ON && cmake --build build-gui --target GenesysQtGUI -j2`, which reported the variable unused and still did not produce the GUI target. 
- Checked `qmake --version` and found `qmake` is not installed, so Qt toolchain / qmake-based build is not available here; changes were validated by code inspection and local diffs rather than a full GUI build.
- Verified by source inspection and diff that `runAnimateTransition()` now listens for `destroyed` to exit the local loop and that all requested `deleteLater()` -> `delete` swaps were applied only in the specified terminal-cleanup paths of the two files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d81c6639ac83219b96e63eae653f73)