### PR TITLE
KERNEL/TESTS: fix runtime sanitizer regressions for kernel unit targets

### DIFF
--- a/source/kernel/simulator/ExperimentManager.cpp
+++ b/source/kernel/simulator/ExperimentManager.cpp
@@ -19,6 +19,14 @@ ExperimentManager::ExperimentManager(Simulator* simulator) {
 	_currentSimulationExperiment = nullptr;
 }
 
+// Delete stored experiments and release the manager-owned list container.
+ExperimentManager::~ExperimentManager() {
+	for (SimulationExperiment* experiment : *_experiments->list()) {
+		delete experiment;
+	}
+	delete _experiments;
+}
+
 List<SimulationExperiment*>* ExperimentManager::getExperiments() const {
 	return _experiments;
 }
@@ -96,4 +104,3 @@ SimulationExperiment* ExperimentManager::front() {
 SimulationExperiment* ExperimentManager::next() {
 	return _experiments->next();
 }
-

--- a/source/kernel/simulator/ExperimentManager.h
+++ b/source/kernel/simulator/ExperimentManager.h
@@ -70,6 +70,8 @@ public:
 
 public:
 	ExperimentManager(Simulator* simulator);
+	// Release owned experiment instances and container storage during simulator shutdown.
+	virtual ~ExperimentManager();
 
 public:
 	SimulationExperiment* newSimulationExperiment();
@@ -96,4 +98,3 @@ private:
 };
 
 #endif /* EXPERIMENTMANAGER_H */
-

--- a/source/kernel/simulator/ParserDefaultImpl2.cpp
+++ b/source/kernel/simulator/ParserDefaultImpl2.cpp
@@ -15,9 +15,14 @@
 
 //using namespace GenesysKernel;
 
-ParserDefaultImpl2::ParserDefaultImpl2(Model* model, Sampler_if* sampler, bool throws) {
-	_model = model;
-	_wrapper = genesyspp_driver(_model, sampler, throws);
+// Construct parser wrapper in-place to avoid copying partially initialized driver state.
+ParserDefaultImpl2::ParserDefaultImpl2(Model* model, Sampler_if* sampler, bool throws)
+	: _model(model), _wrapper(model, sampler, throws) {}
+
+// Delete the sampler owned by this parser wrapper to avoid leaking per-model parser state.
+ParserDefaultImpl2::~ParserDefaultImpl2() {
+	delete _wrapper.getSampler();
+	_wrapper.setSampler(nullptr);
 }
 
 double ParserDefaultImpl2::parse(const std::string expression) { // may throw exception

--- a/source/kernel/simulator/ParserDefaultImpl2.h
+++ b/source/kernel/simulator/ParserDefaultImpl2.h
@@ -25,7 +25,8 @@
 class ParserDefaultImpl2 : public Parser_if {
 public:
 	ParserDefaultImpl2(Model* model, Sampler_if* sampler, bool throws = false);
-	virtual ~ParserDefaultImpl2() = default;
+	// Release parser-owned sampler instance created for expression evaluation.
+	virtual ~ParserDefaultImpl2();
 public:
 	virtual double parse(const std::string expression) override; // may throw exception
     virtual double parse(const std::string expression, bool& success, std::string& errorMessage) override;
@@ -39,4 +40,3 @@ private:
 };
 //namespace\\}
 #endif /* PARSERDEFAULTIMPL2_H */
-

--- a/source/kernel/simulator/Plugin.cpp
+++ b/source/kernel/simulator/Plugin.cpp
@@ -33,6 +33,11 @@ Plugin::Plugin(StaticGetPluginInformation getInformation) {
 	}
 }
 
+// Release metadata allocated by the plugin information factory while tearing down plugin wrappers.
+Plugin::~Plugin() {
+	delete _pluginInfo;
+}
+
 std::string Plugin::show() {
 
 	std::string message = "<" + _pluginInfo->getCategory() + "> ";

--- a/source/kernel/simulator/Plugin.h
+++ b/source/kernel/simulator/Plugin.h
@@ -32,7 +32,8 @@ class Plugin {
 public:
 	Plugin(std::string filename_so_dll);
 	Plugin(StaticGetPluginInformation getInformation); // @TODO: temporary. Just while compiled together
-	virtual ~Plugin() = default;
+	// Destroy plugin-owned metadata allocated by the plugin-information callback.
+	virtual ~Plugin();
 public:
 	std::string show();
 public:
@@ -73,11 +74,12 @@ private:
 	ModelDataDefinition* _loadNewElement(Model* model, PersistenceRecord *fields);
 
 private: // read only
-	bool _isValidPlugin;
-	PluginInformation* _pluginInfo;
+	// Default invalid state avoids reading indeterminate validity after construction failures.
+	bool _isValidPlugin = false;
+	// Store plugin metadata pointer with a safe default for invalid plugin construction paths.
+	PluginInformation* _pluginInfo = nullptr;
 private:
 	StaticGetPluginInformation _StatMethodGetInformation;
 };
 //namespace\\}
 #endif /* PLUGIN_H */
-

--- a/source/kernel/simulator/PluginConnectorDummyBootstrap.cpp
+++ b/source/kernel/simulator/PluginConnectorDummyBootstrap.cpp
@@ -1,4 +1,5 @@
-#include "PluginConnectorDummyImpl1.h"
+// Use an explicit relative include so kernel runtime builds can resolve the dummy connector header.
+#include "../../plugins/PluginConnectorDummyImpl1.h"
 
 PluginConnectorDummyImpl1::PluginConnectorDummyImpl1() = default;
 
@@ -18,38 +19,10 @@ bool PluginConnectorDummyImpl1::disconnect(Plugin*) {
     return false;
 }
 
-StaticGetPluginInformation PluginConnectorDummyImpl1::_connectBasic(const std::string) {
-    return nullptr;
+// Return an empty discovery list for the bootstrap stub when plugin scanning is unavailable.
+List<std::string>* PluginConnectorDummyImpl1::find() {
+    return new List<std::string>();
 }
 
-StaticGetPluginInformation PluginConnectorDummyImpl1::_connectContinuos(const std::string) {
-    return nullptr;
-}
-
-StaticGetPluginInformation PluginConnectorDummyImpl1::_connectDiscrete(const std::string) {
-    return nullptr;
-}
-
-StaticGetPluginInformation PluginConnectorDummyImpl1::_connectInputOutput(const std::string) {
-    return nullptr;
-}
-
-StaticGetPluginInformation PluginConnectorDummyImpl1::_connectIntegrations(const std::string) {
-    return nullptr;
-}
-
-StaticGetPluginInformation PluginConnectorDummyImpl1::_connectNetwork(const std::string) {
-    return nullptr;
-}
-
-StaticGetPluginInformation PluginConnectorDummyImpl1::_connectTransfer(const std::string) {
-    return nullptr;
-}
-
-StaticGetPluginInformation PluginConnectorDummyImpl1::_connectElectronicDomain(const std::string) {
-    return nullptr;
-}
-
-StaticGetPluginInformation PluginConnectorDummyImpl1::_connectBiochemicalDomain(const std::string) {
-    return nullptr;
-}
+// Keep bootstrap connector behavior as a no-op to avoid mutating plugin registries in unit test builds.
+void PluginConnectorDummyImpl1::_connect(List<Plugin*>*, Plugin*) {}

--- a/source/kernel/simulator/PluginInformation.cpp
+++ b/source/kernel/simulator/PluginInformation.cpp
@@ -31,6 +31,12 @@ PluginInformation::PluginInformation(std::string pluginTypename, StaticLoaderDat
 	this->_pluginTypename = pluginTypename;
 }
 
+// Free dependency and field containers owned by plugin metadata instances.
+PluginInformation::~PluginInformation() {
+	delete _dynamicLibFilenameDependencies;
+	delete _fields;
+}
+
 StaticConstructorDataDefinitionInstance PluginInformation::getDataDefinitionConstructor() const {
 	return _elementConstructor;
 }
@@ -198,5 +204,4 @@ void PluginInformation::setCategory(std::string _category) {
 std::string PluginInformation::getCategory() const {
 	return _category;
 }
-
 

--- a/source/kernel/simulator/PluginInformation.h
+++ b/source/kernel/simulator/PluginInformation.h
@@ -35,6 +35,8 @@ class PluginInformation {
 public:
 	PluginInformation(std::string pluginTypename, StaticLoaderComponentInstance componentloader, StaticConstructorDataDefinitionInstance elementConstructor);
 	PluginInformation(std::string pluginTypename, StaticLoaderDataDefinitionInstance elementloader, StaticConstructorDataDefinitionInstance elementConstructor);
+	// Release owned metadata containers allocated alongside plugin-information objects.
+	virtual ~PluginInformation();
 public:
 	// gets
 	StaticLoaderDataDefinitionInstance getDataDefinitionLoader() const;
@@ -114,4 +116,3 @@ private:
 //namespace\\}
 
 #endif /* PLUGININFORMATION_H */
-

--- a/source/kernel/simulator/PluginManager.cpp
+++ b/source/kernel/simulator/PluginManager.cpp
@@ -29,6 +29,15 @@ PluginManager::PluginManager(Simulator* simulator) {
 	_insertDefaultKernelElements();
 }
 
+// Release connector and plugin wrappers owned by the manager during simulator teardown.
+PluginManager::~PluginManager() {
+	for (Plugin* plugin : *_plugins->list()) {
+		delete plugin;
+	}
+	delete _plugins;
+	delete _pluginConnector;
+}
+
 List<Plugin*>* PluginManager::_autoFindPlugins() {
 	List<std::string>* filenames = _pluginConnector->find();
 	for (std::string filename: *filenames->list()) {

--- a/source/kernel/simulator/PluginManager.h
+++ b/source/kernel/simulator/PluginManager.h
@@ -36,7 +36,8 @@ class PluginManager {
 public:
 	/*! \brief Creates a plugin manager bound to a simulator instance. */
 	PluginManager(Simulator* simulator);
-	virtual ~PluginManager() = default;
+	/*! \brief Destroys owned plugin wrappers and connector resources. */
+	virtual ~PluginManager();
 public:
 	/*! \brief Returns a human-readable summary of currently connected plugins. */
 	std::string show();


### PR DESCRIPTION
KERNEL/TESTS

### Motivation
- Resolve real failures observed when building/running kernel unit tests under sanitizers: compile error in plugin bootstrap, undefined behavior in parser wrapper construction, and major leaks from manager/plugin ownership.

### Description
- Fix `PluginConnectorDummyBootstrap.cpp` include and align stubs with the dummy header so runtime build succeeds.  
- Construct `ParserDefaultImpl2::_wrapper` in-place and add a destructor to free the parser-owned sampler to remove UB and reduce leaks.  
- Add destructors and defensive initialization to `PluginManager`, `Plugin`, `PluginInformation`, and `ExperimentManager` to reclaim owned containers and plugin metadata at shutdown.  
- Keep changes minimal and constrained to `source/kernel/simulator/*` and the parser wrapper; added short English comments above changed blocks describing intent.

### Testing
- Configured and built with `cmake --preset tests-kernel-unit` and built targets by invoking `cmake --build build/tests-kernel-unit --target genesys_test_simulator_runtime genesys_test_support_modelmanager genesys_test_support_connectionmanager`.  
- Ran unit binaries directly: `./build/tests-kernel-unit/source/tests/unit/genesys_test_simulator_runtime`, `.../genesys_test_support_modelmanager`, `.../genesys_test_support_connectionmanager`, and all passed in normal build.  
- Built with `cmake --preset asan` and `cmake --build build/asan --target genesys_test_simulator_runtime genesys_test_support_modelmanager genesys_test_support_connectionmanager`.  
- ASan execution results: `genesys_test_support_modelmanager` and `genesys_test_support_connectionmanager` pass cleanly; `genesys_test_simulator_runtime` no longer reports the earlier UB but still shows residual leaks coming from `ModelCheckerDefaultImpl1` and `SimulationReporterDefaultImpl1` flows.  
- Built with `cmake --preset ubsan` and executed all three UBSan targets; all UBSan runs passed without reports.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8121c60d48321898d0fd30b574fe7)