### PR TITLE
Exclude obsolete PluginConnectorDummyBootstrap.cpp from runtime sources to fix parser test build

### DIFF
--- a/source/kernel/simulator/CMakeLists.txt
+++ b/source/kernel/simulator/CMakeLists.txt
@@ -37,6 +37,10 @@ file(GLOB GENESYS_KERNEL_SIMULATOR_RUNTIME_SOURCES CONFIGURE_DEPENDS
     "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"
 )
 
+list(REMOVE_ITEM GENESYS_KERNEL_SIMULATOR_RUNTIME_SOURCES
+    "${CMAKE_CURRENT_SOURCE_DIR}/PluginConnectorDummyBootstrap.cpp"
+)
+
 list(APPEND GENESYS_KERNEL_SIMULATOR_RUNTIME_SOURCES
         "${CMAKE_SOURCE_DIR}/source/plugins/PluginConnectorStaticImpl1.cpp"
         "${CMAKE_SOURCE_DIR}/source/plugins/PluginConnectorDummyImpl1.cpp"


### PR DESCRIPTION
### Motivation
- The test target `genesys_test_parser_expressions` pulled `genesys_kernel_simulator_runtime`, which globbed all `*.cpp` in `source/kernel/simulator` and attempted to compile a legacy bootstrap translation unit that was out-of-sync with the real dummy connector header/implementation. 
- `PluginConnectorDummyBootstrap.cpp` included `PluginConnectorDummyImpl1.h` using a local include and declared methods not present in the current header, causing a compilation failure. 
- The minimal safe fix is to stop compiling the obsolete bootstrap file rather than changing plugin architecture or test logic. 

### Description
- Removed `source/kernel/simulator/PluginConnectorDummyBootstrap.cpp` from the runtime source list by adding a `list(REMOVE_ITEM ...)` before appending the runtime sources in `source/kernel/simulator/CMakeLists.txt`. 
- Kept the canonical dummy connector implementation `source/plugins/PluginConnectorDummyImpl1.cpp` in the runtime target to preserve runtime behavior. 
- Changed file: `source/kernel/simulator/CMakeLists.txt`.

### Testing
- Configured and generated build files with `cmake --preset tests-kernel-unit` and built the parser test target with `cmake --build build/tests-kernel-unit --target genesys_test_parser_expressions -j4`, which completed successfully. 
- Executed the test binary `./build/tests-kernel-unit/source/tests/unit/genesys_test_parser_expressions` and observed `7 tests ran, 7 passed, 0 failed`. 
- The fix is minimal and directly addressed the compile error without modifying parser/sampler logic or test sources.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d81e2f86b88321b2b91379fe2af08d)