### PR TITLE
Guard AnimationTransition usage after local event loop in GUI

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
@@ -54,6 +54,7 @@
 #include "animations/AnimationQueue.h"
 #include <QCoreApplication>
 #include <QThread>
+#include <QPointer>
 
 namespace {
 // Safely cast the scene parent to a generic graphics view.
@@ -1383,6 +1384,9 @@ void ModelGraphicsScene::animateTransition(ModelComponent *source, ModelComponen
 }
 
 void ModelGraphicsScene::runAnimateTransition(AnimationTransition *animationTransition, Event *event, bool restart) {
+    // Track transition lifetime across nested event loop execution.
+    QPointer<AnimationTransition> guardedTransition(animationTransition);
+
     _animationsTransition->append(animationTransition);
 
     // Create the local event loop before starting the animation to avoid missing early signals.
@@ -1413,11 +1417,19 @@ void ModelGraphicsScene::runAnimateTransition(AnimationTransition *animationTran
     QObject::disconnect(destroyedConnection);
     QObject::disconnect(stateChangedConnection);
 
-    _animationsTransition->removeOne(animationTransition);
+    // Stop post-loop processing when the transition was destroyed during loop execution.
+    if (guardedTransition.isNull()) {
+        _animationsTransition->removeOne(animationTransition);
+        return;
+    }
 
-    // Destroy non-paused transitions immediately after loop completion and list removal.
-    if (animationTransition->state() != QAbstractAnimation::Paused) {
-        delete animationTransition;
+    // Use the guarded pointer for safe list cleanup and optional deletion.
+    AnimationTransition* transitionPtr = guardedTransition.data();
+    _animationsTransition->removeOne(transitionPtr);
+
+    // Destroy non-paused transitions only while the guarded object is still alive.
+    if (transitionPtr->state() != QAbstractAnimation::Paused) {
+        delete transitionPtr;
     }
 }
 


### PR DESCRIPTION
### Motivation
- Prevent unsafe dereference of an `AnimationTransition*` that may have been destroyed while a nested `QEventLoop` (`loop.exec()`) was running in `ModelGraphicsScene::runAnimateTransition()`.

### Description
- Added `#include <QPointer>` and created a local `QPointer<AnimationTransition> guardedTransition(animationTransition);` at the start of `runAnimateTransition()` to track the transition lifetime across the nested event loop. 
- After `loop.exec()` the code now disconnects temporary connections, checks `guardedTransition.isNull()` and returns early if the transition was destroyed during the loop. 
- When the transition still exists, the code uses `guardedTransition.data()` for safe `_animationsTransition->removeOne(...)` and conditionally calls `state()`/`delete` only while the object is alive. 
- All edits are limited to `source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp` and include short technical comments in English immediately above each changed code snippet.

### Testing
- Ran configuration with `cmake -S . -B build` which completed successfully (project configured with GUI off in the current environment). 
- Attempted GUI configuration with `cmake -S . -B build-gui -DGENESYS_BUILD_GUI=ON` which generated build files but the `GenesysQtGUI` target was not produced by the current CMake config, so building the GUI target failed with `No rule to make target 'GenesysQtGUI'`. 
- Attempted to build the GUI target with `cmake --build build-gui --target GenesysQtGUI -j4` and it failed as described above. 
- Verified `qmake`/`qmake6`/`qt6-qmake` are not available in the environment, so runtime GUI build/run could not be performed. 
- Static inspection of the modified file confirms `QPointer` is used and no code path dereferences the raw `animationTransition` after `loop.exec()`; the scope of changes is restricted to the specified file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d82121c6a0832194135b5d880d1bec)