### PR TITLE
GUI R3: guard AnimationTransition cleanup after loop.exec()

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
@@ -1423,13 +1423,15 @@ void ModelGraphicsScene::runAnimateTransition(AnimationTransition *animationTran
         return;
     }
 
-    // Use the guarded pointer for safe list cleanup and optional deletion.
+    // Resolve the guarded pointer before any post-loop state checks or deletion.
     AnimationTransition* transitionPtr = guardedTransition.data();
-    _animationsTransition->removeOne(transitionPtr);
 
-    // Destroy non-paused transitions only while the guarded object is still alive.
-    if (transitionPtr->state() != QAbstractAnimation::Paused) {
-        delete transitionPtr;
+    // Remove and delete only when the guarded transition is still valid.
+    if (transitionPtr != nullptr) {
+        _animationsTransition->removeOne(transitionPtr);
+        if (transitionPtr->state() != QAbstractAnimation::Paused) {
+            delete transitionPtr;
+        }
     }
 }
 


### PR DESCRIPTION
### Motivation
- Prevent potential use-after-free of `AnimationTransition` when it may be destroyed during the local `QEventLoop` in `runAnimateTransition()` by ensuring post-loop code only dereferences a validated pointer.

### Description
- Resolve the existing `QPointer<AnimationTransition>` after `loop.exec()` and gate the `_animationsTransition` removal, `state()` inspection and `delete` behind an explicit `nullptr` check, adding concise English comments above the modified blocks; changes are restricted to `source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp`.

### Testing
- Committed the change and inspected the modified file to confirm `QPointer<AnimationTransition>` is used and post-loop access is guarded, and attempted the GUI build with `cmake -S . -B build-gui-check -DGENESYS_BUILD_GUI_APPLICATION=ON` which failed in this environment because `qmake` is not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d823324c6083218258fd2c23aff565)