### PR TITLE
Stage 2 web API: model endpoints + SessionManager synchronization

### DIFF
--- a/source/applications/web/api/ApiRouter.cpp
+++ b/source/applications/web/api/ApiRouter.cpp
@@ -56,6 +56,42 @@ HttpResponse ApiRouter::handle(const HttpRequest& request) const {
         return HttpResponse{200, "application/json", body};
     }
 
+    if (request.path == "/api/v1/models") {
+        if (request.method != "POST") {
+            return _jsonError(405, "METHOD_NOT_ALLOWED", "Only POST is allowed for /api/v1/models");
+        }
+
+        const std::string token = _extractBearerToken(request);
+        if (token.empty()) {
+            return _jsonError(401, "UNAUTHORIZED", "Missing or invalid Bearer token");
+        }
+
+        SimulatorSessionService::ModelInfoResult info{};
+        if (!_simulatorService.tryCreateModel(token, info)) {
+            return _jsonError(401, "UNAUTHORIZED", "Invalid or expired session token");
+        }
+
+        return HttpResponse{201, "application/json", "{\"ok\":true,\"data\":" + _modelInfoDataJson(info) + "}"};
+    }
+
+    if (request.path == "/api/v1/models/current") {
+        if (request.method != "GET") {
+            return _jsonError(405, "METHOD_NOT_ALLOWED", "Only GET is allowed for /api/v1/models/current");
+        }
+
+        const std::string token = _extractBearerToken(request);
+        if (token.empty()) {
+            return _jsonError(401, "UNAUTHORIZED", "Missing or invalid Bearer token");
+        }
+
+        SimulatorSessionService::ModelInfoResult info{};
+        if (!_simulatorService.tryGetCurrentModelInfo(token, info)) {
+            return _jsonError(401, "UNAUTHORIZED", "Invalid or expired session token");
+        }
+
+        return HttpResponse{200, "application/json", "{\"ok\":true,\"data\":" + _modelInfoDataJson(info) + "}"};
+    }
+
     return _jsonError(404, "NOT_FOUND", "Route not found");
 }
 
@@ -93,4 +129,21 @@ std::string ApiRouter::_escapeJson(const std::string& value) {
         }
     }
     return out;
+}
+
+std::string ApiRouter::_modelInfoDataJson(const SimulatorSessionService::ModelInfoResult& info) {
+    if (!info.exists) {
+        return "{\"exists\":false}";
+    }
+
+    return "{\"exists\":true,"
+           "\"modelId\":" + std::to_string(info.modelId) + ","
+           "\"hasChanged\":" + std::string(info.hasChanged ? "true" : "false") + ","
+           "\"level\":" + std::to_string(info.level) + ","
+           "\"name\":\"" + _escapeJson(info.name) + "\","
+           "\"analystName\":\"" + _escapeJson(info.analystName) + "\","
+           "\"projectTitle\":\"" + _escapeJson(info.projectTitle) + "\","
+           "\"version\":\"" + _escapeJson(info.version) + "\","
+           "\"description\":\"" + _escapeJson(info.description) + "\","
+           "\"componentCount\":" + std::to_string(info.componentCount) + "}";
 }

--- a/source/applications/web/api/ApiRouter.h
+++ b/source/applications/web/api/ApiRouter.h
@@ -16,4 +16,5 @@ private:
     static HttpResponse _jsonError(int status, const char* code, const char* message);
     static std::string _extractBearerToken(const HttpRequest& request);
     static std::string _escapeJson(const std::string& value);
+    static std::string _modelInfoDataJson(const SimulatorSessionService::ModelInfoResult& info);
 };

--- a/source/applications/web/service/SimulatorSessionService.cpp
+++ b/source/applications/web/service/SimulatorSessionService.cpp
@@ -2,6 +2,27 @@
 
 #include <mutex>
 
+namespace {
+void _populateModelInfoFromModel(Model* model, SimulatorSessionService::ModelInfoResult& outInfo) {
+    outInfo.exists = true;
+    outInfo.modelId = static_cast<unsigned int>(model->getId());
+    outInfo.hasChanged = model->hasChanged();
+    outInfo.level = model->getLevel();
+
+    if (const ModelInfo* modelInfo = model->getInfos(); modelInfo != nullptr) {
+        outInfo.name = modelInfo->getName();
+        outInfo.analystName = modelInfo->getAnalystName();
+        outInfo.projectTitle = modelInfo->getProjectTitle();
+        outInfo.version = modelInfo->getVersion();
+        outInfo.description = modelInfo->getDescription();
+    }
+
+    if (ComponentManager* componentManager = model->getComponentManager(); componentManager != nullptr) {
+        outInfo.componentCount = componentManager->getNumberOfComponents();
+    }
+}
+}  // namespace
+
 SimulatorSessionService::SimulatorSessionService(SessionManager& sessionManager) : _sessionManager(sessionManager) {}
 
 SimulatorSessionService::CreateSessionResult SimulatorSessionService::createSession() {
@@ -19,5 +40,49 @@ bool SimulatorSessionService::tryGetSimulatorInfo(const std::string& accessToken
     outInfo.name = session->simulator->getName();
     outInfo.versionName = session->simulator->getVersion();
     outInfo.versionNumber = session->simulator->getVersionNumber();
+    return true;
+}
+
+bool SimulatorSessionService::tryCreateModel(const std::string& accessToken, ModelInfoResult& outInfo) {
+    SessionContext* session = _sessionManager.getSessionByToken(accessToken);
+    if (session == nullptr || session->simulator == nullptr) {
+        return false;
+    }
+
+    std::scoped_lock lock(session->mutex);
+    ModelManager* modelManager = session->simulator->getModelManager();
+    if (modelManager == nullptr) {
+        return false;
+    }
+
+    Model* model = modelManager->newModel();
+    if (model == nullptr) {
+        return false;
+    }
+
+    outInfo = ModelInfoResult{};
+    _populateModelInfoFromModel(model, outInfo);
+    return true;
+}
+
+bool SimulatorSessionService::tryGetCurrentModelInfo(const std::string& accessToken, ModelInfoResult& outInfo) {
+    SessionContext* session = _sessionManager.getSessionByToken(accessToken);
+    if (session == nullptr || session->simulator == nullptr) {
+        return false;
+    }
+
+    std::scoped_lock lock(session->mutex);
+    ModelManager* modelManager = session->simulator->getModelManager();
+    if (modelManager == nullptr) {
+        return false;
+    }
+
+    outInfo = ModelInfoResult{};
+    Model* model = modelManager->current();
+    if (model == nullptr) {
+        return true;
+    }
+
+    _populateModelInfoFromModel(model, outInfo);
     return true;
 }

--- a/source/applications/web/service/SimulatorSessionService.h
+++ b/source/applications/web/service/SimulatorSessionService.h
@@ -17,10 +17,25 @@ public:
         unsigned int versionNumber;
     };
 
+    struct ModelInfoResult {
+        bool exists = false;
+        unsigned int modelId = 0;
+        bool hasChanged = false;
+        unsigned int level = 0;
+        std::string name;
+        std::string analystName;
+        std::string projectTitle;
+        std::string version;
+        std::string description;
+        unsigned int componentCount = 0;
+    };
+
     explicit SimulatorSessionService(SessionManager& sessionManager);
 
     CreateSessionResult createSession();
     bool tryGetSimulatorInfo(const std::string& accessToken, SimulatorInfoResult& outInfo);
+    bool tryCreateModel(const std::string& accessToken, ModelInfoResult& outInfo);
+    bool tryGetCurrentModelInfo(const std::string& accessToken, ModelInfoResult& outInfo);
 
 private:
     SessionManager& _sessionManager;

--- a/source/applications/web/session/SessionManager.cpp
+++ b/source/applications/web/session/SessionManager.cpp
@@ -1,5 +1,6 @@
 #include "SessionManager.h"
 
+#include <mutex>
 #include <stdexcept>
 #include <utility>
 
@@ -7,6 +8,8 @@ SessionManager::SessionManager(TokenService& tokenService, SimulatorFactory simu
     : _tokenService(tokenService), _simulatorFactory(std::move(simulatorFactory)) {}
 
 SessionContext* SessionManager::createSession() {
+    std::scoped_lock lock(_sessionsMutex);
+
     auto session = std::make_unique<SessionContext>();
     session->sessionId = _tokenService.generateSessionId();
 
@@ -27,6 +30,8 @@ SessionContext* SessionManager::createSession() {
 }
 
 SessionContext* SessionManager::getSessionByToken(const std::string& token) {
+    std::scoped_lock lock(_sessionsMutex);
+
     auto it = _sessionsByToken.find(token);
     if (it == _sessionsByToken.end()) {
         return nullptr;

--- a/source/applications/web/session/SessionManager.h
+++ b/source/applications/web/session/SessionManager.h
@@ -5,6 +5,7 @@
 
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <unordered_map>
 
@@ -20,5 +21,6 @@ public:
 private:
     TokenService& _tokenService;
     SimulatorFactory _simulatorFactory;
+    mutable std::mutex _sessionsMutex;
     std::unordered_map<std::string, std::unique_ptr<SessionContext>> _sessionsByToken;
 };

--- a/source/tests/unit/test_web_api_router.cpp
+++ b/source/tests/unit/test_web_api_router.cpp
@@ -15,6 +15,22 @@ struct ApiRouterFixture {
     SimulatorSessionService simulatorService{sessionManager};
     ApiRouter router{simulatorService};
 };
+
+std::string extractJsonStringField(const std::string& json, const std::string& fieldName) {
+    const std::string marker = "\"" + fieldName + "\":\"";
+    const auto tokenStart = json.find(marker);
+    if (tokenStart == std::string::npos) {
+        return {};
+    }
+
+    const auto valueStart = tokenStart + marker.size();
+    const auto valueEnd = json.find('"', valueStart);
+    if (valueEnd == std::string::npos) {
+        return {};
+    }
+
+    return json.substr(valueStart, valueEnd - valueStart);
+}
 }  // namespace
 
 TEST(WebSessionManagerTest, CreateSessionProducesUniqueTokens) {
@@ -54,13 +70,7 @@ TEST(WebApiRouterTest, AuthSessionThenSimulatorInfoWithBearerToken) {
     const HttpResponse createResponse = fixture.router.handle(createRequest);
     ASSERT_EQ(createResponse.status, 201);
 
-    const std::string marker = "\"accessToken\":\"";
-    const auto tokenStart = createResponse.body.find(marker);
-    ASSERT_NE(tokenStart, std::string::npos);
-    const auto valueStart = tokenStart + marker.size();
-    const auto valueEnd = createResponse.body.find('"', valueStart);
-    ASSERT_NE(valueEnd, std::string::npos);
-    const std::string token = createResponse.body.substr(valueStart, valueEnd - valueStart);
+    const std::string token = extractJsonStringField(createResponse.body, "accessToken");
     ASSERT_FALSE(token.empty());
 
     HttpRequest infoRequest;
@@ -86,4 +96,106 @@ TEST(WebApiRouterTest, SimulatorInfoWithoutTokenReturnsUnauthorized) {
 
     EXPECT_EQ(infoResponse.status, 401);
     EXPECT_NE(infoResponse.body.find("\"ok\":false"), std::string::npos);
+}
+
+TEST(WebApiRouterTest, CurrentModelWithoutTokenReturnsUnauthorized) {
+    ApiRouterFixture fixture;
+
+    HttpRequest request;
+    request.method = "GET";
+    request.path = "/api/v1/models/current";
+
+    const HttpResponse response = fixture.router.handle(request);
+
+    EXPECT_EQ(response.status, 401);
+    EXPECT_NE(response.body.find("\"ok\":false"), std::string::npos);
+}
+
+TEST(WebApiRouterTest, CurrentModelAfterSessionCreationReturnsExistsFalse) {
+    ApiRouterFixture fixture;
+
+    HttpRequest createRequest;
+    createRequest.method = "POST";
+    createRequest.path = "/api/v1/auth/session";
+    const HttpResponse createResponse = fixture.router.handle(createRequest);
+    ASSERT_EQ(createResponse.status, 201);
+
+    const std::string token = extractJsonStringField(createResponse.body, "accessToken");
+    ASSERT_FALSE(token.empty());
+
+    HttpRequest currentRequest;
+    currentRequest.method = "GET";
+    currentRequest.path = "/api/v1/models/current";
+    currentRequest.headers["authorization"] = "Bearer " + token;
+
+    const HttpResponse currentResponse = fixture.router.handle(currentRequest);
+
+    EXPECT_EQ(currentResponse.status, 200);
+    EXPECT_NE(currentResponse.body.find("\"ok\":true"), std::string::npos);
+    EXPECT_NE(currentResponse.body.find("\"exists\":false"), std::string::npos);
+}
+
+TEST(WebApiRouterTest, CreateModelWithTokenSucceeds) {
+    ApiRouterFixture fixture;
+
+    HttpRequest createSessionRequest;
+    createSessionRequest.method = "POST";
+    createSessionRequest.path = "/api/v1/auth/session";
+    const HttpResponse createSessionResponse = fixture.router.handle(createSessionRequest);
+    ASSERT_EQ(createSessionResponse.status, 201);
+
+    const std::string token = extractJsonStringField(createSessionResponse.body, "accessToken");
+    ASSERT_FALSE(token.empty());
+
+    HttpRequest createModelRequest;
+    createModelRequest.method = "POST";
+    createModelRequest.path = "/api/v1/models";
+    createModelRequest.headers["authorization"] = "Bearer " + token;
+
+    const HttpResponse createModelResponse = fixture.router.handle(createModelRequest);
+
+    EXPECT_EQ(createModelResponse.status, 201);
+    EXPECT_NE(createModelResponse.body.find("\"ok\":true"), std::string::npos);
+    EXPECT_NE(createModelResponse.body.find("\"exists\":true"), std::string::npos);
+    EXPECT_NE(createModelResponse.body.find("\"modelId\":"), std::string::npos);
+}
+
+TEST(WebApiRouterTest, CurrentModelAfterCreationReturnsExpectedFields) {
+    ApiRouterFixture fixture;
+
+    HttpRequest createSessionRequest;
+    createSessionRequest.method = "POST";
+    createSessionRequest.path = "/api/v1/auth/session";
+    const HttpResponse createSessionResponse = fixture.router.handle(createSessionRequest);
+    ASSERT_EQ(createSessionResponse.status, 201);
+
+    const std::string token = extractJsonStringField(createSessionResponse.body, "accessToken");
+    ASSERT_FALSE(token.empty());
+
+    HttpRequest createModelRequest;
+    createModelRequest.method = "POST";
+    createModelRequest.path = "/api/v1/models";
+    createModelRequest.headers["authorization"] = "Bearer " + token;
+    const HttpResponse createModelResponse = fixture.router.handle(createModelRequest);
+    ASSERT_EQ(createModelResponse.status, 201);
+
+    HttpRequest currentRequest;
+    currentRequest.method = "GET";
+    currentRequest.path = "/api/v1/models/current";
+    currentRequest.headers["authorization"] = "Bearer " + token;
+
+    const HttpResponse currentResponse = fixture.router.handle(currentRequest);
+
+    EXPECT_EQ(currentResponse.status, 200);
+    EXPECT_NE(currentResponse.body.find("\"ok\":true"), std::string::npos);
+    EXPECT_NE(currentResponse.body.find("\"exists\":true"), std::string::npos);
+    EXPECT_NE(currentResponse.body.find("\"modelId\":"), std::string::npos);
+    EXPECT_NE(currentResponse.body.find("\"hasChanged\":"), std::string::npos);
+    EXPECT_NE(currentResponse.body.find("\"level\":"), std::string::npos);
+    EXPECT_NE(currentResponse.body.find("\"name\":"), std::string::npos);
+    EXPECT_NE(currentResponse.body.find("\"analystName\":"), std::string::npos);
+    EXPECT_NE(currentResponse.body.find("\"projectTitle\":"), std::string::npos);
+    EXPECT_NE(currentResponse.body.find("\"version\":"), std::string::npos);
+    EXPECT_NE(currentResponse.body.find("\"description\":"), std::string::npos);
+    EXPECT_NE(currentResponse.body.find("\"componentCount\":"), std::string::npos);
 }


### PR DESCRIPTION
WEB App

### Motivation
- Expose minimal ModelManager lifecycle over the web API (create + query current model) while keeping router transport-focused and low-risk.
- Ensure session map access is safe for future concurrent transports by adding internal synchronization.
- Keep kernel interactions in the service layer to preserve clean layering and small incremental change scope.

### Description
- Added two authenticated routes in `ApiRouter`: `POST /api/v1/models` to create a new model and `GET /api/v1/models/current` to query the current model, both requiring `Authorization: Bearer <token>` and returning the established JSON envelope. (See `source/applications/web/api/ApiRouter.{h,cpp}`.)
- Extended `SimulatorSessionService` with `ModelInfoResult`, `tryCreateModel(...)`, and `tryGetCurrentModelInfo(...)`, which validate session tokens, lock the per-session mutex, and use `Simulator -> ModelManager -> Model` accessors to populate safe model metadata. (See `source/applications/web/service/SimulatorSessionService.{h,cpp}`.)
- Hardened `SessionManager` by adding a mutex protecting the internal `_sessionsByToken` map and using it in session creation and lookup, while preserving `std::unique_ptr<SessionContext>` ownership. (See `source/applications/web/session/SessionManager.{h,cpp}`.)
- Added focused unit tests to `source/tests/unit/test_web_api_router.cpp` covering: missing token for current model (`401`), current model before creation (`exists=false`), model creation (`POST /api/v1/models`), and current model after creation (`exists=true` and expected fields).

### Testing
- Configured the web build: `cmake -S . -B build/web-debug -G Ninja -DGENESYS_BUILD_WEB_APPLICATION=ON` succeeded.
- Attempted to build targets: `cmake --build build/web-debug --target genesys_webhook genesys_test_web_api_router` failed at link due to pre-existing unresolved symbols related to `SinkModelComponent` (an upstream/runtime plugin linkage issue outside this change set), preventing creation of the test binary.
- Built `genesys_web_core` successfully with `cmake --build build/web-debug --target genesys_web_core`.
- Attempted to run router tests: `ctest --test-dir build/web-debug --output-on-failure -R web_api_router` could not run because the test executable was not produced due to the linker failure.

```markdown
## Stage 2 execution report

### What I completed
- Implemented `POST /api/v1/models` and `GET /api/v1/models/current` as Bearer-token authenticated endpoints with consistent JSON envelopes.
- Added `SimulatorSessionService::ModelInfoResult`, `tryCreateModel(...)`, and `tryGetCurrentModelInfo(...)` to keep kernel access in the service layer.
- Added internal synchronization to `SessionManager` for session map create/lookup while preserving `unique_ptr` ownership.
- Extended `source/tests/unit/test_web_api_router.cpp` with focused tests for Stage 2 behaviors.

### What I could not complete
- End-to-end test execution: `genesys_test_web_api_router` did not run because linking failed for `genesys_webhook` and the test binary was not produced.

### Why anything remains incomplete
- A pre-existing linker error (unresolved `SinkModelComponent` symbols in plugin/runtime linkage) stopped the build/link step unrelated to the web-layer edits, preventing test binary production.

### Validation performed
- Ran CMake configure for web build and verified generation of build files.
- Attempted build of requested targets and observed a linker failure external to these changes.
- Built `genesys_web_core` target successfully.

### Risks remaining
- Upstream plugin/runtime linkage must be resolved to run the full test binary and validate runtime interaction; until then, end-to-end automated test execution in this environment is blocked.
- No change to kernel internals was made, but the new code assumes existing `ModelManager`, `Model`, `ModelInfo`, and `ComponentManager` accessors remain stable.

### Files changed
- `source/applications/web/api/ApiRouter.h`
- `source/applications/web/api/ApiRouter.cpp`
- `source/applications/web/service/SimulatorSessionService.h`
- `source/applications/web/service/SimulatorSessionService.cpp`
- `source/applications/web/session/SessionManager.h`
- `source/applications/web/session/SessionManager.cpp`
- `source/tests/unit/test_web_api_router.cpp`
```

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d823756ea48321b3851b03bee84323)