### PR TITLE
test: expand parser probabilistic regression coverage

### DIFF
--- a/source/tests/unit/test_parser_expressions.cpp
+++ b/source/tests/unit/test_parser_expressions.cpp
@@ -65,6 +65,52 @@ TEST_F(ParserExpressionsTest, ProbabilisticFunctionsValidExpressionsWithThrowsEx
     EXPECT_TRUE(errorMessage.empty());
     EXPECT_TRUE(std::isfinite(expoValue));
     EXPECT_GE(expoValue, 0.0);
+
+    errorMessage.clear();
+    const double weibValue = model->parseExpression("weib(2,3)", success, errorMessage);
+    EXPECT_TRUE(success);
+    EXPECT_TRUE(errorMessage.empty());
+    EXPECT_TRUE(std::isfinite(weibValue));
+    EXPECT_GE(weibValue, 0.0);
+}
+
+TEST_F(ParserExpressionsTest, AdditionalProbabilisticFunctionsValidExpressionsWithThrowsExceptionTrue) {
+    bool success = false;
+    std::string errorMessage;
+
+    const double normValue = model->parseExpression("norm(0,1)", success, errorMessage);
+    EXPECT_TRUE(success);
+    EXPECT_TRUE(errorMessage.empty());
+    EXPECT_TRUE(std::isfinite(normValue));
+
+    errorMessage.clear();
+    const double lognValue = model->parseExpression("logn(2,0.5)", success, errorMessage);
+    EXPECT_TRUE(success);
+    EXPECT_TRUE(errorMessage.empty());
+    EXPECT_TRUE(std::isfinite(lognValue));
+    EXPECT_GE(lognValue, 0.0);
+
+    errorMessage.clear();
+    const double gammValue = model->parseExpression("gamm(2,3)", success, errorMessage);
+    EXPECT_TRUE(success);
+    EXPECT_TRUE(errorMessage.empty());
+    EXPECT_TRUE(std::isfinite(gammValue));
+    EXPECT_GE(gammValue, 0.0);
+
+    errorMessage.clear();
+    const double erlaValue = model->parseExpression("erla(4,2)", success, errorMessage);
+    EXPECT_TRUE(success);
+    EXPECT_TRUE(errorMessage.empty());
+    EXPECT_TRUE(std::isfinite(erlaValue));
+    EXPECT_GE(erlaValue, 0.0);
+
+    errorMessage.clear();
+    const double betaValue = model->parseExpression("beta(2,3,0,1)", success, errorMessage);
+    EXPECT_TRUE(success);
+    EXPECT_TRUE(errorMessage.empty());
+    EXPECT_TRUE(std::isfinite(betaValue));
+    EXPECT_GE(betaValue, 0.0);
+    EXPECT_LE(betaValue, 1.0);
 }
 
 TEST_F(ParserExpressionsTest, ProbabilisticFunctionsInvalidExpressionsAreRecoverableWithThrowsExceptionTrue) {
@@ -87,6 +133,46 @@ TEST_F(ParserExpressionsTest, ProbabilisticFunctionsInvalidExpressionsAreRecover
     EXPECT_FALSE(success);
     EXPECT_FALSE(errorMessage.empty());
     EXPECT_NE(errorMessage.find("weib"), std::string::npos);
+}
+
+TEST_F(ParserExpressionsTest, AdditionalProbabilisticFunctionsInvalidExpressionsAreRecoverableWithThrowsExceptionTrue) {
+    bool success = true;
+    std::string errorMessage;
+
+    (void) model->parseExpression("norm(0,-1)", success, errorMessage);
+    EXPECT_FALSE(success);
+    EXPECT_FALSE(errorMessage.empty());
+    EXPECT_NE(errorMessage.find("norm"), std::string::npos);
+
+    errorMessage.clear();
+    (void) model->parseExpression("logn(0,0.5)", success, errorMessage);
+    EXPECT_FALSE(success);
+    EXPECT_FALSE(errorMessage.empty());
+    EXPECT_NE(errorMessage.find("logn"), std::string::npos);
+
+    errorMessage.clear();
+    (void) model->parseExpression("logn(2,-0.5)", success, errorMessage);
+    EXPECT_FALSE(success);
+    EXPECT_FALSE(errorMessage.empty());
+    EXPECT_NE(errorMessage.find("logn"), std::string::npos);
+
+    errorMessage.clear();
+    (void) model->parseExpression("gamm(2,0)", success, errorMessage);
+    EXPECT_FALSE(success);
+    EXPECT_FALSE(errorMessage.empty());
+    EXPECT_NE(errorMessage.find("gamm"), std::string::npos);
+
+    errorMessage.clear();
+    (void) model->parseExpression("erla(4,0)", success, errorMessage);
+    EXPECT_FALSE(success);
+    EXPECT_FALSE(errorMessage.empty());
+    EXPECT_NE(errorMessage.find("erla"), std::string::npos);
+
+    errorMessage.clear();
+    (void) model->parseExpression("beta(2,3,1,0)", success, errorMessage);
+    EXPECT_FALSE(success);
+    EXPECT_FALSE(errorMessage.empty());
+    EXPECT_NE(errorMessage.find("beta"), std::string::npos);
 }
 
 TEST(ParserDriverThrowsFalseTest, ProbabilisticFunctionsRecoverWithoutThrowing) {
@@ -128,5 +214,14 @@ TEST(ParserDriverThrowsFalseTest, ProbabilisticFunctionsRecoverWithoutThrowing) 
         const std::string message = driver.getErrorMessage();
         EXPECT_FALSE(message.empty());
         EXPECT_NE(message.find("weib"), std::string::npos);
+    });
+
+    EXPECT_NO_THROW({
+        const int parseResult = driver.parse_str("logn(2,-0.5)");
+        EXPECT_NE(parseResult, 0);
+        EXPECT_EQ(driver.getResult(), -1.0);
+        const std::string message = driver.getErrorMessage();
+        EXPECT_FALSE(message.empty());
+        EXPECT_NE(message.find("logn"), std::string::npos);
     });
 }


### PR DESCRIPTION
### Motivation
- Consolidate regression coverage for probabilistic functions whose sampler validation was changed so assertion failures became recoverable errors, to prevent regressions in parser→sampler behavior.
- Ensure explicit tests for `norm`, `logn`, `gamm`, `erla`, and `beta` (valid and invalid cases) while preserving existing coverage for `unif`, `tria`, `expo`, and `weib`.

### Description
- Added / expanded tests in `source/tests/unit/test_parser_expressions.cpp` to include valid and invalid scenarios for `norm`, `logn`, `gamm`, `erla`, and `beta`, and an explicit valid check for `weib(2,3)`; preserved existing `unif`, `tria`, and `expo` checks.
- Invalid-case checks assert recoverable failure via `model->parseExpression(expr, success, errorMessage)` and verify the error message contains the function name.
- Added a representative `throwsException=false` coverage case using `genesyspp_driver(..., false)` for an invalid `logn(2,-0.5)` parse to exercise the non-throwing driver path.
- Changes are limited to tests only; no runtime/parser/sampler production code was modified.

### Testing
- Built and ran unit tests (normal preset) with `cmake --preset tests-kernel-unit`, `cmake --build build/tests-kernel-unit --target genesys_test_parser_expressions -j4`, and `./build/tests-kernel-unit/source/tests/unit/genesys_test_parser_expressions`, and observed all tests pass (`9 tests`, all PASSED).
- Built and ran under UBSan with `cmake --preset ubsan`, `cmake --build build/ubsan --target genesys_test_parser_expressions -j4`, and `./build/ubsan/source/tests/unit/genesys_test_parser_expressions`, and observed all tests pass.
- Built and ran under ASan with `cmake --preset asan` and `cmake --build build/asan --target genesys_test_parser_expressions -j4` and `./build/asan/source/tests/unit/genesys_test_parser_expressions`; the tests themselves passed but the process exited non-zero due to pre-existing LeakSanitizer-reported leaks rooted in parser/driver allocation/destruction paths.
- Branch used: `WiP20261`, and only `source/tests/unit/test_parser_expressions.cpp` was modified in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8222a2ff08321ad56a7dd2dfc841d)