### PR TITLE
Avoid heap temporaries in ModelChecker and SimulationReporter to fix leaks

### DIFF
--- a/source/kernel/simulator/ModelCheckerDefaultImpl1.cpp
+++ b/source/kernel/simulator/ModelCheckerDefaultImpl1.cpp
@@ -93,8 +93,9 @@ bool ModelCheckerDefaultImpl1::checkConnected() {
 	Plugin* plugin;
 	Util::IncIndent();
 	{
-		List<ModelComponent*>* visited = new List<ModelComponent*>();
-		List<ModelComponent*>* unconnected = new List<ModelComponent*>();
+		// Use automatic local containers to avoid leaking traversal bookkeeping structures.
+		List<ModelComponent*> visited;
+		List<ModelComponent*> unconnected;
 		ModelComponent* comp;
 		for (std::list<ModelComponent*>::iterator it = _model->getComponentManager()->begin(); it != _model->getComponentManager()->end(); it++) {
 			comp = (*it);
@@ -103,7 +104,7 @@ bool ModelCheckerDefaultImpl1::checkConnected() {
 			if (plugin->getPluginInfo()->isSource() || plugin->getPluginInfo()->isReceiveTransfer()) { //(dynamic_cast<SourceModelComponent*> (comp) != nullptr) {
 				// it is a source component OR it can receive enetities from transfer
 				bool drenoFound = false;
-				_recursiveConnectedTo(pluginManager, comp, visited, unconnected, &drenoFound);
+				_recursiveConnectedTo(pluginManager, comp, &visited, &unconnected, &drenoFound);
 				if (!drenoFound)
 					resultAll = false;
 			}
@@ -111,7 +112,7 @@ bool ModelCheckerDefaultImpl1::checkConnected() {
 		// check if any component remains unconnected
 		for (std::list<ModelComponent*>::iterator it = _model->getComponentManager()->begin(); it != _model->getComponentManager()->end(); it++) {
 			comp = (*it);
-			if (visited->find(comp) == visited->list()->end()) { //not found
+			if (visited.find(comp) == visited.list()->end()) { //not found
 				resultAll = false;
 				_model->getTracer()->traceError("Component \"" + comp->getName() + "\" is unconnected.");
 			}
@@ -232,13 +233,14 @@ bool ModelCheckerDefaultImpl1::checkOrphaned() {
 	_model->getTracer()->trace("Checking Orphaned DataDefinitions", TraceManager::Level::L7_internal);
 	Util::IncIndent();
 	{
-		std::list<ModelDataDefinition*>* orphaned = new std::list<ModelDataDefinition*>();
+		// Track orphan candidates in automatic storage to prevent per-check leaks.
+		std::list<ModelDataDefinition*> orphaned;
 		// Start by including all elements as orphaned
 		// Use a value snapshot of type names when enumerating initial orphan candidates.
 		std::list<std::string> allTypes = _model->getDataManager()->getDataDefinitionClassnames();
 		for (std::string ddtypename : allTypes) {
 			for (ModelDataDefinition* element : *_model->getDataManager()->getDataDefinitionList(ddtypename)->list()) {
-				orphaned->insert(orphaned->end(), element);
+				orphaned.insert(orphaned.end(), element);
 			}
 		}
 		// now exclude all those are refered by someone.
@@ -250,12 +252,12 @@ bool ModelCheckerDefaultImpl1::checkOrphaned() {
 			for (ModelDataDefinition* element : *_model->getDataManager()->getDataDefinitionList(ddtypename)->list()) {
 				for (std::pair<std::string, ModelDataDefinition*> pairInternal : *element->getInternalData()) {
 					mdd = pairInternal.second;
-					orphaned->remove(mdd);
+					orphaned.remove(mdd);
 					_model->getTracer()->trace("(" + element->getClassname() + ") " + element->getName() + " <#>--> " + "(" + mdd->getClassname() + ") " + mdd->getName());
 				}
 				for (std::pair<std::string, ModelDataDefinition*> pairAttached : *element->getAttachedData()) {
 					mdd = pairAttached.second;
-					orphaned->remove(mdd);
+					orphaned.remove(mdd);
 					_model->getTracer()->trace("(" + element->getClassname() + ") " + element->getName() + " < >--> " + "(" + mdd->getClassname() + ") " + mdd->getName());
 				}
 			}
@@ -264,21 +266,21 @@ bool ModelCheckerDefaultImpl1::checkOrphaned() {
 		for (ModelComponent* component : *_model->getComponentManager()->getAllComponents()) {
 			for (std::pair<std::string, ModelDataDefinition*> pairInternal : *component->getInternalData()) {
 				mdd = pairInternal.second;
-				orphaned->remove(mdd);
+				orphaned.remove(mdd);
 				_model->getTracer()->trace("(" + component->getClassname() + ") " + component->getName() + " <#>--> " + "(" + mdd->getClassname() + ") " + mdd->getName());
 			}
 			for (std::pair<std::string, ModelDataDefinition*> pairAttached : *component->getAttachedData()) {
 				mdd = pairAttached.second;
-				orphaned->remove(mdd);
+				orphaned.remove(mdd);
 				_model->getTracer()->trace("(" + component->getClassname() + ") " + component->getName() + " < >--> " + "(" + mdd->getClassname() + ") " + mdd->getName());
 			}
 		}
 		// every one in orphaned list now is really orphaned
-		if (orphaned->size() > 0) {
+		if (orphaned.size() > 0) {
 			_model->getTracer()->trace("Orphaned DataDefinitions found and will be removed:", TraceManager::Level::L7_internal);
 			Util::IncIndent();
 			{
-				for (ModelDataDefinition* orphanElem : *orphaned) {
+				for (ModelDataDefinition* orphanElem : orphaned) {
 					_model->getTracer()->trace("Orphan (" + orphanElem->getClassname() + ") " + orphanElem->getName() + "(id=" + std::to_string(orphanElem->getId()) + ") removed");
 					_model->getDataManager()->remove(orphanElem);
 				}

--- a/source/kernel/simulator/SimulationReporterDefaultImpl1.cpp
+++ b/source/kernel/simulator/SimulationReporterDefaultImpl1.cpp
@@ -52,15 +52,15 @@ void SimulationReporterDefaultImpl1::showReplicationStatistics() {
 	if (_simulation->isShowSimulationControlsInReport())
 		this->showSimulationControls(); // assumed the controls are the same for all replications, show them only for the whole simulation
 
-	// copy the list of statistics and counters into a single new list
-	std::list<ModelDataDefinition*>* statisticsAndCounters = new std::list<ModelDataDefinition*>(*(_model->getDataManager()->getDataDefinitionList(UtilTypeOfStatisticsCollector)->list()));
-	std::list<ModelDataDefinition*>* counters = new std::list<ModelDataDefinition*>(*(_model->getDataManager()->getDataDefinitionList(UtilTypeOfCounter)->list()));
-	statisticsAndCounters->merge(*counters);
+	// Combine stats and counters in local temporary lists without heap allocation.
+	std::list<ModelDataDefinition*> statisticsAndCounters(*(_model->getDataManager()->getDataDefinitionList(UtilTypeOfStatisticsCollector)->list()));
+	std::list<ModelDataDefinition*> counters(*(_model->getDataManager()->getDataDefinitionList(UtilTypeOfCounter)->list()));
+	statisticsAndCounters.merge(counters);
 	//statisticsAndCounters->insert(counters->list()->begin(), counters->list()->end());
-	// organizes statistics into a map of maps
-	std::map< std::string, std::map<std::string, std::list<ModelDataDefinition*>*>* >* mapMapTypeStat = new std::map<std::string, std::map<std::string, std::list<ModelDataDefinition*>*>*>();
+	// Group report items by parent type and parent name with automatic storage containers.
+	std::map<std::string, std::map<std::string, std::list<ModelDataDefinition*> > > mapMapTypeStat;
 
-	for (ModelDataDefinition* cstatOrCounter : *statisticsAndCounters) {
+	for (ModelDataDefinition* cstatOrCounter : statisticsAndCounters) {
 		std::string parentName, parentTypename;
 		//std::cout << statOrCnt->getName() << ": " << statOrCnt->getTypename() << std::endl;
 		if (cstatOrCounter->getClassname() == UtilTypeOfStatisticsCollector) {
@@ -76,26 +76,9 @@ void SimulationReporterDefaultImpl1::showReplicationStatistics() {
 			}
 		}
 		// look for key=parentTypename
-		std::map<std::string, std::map<std::string, std::list<ModelDataDefinition*>*>*>::iterator mapMapIt = mapMapTypeStat->find(parentTypename);
-		if (mapMapIt == mapMapTypeStat->end()) { // parentTypename does not exists in map. Include it.
-			std::pair< std::string, std::map<std::string, std::list<ModelDataDefinition*>*>* >* newPair = new std::pair<std::string, std::map<std::string, std::list<ModelDataDefinition*>*>*>(parentTypename, new std::map<std::string, std::list<ModelDataDefinition*>*>());
-			mapMapTypeStat->insert(*newPair);
-			mapMapIt = mapMapTypeStat->find(parentTypename); // find again. Now it will.
-		}
-		//assert(mapMapIt != mapMapTypeStat->end());
-		std::map<std::string, std::list<ModelDataDefinition*>*>* mapTypeStat = (*mapMapIt).second;
-		assert(mapTypeStat != nullptr);
-		// look for key=parentName
-		std::map<std::string, std::list<ModelDataDefinition*>*>::iterator mapIt = mapTypeStat->find(parentName);
-		if (mapIt == mapTypeStat->end()) { // parentTypename does not exists in map. Include it.
-			std::pair< std::string, std::list<ModelDataDefinition*>* >* newPair = new std::pair<std::string, std::list<ModelDataDefinition*>*>(parentName, new std::list<ModelDataDefinition*>());
-			mapTypeStat->insert(*newPair);
-			mapIt = mapTypeStat->find(parentName); // find again. Now it will.
-		}
-		// get the list and insert the stat in that list
-		std::list<ModelDataDefinition*>* listStatAndCount = (*mapIt).second;
-		assert(listStatAndCount != nullptr);
-		listStatAndCount->insert(listStatAndCount->end(), cstatOrCounter);
+		// Insert into nested maps/lists via references to avoid heap-allocated pairs and lists.
+		std::list<ModelDataDefinition*>& listStatAndCount = mapMapTypeStat[parentTypename][parentName];
+		listStatAndCount.insert(listStatAndCount.end(), cstatOrCounter);
 		//_model->getTraceManager()->traceReport(parentTypename + " -> " + parentName + " -> " + stat->show());
 	}
 	//
@@ -107,16 +90,16 @@ void SimulationReporterDefaultImpl1::showReplicationStatistics() {
 	Util::DecIndent();
 	Util::DecIndent();
 	const unsigned short _w1 = _w - 1;
-	for (auto mapmapItem : *mapMapTypeStat) {
+	for (const auto& mapmapItem : mapMapTypeStat) {
 		_model->getTracer()->traceReport("Statistics for " + mapmapItem.first + ":");
 		Util::IncIndent();
 		{
-			for (auto mapItem : *(mapmapItem.second)) {
+			for (const auto& mapItem : mapmapItem.second) {
 				_model->getTracer()->traceReport(mapItem.first + ":");
 				Util::IncIndent();
 				{
 					//					_model->getTracer()->traceReport(Util::SetW("name", _nameW) + Util::SetW("elems", _w) + Util::SetW("min", _w) + Util::SetW("max", _w) + Util::SetW("average", _w) + Util::SetW("variance", _w) + Util::SetW("stddev", _w) + Util::SetW("varCoef", _w) + Util::SetW("confInterv", _w) + Util::SetW("confLevel", _w));
-					for (ModelDataDefinition * const item : *(mapItem.second)) {
+					for (ModelDataDefinition* const item : mapItem.second) {
 						if (item->getClassname() == UtilTypeOfStatisticsCollector) {
 							Statistics_if* stat = dynamic_cast<StatisticsCollector*> (item)->getStatistics();
 							_model->getTracer()->traceReport(
@@ -175,8 +158,8 @@ void SimulationReporterDefaultImpl1::showSimulationStatistics() {//List<Statisti
 	// runs over all elements and list the statistics for each one, and then the statistics with no parent
 	// COPY the list of statistics and counters into a single new list
 	//std::list<ModelDataDefinition*>* statisticsAndCounters = //new std::list<ModelDataDefinition*>(*(this->_statsCountersSimulation->list()));
-	// organizes statistics into a map of maps
-	std::map< std::string, std::map<std::string, std::list<ModelDataDefinition*>*>* >* mapMapTypeStat = new std::map<std::string, std::map<std::string, std::list<ModelDataDefinition*>*>*>();
+	// Group simulation-level stats and counters in local containers without heap-allocated nodes.
+	std::map<std::string, std::map<std::string, std::list<ModelDataDefinition*> > > mapMapTypeStat;
 
 	for (std::list<ModelDataDefinition*>::iterator it = _statsCountersSimulation->list()->begin(); it != _statsCountersSimulation->list()->end(); it++) {
 		std::string parentName, parentTypename;
@@ -195,25 +178,9 @@ void SimulationReporterDefaultImpl1::showSimulationStatistics() {//List<Statisti
 			}
 		}
 		// look for key=parentTypename
-		std::map<std::string, std::map<std::string, std::list<ModelDataDefinition*>*>*>::iterator mapMapIt = mapMapTypeStat->find(parentTypename);
-		if (mapMapIt == mapMapTypeStat->end()) { // parentTypename does not exists in map. Include it.
-			std::pair< std::string, std::map<std::string, std::list<ModelDataDefinition*>*>* >* newPair = new std::pair<std::string, std::map<std::string, std::list<ModelDataDefinition*>*>*>(parentTypename, new std::map<std::string, std::list<ModelDataDefinition*>*>());
-			mapMapTypeStat->insert(*newPair);
-			mapMapIt = mapMapTypeStat->find(parentTypename); // find again. Now it will.
-		}
-		assert(mapMapIt != mapMapTypeStat->end());
-		std::map<std::string, std::list<ModelDataDefinition*>*>* mapTypeStat = (*mapMapIt).second;
-		assert(mapTypeStat != nullptr);
-		// look for key=parentName
-		std::map<std::string, std::list<ModelDataDefinition*>*>::iterator mapIt = mapTypeStat->find(parentName);
-		if (mapIt == mapTypeStat->end()) { // parentTypename does not exists in map. Include it.
-			std::pair< std::string, std::list<ModelDataDefinition*>* >* newPair = new std::pair<std::string, std::list<ModelDataDefinition*>*>(parentName, new std::list<ModelDataDefinition*>());
-			mapTypeStat->insert(*newPair);
-			mapIt = mapTypeStat->find(parentName); // find again. Now it will.
-		}
-		// get the list and insert the stat in that list
-		std::list<ModelDataDefinition*>* listStat = (*mapIt).second;
-		listStat->insert(listStat->end(), statOrCnt);
+		// Insert into grouped lists using map references to avoid manual heap lifecycle.
+		std::list<ModelDataDefinition*>& listStat = mapMapTypeStat[parentTypename][parentName];
+		listStat.insert(listStat.end(), statOrCnt);
 		//_model->getTraceManager()->traceReport(parentTypename + " -> " + parentName + " -> " + stat->show());
 	}
 	// now runs over that map of maps showing the statistics
@@ -225,15 +192,15 @@ void SimulationReporterDefaultImpl1::showSimulationStatistics() {//List<Statisti
 	Util::DecIndent();
 	// @TODO: USE REFERENCE TO MAPITEM TO AVOID COPY
 	const unsigned short _w1 = _w - 1;
-	for (auto mapmapItem : *mapMapTypeStat) {
+	for (const auto& mapmapItem : mapMapTypeStat) {
 		_model->getTracer()->traceReport("Statistics for " + mapmapItem.first + ":");
 		Util::IncIndent();
 		{
-			for (auto mapItem : *(mapmapItem.second)) {
+			for (const auto& mapItem : mapmapItem.second) {
 				_model->getTracer()->traceReport(mapItem.first + ":");
 				Util::IncIndent();
 				{
-					for (ModelDataDefinition * const item : *(mapItem.second)) {
+					for (ModelDataDefinition* const item : mapItem.second) {
 						if (item->getClassname() == UtilTypeOfStatisticsCollector) {
 							Statistics_if* stat = dynamic_cast<StatisticsCollector*> (item)->getStatistics();
 							_model->getTracer()->traceReport(


### PR DESCRIPTION
### Motivation
- Remove obvious, short-lived heap allocations that caused ASan/LSan-reported leaks in runtime checks and reporting while keeping behavior unchanged.
- Limit the patch to the two specified files to eliminate residual leaks originating from trivial temporary containers.

### Description
- Replaced heap-allocated traversal bookkeeping in `ModelCheckerDefaultImpl1::checkConnected()` with automatic `List<ModelComponent*> visited` and `List<ModelComponent*> unconnected` and adjusted the recursive call to pass their addresses; added a short English comment above the changed block.
- Replaced heap-allocated `std::list<ModelDataDefinition*> orphaned` in `ModelCheckerDefaultImpl1::checkOrphaned()` with an automatic `std::list<ModelDataDefinition*> orphaned` and updated usages accordingly; added a short English comment above the changed block.
- Reworked `SimulationReporterDefaultImpl1::showReplicationStatistics()` to use automatic `std::list` and nested `std::map` containers and to insert directly into nested lists instead of creating `new`ed maps/pairs/lists; added a short English comment above the changed block.
- Applied the same automatic-container strategy to `SimulationReporterDefaultImpl1::showSimulationStatistics()` to eliminate `new`-allocated temporary maps/lists/pairs while preserving report structure; added a short English comment above the changed block.

### Testing
- Configured and built the normal test preset with `cmake --preset tests-kernel-unit` and `cmake --build build/tests-kernel-unit --target genesys_test_simulator_runtime -j4`, and the build completed successfully.
- Ran the unit test executable `./build/tests-kernel-unit/source/tests/unit/genesys_test_simulator_runtime` and all tests passed: `17/17 tests passed`.
- Configured and built ASan preset with `cmake --preset asan` and `cmake --build build/asan --target genesys_test_simulator_runtime -j4`, and the ASan build completed successfully.
- Ran ASan test binary with `ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 ./build/asan/source/tests/unit/genesys_test_simulator_runtime`; functional tests passed (17/17) but LeakSanitizer reported residual leaks (summary: 720 bytes leaked in 15 allocations) traced to `genesyspp_driver::genesyspp_driver(...)` → `ParserDefaultImpl2::ParserDefaultImpl2(...)` → `Model::Model(...)`, which is outside the two-file scope of this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8235573648321b96798672ed71a8f)