### PR TITLE
GUI R4: Gate transition event loop on ready-to-run animations

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/animations/AnimationTransition.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/animations/AnimationTransition.cpp
@@ -137,6 +137,16 @@ unsigned int AnimationTransition::getPortNumber() const {
     return _portNumber;
 }
 
+// Validate transition runtime invariants before starting or resuming animation.
+bool AnimationTransition::isReadyToRun() const {
+    return _myScene != nullptr
+            && _graphicalStartComponent != nullptr
+            && _graphicalEndComponent != nullptr
+            && _graphicalConnection != nullptr
+            && _imageAnimation != nullptr
+            && _pointsForAnimation.size() >= 2;
+}
+
 // Setters
 void AnimationTransition::setImageAnimation(GraphicalImageAnimation* imageAnimation) {
     _imageAnimation = imageAnimation;
@@ -156,8 +166,8 @@ void AnimationTransition::setRunning(bool running) {
 
 // Outros
 void AnimationTransition::startAnimation() {
-    // Guard against partially constructed transitions before interacting with scene/image pointers.
-    if (_myScene == nullptr || _imageAnimation == nullptr) {
+    // Block animation start when transition invariants are not fully satisfied.
+    if (!isReadyToRun()) {
         return;
     }
 
@@ -205,8 +215,8 @@ void AnimationTransition::stopAnimation() {
 }
 
 void AnimationTransition::restartAnimation() {
-    // Guard resume against missing image or invalid animation duration.
-    if (_imageAnimation == nullptr || duration() <= 0) {
+    // Block animation restart when transition invariants are not fully satisfied.
+    if (!isReadyToRun() || duration() <= 0) {
         return;
     }
 

--- a/source/applications/gui/qt/GenesysQtGUI/animations/AnimationTransition.h
+++ b/source/applications/gui/qt/GenesysQtGUI/animations/AnimationTransition.h
@@ -32,6 +32,8 @@ public:
     QList<QPointF> getPointsForAnimation() const;
     GraphicalImageAnimation* getImageAnimation() const;
     unsigned int getPortNumber() const;
+    // Expose whether transition has all runtime prerequisites to safely animate.
+    bool isReadyToRun() const;
 
     // Setters
     void setImageAnimation(GraphicalImageAnimation* imageAnimation);

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
@@ -1373,7 +1373,11 @@ void ModelGraphicsScene::animateTransition(ModelComponent *source, ModelComponen
     // Cria a animação
     AnimationTransition *animationTransition = new AnimationTransition(this, source, destination, viewSimulation);
 
-    if (animationTransition->getGraphicalStartComponent() != nullptr && animationTransition->getGraphicalEndComponent() != nullptr && viewSimulation) {
+    // Forward transition to local loop only when GUI endpoints and animation runtime are valid.
+    if (animationTransition->getGraphicalStartComponent() != nullptr
+            && animationTransition->getGraphicalEndComponent() != nullptr
+            && animationTransition->isReadyToRun()
+            && viewSimulation) {
         runAnimateTransition(animationTransition, event);
     } else {
         // Ensure invalid/non-visible transition is fully cleaned up to avoid leaks.
@@ -1384,6 +1388,15 @@ void ModelGraphicsScene::animateTransition(ModelComponent *source, ModelComponen
 }
 
 void ModelGraphicsScene::runAnimateTransition(AnimationTransition *animationTransition, Event *event, bool restart) {
+    // Exit before local event loop when transition pointer is invalid or not runnable.
+    if (animationTransition == nullptr || !animationTransition->isReadyToRun()) {
+        if (animationTransition != nullptr) {
+            animationTransition->stopAnimation();
+            delete animationTransition;
+        }
+        return;
+    }
+
     // Track transition lifetime across nested event loop execution.
     QPointer<AnimationTransition> guardedTransition(animationTransition);
 


### PR DESCRIPTION
### Motivation
- Prevent entering a nested `QEventLoop::exec()` for animation transitions that are not actually prepared to run, which can leave the local loop without an exit condition. 
- Introduce an explicit readiness contract on `AnimationTransition` to make runtime checks coherent and centralize the invariants used by callers.

### Description
- Added `bool isReadyToRun() const;` to `AnimationTransition` to expose an explicit readiness contract for running an animation. 
- Implemented `isReadyToRun()` in `AnimationTransition.cpp` to require `_myScene`, `_graphicalStartComponent`, `_graphicalEndComponent`, `_graphicalConnection`, `_imageAnimation` and at least two `_pointsForAnimation`. 
- Hardened `AnimationTransition::startAnimation()` and `AnimationTransition::restartAnimation()` to guard on `isReadyToRun()` before interacting with scene/image or starting the animation. 
- Updated `ModelGraphicsScene::animateTransition(...)` to require `animationTransition->isReadyToRun()` before forwarding to `runAnimateTransition(...)`, and to perform safe cleanup and return when not ready. 
- Added an early guard at the start of `ModelGraphicsScene::runAnimateTransition(...)` to return (with safe cleanup) when `animationTransition == nullptr` or `!animationTransition->isReadyToRun()`, thereby avoiding entering `loop.exec()` for invalid/unready transitions.

### Testing
- Performed static inspection and repository checks to verify diffs and that changes are restricted to the three requested files: `AnimationTransition.h`, `AnimationTransition.cpp`, and `ModelGraphicsScene.cpp`.
- Attempted to verify the GUI toolchain with `qmake --version` but the environment lacks Qt/qmake (`qmake: command not found`), so a full GUI build/test was not executed. 
- Confirmed by code inspection that `AnimationTransition` now exposes `isReadyToRun()` and that both the call sites (`animateTransition`, `runAnimateTransition`) and the transition start/restart paths use the readiness guard.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d827e121d483219dff3f8c67c0dbfe)