### PR TITLE
GUI: add fail-safe timeout to runAnimateTransition local event loop

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
@@ -55,6 +55,7 @@
 #include <QCoreApplication>
 #include <QThread>
 #include <QPointer>
+#include <QTimer>
 
 namespace {
 // Safely cast the scene parent to a generic graphics view.
@@ -1405,11 +1406,24 @@ void ModelGraphicsScene::runAnimateTransition(AnimationTransition *animationTran
     // Create the local event loop before starting the animation to avoid missing early signals.
     QEventLoop loop;
 
+    // Use a local single-shot timer as a fail-safe to guarantee loop termination.
+    QTimer timeoutTimer;
+    timeoutTimer.setSingleShot(true);
+
+    // Track when the local loop exits due to timeout instead of animation signals.
+    bool exitedByTimeout = false;
+
     // Store temporary finished connection to disconnect it after this loop execution.
     QMetaObject::Connection finishedConnection = connect(animationTransition, &AnimationTransition::finished, &loop, &QEventLoop::quit);
 
     // Ensure the local loop exits if the transition is destroyed during execution.
     QMetaObject::Connection destroyedConnection = connect(animationTransition, &QObject::destroyed, &loop, &QEventLoop::quit);
+
+    // Quit the local loop and mark timeout when the fail-safe timer expires.
+    QMetaObject::Connection timeoutConnection = connect(&timeoutTimer, &QTimer::timeout, [&loop, &exitedByTimeout]() {
+        exitedByTimeout = true;
+        loop.quit();
+    });
 
     // Connect state changes before start/restart so pause transitions are observed from the beginning.
     QMetaObject::Connection stateChangedConnection = connect(animationTransition, &QAbstractAnimation::stateChanged, [this, &loop, event, animationTransition](QAbstractAnimation::State newState, QAbstractAnimation::State oldState) {
@@ -1422,8 +1436,21 @@ void ModelGraphicsScene::runAnimateTransition(AnimationTransition *animationTran
     else
         animationTransition->startAnimation();
 
+    // Start the fail-safe timer with an additional margin over animation duration.
+    int timeoutMs = animationTransition->duration() + 1000;
+    if (timeoutMs < 1000) {
+        timeoutMs = 1000;
+    }
+    timeoutTimer.start(timeoutMs);
+
     // Aguarda a conclusão da animação sem bloquear o restante do código
     loop.exec();
+
+    // Stop and disconnect timer resources after leaving the local event loop.
+    if (timeoutTimer.isActive()) {
+        timeoutTimer.stop();
+    }
+    QObject::disconnect(timeoutConnection);
 
     // Explicitly disconnect temporary local connections created for this run only.
     QObject::disconnect(finishedConnection);
@@ -1438,6 +1465,14 @@ void ModelGraphicsScene::runAnimateTransition(AnimationTransition *animationTran
 
     // Resolve the guarded pointer before any post-loop state checks or deletion.
     AnimationTransition* transitionPtr = guardedTransition.data();
+
+    // Perform terminal cleanup when loop exit happened through timeout.
+    if (exitedByTimeout && transitionPtr != nullptr) {
+        transitionPtr->stopAnimation();
+        _animationsTransition->removeOne(transitionPtr);
+        delete transitionPtr;
+        return;
+    }
 
     // Remove and delete only when the guarded transition is still valid.
     if (transitionPtr != nullptr) {


### PR DESCRIPTION
### Motivation
- Prevent a local `QEventLoop` in `ModelGraphicsScene::runAnimateTransition()` from potentially blocking indefinitely when an animation neither finishes, pauses, nor is destroyed.
- Ensure a clear terminal cleanup path for transitions that outlive their expected duration to avoid leaked animations and hung GUI behavior.
- Keep the change scoped to the scene implementation only, without modifying animation or controller types.

### Description
- Added `#include <QTimer>` and created a local single-shot `QTimer timeoutTimer` inside `runAnimateTransition()` to act as a fail-safe for the local `QEventLoop`.
- Introduced a local boolean `exitedByTimeout` and a connection from `timeoutTimer::timeout` to `loop.quit()` that sets the flag so the exit reason is known.
- Start the timer before `loop.exec()` using the animation duration plus a 1000 ms margin (minimum 1000 ms), and stop/disconnect the timer and its connection immediately after `loop.exec()` returns.
- Implemented an explicit terminal timeout cleanup: when `exitedByTimeout` is true and the transition still exists, call `stopAnimation()`, remove it from `_animationsTransition`, `delete` it, and `return` to avoid following the normal paused/finished logic.
- All modifications are confined to `source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp` and include short English comments immediately above each altered code block.

### Testing
- Attempted an automated build-toolchain check with `qmake --version`, which failed because `qmake` is not available in this environment (`command not found`), so a full GUI build/test was not possible.
- Verified the change by code inspection and `git diff` to confirm the intended modifications and that only `ModelGraphicsScene.cpp` was altered; these static checks succeeded.
- No runtime or unit tests were executed due to the missing Qt/qmake toolchain in the environment; recommend running full build and runtime tests in a Qt6-enabled environment to validate behavior under real animation timeouts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d82a8a85f48321b709254d21cc21b7)