### PR TITLE
Fix parser driver ownership/lifetime in kernel parser path

### DIFF
--- a/source/parser/Genesys++-driver.cpp
+++ b/source/parser/Genesys++-driver.cpp
@@ -5,13 +5,107 @@
 
 //using namespace GenesysKernel;
 
-genesyspp_driver::genesyspp_driver() {
+namespace {
+// Deep-copy the referred-data registry so copied drivers do not share list ownership.
+std::map<std::string, std::list<std::string>*>* cloneReferedDataElements(const std::map<std::string, std::list<std::string>*>* source) {
+	auto* cloned = new std::map<std::string, std::list<std::string>*>();
+	if (source == nullptr) {
+		return cloned;
+	}
+	for (const auto& entry : *source) {
+		cloned->insert({entry.first, entry.second != nullptr ? new std::list<std::string>(*entry.second) : nullptr});
+	}
+	return cloned;
 }
+}
+
+genesyspp_driver::genesyspp_driver() {}
 
 genesyspp_driver::genesyspp_driver(/*GenesysKernel::*/Model* model, Sampler_if* sampler, bool throws) {
 	_model = model;
 	_sampler = sampler;
 	throwsException = throws;
+}
+
+// Release all dynamically allocated lists and the registry map owned by this driver.
+genesyspp_driver::~genesyspp_driver() {
+	clearReferedDataElements();
+	delete _referedDataElements;
+	_referedDataElements = nullptr;
+}
+
+// Copy constructor performs a deep copy of referred-data lists to avoid shared ownership.
+genesyspp_driver::genesyspp_driver(const genesyspp_driver& other)
+	: _model(other._model),
+	  _sampler(other._sampler),
+	  _referedDataElements(cloneReferedDataElements(other._referedDataElements)),
+	  _isRegisterReferedDataElements(other._isRegisterReferedDataElements),
+	  result(other.result),
+	  file(other.file),
+	  str_to_parse(other.str_to_parse),
+	  throwsException(other.throwsException),
+	  errorMessage(other.errorMessage) {}
+
+// Copy assignment replaces local registry with a deep-copied registry from the source driver.
+genesyspp_driver& genesyspp_driver::operator=(const genesyspp_driver& other) {
+	if (this == &other) {
+		return *this;
+	}
+	auto* newReferedDataElements = cloneReferedDataElements(other._referedDataElements);
+	clearReferedDataElements();
+	delete _referedDataElements;
+	_model = other._model;
+	_sampler = other._sampler;
+	_referedDataElements = newReferedDataElements;
+	_isRegisterReferedDataElements = other._isRegisterReferedDataElements;
+	result = other.result;
+	file = other.file;
+	str_to_parse = other.str_to_parse;
+	throwsException = other.throwsException;
+	errorMessage = other.errorMessage;
+	return *this;
+}
+
+// Move constructor transfers the registry pointer and leaves source in a valid empty state.
+genesyspp_driver::genesyspp_driver(genesyspp_driver&& other) noexcept
+	: _model(other._model),
+	  _sampler(other._sampler),
+	  _referedDataElements(other._referedDataElements),
+	  _isRegisterReferedDataElements(other._isRegisterReferedDataElements),
+	  result(other.result),
+	  file(std::move(other.file)),
+	  str_to_parse(std::move(other.str_to_parse)),
+	  throwsException(other.throwsException),
+	  errorMessage(std::move(other.errorMessage)) {
+	other._model = nullptr;
+	other._sampler = nullptr;
+	other._referedDataElements = nullptr;
+	other._isRegisterReferedDataElements = false;
+	other.result = 0.0;
+}
+
+// Move assignment safely releases current resources before taking over source ownership.
+genesyspp_driver& genesyspp_driver::operator=(genesyspp_driver&& other) noexcept {
+	if (this == &other) {
+		return *this;
+	}
+	clearReferedDataElements();
+	delete _referedDataElements;
+	_model = other._model;
+	_sampler = other._sampler;
+	_referedDataElements = other._referedDataElements;
+	_isRegisterReferedDataElements = other._isRegisterReferedDataElements;
+	result = other.result;
+	file = std::move(other.file);
+	str_to_parse = std::move(other.str_to_parse);
+	throwsException = other.throwsException;
+	errorMessage = std::move(other.errorMessage);
+	other._model = nullptr;
+	other._sampler = nullptr;
+	other._referedDataElements = nullptr;
+	other._isRegisterReferedDataElements = false;
+	other.result = 0.0;
+	return *this;
 }
 
 /*
@@ -176,6 +270,14 @@ std::map<std::string, std::list<std::string>*>* genesyspp_driver::getReferedData
 	return _referedDataElements;
 }
 void genesyspp_driver::clearReferedDataElements() {
+	// Delete each allocated list before clearing the map to avoid leaking referred-name lists.
+	if (_referedDataElements == nullptr) {
+		return;
+	}
+	for (auto& entry : *_referedDataElements) {
+		delete entry.second;
+		entry.second = nullptr;
+	}
 	_referedDataElements->clear();
 }
 

--- a/source/parser/Genesys++-driver.h
+++ b/source/parser/Genesys++-driver.h
@@ -26,7 +26,11 @@ class genesyspp_driver {
 public:
 	genesyspp_driver();
 	genesyspp_driver(/*GenesysKernel::*/Model* model, Sampler_if* sampler, bool throws = false);
-	virtual ~genesyspp_driver() = default;
+	virtual ~genesyspp_driver();
+	genesyspp_driver(const genesyspp_driver& other);
+	genesyspp_driver& operator=(const genesyspp_driver& other);
+	genesyspp_driver(genesyspp_driver&& other) noexcept;
+	genesyspp_driver& operator=(genesyspp_driver&& other) noexcept;
 public:
 	// Handling the scanner.
 	void scan_begin_file();
@@ -73,10 +77,10 @@ public: // trying to get infos about ModelDataElements refered in expressions (s
 	void addRefered(std::pair<std::string,std::string> referedElement);
 
 private:
-	/*GenesysKernel::*/Model* _model;
-	Sampler_if* _sampler;
+	/*GenesysKernel::*/Model* _model = nullptr;
+	Sampler_if* _sampler = nullptr;
 	std::map<std::string, std::list<std::string>*>* _referedDataElements = new std::map<std::string, std::list<std::string>*>(); // maps each dataelement class referenced to a list of referenced names
-	bool _isRegisterReferedDataElements;
+	bool _isRegisterReferedDataElements = false;
 private:
 	double result = 0;
 	std::string file;


### PR DESCRIPTION
### Motivation
- Prevent leaks and unsafe shallow copies in `genesyspp_driver` caused by a dynamically allocated `_referedDataElements` registry and defaulted destructor while `Parser_if::getParser()` returns the driver by value. 
- Make initialization deterministic for fragile members (`_model`, `_sampler`, `_isRegisterReferedDataElements`) to avoid undefined behavior from uninitialized fields. 
- Keep existing ownership contract for the sampler (parser wrapper / `ParserDefaultImpl2` remains owner) while making driver copies safe.

### Description
- Initialize `genesyspp_driver` members ` _model`, `_sampler`, and `_isRegisterReferedDataElements` inline in `source/parser/Genesys++-driver.h`. 
- Replace the defaulted destructor with an explicit `~genesyspp_driver()` that frees the referred-data lists and the registry map to avoid leaks. 
- Implement a minimal Rule-of-Five: deep-copy `cloneReferedDataElements()` for copy constructor and copy-assignment, and move constructor/move-assignment to transfer registry ownership safely in `source/parser/Genesys++-driver.cpp`. 
- Fix `clearReferedDataElements()` to `delete` each allocated `std::list<std::string>*` before clearing the map. 

### Testing
- Configured the build with `cmake --preset debug-kernel` and built the kernel with `cmake --build build/debug-kernel --target genesys_kernel -j4`. 
- The build completed successfully and the modified units (`genesyspp_driver` and parser/kernel runtime objects) compiled without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d82a9d1564832186c83f6ed729c530)