### PR TITLE
Fix parser driver referenced-data ownership leaks

### DIFF
--- a/source/parser/Genesys++-driver.cpp
+++ b/source/parser/Genesys++-driver.cpp
@@ -6,12 +6,46 @@
 //using namespace GenesysKernel;
 
 genesyspp_driver::genesyspp_driver() {
+	_model = nullptr;
+	_sampler = nullptr;
 }
 
 genesyspp_driver::genesyspp_driver(/*GenesysKernel::*/Model* model, Sampler_if* sampler, bool throws) {
 	_model = model;
 	_sampler = sampler;
 	throwsException = throws;
+}
+
+genesyspp_driver::genesyspp_driver(const genesyspp_driver& other) {
+	_model = other._model;
+	_sampler = other._sampler;
+	_isRegisterReferedDataElements = other._isRegisterReferedDataElements;
+	result = other.result;
+	file = other.file;
+	str_to_parse = other.str_to_parse;
+	throwsException = other.throwsException;
+	errorMessage = other.errorMessage;
+	_copyReferedDataElementsFrom(other);
+}
+
+genesyspp_driver& genesyspp_driver::operator=(const genesyspp_driver& other) {
+	if (this != &other) {
+		_destroyReferedDataElements();
+		_model = other._model;
+		_sampler = other._sampler;
+		_isRegisterReferedDataElements = other._isRegisterReferedDataElements;
+		result = other.result;
+		file = other.file;
+		str_to_parse = other.str_to_parse;
+		throwsException = other.throwsException;
+		errorMessage = other.errorMessage;
+		_copyReferedDataElementsFrom(other);
+	}
+	return *this;
+}
+
+genesyspp_driver::~genesyspp_driver() {
+	_destroyReferedDataElements();
 }
 
 /*
@@ -176,6 +210,9 @@ std::map<std::string, std::list<std::string>*>* genesyspp_driver::getReferedData
 	return _referedDataElements;
 }
 void genesyspp_driver::clearReferedDataElements() {
+	for (auto& dataElementEntry : *_referedDataElements) {
+		delete dataElementEntry.second;
+	}
 	_referedDataElements->clear();
 }
 
@@ -215,4 +252,23 @@ void
 genesyspp_driver::error(const std::string& m) {
 	setErrorMessage(m);
 	setResult(-1);
+}
+
+void genesyspp_driver::_destroyReferedDataElements() {
+	if (_referedDataElements != nullptr) {
+		clearReferedDataElements();
+		delete _referedDataElements;
+		_referedDataElements = nullptr;
+	}
+}
+
+void genesyspp_driver::_copyReferedDataElementsFrom(const genesyspp_driver& other) {
+	_referedDataElements = new std::map<std::string, std::list<std::string>*>();
+	for (const auto& dataElementEntry : *other._referedDataElements) {
+		if (dataElementEntry.second != nullptr) {
+			(*_referedDataElements)[dataElementEntry.first] = new std::list<std::string>(*dataElementEntry.second);
+		} else {
+			(*_referedDataElements)[dataElementEntry.first] = nullptr;
+		}
+	}
 }

--- a/source/parser/Genesys++-driver.cpp
+++ b/source/parser/Genesys++-driver.cpp
@@ -8,11 +8,13 @@
 genesyspp_driver::genesyspp_driver() {
 	_model = nullptr;
 	_sampler = nullptr;
+	_referedDataElements = new std::map<std::string, std::list<std::string>*>();
 }
 
 genesyspp_driver::genesyspp_driver(/*GenesysKernel::*/Model* model, Sampler_if* sampler, bool throws) {
 	_model = model;
 	_sampler = sampler;
+	_referedDataElements = new std::map<std::string, std::list<std::string>*>();
 	throwsException = throws;
 }
 
@@ -25,11 +27,12 @@ genesyspp_driver::genesyspp_driver(const genesyspp_driver& other) {
 	str_to_parse = other.str_to_parse;
 	throwsException = other.throwsException;
 	errorMessage = other.errorMessage;
-	_copyReferedDataElementsFrom(other);
+	_referedDataElements = _cloneReferedDataElements(other);
 }
 
 genesyspp_driver& genesyspp_driver::operator=(const genesyspp_driver& other) {
 	if (this != &other) {
+		std::map<std::string, std::list<std::string>*>* copiedReferedDataElements = _cloneReferedDataElements(other);
 		_destroyReferedDataElements();
 		_model = other._model;
 		_sampler = other._sampler;
@@ -39,7 +42,7 @@ genesyspp_driver& genesyspp_driver::operator=(const genesyspp_driver& other) {
 		str_to_parse = other.str_to_parse;
 		throwsException = other.throwsException;
 		errorMessage = other.errorMessage;
-		_copyReferedDataElementsFrom(other);
+		_referedDataElements = copiedReferedDataElements;
 	}
 	return *this;
 }
@@ -262,13 +265,14 @@ void genesyspp_driver::_destroyReferedDataElements() {
 	}
 }
 
-void genesyspp_driver::_copyReferedDataElementsFrom(const genesyspp_driver& other) {
-	_referedDataElements = new std::map<std::string, std::list<std::string>*>();
+std::map<std::string, std::list<std::string>*>* genesyspp_driver::_cloneReferedDataElements(const genesyspp_driver& other) const {
+	auto* copiedReferedDataElements = new std::map<std::string, std::list<std::string>*>();
 	for (const auto& dataElementEntry : *other._referedDataElements) {
 		if (dataElementEntry.second != nullptr) {
-			(*_referedDataElements)[dataElementEntry.first] = new std::list<std::string>(*dataElementEntry.second);
+			(*copiedReferedDataElements)[dataElementEntry.first] = new std::list<std::string>(*dataElementEntry.second);
 		} else {
-			(*_referedDataElements)[dataElementEntry.first] = nullptr;
+			(*copiedReferedDataElements)[dataElementEntry.first] = nullptr;
 		}
 	}
+	return copiedReferedDataElements;
 }

--- a/source/parser/Genesys++-driver.h
+++ b/source/parser/Genesys++-driver.h
@@ -26,7 +26,9 @@ class genesyspp_driver {
 public:
 	genesyspp_driver();
 	genesyspp_driver(/*GenesysKernel::*/Model* model, Sampler_if* sampler, bool throws = false);
-	virtual ~genesyspp_driver() = default;
+	genesyspp_driver(const genesyspp_driver& other);
+	genesyspp_driver& operator=(const genesyspp_driver& other);
+	virtual ~genesyspp_driver();
 public:
 	// Handling the scanner.
 	void scan_begin_file();
@@ -73,10 +75,13 @@ public: // trying to get infos about ModelDataElements refered in expressions (s
 	void addRefered(std::pair<std::string,std::string> referedElement);
 
 private:
+	void _destroyReferedDataElements();
+	void _copyReferedDataElementsFrom(const genesyspp_driver& other);
+private:
 	/*GenesysKernel::*/Model* _model;
 	Sampler_if* _sampler;
 	std::map<std::string, std::list<std::string>*>* _referedDataElements = new std::map<std::string, std::list<std::string>*>(); // maps each dataelement class referenced to a list of referenced names
-	bool _isRegisterReferedDataElements;
+	bool _isRegisterReferedDataElements = false;
 private:
 	double result = 0;
 	std::string file;

--- a/source/parser/Genesys++-driver.h
+++ b/source/parser/Genesys++-driver.h
@@ -76,11 +76,11 @@ public: // trying to get infos about ModelDataElements refered in expressions (s
 
 private:
 	void _destroyReferedDataElements();
-	void _copyReferedDataElementsFrom(const genesyspp_driver& other);
+	std::map<std::string, std::list<std::string>*>* _cloneReferedDataElements(const genesyspp_driver& other) const;
 private:
 	/*GenesysKernel::*/Model* _model;
 	Sampler_if* _sampler;
-	std::map<std::string, std::list<std::string>*>* _referedDataElements = new std::map<std::string, std::list<std::string>*>(); // maps each dataelement class referenced to a list of referenced names
+	std::map<std::string, std::list<std::string>*>* _referedDataElements; // maps each dataelement class referenced to a list of referenced names
 	bool _isRegisterReferedDataElements = false;
 private:
 	double result = 0;


### PR DESCRIPTION
### Motivation
- Address a LeakSanitizer-reported leak originating from `genesyspp_driver` ownership of `_referedDataElements` when the parser/driver cycle is used. 
- Preserve existing public API (including `ParserDefaultImpl2::getParser()` returning the driver by value) while removing heap leaks and avoiding double-free/shallow-copy risks. 

### Description
- Added explicit ownership management for `genesyspp_driver::_referedDataElements` by introducing `_destroyReferedDataElements()` and `_copyReferedDataElementsFrom()`. 
- Implemented a copy constructor and copy assignment operator for `genesyspp_driver` that perform a deep copy of the referenced-data map and nested lists. 
- Replaced the default destructor with an explicit destructor that frees the map and nested list allocations. 
- Updated `clearReferedDataElements()` to delete the dynamically allocated lists before clearing the map and initialized `_isRegisterReferedDataElements` defensively. 

### Testing
- Reproduced and validated the fix by running `cmake --preset tests-kernel-unit`, `cmake --build build/tests-kernel-unit --target genesys_test_parser_expressions -j4` and `./build/tests-kernel-unit/source/tests/unit/genesys_test_parser_expressions`, which completed with all tests passing. 
- Built and ran with ASan via `cmake --preset asan`, `cmake --build build/asan --target genesys_test_parser_expressions -j4` and `./build/asan/source/tests/unit/genesys_test_parser_expressions`, and the ASan run completed with the tests passing and no LeakSanitizer reports for the parser/driver path. 
- Built and ran with UBSan via `cmake --preset ubsan`, `cmake --build build/ubsan --target genesys_test_parser_expressions -j4` and `./build/ubsan/source/tests/unit/genesys_test_parser_expressions`, which also completed with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8281c4c048321a256a7b5868c0c0f)