### PR TITLE
GUI: normalize scene animation state at simulation boundaries

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/controllers/SimulationEventController.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/SimulationEventController.cpp
@@ -164,6 +164,11 @@ void SimulationEventController::onSimulationStartHandler(SimulationEvent* re) co
     double conversionFactorToSeconds = Util::TimeUnitConvert(replicationBaseTimeUnit, Util::TimeUnit(5));
     AnimationTimer::setConversionFactorToSeconds(conversionFactorToSeconds);
 
+    // Reset scene animation artifacts to guarantee a clean start baseline.
+    _scene->clearAnimationsTransition();
+    _scene->clearAnimationsQueue();
+    _scene->clearAnimationsValues();
+
     QCoreApplication::processEvents();
 }
 
@@ -200,13 +205,15 @@ void SimulationEventController::onSimulationEndHandler(SimulationEvent* re) cons
     Q_UNUSED(re)
     // Destroy all paused-animation lists and remaining paused animations before ending.
     cleanupPausedAnimationMap(_scene->getAnimationPaused(), true);
+    // Clear any remaining scene animation state before final UI updates.
+    _scene->clearAnimationsTransition();
+    _scene->clearAnimationsQueue();
+    _scene->clearAnimationsValues();
     _callbacks.actualizeActions();
     _centralTabWidget->setCurrentIndex(_tabCentralReportsIndex);
     for (unsigned int i = 0; i < 50; i++) {
         QCoreApplication::processEvents();
     }
-
-    _scene->clearAnimationsQueue();
 
     *_modelChecked = false;
 }


### PR DESCRIPTION
### Motivation
- Ensure the graphical scene is in a deterministic, clean baseline at simulation start and fully cleaned at simulation end to avoid visual/structural residues between runs.
- Reuse existing `ModelGraphicsScene` APIs to explicitly clear transitions, queued animations and visual values at simulation boundaries.

### Description
- Added explicit calls to `_scene->clearAnimationsTransition()`, `_scene->clearAnimationsQueue()` and `_scene->clearAnimationsValues()` in `onSimulationStartHandler()` before `QCoreApplication::processEvents()` with a short technical comment above the block.
- Added the same three explicit clear calls in `onSimulationEndHandler()` immediately after `cleanupPausedAnimationMap(...)` with a short technical comment above the block, preserving existing `_callbacks.actualizeActions()`, tab switch, processing loop and `_modelChecked = false` flow.
- Changes are limited to `source/applications/gui/qt/GenesysQtGUI/controllers/SimulationEventController.cpp` and include the requested brief English comments immediately above each modified code block.

### Testing
- Attempted to build the GUI target with `cmake` but the top-level configuration has GUI disabled by default so the `GenesysQtGUI` target was not generated, preventing a runnable GUI build in this environment.
- Verified `qmake` is not available in the environment (`qmake: command not found`), so Qt toolchain invocation is not possible here.
- Performed static code inspection and confirmed both `onSimulationStartHandler()` and `onSimulationEndHandler()` now explicitly clear transitions, queues and visual values as required; no other files were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d82d4eb20c8321a591f2960e3a758a)