### PR TITLE
Web Stage 3: add session-scoped model save/load persistence endpoints

### DIFF
--- a/source/applications/web/README.md
+++ b/source/applications/web/README.md
@@ -2,13 +2,18 @@
 
 First functional implementation of the **Web** application type for GenESyS.
 
-## Current Stage 1 scope
+## Current Stage 3 scope
 - CMake executable: `genesys_webhook` (enabled with `-DGENESYS_BUILD_WEB_APPLICATION=ON`).
 - Layered architecture for HTTP transport, API routing, session/token, and simulator service.
+- Stateful session management with one `Simulator` per session and per-session workspace directories.
 - Endpoints:
   - `GET /health`
   - `POST /api/v1/auth/session`
   - `GET /api/v1/simulator/info` (requires `Authorization: Bearer <token>`)
+  - `POST /api/v1/models` (requires `Authorization: Bearer <token>`)
+  - `GET /api/v1/models/current` (requires `Authorization: Bearer <token>`)
+  - `POST /api/v1/models/save` (requires `Authorization: Bearer <token>`)
+  - `POST /api/v1/models/load` (requires `Authorization: Bearer <token>`)
 
 ## How to run
 ```bash
@@ -23,3 +28,8 @@ Optional parameters:
 
 ## Security notice
 Session creation in Stage 1 is provisional and stateful in memory. Generated tokens are opaque random strings and **not** production-grade authentication.
+
+For Stage 3 model persistence:
+- Save/load operations are restricted to each session workspace directory.
+- API requests accept only a `filename` basename (no paths).
+- Filenames must match `[A-Za-z0-9._-]` and cannot include `..`, `/`, or `\`.

--- a/source/applications/web/api/ApiRouter.cpp
+++ b/source/applications/web/api/ApiRouter.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <regex>
 
 ApiRouter::ApiRouter(SimulatorSessionService& simulatorService) : _simulatorService(simulatorService) {}
 
@@ -92,6 +93,60 @@ HttpResponse ApiRouter::handle(const HttpRequest& request) const {
         return HttpResponse{200, "application/json", "{\"ok\":true,\"data\":" + _modelInfoDataJson(info) + "}"};
     }
 
+    if (request.path == "/api/v1/models/save") {
+        if (request.method != "POST") {
+            return _jsonError(405, "METHOD_NOT_ALLOWED", "Only POST is allowed for /api/v1/models/save");
+        }
+
+        const std::string token = _extractBearerToken(request);
+        if (token.empty()) {
+            return _jsonError(401, "UNAUTHORIZED", "Missing or invalid Bearer token");
+        }
+
+        std::string filename;
+        if (!_tryExtractFilenameFromBody(request.body, filename)) {
+            return _jsonError(400, "BAD_REQUEST", "Invalid request body: expected JSON with filename");
+        }
+
+        const auto result = _simulatorService.saveCurrentModel(token, filename);
+        if (!result.success) {
+            return _mapPersistenceError(result);
+        }
+
+        const std::string body =
+            "{\"ok\":true,\"data\":{"
+            "\"filename\":\"" + _escapeJson(result.filename) + "\","
+            "\"model\":" + _modelInfoDataJson(result.modelInfo) + "}}";
+        return HttpResponse{200, "application/json", body};
+    }
+
+    if (request.path == "/api/v1/models/load") {
+        if (request.method != "POST") {
+            return _jsonError(405, "METHOD_NOT_ALLOWED", "Only POST is allowed for /api/v1/models/load");
+        }
+
+        const std::string token = _extractBearerToken(request);
+        if (token.empty()) {
+            return _jsonError(401, "UNAUTHORIZED", "Missing or invalid Bearer token");
+        }
+
+        std::string filename;
+        if (!_tryExtractFilenameFromBody(request.body, filename)) {
+            return _jsonError(400, "BAD_REQUEST", "Invalid request body: expected JSON with filename");
+        }
+
+        const auto result = _simulatorService.loadModel(token, filename);
+        if (!result.success) {
+            return _mapPersistenceError(result);
+        }
+
+        const std::string body =
+            "{\"ok\":true,\"data\":{"
+            "\"filename\":\"" + _escapeJson(result.filename) + "\","
+            "\"model\":" + _modelInfoDataJson(result.modelInfo) + "}}";
+        return HttpResponse{200, "application/json", body};
+    }
+
     return _jsonError(404, "NOT_FOUND", "Route not found");
 }
 
@@ -114,6 +169,34 @@ std::string ApiRouter::_extractBearerToken(const HttpRequest& request) {
     token.erase(token.begin(), std::find_if(token.begin(), token.end(), [](unsigned char c) { return !std::isspace(c); }));
     token.erase(std::find_if(token.rbegin(), token.rend(), [](unsigned char c) { return !std::isspace(c); }).base(), token.end());
     return token;
+}
+
+bool ApiRouter::_tryExtractFilenameFromBody(const std::string& body, std::string& outFilename) {
+    static const std::regex filenameRegex("\"filename\"\\s*:\\s*\"([^\"]+)\"");
+    std::smatch match;
+    if (!std::regex_search(body, match, filenameRegex) || match.size() < 2) {
+        return false;
+    }
+    outFilename = match[1].str();
+    return !outFilename.empty();
+}
+
+HttpResponse ApiRouter::_mapPersistenceError(const SimulatorSessionService::ModelPersistenceResult& result) {
+    switch (result.error) {
+        case SimulatorSessionService::PersistenceError::InvalidToken:
+            return _jsonError(401, "UNAUTHORIZED", "Invalid or expired session token");
+        case SimulatorSessionService::PersistenceError::InvalidFilename:
+            return _jsonError(400, "INVALID_FILENAME", "Filename must be a safe basename using [A-Za-z0-9._-]");
+        case SimulatorSessionService::PersistenceError::MissingCurrentModel:
+            return _jsonError(409, "NO_CURRENT_MODEL", "No current model available to save");
+        case SimulatorSessionService::PersistenceError::FileNotFound:
+            return _jsonError(404, "MODEL_FILE_NOT_FOUND", "Model file not found in session workspace");
+        case SimulatorSessionService::PersistenceError::OperationFailed:
+            return _jsonError(500, "MODEL_PERSISTENCE_FAILED", "Model persistence operation failed");
+        case SimulatorSessionService::PersistenceError::None:
+        default:
+            return _jsonError(500, "INTERNAL_ERROR", "Unexpected persistence error state");
+    }
 }
 
 std::string ApiRouter::_escapeJson(const std::string& value) {

--- a/source/applications/web/api/ApiRouter.h
+++ b/source/applications/web/api/ApiRouter.h
@@ -15,6 +15,8 @@ private:
 
     static HttpResponse _jsonError(int status, const char* code, const char* message);
     static std::string _extractBearerToken(const HttpRequest& request);
+    static bool _tryExtractFilenameFromBody(const std::string& body, std::string& outFilename);
+    static HttpResponse _mapPersistenceError(const SimulatorSessionService::ModelPersistenceResult& result);
     static std::string _escapeJson(const std::string& value);
     static std::string _modelInfoDataJson(const SimulatorSessionService::ModelInfoResult& info);
 };

--- a/source/applications/web/service/SimulatorSessionService.cpp
+++ b/source/applications/web/service/SimulatorSessionService.cpp
@@ -1,6 +1,8 @@
 #include "SimulatorSessionService.h"
 
+#include <filesystem>
 #include <mutex>
+#include <regex>
 
 namespace {
 void _populateModelInfoFromModel(Model* model, SimulatorSessionService::ModelInfoResult& outInfo) {
@@ -85,4 +87,97 @@ bool SimulatorSessionService::tryGetCurrentModelInfo(const std::string& accessTo
 
     _populateModelInfoFromModel(model, outInfo);
     return true;
+}
+
+SimulatorSessionService::ModelPersistenceResult SimulatorSessionService::saveCurrentModel(
+    const std::string& accessToken,
+    const std::string& filename
+) {
+    if (!_isSafeFilename(filename)) {
+        return ModelPersistenceResult{false, PersistenceError::InvalidFilename, filename, ModelInfoResult{}};
+    }
+
+    SessionContext* session = _sessionManager.getSessionByToken(accessToken);
+    if (session == nullptr || session->simulator == nullptr) {
+        return ModelPersistenceResult{false, PersistenceError::InvalidToken, filename, ModelInfoResult{}};
+    }
+
+    std::scoped_lock lock(session->mutex);
+    ModelManager* modelManager = session->simulator->getModelManager();
+    if (modelManager == nullptr) {
+        return ModelPersistenceResult{false, PersistenceError::OperationFailed, filename, ModelInfoResult{}};
+    }
+
+    Model* model = modelManager->current();
+    if (model == nullptr) {
+        return ModelPersistenceResult{false, PersistenceError::MissingCurrentModel, filename, ModelInfoResult{}};
+    }
+
+    const std::filesystem::path modelPath = session->workspacePath / filename;
+    if (!modelManager->saveModel(modelPath.string())) {
+        return ModelPersistenceResult{false, PersistenceError::OperationFailed, filename, ModelInfoResult{}};
+    }
+
+    ModelPersistenceResult result{};
+    result.success = true;
+    result.error = PersistenceError::None;
+    result.filename = filename;
+    _populateModelInfoFromModel(model, result.modelInfo);
+    return result;
+}
+
+SimulatorSessionService::ModelPersistenceResult SimulatorSessionService::loadModel(
+    const std::string& accessToken,
+    const std::string& filename
+) {
+    if (!_isSafeFilename(filename)) {
+        return ModelPersistenceResult{false, PersistenceError::InvalidFilename, filename, ModelInfoResult{}};
+    }
+
+    SessionContext* session = _sessionManager.getSessionByToken(accessToken);
+    if (session == nullptr || session->simulator == nullptr) {
+        return ModelPersistenceResult{false, PersistenceError::InvalidToken, filename, ModelInfoResult{}};
+    }
+
+    std::scoped_lock lock(session->mutex);
+    ModelManager* modelManager = session->simulator->getModelManager();
+    if (modelManager == nullptr) {
+        return ModelPersistenceResult{false, PersistenceError::OperationFailed, filename, ModelInfoResult{}};
+    }
+
+    const std::filesystem::path modelPath = session->workspacePath / filename;
+    if (!std::filesystem::exists(modelPath) || !std::filesystem::is_regular_file(modelPath)) {
+        return ModelPersistenceResult{false, PersistenceError::FileNotFound, filename, ModelInfoResult{}};
+    }
+
+    Model* model = modelManager->loadModel(modelPath.string());
+    if (model == nullptr) {
+        return ModelPersistenceResult{false, PersistenceError::OperationFailed, filename, ModelInfoResult{}};
+    }
+
+    ModelPersistenceResult result{};
+    result.success = true;
+    result.error = PersistenceError::None;
+    result.filename = filename;
+    _populateModelInfoFromModel(model, result.modelInfo);
+    return result;
+}
+
+bool SimulatorSessionService::_isSafeFilename(const std::string& filename) {
+    if (filename.empty()) {
+        return false;
+    }
+
+    if (filename.find('/') != std::string::npos || filename.find('\\') != std::string::npos ||
+        filename.find("..") != std::string::npos) {
+        return false;
+    }
+
+    const std::filesystem::path path(filename);
+    if (path.is_absolute() || path.has_parent_path()) {
+        return false;
+    }
+
+    static const std::regex safeNamePattern("^[A-Za-z0-9._-]+$");
+    return std::regex_match(filename, safeNamePattern);
 }

--- a/source/applications/web/service/SimulatorSessionService.h
+++ b/source/applications/web/service/SimulatorSessionService.h
@@ -6,6 +6,15 @@
 
 class SimulatorSessionService {
 public:
+    enum class PersistenceError {
+        None,
+        InvalidToken,
+        InvalidFilename,
+        MissingCurrentModel,
+        FileNotFound,
+        OperationFailed
+    };
+
     struct CreateSessionResult {
         std::string sessionId;
         std::string accessToken;
@@ -30,13 +39,24 @@ public:
         unsigned int componentCount = 0;
     };
 
+    struct ModelPersistenceResult {
+        bool success = false;
+        PersistenceError error = PersistenceError::None;
+        std::string filename;
+        ModelInfoResult modelInfo;
+    };
+
     explicit SimulatorSessionService(SessionManager& sessionManager);
 
     CreateSessionResult createSession();
     bool tryGetSimulatorInfo(const std::string& accessToken, SimulatorInfoResult& outInfo);
     bool tryCreateModel(const std::string& accessToken, ModelInfoResult& outInfo);
     bool tryGetCurrentModelInfo(const std::string& accessToken, ModelInfoResult& outInfo);
+    ModelPersistenceResult saveCurrentModel(const std::string& accessToken, const std::string& filename);
+    ModelPersistenceResult loadModel(const std::string& accessToken, const std::string& filename);
 
 private:
+    static bool _isSafeFilename(const std::string& filename);
+
     SessionManager& _sessionManager;
 };

--- a/source/applications/web/session/SessionContext.h
+++ b/source/applications/web/session/SessionContext.h
@@ -2,6 +2,7 @@
 
 #include "../../../kernel/simulator/Simulator.h"
 
+#include <filesystem>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -9,6 +10,7 @@
 struct SessionContext {
     std::string sessionId;
     std::string accessToken;
+    std::filesystem::path workspacePath;
     std::unique_ptr<Simulator> simulator;
     mutable std::mutex mutex;
 };

--- a/source/applications/web/session/SessionManager.cpp
+++ b/source/applications/web/session/SessionManager.cpp
@@ -1,11 +1,20 @@
 #include "SessionManager.h"
 
+#include <filesystem>
 #include <mutex>
 #include <stdexcept>
 #include <utility>
 
 SessionManager::SessionManager(TokenService& tokenService, SimulatorFactory simulatorFactory)
-    : _tokenService(tokenService), _simulatorFactory(std::move(simulatorFactory)) {}
+    : _tokenService(tokenService),
+      _simulatorFactory(std::move(simulatorFactory)),
+      _workspaceRoot(_buildWorkspaceRoot()) {
+    std::error_code ec;
+    std::filesystem::create_directories(_workspaceRoot, ec);
+    if (ec) {
+        throw std::runtime_error("Failed to create workspace root directory for web sessions");
+    }
+}
 
 SessionContext* SessionManager::createSession() {
     std::scoped_lock lock(_sessionsMutex);
@@ -23,6 +32,13 @@ SessionContext* SessionManager::createSession() {
     if (!session->simulator) {
         throw std::runtime_error("Failed to create Simulator for session");
     }
+    session->workspacePath = _workspaceRoot / session->sessionId;
+
+    std::error_code ec;
+    std::filesystem::create_directories(session->workspacePath, ec);
+    if (ec) {
+        throw std::runtime_error("Failed to create workspace directory for session");
+    }
 
     SessionContext* raw = session.get();
     _sessionsByToken.emplace(token, std::move(session));
@@ -37,4 +53,8 @@ SessionContext* SessionManager::getSessionByToken(const std::string& token) {
         return nullptr;
     }
     return it->second.get();
+}
+
+std::filesystem::path SessionManager::_buildWorkspaceRoot() {
+    return std::filesystem::temp_directory_path() / "genesys_web_sessions";
 }

--- a/source/applications/web/session/SessionManager.h
+++ b/source/applications/web/session/SessionManager.h
@@ -4,6 +4,7 @@
 #include "../auth/TokenService.h"
 
 #include <functional>
+#include <filesystem>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -19,8 +20,11 @@ public:
     SessionContext* getSessionByToken(const std::string& token);
 
 private:
+    static std::filesystem::path _buildWorkspaceRoot();
+
     TokenService& _tokenService;
     SimulatorFactory _simulatorFactory;
+    std::filesystem::path _workspaceRoot;
     mutable std::mutex _sessionsMutex;
     std::unordered_map<std::string, std::unique_ptr<SessionContext>> _sessionsByToken;
 };

--- a/source/tests/unit/test_web_api_router.cpp
+++ b/source/tests/unit/test_web_api_router.cpp
@@ -31,6 +31,18 @@ std::string extractJsonStringField(const std::string& json, const std::string& f
 
     return json.substr(valueStart, valueEnd - valueStart);
 }
+
+std::string createSessionAndGetToken(ApiRouter& router) {
+    HttpRequest createSessionRequest;
+    createSessionRequest.method = "POST";
+    createSessionRequest.path = "/api/v1/auth/session";
+    const HttpResponse createSessionResponse = router.handle(createSessionRequest);
+    EXPECT_EQ(createSessionResponse.status, 201);
+
+    const std::string token = extractJsonStringField(createSessionResponse.body, "accessToken");
+    EXPECT_FALSE(token.empty());
+    return token;
+}
 }  // namespace
 
 TEST(WebSessionManagerTest, CreateSessionProducesUniqueTokens) {
@@ -198,4 +210,137 @@ TEST(WebApiRouterTest, CurrentModelAfterCreationReturnsExpectedFields) {
     EXPECT_NE(currentResponse.body.find("\"version\":"), std::string::npos);
     EXPECT_NE(currentResponse.body.find("\"description\":"), std::string::npos);
     EXPECT_NE(currentResponse.body.find("\"componentCount\":"), std::string::npos);
+}
+
+TEST(WebApiRouterTest, SaveModelWithoutTokenReturnsUnauthorized) {
+    ApiRouterFixture fixture;
+
+    HttpRequest request;
+    request.method = "POST";
+    request.path = "/api/v1/models/save";
+    request.body = "{\"filename\":\"model.gen\"}";
+
+    const HttpResponse response = fixture.router.handle(request);
+
+    EXPECT_EQ(response.status, 401);
+    EXPECT_NE(response.body.find("\"ok\":false"), std::string::npos);
+}
+
+TEST(WebApiRouterTest, LoadModelWithoutTokenReturnsUnauthorized) {
+    ApiRouterFixture fixture;
+
+    HttpRequest request;
+    request.method = "POST";
+    request.path = "/api/v1/models/load";
+    request.body = "{\"filename\":\"model.gen\"}";
+
+    const HttpResponse response = fixture.router.handle(request);
+
+    EXPECT_EQ(response.status, 401);
+    EXPECT_NE(response.body.find("\"ok\":false"), std::string::npos);
+}
+
+TEST(WebApiRouterTest, SaveModelWithInvalidBodyReturnsBadRequest) {
+    ApiRouterFixture fixture;
+    const std::string token = createSessionAndGetToken(fixture.router);
+
+    HttpRequest request;
+    request.method = "POST";
+    request.path = "/api/v1/models/save";
+    request.headers["authorization"] = "Bearer " + token;
+    request.body = "{}";
+
+    const HttpResponse response = fixture.router.handle(request);
+
+    EXPECT_EQ(response.status, 400);
+    EXPECT_NE(response.body.find("\"ok\":false"), std::string::npos);
+}
+
+TEST(WebApiRouterTest, LoadModelWithInvalidBodyReturnsBadRequest) {
+    ApiRouterFixture fixture;
+    const std::string token = createSessionAndGetToken(fixture.router);
+
+    HttpRequest request;
+    request.method = "POST";
+    request.path = "/api/v1/models/load";
+    request.headers["authorization"] = "Bearer " + token;
+    request.body = "{\"filename\":42}";
+
+    const HttpResponse response = fixture.router.handle(request);
+
+    EXPECT_EQ(response.status, 400);
+    EXPECT_NE(response.body.find("\"ok\":false"), std::string::npos);
+}
+
+TEST(WebApiRouterTest, SaveModelWithInvalidFilenameReturnsBadRequest) {
+    ApiRouterFixture fixture;
+    const std::string token = createSessionAndGetToken(fixture.router);
+
+    HttpRequest createModelRequest;
+    createModelRequest.method = "POST";
+    createModelRequest.path = "/api/v1/models";
+    createModelRequest.headers["authorization"] = "Bearer " + token;
+    ASSERT_EQ(fixture.router.handle(createModelRequest).status, 201);
+
+    HttpRequest saveRequest;
+    saveRequest.method = "POST";
+    saveRequest.path = "/api/v1/models/save";
+    saveRequest.headers["authorization"] = "Bearer " + token;
+    saveRequest.body = "{\"filename\":\"../model.gen\"}";
+
+    const HttpResponse saveResponse = fixture.router.handle(saveRequest);
+
+    EXPECT_EQ(saveResponse.status, 400);
+    EXPECT_NE(saveResponse.body.find("\"INVALID_FILENAME\""), std::string::npos);
+}
+
+TEST(WebApiRouterTest, SaveAndLoadModelInSessionWorkspaceSucceeds) {
+    ApiRouterFixture fixture;
+    const std::string token = createSessionAndGetToken(fixture.router);
+
+    HttpRequest createModelRequest;
+    createModelRequest.method = "POST";
+    createModelRequest.path = "/api/v1/models";
+    createModelRequest.headers["authorization"] = "Bearer " + token;
+    ASSERT_EQ(fixture.router.handle(createModelRequest).status, 201);
+
+    HttpRequest saveRequest;
+    saveRequest.method = "POST";
+    saveRequest.path = "/api/v1/models/save";
+    saveRequest.headers["authorization"] = "Bearer " + token;
+    saveRequest.headers["content-type"] = "application/json";
+    saveRequest.body = "{\"filename\":\"model.gen\"}";
+    const HttpResponse saveResponse = fixture.router.handle(saveRequest);
+    ASSERT_EQ(saveResponse.status, 200);
+    EXPECT_NE(saveResponse.body.find("\"ok\":true"), std::string::npos);
+    EXPECT_NE(saveResponse.body.find("\"filename\":\"model.gen\""), std::string::npos);
+
+    HttpRequest loadRequest;
+    loadRequest.method = "POST";
+    loadRequest.path = "/api/v1/models/load";
+    loadRequest.headers["authorization"] = "Bearer " + token;
+    loadRequest.headers["content-type"] = "application/json";
+    loadRequest.body = "{\"filename\":\"model.gen\"}";
+    const HttpResponse loadResponse = fixture.router.handle(loadRequest);
+    EXPECT_EQ(loadResponse.status, 200);
+    EXPECT_NE(loadResponse.body.find("\"ok\":true"), std::string::npos);
+    EXPECT_NE(loadResponse.body.find("\"filename\":\"model.gen\""), std::string::npos);
+    EXPECT_NE(loadResponse.body.find("\"exists\":true"), std::string::npos);
+}
+
+TEST(WebApiRouterTest, LoadModelForMissingFileReturnsNotFound) {
+    ApiRouterFixture fixture;
+    const std::string token = createSessionAndGetToken(fixture.router);
+
+    HttpRequest request;
+    request.method = "POST";
+    request.path = "/api/v1/models/load";
+    request.headers["authorization"] = "Bearer " + token;
+    request.body = "{\"filename\":\"missing.gen\"}";
+
+    const HttpResponse response = fixture.router.handle(request);
+
+    EXPECT_EQ(response.status, 404);
+    EXPECT_NE(response.body.find("\"ok\":false"), std::string::npos);
+    EXPECT_NE(response.body.find("\"MODEL_FILE_NOT_FOUND\""), std::string::npos);
 }


### PR DESCRIPTION
### Motivation
- Provide controlled persistence for session models so clients can save/load models without exposing filesystem paths and while enforcing simple filename safety.

### Description
- Add `workspacePath` to `SessionContext` and create a per-session workspace under `std::filesystem::temp_directory_path()/genesys_web_sessions/<sessionId>` in `SessionManager`.
- Add `saveCurrentModel(token, filename)` and `loadModel(token, filename)` to `SimulatorSessionService` with `ModelPersistenceResult`/`PersistenceError` and strict filename validation using the regex `^[A-Za-z0-9._-]+$` (rejects empty, `/`, `\\`, `..`, absolute paths and parent paths).
- Implement `POST /api/v1/models/save` and `POST /api/v1/models/load` in `ApiRouter` with minimal JSON `filename` extraction (regex), Bearer token extraction, and mapping of service errors to coherent HTTP status codes and the existing `{ok,data}` / `{ok,error}` envelope.
- Add focused unit tests in `source/tests/unit/test_web_api_router.cpp` and update the web `README.md` to document Stage 3 endpoints and filename policy.

### Testing
- Configured the project with `cmake -S . -B build/web-debug -G Ninja -DGENESYS_BUILD_WEB_APPLICATION=ON` which completed successfully.
- Attempted to build `genesys_webhook` and `genesys_test_web_api_router` with `cmake --build build/web-debug --target genesys_webhook genesys_test_web_api_router`, but the build failed at link time due to an unrelated, pre-existing linker error (`undefined reference` to `SinkModelComponent`) preventing generation of the binaries.
- `ctest --test-dir build/web-debug --output-on-failure -R web_api_router` could not run because the test binary was not produced by the build step.

## Stage 3 execution report

### What I completed
- Implemented per-session workspace directory creation and storage in session context.
- Added `POST /api/v1/models/save` and `POST /api/v1/models/load` with Bearer auth.
- Implemented filename safety validation and server-side path resolution inside session workspace only.
- Added service-layer save/load logic with structured result/error mapping and router-level minimal body parsing.

### What I could not complete
- Full build+test pass and manual webhook/curl smoke run in this environment.

### Why anything remains incomplete
- The environment currently has a linker failure unrelated to this patch (`undefined reference` to `SinkModelComponent` from plugin linkage), which blocks `genesys_webhook` and `genesys_test_web_api_router` binaries from being produced.

### Validation performed
- Configured project with CMake + Ninja.
- Attempted build for `genesys_webhook` and `genesys_test_web_api_router`.
- Attempted `ctest -R web_api_router` run (blocked because test binary was not built).

### Risks remaining
- Runtime behavior of the new endpoints could not be smoke-tested via live `genesys_webhook` process due to build/link blockage.
- JSON body parsing is intentionally minimal/contract-focused (stage scope), so malformed-but-unusual JSON variants outside the expected contract may be rejected.

### Files changed
- `source/applications/web/session/SessionContext.h`
- `source/applications/web/session/SessionManager.h`
- `source/applications/web/session/SessionManager.cpp`
- `source/applications/web/service/SimulatorSessionService.h`
- `source/applications/web/service/SimulatorSessionService.cpp`
- `source/applications/web/api/ApiRouter.h`
- `source/applications/web/api/ApiRouter.cpp`
- `source/tests/unit/test_web_api_router.cpp`
- `source/applications/web/README.md`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d82be3eaec8321802e15cb9db3202e)