### PR TITLE
Fix smoke simulator_start static link order

### DIFF
--- a/source/tests/smoke/CMakeLists.txt
+++ b/source/tests/smoke/CMakeLists.txt
@@ -6,6 +6,8 @@ target_link_libraries(genesys_smoke_simulator_start
     PRIVATE
         genesys_kernel_simulator_runtime
         genesys_kernel_util
+        genesys_plugins_components_minimal
+        genesys_kernel_simulator_runtime
 )
 
 add_test(NAME smoke_simulator_start COMMAND genesys_smoke_simulator_start)


### PR DESCRIPTION
WEB App

### Motivation
- Resolve the linker failure in `genesys_smoke_simulator_start` (undefined reference to `SinkModelComponent`) by stabilizing the static library link order for the smoke baseline; work was performed on local branch `work` because `WiP20261` was not present locally.

### Description
- Modify `source/tests/smoke/CMakeLists.txt` to explicitly link `genesys_plugins_components_minimal` and repeat `genesys_kernel_simulator_runtime` in the `target_link_libraries` for `genesys_smoke_simulator_start`, keeping the change minimal and limited to the smoke test target.

### Testing
- Executed `cmake -S . -B build/tests-audit -G Ninja -DGENESYS_BUILD_TESTS=ON`, `cmake --build build/tests-audit --target genesys_tests`, and `ctest --test-dir build/tests-audit --output-on-failure` (including `-L unit` and `-L smoke`), and the unit and smoke tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d82cba884483219e7e5d48753e668a)