### PR TITLE
Fix dangling referenced-data pointers in Model reference checks

### DIFF
--- a/source/kernel/simulator/Model.cpp
+++ b/source/kernel/simulator/Model.cpp
@@ -211,7 +211,23 @@ void Model::checkReferencesToDataDefinitions(std::string expression, std::map<st
 	wrapper.clearReferedDataElements();
 	wrapper.parse_str(expression);
 	std::map<std::string, std::list<std::string>*>* refs = wrapper.getReferedDataElements();
-	referencedDataDefinitions->insert(refs->begin(), refs->end());
+	// Deep-copy referred element names so output map owns stable lists beyond parser wrapper lifetime.
+	for (const auto& typeAndNames : *refs) {
+		const std::string& typeName = typeAndNames.first;
+		const std::list<std::string>* sourceNames = typeAndNames.second;
+		if (sourceNames == nullptr) {
+			continue;
+		}
+		std::list<std::string>*& destinationNames = (*referencedDataDefinitions)[typeName];
+		if (destinationNames == nullptr) {
+			destinationNames = new std::list<std::string>();
+		}
+		for (const std::string& referencedName : *sourceNames) {
+			if (std::find(destinationNames->begin(), destinationNames->end(), referencedName) == destinationNames->end()) {
+				destinationNames->push_back(referencedName);
+			}
+		}
+	}
 	wrapper.setRegisterReferedDataElements(false);
 }
 

--- a/source/kernel/simulator/ModelDataDefinition.cpp
+++ b/source/kernel/simulator/ModelDataDefinition.cpp
@@ -212,6 +212,12 @@ void ModelDataDefinition::_checkCreateAttachedReferencedDataDefinition(std::stri
 		}
 		Util::DecIndent();
 	}
+	// Release temporary lists allocated during reference extraction to avoid local ownership leaks.
+	for (auto& pair : referencedDataDefinitions) {
+		delete pair.second;
+		pair.second = nullptr;
+	}
+	referencedDataDefinitions.clear();
 }
 
 bool ModelDataDefinition::_getSaveDefaultsOption() {


### PR DESCRIPTION
KERNEL

### Motivation
- The parser driver returns a temporary map of `std::list<std::string>*` owned by the parser wrapper, and copying those pointers left dangling when the wrapper was destroyed. 
- A local map in `_checkCreateAttachedReferencedDataDefinition()` held allocated lists without deleting them, leaking memory.

### Description
- Replaced the shallow `insert(refs->begin(), refs->end())` in `Model::checkReferencesToDataDefinitions()` with a deep-copy loop that allocates caller-owned `std::list<std::string>` per type, defensively skips `nullptr` sources and avoids simple duplicates.  (A short comment was added just above the changed block explaining the intent.)
- Added explicit cleanup in `ModelDataDefinition::_checkCreateAttachedReferencedDataDefinition()` that deletes each `std::list<std::string>*` in the temporary map and clears the map afterward, removing the local leak (with a short explanatory comment above the cleanup block).
- Preserved the public API of `Model::checkReferencesToDataDefinitions()` and kept the `_attachedData` non-owner policy unchanged.
- Files changed: `source/kernel/simulator/Model.cpp`, `source/kernel/simulator/ModelDataDefinition.cpp`.

### Testing
- Configured the project with `cmake --preset debug-kernel` and built the kernel target with `cmake --build build/debug-kernel --target genesys_kernel -j4`, both succeeded and the modified files were recompiled. 
- No unit tests were added or executed as requested.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d82dfef3e88321aea5c650b6527a91)