### PR TITLE
web: add /api/v1/simulation/status and /api/v1/simulation/config endpoints (Stage 4)

### DIFF
--- a/source/applications/web/README.md
+++ b/source/applications/web/README.md
@@ -2,7 +2,7 @@
 
 First functional implementation of the **Web** application type for GenESyS.
 
-## Current Stage 3 scope
+## Current Stage 4 scope
 - CMake executable: `genesys_webhook` (enabled with `-DGENESYS_BUILD_WEB_APPLICATION=ON`).
 - Layered architecture for HTTP transport, API routing, session/token, and simulator service.
 - Stateful session management with one `Simulator` per session and per-session workspace directories.
@@ -14,6 +14,8 @@ First functional implementation of the **Web** application type for GenESyS.
   - `GET /api/v1/models/current` (requires `Authorization: Bearer <token>`)
   - `POST /api/v1/models/save` (requires `Authorization: Bearer <token>`)
   - `POST /api/v1/models/load` (requires `Authorization: Bearer <token>`)
+  - `GET /api/v1/simulation/status` (requires `Authorization: Bearer <token>`)
+  - `POST /api/v1/simulation/config` (requires `Authorization: Bearer <token>`)
 
 ## How to run
 ```bash
@@ -33,3 +35,7 @@ For Stage 3 model persistence:
 - Save/load operations are restricted to each session workspace directory.
 - API requests accept only a `filename` basename (no paths).
 - Filenames must match `[A-Za-z0-9._-]` and cannot include `..`, `/`, or `\`.
+
+For Stage 4 simulation configuration:
+- `POST /api/v1/simulation/config` currently uses a minimal contract parser without external JSON libraries.
+- All configuration fields are required in the request body: `numberOfReplications`, `replicationLength`, `warmUpPeriod`, `pauseOnEvent`, `pauseOnReplication`, `initializeStatistics`, `initializeSystem`.

--- a/source/applications/web/api/ApiRouter.cpp
+++ b/source/applications/web/api/ApiRouter.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstdlib>
 #include <regex>
 
 ApiRouter::ApiRouter(SimulatorSessionService& simulatorService) : _simulatorService(simulatorService) {}
@@ -147,6 +148,64 @@ HttpResponse ApiRouter::handle(const HttpRequest& request) const {
         return HttpResponse{200, "application/json", body};
     }
 
+    if (request.path == "/api/v1/simulation/status") {
+        if (request.method != "GET") {
+            return _jsonError(405, "METHOD_NOT_ALLOWED", "Only GET is allowed for /api/v1/simulation/status");
+        }
+
+        const std::string token = _extractBearerToken(request);
+        if (token.empty()) {
+            return _jsonError(401, "UNAUTHORIZED", "Missing or invalid Bearer token");
+        }
+
+        const auto result = _simulatorService.getSimulationStatus(token);
+        if (!result.success) {
+            if (result.invalidToken) {
+                return _jsonError(401, "UNAUTHORIZED", "Invalid or expired session token");
+            }
+            return _jsonError(500, "INTERNAL_ERROR", "Unable to query simulation status");
+        }
+
+        return HttpResponse{200, "application/json", "{\"ok\":true,\"data\":" + _simulationStatusDataJson(result) + "}"};
+    }
+
+    if (request.path == "/api/v1/simulation/config") {
+        if (request.method != "POST") {
+            return _jsonError(405, "METHOD_NOT_ALLOWED", "Only POST is allowed for /api/v1/simulation/config");
+        }
+
+        const std::string token = _extractBearerToken(request);
+        if (token.empty()) {
+            return _jsonError(401, "UNAUTHORIZED", "Missing or invalid Bearer token");
+        }
+
+        const auto config = _parseSimulationConfigBody(request.body);
+        if (!config.has_value()) {
+            return _jsonError(
+                400,
+                "INVALID_SIMULATION_CONFIG",
+                "Invalid request body: required fields are numberOfReplications, replicationLength, warmUpPeriod, pauseOnEvent, pauseOnReplication, initializeStatistics, initializeSystem"
+            );
+        }
+
+        const auto result = _simulatorService.configureSimulation(token, config.value());
+        if (!result.success) {
+            if (result.invalidToken) {
+                return _jsonError(401, "UNAUTHORIZED", "Invalid or expired session token");
+            }
+            if (result.missingCurrentModel) {
+                return _jsonError(409, "NO_CURRENT_MODEL", "No current model available to configure simulation");
+            }
+            return _jsonError(500, "INTERNAL_ERROR", "Unable to configure simulation");
+        }
+
+        return HttpResponse{
+            200,
+            "application/json",
+            "{\"ok\":true,\"data\":" + _simulationStatusDataJson(result.status) + "}"
+        };
+    }
+
     return _jsonError(404, "NOT_FOUND", "Route not found");
 }
 
@@ -179,6 +238,90 @@ bool ApiRouter::_tryExtractFilenameFromBody(const std::string& body, std::string
     }
     outFilename = match[1].str();
     return !outFilename.empty();
+}
+
+bool ApiRouter::_tryExtractUnsignedIntField(const std::string& body, const std::string& fieldName, unsigned int& outValue) {
+    const std::regex pattern("\"" + fieldName + "\"\\s*:\\s*([0-9]+)");
+    std::smatch match;
+    if (!std::regex_search(body, match, pattern) || match.size() < 2) {
+        return false;
+    }
+
+    const std::string value = match[1].str();
+    char* endPtr = nullptr;
+    const unsigned long parsed = std::strtoul(value.c_str(), &endPtr, 10);
+    if (endPtr == nullptr || *endPtr != '\0') {
+        return false;
+    }
+
+    outValue = static_cast<unsigned int>(parsed);
+    return true;
+}
+
+bool ApiRouter::_tryExtractDoubleField(const std::string& body, const std::string& fieldName, double& outValue) {
+    const std::regex pattern("\"" + fieldName + "\"\\s*:\\s*(-?(?:[0-9]+(?:\\.[0-9]+)?|\\.[0-9]+)(?:[eE][+-]?[0-9]+)?)");
+    std::smatch match;
+    if (!std::regex_search(body, match, pattern) || match.size() < 2) {
+        return false;
+    }
+
+    const std::string value = match[1].str();
+    char* endPtr = nullptr;
+    const double parsed = std::strtod(value.c_str(), &endPtr);
+    if (endPtr == nullptr || *endPtr != '\0') {
+        return false;
+    }
+
+    outValue = parsed;
+    return true;
+}
+
+bool ApiRouter::_tryExtractBooleanField(const std::string& body, const std::string& fieldName, bool& outValue) {
+    const std::regex pattern("\"" + fieldName + "\"\\s*:\\s*(true|false)");
+    std::smatch match;
+    if (!std::regex_search(body, match, pattern) || match.size() < 2) {
+        return false;
+    }
+
+    outValue = match[1].str() == "true";
+    return true;
+}
+
+std::optional<SimulatorSessionService::SimulationConfigInput> ApiRouter::_parseSimulationConfigBody(const std::string& body) {
+    SimulatorSessionService::SimulationConfigInput config{};
+    if (!_tryExtractUnsignedIntField(body, "numberOfReplications", config.numberOfReplications) ||
+        !_tryExtractDoubleField(body, "replicationLength", config.replicationLength) ||
+        !_tryExtractDoubleField(body, "warmUpPeriod", config.warmUpPeriod) ||
+        !_tryExtractBooleanField(body, "pauseOnEvent", config.pauseOnEvent) ||
+        !_tryExtractBooleanField(body, "pauseOnReplication", config.pauseOnReplication) ||
+        !_tryExtractBooleanField(body, "initializeStatistics", config.initializeStatistics) ||
+        !_tryExtractBooleanField(body, "initializeSystem", config.initializeSystem)) {
+        return std::nullopt;
+    }
+
+    return config;
+}
+
+std::string ApiRouter::_simulationStatusDataJson(const SimulatorSessionService::SimulationStatusResult& status) {
+    std::string json = "{\"hasCurrentModel\":" + std::string(status.hasCurrentModel ? "true" : "false");
+    if (!status.hasCurrentModel) {
+        json += "}";
+        return json;
+    }
+
+    json += ",\"isRunning\":" + std::string(status.isRunning ? "true" : "false");
+    json += ",\"isPaused\":" + std::string(status.isPaused ? "true" : "false");
+    json += ",\"simulatedTime\":" + std::to_string(status.simulatedTime);
+    json += ",\"currentReplicationNumber\":" + std::to_string(status.currentReplicationNumber);
+    json += ",\"numberOfReplications\":" + std::to_string(status.numberOfReplications);
+    json += ",\"replicationLength\":" + std::to_string(status.replicationLength);
+    json += ",\"warmUpPeriod\":" + std::to_string(status.warmUpPeriod);
+    json += ",\"pauseOnEvent\":" + std::string(status.pauseOnEvent ? "true" : "false");
+    json += ",\"pauseOnReplication\":" + std::string(status.pauseOnReplication ? "true" : "false");
+    json += ",\"initializeStatistics\":" + std::string(status.initializeStatistics ? "true" : "false");
+    json += ",\"initializeSystem\":" + std::string(status.initializeSystem ? "true" : "false");
+    json += "}";
+    return json;
 }
 
 HttpResponse ApiRouter::_mapPersistenceError(const SimulatorSessionService::ModelPersistenceResult& result) {

--- a/source/applications/web/api/ApiRouter.h
+++ b/source/applications/web/api/ApiRouter.h
@@ -4,6 +4,8 @@
 #include "../http/HttpResponse.h"
 #include "../service/SimulatorSessionService.h"
 
+#include <optional>
+
 class ApiRouter {
 public:
     explicit ApiRouter(SimulatorSessionService& simulatorService);
@@ -16,6 +18,11 @@ private:
     static HttpResponse _jsonError(int status, const char* code, const char* message);
     static std::string _extractBearerToken(const HttpRequest& request);
     static bool _tryExtractFilenameFromBody(const std::string& body, std::string& outFilename);
+    static bool _tryExtractUnsignedIntField(const std::string& body, const std::string& fieldName, unsigned int& outValue);
+    static bool _tryExtractDoubleField(const std::string& body, const std::string& fieldName, double& outValue);
+    static bool _tryExtractBooleanField(const std::string& body, const std::string& fieldName, bool& outValue);
+    static std::optional<SimulatorSessionService::SimulationConfigInput> _parseSimulationConfigBody(const std::string& body);
+    static std::string _simulationStatusDataJson(const SimulatorSessionService::SimulationStatusResult& status);
     static HttpResponse _mapPersistenceError(const SimulatorSessionService::ModelPersistenceResult& result);
     static std::string _escapeJson(const std::string& value);
     static std::string _modelInfoDataJson(const SimulatorSessionService::ModelInfoResult& info);

--- a/source/applications/web/service/SimulatorSessionService.cpp
+++ b/source/applications/web/service/SimulatorSessionService.cpp
@@ -23,6 +23,26 @@ void _populateModelInfoFromModel(Model* model, SimulatorSessionService::ModelInf
         outInfo.componentCount = componentManager->getNumberOfComponents();
     }
 }
+
+void _populateSimulationStatusFromModel(Model* model, SimulatorSessionService::SimulationStatusResult& outStatus) {
+    outStatus.hasCurrentModel = true;
+    ModelSimulation* simulation = model->getSimulation();
+    if (simulation == nullptr) {
+        return;
+    }
+
+    outStatus.isRunning = simulation->isRunning();
+    outStatus.isPaused = simulation->isPaused();
+    outStatus.simulatedTime = simulation->getSimulatedTime();
+    outStatus.currentReplicationNumber = simulation->getCurrentReplicationNumber();
+    outStatus.numberOfReplications = simulation->getNumberOfReplications();
+    outStatus.replicationLength = simulation->getReplicationLength();
+    outStatus.warmUpPeriod = simulation->getWarmUpPeriod();
+    outStatus.pauseOnEvent = simulation->isPauseOnEvent();
+    outStatus.pauseOnReplication = simulation->isPauseOnReplication();
+    outStatus.initializeStatistics = simulation->isInitializeStatistics();
+    outStatus.initializeSystem = simulation->isInitializeSystem();
+}
 }  // namespace
 
 SimulatorSessionService::SimulatorSessionService(SessionManager& sessionManager) : _sessionManager(sessionManager) {}
@@ -87,6 +107,69 @@ bool SimulatorSessionService::tryGetCurrentModelInfo(const std::string& accessTo
 
     _populateModelInfoFromModel(model, outInfo);
     return true;
+}
+
+SimulatorSessionService::SimulationStatusResult SimulatorSessionService::getSimulationStatus(const std::string& accessToken) {
+    SessionContext* session = _sessionManager.getSessionByToken(accessToken);
+    if (session == nullptr || session->simulator == nullptr) {
+        return SimulationStatusResult{false, true};
+    }
+
+    std::scoped_lock lock(session->mutex);
+    ModelManager* modelManager = session->simulator->getModelManager();
+    if (modelManager == nullptr) {
+        return SimulationStatusResult{false, false};
+    }
+
+    SimulationStatusResult result{};
+    result.success = true;
+    Model* model = modelManager->current();
+    if (model == nullptr) {
+        return result;
+    }
+
+    _populateSimulationStatusFromModel(model, result);
+    return result;
+}
+
+SimulatorSessionService::SimulationConfigResult SimulatorSessionService::configureSimulation(
+    const std::string& accessToken,
+    const SimulationConfigInput& input
+) {
+    SessionContext* session = _sessionManager.getSessionByToken(accessToken);
+    if (session == nullptr || session->simulator == nullptr) {
+        return SimulationConfigResult{false, true, false, SimulationStatusResult{}};
+    }
+
+    std::scoped_lock lock(session->mutex);
+    ModelManager* modelManager = session->simulator->getModelManager();
+    if (modelManager == nullptr) {
+        return SimulationConfigResult{false, false, true, SimulationStatusResult{}};
+    }
+
+    Model* model = modelManager->current();
+    if (model == nullptr) {
+        return SimulationConfigResult{false, false, true, SimulationStatusResult{}};
+    }
+
+    ModelSimulation* simulation = model->getSimulation();
+    if (simulation == nullptr) {
+        return SimulationConfigResult{false, false, true, SimulationStatusResult{}};
+    }
+
+    simulation->setNumberOfReplications(input.numberOfReplications);
+    simulation->setReplicationLength(input.replicationLength);
+    simulation->setWarmUpPeriod(input.warmUpPeriod);
+    simulation->setPauseOnEvent(input.pauseOnEvent);
+    simulation->setPauseOnReplication(input.pauseOnReplication);
+    simulation->setInitializeStatistics(input.initializeStatistics);
+    simulation->setInitializeSystem(input.initializeSystem);
+
+    SimulationConfigResult result{};
+    result.success = true;
+    result.status.success = true;
+    _populateSimulationStatusFromModel(model, result.status);
+    return result;
 }
 
 SimulatorSessionService::ModelPersistenceResult SimulatorSessionService::saveCurrentModel(

--- a/source/applications/web/service/SimulatorSessionService.h
+++ b/source/applications/web/service/SimulatorSessionService.h
@@ -46,12 +46,48 @@ public:
         ModelInfoResult modelInfo;
     };
 
+    struct SimulationStatusResult {
+        bool success = false;
+        bool invalidToken = false;
+        bool hasCurrentModel = false;
+        bool isRunning = false;
+        bool isPaused = false;
+        double simulatedTime = 0.0;
+        unsigned int currentReplicationNumber = 0;
+        unsigned int numberOfReplications = 0;
+        double replicationLength = 0.0;
+        double warmUpPeriod = 0.0;
+        bool pauseOnEvent = false;
+        bool pauseOnReplication = false;
+        bool initializeStatistics = false;
+        bool initializeSystem = false;
+    };
+
+    struct SimulationConfigInput {
+        unsigned int numberOfReplications = 0;
+        double replicationLength = 0.0;
+        double warmUpPeriod = 0.0;
+        bool pauseOnEvent = false;
+        bool pauseOnReplication = false;
+        bool initializeStatistics = false;
+        bool initializeSystem = false;
+    };
+
+    struct SimulationConfigResult {
+        bool success = false;
+        bool invalidToken = false;
+        bool missingCurrentModel = false;
+        SimulationStatusResult status;
+    };
+
     explicit SimulatorSessionService(SessionManager& sessionManager);
 
     CreateSessionResult createSession();
     bool tryGetSimulatorInfo(const std::string& accessToken, SimulatorInfoResult& outInfo);
     bool tryCreateModel(const std::string& accessToken, ModelInfoResult& outInfo);
     bool tryGetCurrentModelInfo(const std::string& accessToken, ModelInfoResult& outInfo);
+    SimulationStatusResult getSimulationStatus(const std::string& accessToken);
+    SimulationConfigResult configureSimulation(const std::string& accessToken, const SimulationConfigInput& input);
     ModelPersistenceResult saveCurrentModel(const std::string& accessToken, const std::string& filename);
     ModelPersistenceResult loadModel(const std::string& accessToken, const std::string& filename);
 

--- a/source/tests/unit/test_web_api_router.cpp
+++ b/source/tests/unit/test_web_api_router.cpp
@@ -344,3 +344,141 @@ TEST(WebApiRouterTest, LoadModelForMissingFileReturnsNotFound) {
     EXPECT_NE(response.body.find("\"ok\":false"), std::string::npos);
     EXPECT_NE(response.body.find("\"MODEL_FILE_NOT_FOUND\""), std::string::npos);
 }
+
+TEST(WebApiRouterTest, SimulationStatusWithoutTokenReturnsUnauthorized) {
+    ApiRouterFixture fixture;
+
+    HttpRequest request;
+    request.method = "GET";
+    request.path = "/api/v1/simulation/status";
+
+    const HttpResponse response = fixture.router.handle(request);
+
+    EXPECT_EQ(response.status, 401);
+    EXPECT_NE(response.body.find("\"ok\":false"), std::string::npos);
+}
+
+TEST(WebApiRouterTest, SimulationStatusWithoutCurrentModelReturnsHasCurrentModelFalse) {
+    ApiRouterFixture fixture;
+    const std::string token = createSessionAndGetToken(fixture.router);
+
+    HttpRequest request;
+    request.method = "GET";
+    request.path = "/api/v1/simulation/status";
+    request.headers["authorization"] = "Bearer " + token;
+
+    const HttpResponse response = fixture.router.handle(request);
+
+    EXPECT_EQ(response.status, 200);
+    EXPECT_NE(response.body.find("\"ok\":true"), std::string::npos);
+    EXPECT_NE(response.body.find("\"hasCurrentModel\":false"), std::string::npos);
+}
+
+TEST(WebApiRouterTest, SimulationConfigWithoutTokenReturnsUnauthorized) {
+    ApiRouterFixture fixture;
+
+    HttpRequest request;
+    request.method = "POST";
+    request.path = "/api/v1/simulation/config";
+    request.body =
+        "{\"numberOfReplications\":3,\"replicationLength\":120.0,\"warmUpPeriod\":10.0,"
+        "\"pauseOnEvent\":false,\"pauseOnReplication\":false,\"initializeStatistics\":true,\"initializeSystem\":true}";
+
+    const HttpResponse response = fixture.router.handle(request);
+
+    EXPECT_EQ(response.status, 401);
+    EXPECT_NE(response.body.find("\"ok\":false"), std::string::npos);
+}
+
+TEST(WebApiRouterTest, SimulationConfigWithoutCurrentModelReturnsConflict) {
+    ApiRouterFixture fixture;
+    const std::string token = createSessionAndGetToken(fixture.router);
+
+    HttpRequest request;
+    request.method = "POST";
+    request.path = "/api/v1/simulation/config";
+    request.headers["authorization"] = "Bearer " + token;
+    request.body =
+        "{\"numberOfReplications\":3,\"replicationLength\":120.0,\"warmUpPeriod\":10.0,"
+        "\"pauseOnEvent\":false,\"pauseOnReplication\":false,\"initializeStatistics\":true,\"initializeSystem\":true}";
+
+    const HttpResponse response = fixture.router.handle(request);
+
+    EXPECT_EQ(response.status, 409);
+    EXPECT_NE(response.body.find("\"NO_CURRENT_MODEL\""), std::string::npos);
+}
+
+TEST(WebApiRouterTest, SimulationStatusAndConfigFlowUpdatesValues) {
+    ApiRouterFixture fixture;
+    const std::string token = createSessionAndGetToken(fixture.router);
+
+    HttpRequest createModelRequest;
+    createModelRequest.method = "POST";
+    createModelRequest.path = "/api/v1/models";
+    createModelRequest.headers["authorization"] = "Bearer " + token;
+    ASSERT_EQ(fixture.router.handle(createModelRequest).status, 201);
+
+    HttpRequest initialStatusRequest;
+    initialStatusRequest.method = "GET";
+    initialStatusRequest.path = "/api/v1/simulation/status";
+    initialStatusRequest.headers["authorization"] = "Bearer " + token;
+    const HttpResponse initialStatusResponse = fixture.router.handle(initialStatusRequest);
+    ASSERT_EQ(initialStatusResponse.status, 200);
+    EXPECT_NE(initialStatusResponse.body.find("\"hasCurrentModel\":true"), std::string::npos);
+    EXPECT_NE(initialStatusResponse.body.find("\"numberOfReplications\":1"), std::string::npos);
+    EXPECT_NE(initialStatusResponse.body.find("\"replicationLength\":60.000000"), std::string::npos);
+    EXPECT_NE(initialStatusResponse.body.find("\"warmUpPeriod\":0.000000"), std::string::npos);
+
+    HttpRequest configRequest;
+    configRequest.method = "POST";
+    configRequest.path = "/api/v1/simulation/config";
+    configRequest.headers["authorization"] = "Bearer " + token;
+    configRequest.body =
+        "{\"numberOfReplications\":5,\"replicationLength\":120.0,\"warmUpPeriod\":10.0,"
+        "\"pauseOnEvent\":true,\"pauseOnReplication\":true,\"initializeStatistics\":false,\"initializeSystem\":false}";
+    const HttpResponse configResponse = fixture.router.handle(configRequest);
+    ASSERT_EQ(configResponse.status, 200);
+    EXPECT_NE(configResponse.body.find("\"numberOfReplications\":5"), std::string::npos);
+    EXPECT_NE(configResponse.body.find("\"replicationLength\":120.000000"), std::string::npos);
+    EXPECT_NE(configResponse.body.find("\"warmUpPeriod\":10.000000"), std::string::npos);
+    EXPECT_NE(configResponse.body.find("\"pauseOnEvent\":true"), std::string::npos);
+    EXPECT_NE(configResponse.body.find("\"pauseOnReplication\":true"), std::string::npos);
+    EXPECT_NE(configResponse.body.find("\"initializeStatistics\":false"), std::string::npos);
+    EXPECT_NE(configResponse.body.find("\"initializeSystem\":false"), std::string::npos);
+
+    HttpRequest updatedStatusRequest;
+    updatedStatusRequest.method = "GET";
+    updatedStatusRequest.path = "/api/v1/simulation/status";
+    updatedStatusRequest.headers["authorization"] = "Bearer " + token;
+    const HttpResponse updatedStatusResponse = fixture.router.handle(updatedStatusRequest);
+    ASSERT_EQ(updatedStatusResponse.status, 200);
+    EXPECT_NE(updatedStatusResponse.body.find("\"numberOfReplications\":5"), std::string::npos);
+    EXPECT_NE(updatedStatusResponse.body.find("\"replicationLength\":120.000000"), std::string::npos);
+    EXPECT_NE(updatedStatusResponse.body.find("\"warmUpPeriod\":10.000000"), std::string::npos);
+    EXPECT_NE(updatedStatusResponse.body.find("\"pauseOnEvent\":true"), std::string::npos);
+    EXPECT_NE(updatedStatusResponse.body.find("\"pauseOnReplication\":true"), std::string::npos);
+    EXPECT_NE(updatedStatusResponse.body.find("\"initializeStatistics\":false"), std::string::npos);
+    EXPECT_NE(updatedStatusResponse.body.find("\"initializeSystem\":false"), std::string::npos);
+}
+
+TEST(WebApiRouterTest, SimulationConfigWithInvalidBodyReturnsBadRequest) {
+    ApiRouterFixture fixture;
+    const std::string token = createSessionAndGetToken(fixture.router);
+
+    HttpRequest createModelRequest;
+    createModelRequest.method = "POST";
+    createModelRequest.path = "/api/v1/models";
+    createModelRequest.headers["authorization"] = "Bearer " + token;
+    ASSERT_EQ(fixture.router.handle(createModelRequest).status, 201);
+
+    HttpRequest configRequest;
+    configRequest.method = "POST";
+    configRequest.path = "/api/v1/simulation/config";
+    configRequest.headers["authorization"] = "Bearer " + token;
+    configRequest.body = "{\"numberOfReplications\":2}";
+
+    const HttpResponse configResponse = fixture.router.handle(configRequest);
+
+    EXPECT_EQ(configResponse.status, 400);
+    EXPECT_NE(configResponse.body.find("\"INVALID_SIMULATION_CONFIG\""), std::string::npos);
+}


### PR DESCRIPTION
### Motivation
- Provide session-scoped simulation status and configuration endpoints for Stage 4 while avoiding cross-request async control changes to the kernel.
- Keep all direct interaction with `ModelSimulation` inside the service layer to maintain separation of concerns and reuse existing session locking.

### Description
- Added `GET /api/v1/simulation/status` and `POST /api/v1/simulation/config` routes to `ApiRouter` with Bearer token validation and consistent JSON envelopes for success/error responses.
- Implemented minimal contract-only JSON parsing helpers in `ApiRouter` for required fields `numberOfReplications`, `replicationLength`, `warmUpPeriod`, `pauseOnEvent`, `pauseOnReplication`, `initializeStatistics`, `initializeSystem` without adding an external JSON dependency.
- Extended `SimulatorSessionService` with `SimulationStatusResult`, `SimulationConfigInput`, `SimulationConfigResult`, and methods `getSimulationStatus()` and `configureSimulation()` that use only real `ModelSimulation` getters/setters and session locking.
- Added unit tests in `source/tests/unit/test_web_api_router.cpp` covering `401` (no token), `hasCurrentModel=false` (no model), `401`/`409` error cases for `/simulation/config`, successful status→config→status flow, and invalid-body `400` handling; and updated the web README to Stage 4 and documented the config contract.

### Testing
- Ran CMake configure with `cmake -S . -B build/web-debug -G Ninja -DGENESYS_BUILD_WEB_APPLICATION=ON` which completed successfully.
- Attempted build with `cmake --build build/web-debug --target genesys_webhook genesys_test_web_api_router` which failed at link time due to pre-existing undefined references from `Dispose.cpp` / `SinkModelComponent` in `genesys_plugins_components_minimal.a`, preventing test binary generation.
- Attempted to build and run the `genesys_test_web_api_router` target separately and to run `ctest -R web_api_router`, but these steps could not execute because the test executable was not produced due to the link error.
- Unit tests were added as source changes but could not be executed in this environment because of the link failure.

```markdown
## Stage 4 execution report

### What I completed
- ...

### What I could not complete
- ...

### Why anything remains incomplete
- ...

### Validation performed
- ...

### Risks remaining
- ...

### Files changed
- ...
```

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8495f37048321ad3b95c4337f18a5)