### PR TITLE
Fix ParserDefaultImpl2 sampler ownership on replacement

### DIFF
--- a/source/kernel/simulator/ParserDefaultImpl2.cpp
+++ b/source/kernel/simulator/ParserDefaultImpl2.cpp
@@ -18,12 +18,24 @@
 
 // Construct parser wrapper in-place to avoid copying partially initialized driver state.
 ParserDefaultImpl2::ParserDefaultImpl2(Model* model, Sampler_if* sampler, bool throws)
-	: _model(model), _wrapper(model, sampler, throws) {}
+	: _model(model), _wrapper(model, sampler, throws), _ownsSampler(true) {}
 
-// Delete the sampler owned by this parser wrapper to avoid leaking per-model parser state.
+// Delete sampler only when parser explicitly owns it.
 ParserDefaultImpl2::~ParserDefaultImpl2() {
-	delete _wrapper.getSampler();
+	if (_ownsSampler) {
+		delete _wrapper.getSampler();
+	}
 	_wrapper.setSampler(nullptr);
+	_ownsSampler = false;
+}
+
+void ParserDefaultImpl2::_setSamplerInternal(Sampler_if* sampler, bool ownsSampler) {
+	Sampler_if* currentSampler = _wrapper.getSampler();
+	if (_ownsSampler && currentSampler != nullptr && currentSampler != sampler) {
+		delete currentSampler;
+	}
+	_wrapper.setSampler(sampler);
+	_ownsSampler = ownsSampler;
 }
 
 double ParserDefaultImpl2::parse(const std::string expression) { // may throw exception
@@ -95,7 +107,8 @@ double ParserDefaultImpl2::parse(const std::string expression, bool& success, st
 }
 
 void ParserDefaultImpl2::setSampler(Sampler_if* _sampler) {
-	_wrapper.setSampler(_sampler);
+	// setSampler adopts an externally-owned sampler by default.
+	_setSamplerInternal(_sampler, false);
 }
 
 Sampler_if* ParserDefaultImpl2::getSampler() const {

--- a/source/kernel/simulator/ParserDefaultImpl2.h
+++ b/source/kernel/simulator/ParserDefaultImpl2.h
@@ -35,8 +35,11 @@ public:
 	virtual Sampler_if* getSampler() const override;
 	virtual genesyspp_driver getParser() const override;
 private:
+	void _setSamplerInternal(Sampler_if* sampler, bool ownsSampler);
+private:
 	Model* _model;
 	genesyspp_driver _wrapper;
+	bool _ownsSampler = false;
 };
 //namespace\\}
 #endif /* PARSERDEFAULTIMPL2_H */

--- a/source/tests/unit/test_parser_expressions.cpp
+++ b/source/tests/unit/test_parser_expressions.cpp
@@ -3,6 +3,7 @@
 
 #include "kernel/simulator/Model.h"
 #include "kernel/simulator/Simulator.h"
+#include "kernel/simulator/ParserDefaultImpl2.h"
 #include "kernel/statistics/SamplerDefaultImpl1.h"
 #include "parser/Genesys++-driver.h"
 
@@ -224,4 +225,63 @@ TEST(ParserDriverThrowsFalseTest, ProbabilisticFunctionsRecoverWithoutThrowing) 
         EXPECT_FALSE(message.empty());
         EXPECT_NE(message.find("logn"), std::string::npos);
     });
+}
+
+
+class CountingSampler final : public Sampler_if {
+public:
+    explicit CountingSampler(int* destroyedCounter, bool* destroyedFlag = nullptr)
+        : _destroyedCounter(destroyedCounter), _destroyedFlag(destroyedFlag) {}
+
+    ~CountingSampler() override {
+        if (_destroyedCounter != nullptr) {
+            ++(*_destroyedCounter);
+        }
+        if (_destroyedFlag != nullptr) {
+            *_destroyedFlag = true;
+        }
+    }
+
+    double random() override { return 0.5; }
+    double sampleBeta(double, double, double infLimit, double) override { return infLimit; }
+    double sampleBeta(double, double) override { return 0.5; }
+    double sampleErlang(double, int, double offset = 0.0) override { return offset; }
+    double sampleExponential(double, double offset = 0.0) override { return offset; }
+    double sampleGamma(double, double, double offset = 0.0) override { return offset; }
+    double sampleGumbell(double mode, double) override { return mode; }
+    double sampleLogNormal(double, double, double offset = 0.0) override { return offset; }
+    double sampleNormal(double mean, double) override { return mean; }
+    double sampleTriangular(double min, double, double) override { return min; }
+    double sampleUniform(double min, double) override { return min; }
+    double sampleWeibull(double, double) override { return 0.0; }
+    double sampleBinomial(int, double) override { return 0.0; }
+    double sampleBernoulli(double) override { return 0.0; }
+    double sampleDiscrete(double, double, ...) override { return 0.0; }
+    double sampleDiscrete(double*, double*, int) override { return 0.0; }
+    double sampleGeometric(double) override { return 0.0; }
+    void setRNGparameters(RNG_Parameters*) override {}
+    RNG_Parameters* getRNGparameters() const override { return nullptr; }
+
+private:
+    int* _destroyedCounter = nullptr;
+    bool* _destroyedFlag = nullptr;
+};
+
+TEST_F(ParserExpressionsTest, ParserDefaultImpl2SetSamplerDeletesPreviousOwnedSamplerAndDoesNotDeleteExternalSampler) {
+    int destroyedCounter = 0;
+    bool externalDestroyed = false;
+
+    auto* initiallyOwnedSampler = new CountingSampler(&destroyedCounter);
+    CountingSampler externalSampler(&destroyedCounter, &externalDestroyed);
+
+    {
+        ParserDefaultImpl2 parser(model, initiallyOwnedSampler, false);
+        parser.setSampler(&externalSampler);
+        EXPECT_EQ(parser.getSampler(), &externalSampler);
+        EXPECT_EQ(destroyedCounter, 1);
+        EXPECT_FALSE(externalDestroyed);
+    }
+
+    EXPECT_FALSE(externalDestroyed);
+    EXPECT_EQ(destroyedCounter, 1);
 }


### PR DESCRIPTION
### Motivation
- Revalidated current code and found the original driver leak already fixed but a remaining ownership ambiguity in `ParserDefaultImpl2` that could cause either a leak of the previous sampler on replacement or an unintended `delete` of an externally-owned sampler. 
- Keep changes minimal and local to the parser wrapper to avoid touching parser logic, driver deep-copy, or broader architecture. 

### Description
- Add explicit ownership tracking (`_ownsSampler`) to `ParserDefaultImpl2` and expose a small internal helper `_setSamplerInternal(Sampler_if*, bool)` to centralize safe sampler replacement semantics. 
- Mark the sampler passed in the `ParserDefaultImpl2` constructor as owned and delete it in the destructor only when `_ownsSampler == true`. 
- Make `setSampler(...)` adopt externally-provided samplers by default (calls `_setSamplerInternal(..., false)`) and delete the previous sampler only when it was owned. 
- Add a focused unit test `ParserDefaultImpl2SetSamplerDeletesPreviousOwnedSamplerAndDoesNotDeleteExternalSampler` validating that replacing an owned sampler releases it and that externally-provided samplers are not deleted by the parser. 

### Testing
- Built and ran the parser expression unit target with: `cmake --preset tests-kernel-unit`, `cmake --build build/tests-kernel-unit --target genesys_test_parser_expressions -j4`, and `./build/tests-kernel-unit/source/tests/unit/genesys_test_parser_expressions`, which completed successfully. 
- Rebuilt and ran under ASan with: `cmake --preset asan`, `cmake --build build/asan --target genesys_test_parser_expressions -j4`, and `ASAN_OPTIONS=detect_leaks=1 ./build/asan/source/tests/unit/genesys_test_parser_expressions`, which completed successfully with no leak reported for the parser/driver target. 
- Rebuilt and ran under UBSan with: `cmake --preset ubsan`, `cmake --build build/ubsan --target genesys_test_parser_expressions -j4`, and `./build/ubsan/source/tests/unit/genesys_test_parser_expressions`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d849460ff88321a660b94a737bedcb)