### PR TITLE
Add GUI diagnostic logging for animation transition pipeline

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/animations/AnimationTransition.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/animations/AnimationTransition.cpp
@@ -1,6 +1,7 @@
 #include <QEventLoop>
 #include <QThread>
 #include <QCoreApplication>
+#include <QDebug>
 
 #include "AnimationTransition.h"
 #include "graphicals/ModelGraphicsScene.h"
@@ -30,6 +31,10 @@ AnimationTransition::AnimationTransition(ModelGraphicsScene* myScene, ModelCompo
 
     // Abort construction when required input pointers are missing.
     if (_myScene == nullptr || graphicalStartComponent == nullptr || graphicalEndComponent == nullptr) {
+        // Log constructor early exit when mandatory input pointers are missing.
+        qInfo() << "GUI AnimationTransition ctor earlyExit reason=missingInput sceneNull=" << (_myScene == nullptr)
+                << "sourceNull=" << (graphicalStartComponent == nullptr)
+                << "destinationNull=" << (graphicalEndComponent == nullptr);
         return;
     }
 
@@ -39,6 +44,10 @@ AnimationTransition::AnimationTransition(ModelGraphicsScene* myScene, ModelCompo
 
     // Stop setup when either graphical endpoint is not present in the scene.
     if (_graphicalStartComponent == nullptr || _graphicalEndComponent == nullptr) {
+        // Log constructor early exit when graphical endpoints are not found in the scene.
+        qInfo() << "GUI AnimationTransition ctor earlyExit reason=missingGraphicalEndpoint sourceId="
+                << graphicalStartComponent->getId()
+                << "destinationId=" << graphicalEndComponent->getId();
         return;
     }
 
@@ -62,6 +71,10 @@ AnimationTransition::AnimationTransition(ModelGraphicsScene* myScene, ModelCompo
         if (connection == nullptr) {
             _graphicalEndComponent = nullptr;
             _graphicalConnection = nullptr;
+            // Log constructor early exit when no compatible graphical connection exists.
+            qInfo() << "GUI AnimationTransition ctor earlyExit reason=missingConnection sourceId="
+                    << graphicalStartComponent->getId()
+                    << "destinationId=" << graphicalEndComponent->getId();
             return;
         }
 
@@ -77,6 +90,8 @@ AnimationTransition::AnimationTransition(ModelGraphicsScene* myScene, ModelCompo
         if (pointsConnection.size() < 4) {
             _graphicalEndComponent = nullptr;
             _graphicalConnection = nullptr;
+            // Log constructor early exit when connection geometry has insufficient points.
+            qInfo() << "GUI AnimationTransition ctor earlyExit reason=insufficientPoints count=" << pointsConnection.size();
             return;
         }
 
@@ -101,6 +116,11 @@ AnimationTransition::AnimationTransition(ModelGraphicsScene* myScene, ModelCompo
 
         // Configura a animação
         configureAnimation();
+        // Log constructor completion with endpoint ids and runtime data used by the animation.
+        qInfo() << "GUI AnimationTransition ctor sourceId=" << graphicalStartComponent->getId()
+                << "destinationId=" << graphicalEndComponent->getId()
+                << "imageCreated=" << (_imageAnimation != nullptr)
+                << "pointsCount=" << _pointsForAnimation.size();
     }
 }
 
@@ -166,6 +186,9 @@ void AnimationTransition::setRunning(bool running) {
 
 // Outros
 void AnimationTransition::startAnimation() {
+    // Log start request readiness and current animation duration before running.
+    qInfo() << "GUI AnimationTransition startAnimation ready=" << isReadyToRun()
+            << "durationMs=" << duration();
     // Block animation start when transition invariants are not fully satisfied.
     if (!isReadyToRun()) {
         return;
@@ -184,6 +207,9 @@ void AnimationTransition::startAnimation() {
 }
 
 void AnimationTransition::stopAnimation() {
+    // Log stop request including idempotent path and image ownership status.
+    qInfo() << "GUI AnimationTransition stopAnimation idempotent=" << _isStopping
+            << "hasImage=" << (_imageAnimation != nullptr);
     // Return immediately when stop cleanup is already in progress.
     if (_isStopping) {
         return;
@@ -215,6 +241,9 @@ void AnimationTransition::stopAnimation() {
 }
 
 void AnimationTransition::restartAnimation() {
+    // Log restart request readiness and current animation duration before running.
+    qInfo() << "GUI AnimationTransition restartAnimation ready=" << isReadyToRun()
+            << "durationMs=" << duration();
     // Block animation restart when transition invariants are not fully satisfied.
     if (!isReadyToRun() || duration() <= 0) {
         return;
@@ -270,18 +299,27 @@ void AnimationTransition::connectValueChangedSignal() {
 void AnimationTransition::onAnimationValueChanged(const QVariant& value) {
     // Stop and exit immediately when simulation runtime is no longer running.
     if (_running == false) {
+        // Log runtime deviation when animation receives ticks while running flag is false.
+        qInfo() << "GUI AnimationTransition onAnimationValueChanged deviation=runningFalse";
         stopAnimation();
         return;
     }
 
     // Pause and exit immediately to avoid running animation logic while paused.
     if (_pause == true) {
+        // Log runtime deviation when animation receives ticks while paused.
+        qInfo() << "GUI AnimationTransition onAnimationValueChanged deviation=pausedTrue";
         pause();
         return;
     }
 
     // Validate mandatory runtime pointers and geometry before processing interpolation.
     if (_myScene == nullptr || _imageAnimation == nullptr || _pointsForAnimation.size() < 2) {
+        // Log runtime deviation when mandatory animation guards are invalid.
+        qInfo() << "GUI AnimationTransition onAnimationValueChanged deviation=invalidGuards"
+                << "sceneNull=" << (_myScene == nullptr)
+                << "imageNull=" << (_imageAnimation == nullptr)
+                << "pointsCount=" << _pointsForAnimation.size();
         return;
     }
 
@@ -297,6 +335,8 @@ void AnimationTransition::onAnimationValueChanged(const QVariant& value) {
         totalDistance += QLineF(_pointsForAnimation[i], _pointsForAnimation[i + 1]).length();
     }
     if (totalDistance <= 0.0) {
+        // Log runtime deviation when total path geometry distance is degenerate.
+        qInfo() << "GUI AnimationTransition onAnimationValueChanged deviation=totalDistanceNonPositive";
         return;
     }
 
@@ -311,12 +351,18 @@ void AnimationTransition::onAnimationValueChanged(const QVariant& value) {
         ++currentSegment;
     }
     if (currentSegment < 0 || currentSegment >= numSegments) {
+        // Log runtime deviation when current interpolation segment index is invalid.
+        qInfo() << "GUI AnimationTransition onAnimationValueChanged deviation=invalidSegmentIndex"
+                << "currentSegment=" << currentSegment
+                << "numSegments=" << numSegments;
         return;
     }
 
     // Guard segment interpolation against zero-length segments before dividing.
     qreal segmentLength = QLineF(_pointsForAnimation[currentSegment], _pointsForAnimation[currentSegment + 1]).length();
     if (segmentLength <= 0.0) {
+        // Log runtime deviation when active segment length is non-positive.
+        qInfo() << "GUI AnimationTransition onAnimationValueChanged deviation=segmentLengthNonPositive";
         return;
     }
 
@@ -336,6 +382,8 @@ void AnimationTransition::connectFinishedSignal() {
 }
 
 void AnimationTransition::onAnimationFinished() {
+    // Log finished callback entry and whether this callback was already processed.
+    qInfo() << "GUI AnimationTransition onAnimationFinished begin alreadyHandled=" << _isFinishedHandled;
     // Return when finished callback cleanup already ran before.
     if (_isFinishedHandled) {
         return;
@@ -346,16 +394,22 @@ void AnimationTransition::onAnimationFinished() {
 
     // Only notify queue insertion when both scene and destination component are valid.
     if (_myScene != nullptr && _graphicalEndComponent != nullptr) {
+        // Log queue-insert dispatch performed on a valid destination component.
+        qInfo() << "GUI AnimationTransition onAnimationFinished animateQueueInsert=true";
         _myScene->animateQueueInsert(_graphicalEndComponent->getComponent(), _viewSimulation);
     }
 
     // Remove image only when it is valid and still attached to this scene.
     if (_myScene != nullptr && _imageAnimation != nullptr && _imageAnimation->scene() == _myScene) {
+        // Log image removal from scene during finished cleanup.
+        qInfo() << "GUI AnimationTransition onAnimationFinished cleanup=removeImageFromScene";
         _myScene->removeItem(_imageAnimation);
     }
 
     // Delete the owned image item explicitly after animation completion.
     if (_imageAnimation != nullptr) {
+        // Log image object destruction during finished cleanup.
+        qInfo() << "GUI AnimationTransition onAnimationFinished cleanup=deleteImage";
         delete _imageAnimation;
         _imageAnimation = nullptr;
     }

--- a/source/applications/gui/qt/GenesysQtGUI/controllers/SimulationCommandController.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/SimulationCommandController.cpp
@@ -3,6 +3,7 @@
 #include "controllers/SimulationController.h"
 #include "animations/AnimationTransition.h"
 #include "../../../../../kernel/simulator/ModelSimulation.h"
+#include <QDebug>
 
 SimulationCommandController::SimulationCommandController(
     SimulationController* simulationController,
@@ -28,10 +29,14 @@ void SimulationCommandController::onActionSimulationStartTriggered(bool modelChe
     }
 
     ModelSimulation* simulation = _simulationController->currentSimulation();
+    // Log start command context before dereferencing the simulation pointer.
+    qInfo() << "GUI SimulationCommand start simulationNull=" << (simulation == nullptr);
     if (simulation == nullptr) {
         return;
     }
 
+    // Log static animation runtime flags applied by the start action.
+    qInfo() << "GUI SimulationCommand start setRunning=true setPause=false";
     AnimationTransition::setRunning(true);
     AnimationTransition::setPause(false);
     _insertCommandInConsole("start");
@@ -49,10 +54,14 @@ void SimulationCommandController::onActionSimulationStepTriggered(bool modelChec
     }
 
     ModelSimulation* simulation = _simulationController->currentSimulation();
+    // Log step command context before dereferencing the simulation pointer.
+    qInfo() << "GUI SimulationCommand step simulationNull=" << (simulation == nullptr);
     if (simulation == nullptr) {
         return;
     }
 
+    // Log static animation runtime flags applied by the step action.
+    qInfo() << "GUI SimulationCommand step setRunning=true setPause=false";
     AnimationTransition::setRunning(true);
     AnimationTransition::setPause(false);
     _insertCommandInConsole("step");
@@ -66,10 +75,14 @@ void SimulationCommandController::onActionSimulationPauseTriggered() const {
     }
 
     ModelSimulation* simulation = _simulationController->currentSimulation();
+    // Log pause command context before dereferencing the simulation pointer.
+    qInfo() << "GUI SimulationCommand pause simulationNull=" << (simulation == nullptr);
     if (simulation == nullptr) {
         return;
     }
 
+    // Log static animation runtime flags applied by the pause action.
+    qInfo() << "GUI SimulationCommand pause setRunning=true setPause=true";
     AnimationTransition::setRunning(true);
     AnimationTransition::setPause(true);
 
@@ -88,10 +101,14 @@ void SimulationCommandController::onActionSimulationResumeTriggered(bool modelCh
     }
 
     ModelSimulation* simulation = _simulationController->currentSimulation();
+    // Log resume command context before dereferencing the simulation pointer.
+    qInfo() << "GUI SimulationCommand resume simulationNull=" << (simulation == nullptr);
     if (simulation == nullptr) {
         return;
     }
 
+    // Log static animation runtime flags applied by the resume action.
+    qInfo() << "GUI SimulationCommand resume setRunning=true setPause=false";
     AnimationTransition::setRunning(true);
     AnimationTransition::setPause(false);
 
@@ -106,10 +123,14 @@ void SimulationCommandController::onActionSimulationStopTriggered() const {
     }
 
     ModelSimulation* simulation = _simulationController->currentSimulation();
+    // Log stop command context before dereferencing the simulation pointer.
+    qInfo() << "GUI SimulationCommand stop simulationNull=" << (simulation == nullptr);
     if (simulation == nullptr) {
         return;
     }
 
+    // Log static animation runtime flags applied by the stop action.
+    qInfo() << "GUI SimulationCommand stop setRunning=false setPause=false";
     AnimationTransition::setRunning(false);
     AnimationTransition::setPause(false);
 

--- a/source/applications/gui/qt/GenesysQtGUI/controllers/SimulationEventController.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/SimulationEventController.cpp
@@ -20,6 +20,7 @@
 #include <QTabWidget>
 #include <QTableWidget>
 #include <QTextEdit>
+#include <QDebug>
 
 #include <string>
 #include <utility>
@@ -149,6 +150,8 @@ void SimulationEventController::onReplicationStartHandler(SimulationEvent* re) c
 
 // Preserve simulation-start setup, clears and conversion factor update behavior.
 void SimulationEventController::onSimulationStartHandler(SimulationEvent* re) const {
+    // Log simulation-start handler entry for animation pipeline tracing.
+    qInfo() << "GUI SimulationEvent onSimulationStartHandler begin";
     Q_UNUSED(re)
     _callbacks.actualizeActions();
     _simulationProgressBar->setMaximum(
@@ -169,6 +172,8 @@ void SimulationEventController::onSimulationStartHandler(SimulationEvent* re) co
     _scene->clearAnimationsQueue();
     _scene->clearAnimationsValues();
 
+    // Log simulation-start handler exit after scene reset and timer factor setup.
+    qInfo() << "GUI SimulationEvent onSimulationStartHandler end";
     QCoreApplication::processEvents();
 }
 
@@ -181,6 +186,8 @@ void SimulationEventController::onSimulationPausedHandler(SimulationEvent* re) c
 
 // Preserve simulation-resume animation continuation behavior.
 void SimulationEventController::onSimulationResumeHandler(SimulationEvent* re) const {
+    // Log simulation-resume handler entry before paused-animation lookup.
+    qInfo() << "GUI SimulationEvent onSimulationResumeHandler begin";
     _callbacks.actualizeActions();
 
     // Resume detached paused animations using the same key selected from the paused map.
@@ -188,6 +195,11 @@ void SimulationEventController::onSimulationResumeHandler(SimulationEvent* re) c
     Event* currentEvent = re ? re->getCurrentEvent() : nullptr;
     auto [resumeEventKey, pausedAnimations] =
         takePausedAnimationListForResume(pausedAnimationsMap, currentEvent);
+    // Log resume selection details including paused list size and effective resume key.
+    qInfo() << "GUI SimulationEvent onSimulationResumeHandler pausedMapEmpty="
+            << (pausedAnimationsMap == nullptr || pausedAnimationsMap->empty())
+            << "pausedListSize=" << (pausedAnimations ? pausedAnimations->size() : 0)
+            << "resumeEventKeyPresent=" << (resumeEventKey != nullptr);
     if (pausedAnimations) {
         for (AnimationTransition* animation : *pausedAnimations) {
             if (animation) {
@@ -197,12 +209,19 @@ void SimulationEventController::onSimulationResumeHandler(SimulationEvent* re) c
     }
     cleanupPausedAnimationList(pausedAnimations, false);
 
+    // Log simulation-resume handler exit after paused animations are processed.
+    qInfo() << "GUI SimulationEvent onSimulationResumeHandler end";
     QCoreApplication::processEvents();
 }
 
 // Preserve simulation-end cleanup, tab switch and model-check flag reset behavior.
 void SimulationEventController::onSimulationEndHandler(SimulationEvent* re) const {
+    // Log simulation-end handler entry before paused-animation cleanup.
+    qInfo() << "GUI SimulationEvent onSimulationEndHandler begin";
     Q_UNUSED(re)
+    // Log paused-animation map size before terminal cleanup.
+    qInfo() << "GUI SimulationEvent onSimulationEndHandler pausedMapSizeBeforeCleanup="
+            << (_scene->getAnimationPaused() ? _scene->getAnimationPaused()->size() : 0);
     // Destroy all paused-animation lists and remaining paused animations before ending.
     cleanupPausedAnimationMap(_scene->getAnimationPaused(), true);
     // Clear any remaining scene animation state before final UI updates.
@@ -216,6 +235,8 @@ void SimulationEventController::onSimulationEndHandler(SimulationEvent* re) cons
     }
 
     *_modelChecked = false;
+    // Log simulation-end handler exit after terminal GUI state updates.
+    qInfo() << "GUI SimulationEvent onSimulationEndHandler end";
 }
 
 // Preserve process-event UI updates and delegated debug/graphical refresh behavior.
@@ -240,6 +261,9 @@ void SimulationEventController::onEntityRemoveHandler(SimulationEvent* re) const
 
 // Preserve entity-move animation pipeline behavior.
 void SimulationEventController::onMoveEntityEvent(SimulationEvent* re) const {
+    // Log move-entity handler entry and graphical simulation toggle state.
+    qInfo() << "GUI SimulationEvent onMoveEntityEvent begin graphicalSimulationChecked="
+            << (_activateGraphicalSimulation ? _activateGraphicalSimulation->isChecked() : false);
     _scene->animateCounter();
     _scene->animateVariable();
 
@@ -248,6 +272,11 @@ void SimulationEventController::onMoveEntityEvent(SimulationEvent* re) const {
             if (re->getCurrentEvent()->getComponent()) {
                 ModelComponent* source = re->getCurrentEvent()->getComponent();
                 ModelComponent* destination = re->getDestinationComponent();
+                // Log source and destination identifiers before transition dispatch.
+                qInfo() << "GUI SimulationEvent onMoveEntityEvent sourceId="
+                        << (source ? source->getId() : 0)
+                        << "destinationId="
+                        << (destination ? destination->getId() : 0);
 
                 _scene->animateQueueRemove(source);
 
@@ -259,6 +288,8 @@ void SimulationEventController::onMoveEntityEvent(SimulationEvent* re) const {
             }
         }
     }
+    // Log move-entity handler exit after animation pipeline delegation.
+    qInfo() << "GUI SimulationEvent onMoveEntityEvent end";
 }
 
 // Preserve after-process animation update behavior.

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
@@ -56,6 +56,7 @@
 #include <QThread>
 #include <QPointer>
 #include <QTimer>
+#include <QDebug>
 
 namespace {
 // Safely cast the scene parent to a generic graphics view.
@@ -1366,8 +1367,16 @@ bool ModelGraphicsScene::getSnapToGrid() {
 }
 
 void ModelGraphicsScene::animateTransition(ModelComponent *source, ModelComponent *destination, bool viewSimulation, Event *event) {
+    // Log transition dispatch request with endpoints and simulation-visibility flag.
+    qInfo() << "GUI ModelGraphicsScene animateTransition sourceId="
+            << (source ? source->getId() : 0)
+            << "destinationId=" << (destination ? destination->getId() : 0)
+            << "viewSimulation=" << viewSimulation
+            << "eventPtr=" << event;
     // Skip transition creation when source or destination is missing.
     if (source == nullptr || destination == nullptr) {
+        // Log rejection reason when transition endpoints are missing.
+        qInfo() << "GUI ModelGraphicsScene animateTransition rejected reason=missingEndpoint";
         return;
     }
 
@@ -1381,6 +1390,12 @@ void ModelGraphicsScene::animateTransition(ModelComponent *source, ModelComponen
             && viewSimulation) {
         runAnimateTransition(animationTransition, event);
     } else {
+        // Log rejection reason when transition is not ready or simulation view is disabled.
+        qInfo() << "GUI ModelGraphicsScene animateTransition rejected reason=invalidTransitionOrViewDisabled"
+                << "hasStart=" << (animationTransition->getGraphicalStartComponent() != nullptr)
+                << "hasEnd=" << (animationTransition->getGraphicalEndComponent() != nullptr)
+                << "ready=" << animationTransition->isReadyToRun()
+                << "viewSimulation=" << viewSimulation;
         // Ensure invalid/non-visible transition is fully cleaned up to avoid leaks.
         animationTransition->stopAnimation();
         delete animationTransition;
@@ -1389,8 +1404,16 @@ void ModelGraphicsScene::animateTransition(ModelComponent *source, ModelComponen
 }
 
 void ModelGraphicsScene::runAnimateTransition(AnimationTransition *animationTransition, Event *event, bool restart) {
+    // Log transition runner entry and the restart mode selected by caller.
+    qInfo() << "GUI ModelGraphicsScene runAnimateTransition begin restart=" << restart
+            << "eventPtr=" << event
+            << "transitionPtr=" << animationTransition;
     // Exit before local event loop when transition pointer is invalid or not runnable.
     if (animationTransition == nullptr || !animationTransition->isReadyToRun()) {
+        // Log rejection reason when transition pointer is invalid at runner entry.
+        qInfo() << "GUI ModelGraphicsScene runAnimateTransition rejected transitionNull="
+                << (animationTransition == nullptr)
+                << "ready=" << (animationTransition ? animationTransition->isReadyToRun() : false);
         if (animationTransition != nullptr) {
             animationTransition->stopAnimation();
             delete animationTransition;
@@ -1435,6 +1458,10 @@ void ModelGraphicsScene::runAnimateTransition(AnimationTransition *animationTran
         animationTransition->restartAnimation();
     else
         animationTransition->startAnimation();
+    // Log transition runtime parameters after start/restart call.
+    qInfo() << "GUI ModelGraphicsScene runAnimateTransition runtime ready="
+            << animationTransition->isReadyToRun()
+            << "durationMs=" << animationTransition->duration();
 
     // Start the fail-safe timer with an additional margin over animation duration.
     int timeoutMs = animationTransition->duration() + 1000;
@@ -1443,8 +1470,12 @@ void ModelGraphicsScene::runAnimateTransition(AnimationTransition *animationTran
     }
     timeoutTimer.start(timeoutMs);
 
+    // Log local event loop entry for transition execution.
+    qInfo() << "GUI ModelGraphicsScene runAnimateTransition loop.exec enter timeoutMs=" << timeoutMs;
     // Aguarda a conclusão da animação sem bloquear o restante do código
     loop.exec();
+    // Log local event loop exit and timeout status.
+    qInfo() << "GUI ModelGraphicsScene runAnimateTransition loop.exec exit exitedByTimeout=" << exitedByTimeout;
 
     // Stop and disconnect timer resources after leaving the local event loop.
     if (timeoutTimer.isActive()) {
@@ -1459,6 +1490,8 @@ void ModelGraphicsScene::runAnimateTransition(AnimationTransition *animationTran
 
     // Stop post-loop processing when the transition was destroyed during loop execution.
     if (guardedTransition.isNull()) {
+        // Log guarded transition destruction observed after leaving the local loop.
+        qInfo() << "GUI ModelGraphicsScene runAnimateTransition guardedTransitionNull=true";
         _animationsTransition->removeOne(animationTransition);
         return;
     }
@@ -1468,6 +1501,8 @@ void ModelGraphicsScene::runAnimateTransition(AnimationTransition *animationTran
 
     // Perform terminal cleanup when loop exit happened through timeout.
     if (exitedByTimeout && transitionPtr != nullptr) {
+        // Log terminal timeout cleanup path for this transition execution.
+        qInfo() << "GUI ModelGraphicsScene runAnimateTransition terminalCleanup reason=timeout";
         transitionPtr->stopAnimation();
         _animationsTransition->removeOne(transitionPtr);
         delete transitionPtr;
@@ -1476,14 +1511,24 @@ void ModelGraphicsScene::runAnimateTransition(AnimationTransition *animationTran
 
     // Remove and delete only when the guarded transition is still valid.
     if (transitionPtr != nullptr) {
+        // Log final state before deciding paused retention versus terminal destruction.
+        qInfo() << "GUI ModelGraphicsScene runAnimateTransition finalState="
+                << transitionPtr->state()
+                << "paused=" << (transitionPtr->state() == QAbstractAnimation::Paused);
         _animationsTransition->removeOne(transitionPtr);
         if (transitionPtr->state() != QAbstractAnimation::Paused) {
+            // Log terminal destruction path when transition does not remain paused.
+            qInfo() << "GUI ModelGraphicsScene runAnimateTransition terminalCleanup reason=notPaused";
             delete transitionPtr;
         }
     }
 }
 
 void ModelGraphicsScene::handleAnimationStateChanged(QAbstractAnimation::State newState, QEventLoop* loop, Event* event, AnimationTransition* animationTransition) {
+    // Log state notifications routed from transition stateChanged signal.
+    qInfo() << "GUI ModelGraphicsScene handleAnimationStateChanged state=" << newState
+            << "eventPtr=" << event
+            << "transitionPtr=" << animationTransition;
     // Process only paused transitions and exit early for other states.
     if (newState != QAbstractAnimation::Paused) {
         return;
@@ -1508,6 +1553,8 @@ void ModelGraphicsScene::handleAnimationStateChanged(QAbstractAnimation::State n
     // Append only when this transition is not already tracked for the event.
     QList<AnimationTransition*>* pausedAnimations = _animationPaused->value(event);
     if (pausedAnimations != nullptr && !pausedAnimations->contains(animationTransition)) {
+        // Log paused-list append when transition is first tracked for this event.
+        qInfo() << "GUI ModelGraphicsScene handleAnimationStateChanged appendPaused=true eventPtr=" << event;
         pausedAnimations->append(animationTransition);
     }
 


### PR DESCRIPTION
### Motivation
- Provide lightweight runtime instrumentation to trace the full lifecycle of animation transitions (start/step/resume/pause/stop → loop → cleanup) without changing behavior. 
- This is step 1/3 of the diagnostic instrumentation phase and reuses the previously applied runtime hardening (guards, idempotent cleanup, local event loop) as-is. 

### Description
- Added concise `qInfo()` logs (prefixed `GUI`) and a short English comment above each change in the four target files: `SimulationCommandController.cpp`, `SimulationEventController.cpp`, `ModelGraphicsScene.cpp`, and `AnimationTransition.cpp`. 
- Instrumented `SimulationCommandController` handlers `onActionSimulationStartTriggered`, `onActionSimulationStepTriggered`, `onActionSimulationPauseTriggered`, `onActionSimulationResumeTriggered`, and `onActionSimulationStopTriggered` to log the action, `simulation==nullptr` and the `AnimationTransition::setRunning`/`setPause` values. 
- Instrumented `SimulationEventController` handlers `onSimulationStartHandler`, `onSimulationResumeHandler`, `onSimulationEndHandler`, and `onMoveEntityEvent` to log handler entry/exit, paused-list/map sizes and `resumeEventKey` presence, and `source`/`destination` ids plus `_activateGraphicalSimulation->isChecked()` state. 
- Instrumented `ModelGraphicsScene` methods `animateTransition`, `runAnimateTransition`, and `handleAnimationStateChanged` to log transition dispatch details (endpoint ids, `viewSimulation`, rejection reasons), local event-loop lifecycle (`loop.exec()` enter/exit, `duration()`, `restart`), timeout/guarded-destruction paths, and paused-list appends. 
- Instrumented `AnimationTransition` constructor and methods `startAnimation`, `restartAnimation`, `stopAnimation`, `onAnimationValueChanged`, and `onAnimationFinished` to log constructor early-exit reasons, image/points info, readiness/duration on start/restart, idempotent stop info, selective deviation logs in `onAnimationValueChanged`, and finished/cleanup events. 
- No header changes, no new macros, no external dependencies, and no functional semantics were altered; only `#include <QDebug>` was added where needed for logging. 

### Testing
- Configured a non-GUI build successfully with `cmake --preset debug` to validate CMake configure for kernel/tests (succeeded). 
- Attempted to configure the GUI build with `cmake -S . -B build/gui-debug -DCMAKE_BUILD_TYPE=Debug -DGENESYS_BUILD_GUI_APPLICATION=ON`, which failed because `qmake` (Qt toolchain) is not available in `PATH` in this environment, so a full GUI build/run could not be executed. 
- Performed code inspection and diff verification to confirm that logging was added only to the requested functions in the four `.cpp` files and that no behavioral changes were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d84b7812ec832182a716b4d92a8c1b)