### PR TITLE
test(web): close stage 4 simulation config coverage

### DIFF
--- a/source/tests/unit/test_web_api_router.cpp
+++ b/source/tests/unit/test_web_api_router.cpp
@@ -5,6 +5,7 @@
 #include "applications/web/service/SimulatorSessionService.h"
 #include "applications/web/session/SessionManager.h"
 
+#include <array>
 #include <memory>
 #include <string>
 
@@ -481,4 +482,69 @@ TEST(WebApiRouterTest, SimulationConfigWithInvalidBodyReturnsBadRequest) {
 
     EXPECT_EQ(configResponse.status, 400);
     EXPECT_NE(configResponse.body.find("\"INVALID_SIMULATION_CONFIG\""), std::string::npos);
+}
+
+TEST(WebApiRouterTest, SimulationConfigRequiresAllFieldsInRequestBody) {
+    ApiRouterFixture fixture;
+    const std::string token = createSessionAndGetToken(fixture.router);
+
+    HttpRequest createModelRequest;
+    createModelRequest.method = "POST";
+    createModelRequest.path = "/api/v1/models";
+    createModelRequest.headers["authorization"] = "Bearer " + token;
+    ASSERT_EQ(fixture.router.handle(createModelRequest).status, 201);
+
+    const std::string baseBody =
+        "\"numberOfReplications\":2,\"replicationLength\":90.0,\"warmUpPeriod\":15.0,"
+        "\"pauseOnEvent\":true,\"pauseOnReplication\":false,\"initializeStatistics\":true,\"initializeSystem\":false";
+
+    const std::array<std::string, 7> requiredFields = {
+        "numberOfReplications",
+        "replicationLength",
+        "warmUpPeriod",
+        "pauseOnEvent",
+        "pauseOnReplication",
+        "initializeStatistics",
+        "initializeSystem"
+    };
+
+    for (const std::string& missingField : requiredFields) {
+        std::string bodyWithoutField = baseBody;
+
+        if (missingField == "numberOfReplications") {
+            bodyWithoutField = "\"replicationLength\":90.0,\"warmUpPeriod\":15.0,"
+                               "\"pauseOnEvent\":true,\"pauseOnReplication\":false,\"initializeStatistics\":true,"
+                               "\"initializeSystem\":false";
+        } else if (missingField == "replicationLength") {
+            bodyWithoutField = "\"numberOfReplications\":2,\"warmUpPeriod\":15.0,"
+                               "\"pauseOnEvent\":true,\"pauseOnReplication\":false,\"initializeStatistics\":true,"
+                               "\"initializeSystem\":false";
+        } else if (missingField == "warmUpPeriod") {
+            bodyWithoutField = "\"numberOfReplications\":2,\"replicationLength\":90.0,"
+                               "\"pauseOnEvent\":true,\"pauseOnReplication\":false,\"initializeStatistics\":true,"
+                               "\"initializeSystem\":false";
+        } else if (missingField == "pauseOnEvent") {
+            bodyWithoutField = "\"numberOfReplications\":2,\"replicationLength\":90.0,\"warmUpPeriod\":15.0,"
+                               "\"pauseOnReplication\":false,\"initializeStatistics\":true,\"initializeSystem\":false";
+        } else if (missingField == "pauseOnReplication") {
+            bodyWithoutField = "\"numberOfReplications\":2,\"replicationLength\":90.0,\"warmUpPeriod\":15.0,"
+                               "\"pauseOnEvent\":true,\"initializeStatistics\":true,\"initializeSystem\":false";
+        } else if (missingField == "initializeStatistics") {
+            bodyWithoutField = "\"numberOfReplications\":2,\"replicationLength\":90.0,\"warmUpPeriod\":15.0,"
+                               "\"pauseOnEvent\":true,\"pauseOnReplication\":false,\"initializeSystem\":false";
+        } else if (missingField == "initializeSystem") {
+            bodyWithoutField = "\"numberOfReplications\":2,\"replicationLength\":90.0,\"warmUpPeriod\":15.0,"
+                               "\"pauseOnEvent\":true,\"pauseOnReplication\":false,\"initializeStatistics\":true";
+        }
+
+        HttpRequest configRequest;
+        configRequest.method = "POST";
+        configRequest.path = "/api/v1/simulation/config";
+        configRequest.headers["authorization"] = "Bearer " + token;
+        configRequest.body = "{" + bodyWithoutField + "}";
+
+        const HttpResponse response = fixture.router.handle(configRequest);
+        EXPECT_EQ(response.status, 400) << "Expected 400 when missing field: " << missingField;
+        EXPECT_NE(response.body.find("\"INVALID_SIMULATION_CONFIG\""), std::string::npos);
+    }
 }


### PR DESCRIPTION
WEB

### Motivation
- Close stage 4 by adding missing unit coverage for the `/api/v1/simulation/*` surface to assert the contract for simulation status and configuration endpoints.
- Ensure tests explicitly document that all fields in `POST /api/v1/simulation/config` are required at this stage.

### Description
- Added a new unit test `SimulationConfigRequiresAllFieldsInRequestBody` to `source/tests/unit/test_web_api_router.cpp` that iteratively omits each of the 7 required fields and asserts a `400 INVALID_SIMULATION_CONFIG` response.
- Added `#include <array>` to the test file to support enumeration of required fields.
- Did not modify production code; verified existing `ApiRouter` and `SimulatorSessionService` already implement the expected behavior for `/api/v1/simulation/status` and `/api/v1/simulation/config`.

### Testing
- Ran CMake configure with `-DGENESYS_BUILD_WEB_APPLICATION=ON`, which completed successfully.
- Attempted to build `genesys_test_web_api_router`, but the build failed at link time due to a pre-existing unresolved symbol (`SinkModelComponent`) in `libgenesys_plugins_components_minimal.a`, preventing the test binary from being produced.
- `ctest -R web_api_router` did not run because the test executable was not built due to the linker failure.

## Stage 4 closure report

### What I completed
- Inspected the target files and confirmed stage 4 endpoints are implemented and conform to the expected contract.
- Verified existing tests covered many stage 4 cases (unauthorized accesses, missing current model, invalid body, and status/config flow).
- Added explicit unit test coverage asserting each required field in `/api/v1/simulation/config` is mandatory.

### What I could not complete
- Execution of the updated test binary (`genesys_test_web_api_router`) because the build failed at link time.

### Why anything remains incomplete
- A pre-existing linker error (undefined reference to `SinkModelComponent` in a static plugin library) prevented creation of the test executable; this issue appears unrelated to the test-only changes made here.

### Validation performed
- Configured the project for web build using CMake successfully.
- Attempted targeted build for `genesys_test_web_api_router` and captured the linker failure details.
- Attempted to run `ctest -R web_api_router`, which could not run as the test target was not built.

### Risks remaining
- New unit tests are added and source-level changes are minimal, but runtime verification of test results is blocked until the existing linker problem is resolved.
- No production code was changed, so behavioral risk to runtime code is negligible.

### Files changed
- `source/tests/unit/test_web_api_router.cpp`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d84f28965083218d4b93afef797b21)