### PR TITLE
GUI: add deterministic transition/event log correlation in animation pipeline

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/animations/AnimationTransition.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/animations/AnimationTransition.cpp
@@ -31,8 +31,9 @@ AnimationTransition::AnimationTransition(ModelGraphicsScene* myScene, ModelCompo
 
     // Abort construction when required input pointers are missing.
     if (_myScene == nullptr || graphicalStartComponent == nullptr || graphicalEndComponent == nullptr) {
-        // Log constructor early exit when mandatory input pointers are missing.
+        // Log constructor early exit with transition correlation fields.
         qInfo() << "GUI AnimationTransition ctor earlyExit reason=missingInput sceneNull=" << (_myScene == nullptr)
+                << "transitionPtr=" << this
                 << "sourceNull=" << (graphicalStartComponent == nullptr)
                 << "destinationNull=" << (graphicalEndComponent == nullptr);
         return;
@@ -44,8 +45,9 @@ AnimationTransition::AnimationTransition(ModelGraphicsScene* myScene, ModelCompo
 
     // Stop setup when either graphical endpoint is not present in the scene.
     if (_graphicalStartComponent == nullptr || _graphicalEndComponent == nullptr) {
-        // Log constructor early exit when graphical endpoints are not found in the scene.
+        // Log constructor early exit with endpoint ids for transition correlation.
         qInfo() << "GUI AnimationTransition ctor earlyExit reason=missingGraphicalEndpoint sourceId="
+                << "transitionPtr=" << this
                 << graphicalStartComponent->getId()
                 << "destinationId=" << graphicalEndComponent->getId();
         return;
@@ -71,8 +73,9 @@ AnimationTransition::AnimationTransition(ModelGraphicsScene* myScene, ModelCompo
         if (connection == nullptr) {
             _graphicalEndComponent = nullptr;
             _graphicalConnection = nullptr;
-            // Log constructor early exit when no compatible graphical connection exists.
+            // Log constructor early exit when no graphical connection can be resolved.
             qInfo() << "GUI AnimationTransition ctor earlyExit reason=missingConnection sourceId="
+                    << "transitionPtr=" << this
                     << graphicalStartComponent->getId()
                     << "destinationId=" << graphicalEndComponent->getId();
             return;
@@ -90,8 +93,11 @@ AnimationTransition::AnimationTransition(ModelGraphicsScene* myScene, ModelCompo
         if (pointsConnection.size() < 4) {
             _graphicalEndComponent = nullptr;
             _graphicalConnection = nullptr;
-            // Log constructor early exit when connection geometry has insufficient points.
-            qInfo() << "GUI AnimationTransition ctor earlyExit reason=insufficientPoints count=" << pointsConnection.size();
+            // Log constructor early exit when connection geometry cannot build animation path.
+            qInfo() << "GUI AnimationTransition ctor earlyExit reason=insufficientPoints transitionPtr=" << this
+                    << "sourceId=" << graphicalStartComponent->getId()
+                    << "destinationId=" << graphicalEndComponent->getId()
+                    << "pointsCount=" << pointsConnection.size();
             return;
         }
 
@@ -116,10 +122,12 @@ AnimationTransition::AnimationTransition(ModelGraphicsScene* myScene, ModelCompo
 
         // Configura a animação
         configureAnimation();
-        // Log constructor completion with endpoint ids and runtime data used by the animation.
+        // Log constructor completion with transition pointer and path readiness context.
         qInfo() << "GUI AnimationTransition ctor sourceId=" << graphicalStartComponent->getId()
+                << "transitionPtr=" << this
                 << "destinationId=" << graphicalEndComponent->getId()
-                << "imageCreated=" << (_imageAnimation != nullptr)
+                << "ready=" << isReadyToRun()
+                << "hasImage=" << (_imageAnimation != nullptr)
                 << "pointsCount=" << _pointsForAnimation.size();
     }
 }
@@ -186,8 +194,13 @@ void AnimationTransition::setRunning(bool running) {
 
 // Outros
 void AnimationTransition::startAnimation() {
-    // Log start request readiness and current animation duration before running.
+    // Log start request with transition correlation keys and runtime invariants.
     qInfo() << "GUI AnimationTransition startAnimation ready=" << isReadyToRun()
+            << "transitionPtr=" << this
+            << "sourceId=" << (_graphicalStartComponent ? _graphicalStartComponent->getComponent()->getId() : 0)
+            << "destinationId=" << (_graphicalEndComponent ? _graphicalEndComponent->getComponent()->getId() : 0)
+            << "hasImage=" << (_imageAnimation != nullptr)
+            << "pointsCount=" << _pointsForAnimation.size()
             << "durationMs=" << duration();
     // Block animation start when transition invariants are not fully satisfied.
     if (!isReadyToRun()) {
@@ -207,8 +220,12 @@ void AnimationTransition::startAnimation() {
 }
 
 void AnimationTransition::stopAnimation() {
-    // Log stop request including idempotent path and image ownership status.
+    // Log stop request with transition pointer and endpoint correlation metadata.
     qInfo() << "GUI AnimationTransition stopAnimation idempotent=" << _isStopping
+            << "transitionPtr=" << this
+            << "sourceId=" << (_graphicalStartComponent ? _graphicalStartComponent->getComponent()->getId() : 0)
+            << "destinationId=" << (_graphicalEndComponent ? _graphicalEndComponent->getComponent()->getId() : 0)
+            << "ready=" << isReadyToRun()
             << "hasImage=" << (_imageAnimation != nullptr);
     // Return immediately when stop cleanup is already in progress.
     if (_isStopping) {
@@ -241,8 +258,13 @@ void AnimationTransition::stopAnimation() {
 }
 
 void AnimationTransition::restartAnimation() {
-    // Log restart request readiness and current animation duration before running.
+    // Log restart request with transition correlation keys and runtime invariants.
     qInfo() << "GUI AnimationTransition restartAnimation ready=" << isReadyToRun()
+            << "transitionPtr=" << this
+            << "sourceId=" << (_graphicalStartComponent ? _graphicalStartComponent->getComponent()->getId() : 0)
+            << "destinationId=" << (_graphicalEndComponent ? _graphicalEndComponent->getComponent()->getId() : 0)
+            << "hasImage=" << (_imageAnimation != nullptr)
+            << "pointsCount=" << _pointsForAnimation.size()
             << "durationMs=" << duration();
     // Block animation restart when transition invariants are not fully satisfied.
     if (!isReadyToRun() || duration() <= 0) {
@@ -299,24 +321,31 @@ void AnimationTransition::connectValueChangedSignal() {
 void AnimationTransition::onAnimationValueChanged(const QVariant& value) {
     // Stop and exit immediately when simulation runtime is no longer running.
     if (_running == false) {
-        // Log runtime deviation when animation receives ticks while running flag is false.
-        qInfo() << "GUI AnimationTransition onAnimationValueChanged deviation=runningFalse";
+        // Log running-flag deviation including transition correlation keys.
+        qInfo() << "GUI AnimationTransition onAnimationValueChanged deviation=runningFalse"
+                << "transitionPtr=" << this;
         stopAnimation();
         return;
     }
 
     // Pause and exit immediately to avoid running animation logic while paused.
     if (_pause == true) {
-        // Log runtime deviation when animation receives ticks while paused.
-        qInfo() << "GUI AnimationTransition onAnimationValueChanged deviation=pausedTrue";
+        // Log pause-flag deviation including transition correlation keys.
+        qInfo() << "GUI AnimationTransition onAnimationValueChanged deviation=pausedTrue"
+                << "transitionPtr=" << this;
         pause();
         return;
     }
 
     // Validate mandatory runtime pointers and geometry before processing interpolation.
     if (_myScene == nullptr || _imageAnimation == nullptr || _pointsForAnimation.size() < 2) {
-        // Log runtime deviation when mandatory animation guards are invalid.
+        // Log invalid runtime guard deviation with full transition context.
         qInfo() << "GUI AnimationTransition onAnimationValueChanged deviation=invalidGuards"
+                << "transitionPtr=" << this
+                << "sourceId=" << (_graphicalStartComponent ? _graphicalStartComponent->getComponent()->getId() : 0)
+                << "destinationId=" << (_graphicalEndComponent ? _graphicalEndComponent->getComponent()->getId() : 0)
+                << "ready=" << isReadyToRun()
+                << "hasImage=" << (_imageAnimation != nullptr)
                 << "sceneNull=" << (_myScene == nullptr)
                 << "imageNull=" << (_imageAnimation == nullptr)
                 << "pointsCount=" << _pointsForAnimation.size();
@@ -335,8 +364,12 @@ void AnimationTransition::onAnimationValueChanged(const QVariant& value) {
         totalDistance += QLineF(_pointsForAnimation[i], _pointsForAnimation[i + 1]).length();
     }
     if (totalDistance <= 0.0) {
-        // Log runtime deviation when total path geometry distance is degenerate.
-        qInfo() << "GUI AnimationTransition onAnimationValueChanged deviation=totalDistanceNonPositive";
+        // Log degenerate path deviation including transition correlation keys.
+        qInfo() << "GUI AnimationTransition onAnimationValueChanged deviation=totalDistanceNonPositive"
+                << "transitionPtr=" << this
+                << "sourceId=" << (_graphicalStartComponent ? _graphicalStartComponent->getComponent()->getId() : 0)
+                << "destinationId=" << (_graphicalEndComponent ? _graphicalEndComponent->getComponent()->getId() : 0)
+                << "pointsCount=" << _pointsForAnimation.size();
         return;
     }
 
@@ -351,8 +384,9 @@ void AnimationTransition::onAnimationValueChanged(const QVariant& value) {
         ++currentSegment;
     }
     if (currentSegment < 0 || currentSegment >= numSegments) {
-        // Log runtime deviation when current interpolation segment index is invalid.
+        // Log invalid segment-index deviation including transition correlation keys.
         qInfo() << "GUI AnimationTransition onAnimationValueChanged deviation=invalidSegmentIndex"
+                << "transitionPtr=" << this
                 << "currentSegment=" << currentSegment
                 << "numSegments=" << numSegments;
         return;
@@ -361,8 +395,9 @@ void AnimationTransition::onAnimationValueChanged(const QVariant& value) {
     // Guard segment interpolation against zero-length segments before dividing.
     qreal segmentLength = QLineF(_pointsForAnimation[currentSegment], _pointsForAnimation[currentSegment + 1]).length();
     if (segmentLength <= 0.0) {
-        // Log runtime deviation when active segment length is non-positive.
-        qInfo() << "GUI AnimationTransition onAnimationValueChanged deviation=segmentLengthNonPositive";
+        // Log zero-length segment deviation including transition correlation keys.
+        qInfo() << "GUI AnimationTransition onAnimationValueChanged deviation=segmentLengthNonPositive"
+                << "transitionPtr=" << this;
         return;
     }
 
@@ -382,8 +417,14 @@ void AnimationTransition::connectFinishedSignal() {
 }
 
 void AnimationTransition::onAnimationFinished() {
-    // Log finished callback entry and whether this callback was already processed.
+    // Log finished callback entry with transition correlation context.
     qInfo() << "GUI AnimationTransition onAnimationFinished begin alreadyHandled=" << _isFinishedHandled;
+    qInfo() << "GUI AnimationTransition onAnimationFinished context transitionPtr=" << this
+            << "sourceId=" << (_graphicalStartComponent ? _graphicalStartComponent->getComponent()->getId() : 0)
+            << "destinationId=" << (_graphicalEndComponent ? _graphicalEndComponent->getComponent()->getId() : 0)
+            << "ready=" << isReadyToRun()
+            << "hasImage=" << (_imageAnimation != nullptr)
+            << "pointsCount=" << _pointsForAnimation.size();
     // Return when finished callback cleanup already ran before.
     if (_isFinishedHandled) {
         return;

--- a/source/applications/gui/qt/GenesysQtGUI/controllers/SimulationEventController.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/SimulationEventController.cpp
@@ -261,9 +261,12 @@ void SimulationEventController::onEntityRemoveHandler(SimulationEvent* re) const
 
 // Preserve entity-move animation pipeline behavior.
 void SimulationEventController::onMoveEntityEvent(SimulationEvent* re) const {
-    // Log move-entity handler entry and graphical simulation toggle state.
+    // Log move-event correlation context before dispatching transition animation.
     qInfo() << "GUI SimulationEvent onMoveEntityEvent begin graphicalSimulationChecked="
-            << (_activateGraphicalSimulation ? _activateGraphicalSimulation->isChecked() : false);
+            << (_activateGraphicalSimulation ? _activateGraphicalSimulation->isChecked() : false)
+            << "eventPtr=" << (re ? re->getCurrentEvent() : nullptr)
+            << "sourceId=" << ((re && re->getCurrentEvent() && re->getCurrentEvent()->getComponent()) ? re->getCurrentEvent()->getComponent()->getId() : 0)
+            << "destinationId=" << ((re && re->getDestinationComponent()) ? re->getDestinationComponent()->getId() : 0);
     _scene->animateCounter();
     _scene->animateVariable();
 
@@ -272,11 +275,12 @@ void SimulationEventController::onMoveEntityEvent(SimulationEvent* re) const {
             if (re->getCurrentEvent()->getComponent()) {
                 ModelComponent* source = re->getCurrentEvent()->getComponent();
                 ModelComponent* destination = re->getDestinationComponent();
-                // Log source and destination identifiers before transition dispatch.
+                // Log event and endpoint identifiers used to correlate with scene/animation logs.
                 qInfo() << "GUI SimulationEvent onMoveEntityEvent sourceId="
                         << (source ? source->getId() : 0)
                         << "destinationId="
-                        << (destination ? destination->getId() : 0);
+                        << (destination ? destination->getId() : 0)
+                        << "eventPtr=" << re->getCurrentEvent();
 
                 _scene->animateQueueRemove(source);
 

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
@@ -1367,7 +1367,7 @@ bool ModelGraphicsScene::getSnapToGrid() {
 }
 
 void ModelGraphicsScene::animateTransition(ModelComponent *source, ModelComponent *destination, bool viewSimulation, Event *event) {
-    // Log transition dispatch request with endpoints and simulation-visibility flag.
+    // Log transition creation request with event/endpoint correlation context.
     qInfo() << "GUI ModelGraphicsScene animateTransition sourceId="
             << (source ? source->getId() : 0)
             << "destinationId=" << (destination ? destination->getId() : 0)
@@ -1375,13 +1375,22 @@ void ModelGraphicsScene::animateTransition(ModelComponent *source, ModelComponen
             << "eventPtr=" << event;
     // Skip transition creation when source or destination is missing.
     if (source == nullptr || destination == nullptr) {
-        // Log rejection reason when transition endpoints are missing.
-        qInfo() << "GUI ModelGraphicsScene animateTransition rejected reason=missingEndpoint";
+        // Log explicit rejection reason when transition endpoints are unavailable.
+        qInfo() << "GUI ModelGraphicsScene animateTransition rejected reason=missingEndpoint"
+                << "eventPtr=" << event
+                << "sourceId=" << (source ? source->getId() : 0)
+                << "destinationId=" << (destination ? destination->getId() : 0);
         return;
     }
 
     // Cria a animação
     AnimationTransition *animationTransition = new AnimationTransition(this, source, destination, viewSimulation);
+
+    // Log newly created transition pointer so downstream logs can be correlated.
+    qInfo() << "GUI ModelGraphicsScene animateTransition created transitionPtr=" << animationTransition
+            << "eventPtr=" << event
+            << "sourceId=" << (source ? source->getId() : 0)
+            << "destinationId=" << (destination ? destination->getId() : 0);
 
     // Forward transition to local loop only when GUI endpoints and animation runtime are valid.
     if (animationTransition->getGraphicalStartComponent() != nullptr
@@ -1390,8 +1399,12 @@ void ModelGraphicsScene::animateTransition(ModelComponent *source, ModelComponen
             && viewSimulation) {
         runAnimateTransition(animationTransition, event);
     } else {
-        // Log rejection reason when transition is not ready or simulation view is disabled.
+        // Log explicit rejection reason when transition cannot be scheduled for execution.
         qInfo() << "GUI ModelGraphicsScene animateTransition rejected reason=invalidTransitionOrViewDisabled"
+                << "transitionPtr=" << animationTransition
+                << "eventPtr=" << event
+                << "sourceId=" << (source ? source->getId() : 0)
+                << "destinationId=" << (destination ? destination->getId() : 0)
                 << "hasStart=" << (animationTransition->getGraphicalStartComponent() != nullptr)
                 << "hasEnd=" << (animationTransition->getGraphicalEndComponent() != nullptr)
                 << "ready=" << animationTransition->isReadyToRun()
@@ -1404,15 +1417,18 @@ void ModelGraphicsScene::animateTransition(ModelComponent *source, ModelComponen
 }
 
 void ModelGraphicsScene::runAnimateTransition(AnimationTransition *animationTransition, Event *event, bool restart) {
-    // Log transition runner entry and the restart mode selected by caller.
+    // Log transition runner entry with correlation keys before runtime checks.
     qInfo() << "GUI ModelGraphicsScene runAnimateTransition begin restart=" << restart
             << "eventPtr=" << event
             << "transitionPtr=" << animationTransition;
     // Exit before local event loop when transition pointer is invalid or not runnable.
     if (animationTransition == nullptr || !animationTransition->isReadyToRun()) {
-        // Log rejection reason when transition pointer is invalid at runner entry.
+        // Log rejection details when transition is null or not ready to run.
         qInfo() << "GUI ModelGraphicsScene runAnimateTransition rejected transitionNull="
                 << (animationTransition == nullptr)
+                << "transitionPtr=" << animationTransition
+                << "eventPtr=" << event
+                << "restart=" << restart
                 << "ready=" << (animationTransition ? animationTransition->isReadyToRun() : false);
         if (animationTransition != nullptr) {
             animationTransition->stopAnimation();
@@ -1458,8 +1474,11 @@ void ModelGraphicsScene::runAnimateTransition(AnimationTransition *animationTran
         animationTransition->restartAnimation();
     else
         animationTransition->startAnimation();
-    // Log transition runtime parameters after start/restart call.
+    // Log runtime execution parameters right after start/restart dispatch.
     qInfo() << "GUI ModelGraphicsScene runAnimateTransition runtime ready="
+            << "transitionPtr=" << animationTransition
+            << "eventPtr=" << event
+            << "restart=" << restart
             << animationTransition->isReadyToRun()
             << "durationMs=" << animationTransition->duration();
 
@@ -1470,12 +1489,19 @@ void ModelGraphicsScene::runAnimateTransition(AnimationTransition *animationTran
     }
     timeoutTimer.start(timeoutMs);
 
-    // Log local event loop entry for transition execution.
-    qInfo() << "GUI ModelGraphicsScene runAnimateTransition loop.exec enter timeoutMs=" << timeoutMs;
+    // Log local loop entry and timeout guard values for this transition.
+    qInfo() << "GUI ModelGraphicsScene runAnimateTransition loop.exec enter transitionPtr=" << animationTransition
+            << "eventPtr=" << event
+            << "restart=" << restart
+            << "ready=" << animationTransition->isReadyToRun()
+            << "durationMs=" << animationTransition->duration()
+            << "timeoutMs=" << timeoutMs;
     // Aguarda a conclusão da animação sem bloquear o restante do código
     loop.exec();
-    // Log local event loop exit and timeout status.
-    qInfo() << "GUI ModelGraphicsScene runAnimateTransition loop.exec exit exitedByTimeout=" << exitedByTimeout;
+    // Log local loop exit to capture timeout result for this transition execution.
+    qInfo() << "GUI ModelGraphicsScene runAnimateTransition loop.exec exit transitionPtr=" << animationTransition
+            << "eventPtr=" << event
+            << "timeout=" << exitedByTimeout;
 
     // Stop and disconnect timer resources after leaving the local event loop.
     if (timeoutTimer.isActive()) {
@@ -1490,8 +1516,10 @@ void ModelGraphicsScene::runAnimateTransition(AnimationTransition *animationTran
 
     // Stop post-loop processing when the transition was destroyed during loop execution.
     if (guardedTransition.isNull()) {
-        // Log guarded transition destruction observed after leaving the local loop.
-        qInfo() << "GUI ModelGraphicsScene runAnimateTransition guardedTransitionNull=true";
+        // Log guarded pointer nullification when transition is deleted during loop execution.
+        qInfo() << "GUI ModelGraphicsScene runAnimateTransition guardedTransitionNull=true"
+                << "transitionPtr=" << animationTransition
+                << "eventPtr=" << event;
         _animationsTransition->removeOne(animationTransition);
         return;
     }
@@ -1501,8 +1529,11 @@ void ModelGraphicsScene::runAnimateTransition(AnimationTransition *animationTran
 
     // Perform terminal cleanup when loop exit happened through timeout.
     if (exitedByTimeout && transitionPtr != nullptr) {
-        // Log terminal timeout cleanup path for this transition execution.
-        qInfo() << "GUI ModelGraphicsScene runAnimateTransition terminalCleanup reason=timeout";
+        // Log timeout cleanup path before force-stopping and deleting transition.
+        qInfo() << "GUI ModelGraphicsScene runAnimateTransition terminalCleanup reason=timeout"
+                << "transitionPtr=" << transitionPtr
+                << "eventPtr=" << event
+                << "timeout=" << exitedByTimeout;
         transitionPtr->stopAnimation();
         _animationsTransition->removeOne(transitionPtr);
         delete transitionPtr;
@@ -1511,21 +1542,35 @@ void ModelGraphicsScene::runAnimateTransition(AnimationTransition *animationTran
 
     // Remove and delete only when the guarded transition is still valid.
     if (transitionPtr != nullptr) {
-        // Log final state before deciding paused retention versus terminal destruction.
+        // Log final state used to choose paused retention or terminal destruction.
         qInfo() << "GUI ModelGraphicsScene runAnimateTransition finalState="
+                << "transitionPtr=" << transitionPtr
+                << "eventPtr=" << event
                 << transitionPtr->state()
                 << "paused=" << (transitionPtr->state() == QAbstractAnimation::Paused);
         _animationsTransition->removeOne(transitionPtr);
         if (transitionPtr->state() != QAbstractAnimation::Paused) {
             // Log terminal destruction path when transition does not remain paused.
-            qInfo() << "GUI ModelGraphicsScene runAnimateTransition terminalCleanup reason=notPaused";
+            qInfo() << "GUI ModelGraphicsScene runAnimateTransition cleanup destination=terminalDestroy"
+                    << "transitionPtr=" << transitionPtr
+                    << "eventPtr=" << event;
             delete transitionPtr;
+        } else {
+            // Log paused retention path when transition remains available for resume.
+            qInfo() << "GUI ModelGraphicsScene runAnimateTransition cleanup destination=pausedMap"
+                    << "transitionPtr=" << transitionPtr
+                    << "eventPtr=" << event;
         }
     }
+
+    // Log final cleanup checkpoint after the transition is removed from active list.
+    qInfo() << "GUI ModelGraphicsScene runAnimateTransition cleanup final transitionPtr="
+            << transitionPtr
+            << "eventPtr=" << event;
 }
 
 void ModelGraphicsScene::handleAnimationStateChanged(QAbstractAnimation::State newState, QEventLoop* loop, Event* event, AnimationTransition* animationTransition) {
-    // Log state notifications routed from transition stateChanged signal.
+    // Log each state notification with transition and event correlation keys.
     qInfo() << "GUI ModelGraphicsScene handleAnimationStateChanged state=" << newState
             << "eventPtr=" << event
             << "transitionPtr=" << animationTransition;
@@ -1550,13 +1595,25 @@ void ModelGraphicsScene::handleAnimationStateChanged(QAbstractAnimation::State n
         _animationPaused->insert(event, newList);
     }
 
+    // Track whether paused-list append happened for deterministic state correlation.
+    bool appendedToPausedList = false;
     // Append only when this transition is not already tracked for the event.
     QList<AnimationTransition*>* pausedAnimations = _animationPaused->value(event);
     if (pausedAnimations != nullptr && !pausedAnimations->contains(animationTransition)) {
         // Log paused-list append when transition is first tracked for this event.
-        qInfo() << "GUI ModelGraphicsScene handleAnimationStateChanged appendPaused=true eventPtr=" << event;
+        qInfo() << "GUI ModelGraphicsScene handleAnimationStateChanged appendPaused=true eventPtr=" << event
+                << "transitionPtr=" << animationTransition
+                << "state=" << newState;
         pausedAnimations->append(animationTransition);
+        appendedToPausedList = true;
     }
+
+    // Log paused-state handling outcome even when transition was already present.
+    qInfo() << "GUI ModelGraphicsScene handleAnimationStateChanged appendPaused="
+            << appendedToPausedList
+            << "eventPtr=" << event
+            << "transitionPtr=" << animationTransition
+            << "state=" << newState;
 
     // Preserve local loop exit when the animation transitions to paused.
     if (loop) loop->quit();


### PR DESCRIPTION
### Motivation
- Make GUI animation pipeline logs correlatable end-to-end for each transition/event without changing functional semantics.
- Use only existing identifiers (event pointer, AnimationTransition pointer, sourceId, destinationId) and retain the `GUI` `qInfo()` prefix to improve observability for debugging and tracing.

### Description
- `SimulationEventController.cpp`: enriched `onMoveEntityEvent(...)` entry and dispatch logs with `eventPtr`, `sourceId`, and `destinationId`, and added a short English comment above the modified log block.
- `ModelGraphicsScene.cpp`: enriched `animateTransition(...)`, `runAnimateTransition(...)`, and `handleAnimationStateChanged(...)` with `eventPtr`, created `transitionPtr`, `sourceId`, `destinationId`, loop lifecycle logs (enter/exit), `timeout`/guarded-pointer notifications, explicit rejection/cleanup reasons, paused-list append outcome, and short English comments above each altered log block.
- `AnimationTransition.cpp`: preserved existing logs and augmented constructor, `startAnimation`, `restartAnimation`, `stopAnimation`, `onAnimationValueChanged`, and `onAnimationFinished` logs with `transitionPtr=this` and context fields such as `sourceId`, `destinationId`, `ready`, `hasImage`, and `pointsCount`, plus concise English comments above each changed log block.
- All changes are logging/comment-only, do not alter headers, macros, build system, or runtime semantics, and are restricted to the three requested `.cpp` files.

### Testing
- Ran `qmake --version` to check Qt toolchain availability and the command failed with `qmake: command not found`, indicating the Qt toolchain is not available in this environment (build/runtime GUI not executed). (failed)
- Ran CMake configure with `cmake -S . -B build-gui-check -DCMAKE_BUILD_TYPE=Release` which completed successfully and wrote build files to `build-gui-check` (succeeded), but the resulting configure did not enable the Qt GUI target in this environment.
- Ran `cmake -S . -B build-gui-check -DGENESYS_BUILD_GUI=ON` which completed but reported the `GENESYS_BUILD_GUI` option is not used by the current CMake configuration in this environment, so no GUI build was performed (succeeded with warning).
- Per static inspection of diffs and headers, confirm the modifications are limited to the three specified files, only enhance `qInfo()` logs and comments, and do not change functional behavior (inspection-based validation only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d84fddb54883219fb6630137f4bbd8)