### PR TITLE
Fix Queue ownership lifecycle and safe dequeue paths

### DIFF
--- a/source/plugins/components/Match.cpp
+++ b/source/plugins/components/Match.cpp
@@ -106,11 +106,14 @@ void Match::_onDispatchEvent(Entity* entity, unsigned int inputPortNumber) {
 			Entity* waitingEntity;
 			for (Queue* queue : *_queues->list()) {
 				for (i = 0; i < matchSize; i++) {
-					waiting = queue->first();
-					queue->removeElement(waiting);
+					waiting = queue->takeFirst();
+					if (waiting == nullptr) {
+						break;
+					}
 					// @TODO: Actualize STATISTICS about queue/wait time
 					waitingEntity = waiting->getEntity();
 					_parentModel->sendEntityToComponent(waitingEntity, this->getConnectionManager()->getFrontConnection(), 0.0);
+					delete waiting;
 				}
 			}
 		}

--- a/source/plugins/components/Seize.cpp
+++ b/source/plugins/components/Seize.cpp
@@ -361,10 +361,14 @@ void Seize::_handlerForResourceEvent(Resource* resource) { //@TODO Resource is u
 			}
 		}
 		if (canSeizeAll) {
-			queue->removeElement(first);
+			first = queue->takeFirst();
+			if (first == nullptr) {
+				return;
+			}
 			//traceSimulation(this, tnow, first->getEntity(), this, "Waiting entity " + first->getEntity()->getName() + " removed from queue and will try to seize the resources");// now seizes " + std::to_string(quantity) + " elements of resource \"" + resource->getName() + "\"");
 			trace("Waiting entity " + first->getEntity()->getName() + " removed from queue and will try to seize the resources"); // now seizes " + std::to_string(quantity) + " elements of resource \"" + resource->getName() + "\"");
 			_parentModel->sendEntityToComponent(first->getEntity(), this); // move waiting entity from queue to this component
+			delete first;
 		}
 		/*
 		if (request->getResource() == resource) {

--- a/source/plugins/components/Wait.cpp
+++ b/source/plugins/components/Wait.cpp
@@ -220,14 +220,17 @@ unsigned int Wait::_handlerForSignalDataEvent(SignalData* signalData) {
 	unsigned int freed = 0;
 	unsigned int waitLimit = _parentModel->parseExpression(limitExpression);
 	while (_queue->size() > 0 && signalData->remainsToLimit() > 0 &&  freed <= waitLimit) {
-		Waiting* w = _queue->getAtRank(0);
-		_queue->removeElement(w);
+		Waiting* w = _queue->takeFirst();
+		if (w == nullptr) {
+			break;
+		}
 		freed++;
 		signalData->decreaseRemainLimit();
 		Entity* ent = w->getEntity();
 		std::string message = getName() + " received " + signalData->getName() + ". " + ent->getName() + " removed from " + _queue->getName() + ". " + std::to_string(freed) + " freed, " + std::to_string(signalData->remainsToLimit()) + " remaining";
 		_parentModel->getTracer()->traceSimulation(this, TraceManager::Level::L8_detailed, _parentModel->getSimulation()->getSimulatedTime(), ent, this, message);
 		_parentModel->sendEntityToComponent(w->getEntity(), w->geComponent()->getConnectionManager()->getFrontConnection());
+		delete w;
 	}
 	return freed;
 }
@@ -238,12 +241,15 @@ void Wait::_handlerForAfterProcessEventEvent(SimulationEvent* event) {
 	//traceSimulation(this, TraceManager::Level::L7_internal, _parentModel->getSimulation()->getSimulatedTime(), event->getCurrentEvent()->getEntity(), this, message);
 	if (result) { // condition is true. Remove entities from the queue
 		while (_queue->size() > 0) {
-			Waiting* w = _queue->getAtRank(0);
-			_queue->removeElement(w);
+			Waiting* w = _queue->takeFirst();
+			if (w == nullptr) {
+				break;
+			}
 			Entity* ent = w->getEntity();
 			std::string message = getName() + " evaluated condition " + _condition + " as true. " + ent->getName() + " removed from " + _queue->getName();
 			_parentModel->getTracer()->traceSimulation(this, TraceManager::Level::L8_detailed, _parentModel->getSimulation()->getSimulatedTime(), ent, this, message);
 			_parentModel->sendEntityToComponent(w->getEntity(), w->geComponent()->getConnectionManager()->getFrontConnection());
+			delete w;
 		}
 
 	}

--- a/source/plugins/data/Queue.cpp
+++ b/source/plugins/data/Queue.cpp
@@ -62,8 +62,8 @@ Queue::Queue(Model* model, std::string name) : ModelDataDefinition(model, Util::
 }
 
 Queue::~Queue() {
-	//_parentModel->elements()->remove(Util::TypeOf<StatisticsCollector>(), _cstatNumberInQueue);
-	//_parentModel->elements()->remove(Util::TypeOf<StatisticsCollector>(), _cstatTimeInQueue);
+	_clearOwnedWaitings();
+	delete _list;
 }
 
 std::string Queue::show() {
@@ -81,8 +81,8 @@ void Queue::insertElement(Waiting* modeldatum) {
 	_list->insert(modeldatum);
 }
 
-void Queue::removeElement(Waiting* modeldatum) {
-	if (_reportStatistics) {
+Waiting* Queue::takeElement(Waiting* modeldatum) {
+	if (_reportStatistics && modeldatum != nullptr) {
 		double tnow = _parentModel->getSimulation()->getSimulatedTime();
 		double duration = tnow - _lastTimeNumberInQueueChanged;
 		this->_cstatNumberInQueue->getStatistics()->getCollector()->addValue(_list->size(), duration); // save the OLD quantity and for how long it was there
@@ -91,10 +91,24 @@ void Queue::removeElement(Waiting* modeldatum) {
 		this->_cstatTimeInQueue->getStatistics()->getCollector()->addValue(timeInQueue);
 	}
 	_list->remove(modeldatum);
+	return modeldatum;
+}
+
+Waiting* Queue::takeFirst() {
+	if (_list->size() == 0) {
+		return nullptr;
+	}
+	Waiting* modeldatum = _list->front();
+	return takeElement(modeldatum);
+}
+
+void Queue::removeElement(Waiting* modeldatum) {
+	Waiting* removed = takeElement(modeldatum);
+	delete removed;
 }
 
 void Queue::_initBetweenReplications() {
-	this->_list->clear();
+	_clearOwnedWaitings();
 	_lastTimeNumberInQueueChanged = 0.0;
 }
 
@@ -103,6 +117,9 @@ unsigned int Queue::size() {
 }
 
 Waiting* Queue::first() {
+	if (_list->size() == 0) {
+		return nullptr;
+	}
 	return _list->front();
 }
 
@@ -206,4 +223,11 @@ ParserChangesInformation * Queue::_getParserChangesInformation() {
 	//changes->getProductionToAdd()->insert(...);
 	//changes->getTokensToAdd()->insert(...);
 	return changes;
+}
+
+void Queue::_clearOwnedWaitings() {
+	for (Waiting* waiting : *_list->list()) {
+		delete waiting;
+	}
+	_list->clear();
 }

--- a/source/plugins/data/Queue.h
+++ b/source/plugins/data/Queue.h
@@ -108,6 +108,8 @@ public: // static
 	static ModelDataDefinition* NewInstance(Model* model, std::string name = "");
 public:
 	void insertElement(Waiting* modeldatum);
+	Waiting* takeElement(Waiting* modeldatum);
+	Waiting* takeFirst();
 	void removeElement(Waiting* modeldatum);
 	unsigned int size();
 	Waiting* first();
@@ -134,6 +136,7 @@ protected: // could be overriden
 
 private:
 	void _initCStats();
+	void _clearOwnedWaitings();
 private:
 	List<Waiting*>* _list = new List<Waiting*>();
 	double _lastTimeNumberInQueueChanged;
@@ -151,4 +154,3 @@ private: // inner internal elements
 };
 
 #endif /* QUEUE_H */
-

--- a/source/tests/unit/CMakeLists.txt
+++ b/source/tests/unit/CMakeLists.txt
@@ -103,6 +103,15 @@ genesys_add_unit_test(genesys_test_support_experimentmanager
     genesys_kernel_util
 )
 
+genesys_add_unit_test(genesys_test_plugins_data_queue_lifecycle
+    test_plugins_data_queue_lifecycle.cpp
+    genesys_plugins_data
+    genesys_kernel_simulator_runtime
+    genesys_kernel_util
+    genesys_plugins_components_minimal
+    genesys_kernel_simulator_runtime
+)
+
 add_custom_target(genesys_kernel_unit_tests
     DEPENDS
         genesys_test_util
@@ -118,6 +127,7 @@ add_custom_target(genesys_kernel_unit_tests
         genesys_test_support_connectionmanager
         genesys_test_support_simulationscenario
         genesys_test_support_experimentmanager
+        genesys_test_plugins_data_queue_lifecycle
 )
 
 if(GENESYS_BUILD_WEB_APPLICATION)
@@ -185,6 +195,7 @@ add_custom_target(genesys_kernel_unit_tests_run
     COMMAND $<TARGET_FILE:genesys_test_support_connectionmanager>
     COMMAND $<TARGET_FILE:genesys_test_support_simulationscenario>
     COMMAND $<TARGET_FILE:genesys_test_support_experimentmanager>
+    COMMAND $<TARGET_FILE:genesys_test_plugins_data_queue_lifecycle>
     COMMAND $<TARGET_FILE:genesys_test_kernel_simulator_method_inventory>
     DEPENDS
         genesys_kernel_unit_tests

--- a/source/tests/unit/test_plugins_data_queue_lifecycle.cpp
+++ b/source/tests/unit/test_plugins_data_queue_lifecycle.cpp
@@ -1,0 +1,109 @@
+#include <gtest/gtest.h>
+
+#include "kernel/simulator/Model.h"
+#include "kernel/simulator/Simulator.h"
+#include "plugins/data/Queue.h"
+
+namespace {
+
+static unsigned int g_waitingProbeDestructions = 0;
+
+class WaitingProbe : public Waiting {
+public:
+    WaitingProbe(Entity* entity, double timeStartedWaiting, ModelComponent* thisComponent, unsigned int thisComponentOutputPort = 0)
+        : Waiting(entity, timeStartedWaiting, thisComponent, thisComponentOutputPort) {}
+
+    ~WaitingProbe() override {
+        ++g_waitingProbeDestructions;
+    }
+
+    std::string show() override {
+        return "WaitingProbe";
+    }
+};
+
+class QueueLifecycleProbe : public Queue {
+public:
+    QueueLifecycleProbe(Model* model, const std::string& name)
+        : Queue(model, name) {}
+
+    void InitBetweenReplicationsPublic() {
+        _initBetweenReplications();
+    }
+};
+
+} // namespace
+
+TEST(QueueLifecycleTest, FirstOnEmptyQueueReturnsNullptr) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    auto* queue = new QueueLifecycleProbe(model, "QueueProbe");
+
+    EXPECT_EQ(queue->size(), 0u);
+    EXPECT_EQ(queue->first(), nullptr);
+    EXPECT_EQ(queue->takeFirst(), nullptr);
+}
+
+TEST(QueueLifecycleTest, RemoveElementDeletesOwnedWaiting) {
+    g_waitingProbeDestructions = 0;
+
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+    Entity* entity = model->createEntity("E1", true);
+    ASSERT_NE(entity, nullptr);
+
+    auto* queue = new QueueLifecycleProbe(model, "QueueProbe");
+    queue->setReportStatistics(false);
+    auto* waiting = new WaitingProbe(entity, 0.0, nullptr);
+    queue->insertElement(waiting);
+
+    EXPECT_EQ(queue->size(), 1u);
+    queue->removeElement(waiting);
+
+    EXPECT_EQ(queue->size(), 0u);
+    EXPECT_EQ(g_waitingProbeDestructions, 1u);
+}
+
+TEST(QueueLifecycleTest, InitBetweenReplicationsClearsAndDeletesOwnedWaitings) {
+    g_waitingProbeDestructions = 0;
+
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+    Entity* entity = model->createEntity("E2", true);
+    ASSERT_NE(entity, nullptr);
+
+    auto* queue = new QueueLifecycleProbe(model, "QueueProbe");
+    queue->setReportStatistics(false);
+    queue->insertElement(new WaitingProbe(entity, 1.0, nullptr));
+    queue->insertElement(new WaitingProbe(entity, 2.0, nullptr));
+
+    ASSERT_EQ(queue->size(), 2u);
+    queue->InitBetweenReplicationsPublic();
+
+    EXPECT_EQ(queue->size(), 0u);
+    EXPECT_EQ(g_waitingProbeDestructions, 2u);
+}
+
+TEST(QueueLifecycleTest, QueueDestructorDeletesRemainingOwnedWaitings) {
+    g_waitingProbeDestructions = 0;
+
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+    Entity* entity = model->createEntity("E3", true);
+    ASSERT_NE(entity, nullptr);
+
+    auto* queue = new QueueLifecycleProbe(model, "QueueProbe");
+    queue->setReportStatistics(false);
+    queue->insertElement(new WaitingProbe(entity, 1.0, nullptr));
+    queue->insertElement(new WaitingProbe(entity, 2.0, nullptr));
+    EXPECT_EQ(queue->size(), 2u);
+
+    model->clear();
+
+    EXPECT_EQ(g_waitingProbeDestructions, 2u);
+}


### PR DESCRIPTION
PLUGINS

### Motivation
- Corrigir vazamentos e inconsistências de ownership de `Waiting*` em `Queue` (remoção sem `delete`, limpeza entre replicações sem destruir, `_list` alocado sem ser liberado). 
- Eliminar acesso inseguro a elementos quando a fila está vazia (chamadores que usavam `first()` assumiam não-nulo). 
- Fazer mudanças pequenas e locais que preservem a premissa: `Queue` é owner enquanto um item está enfileirado; ao sair, ownership deve ser transferida ou destruída explicitamente.

### Description
- Introduzidas APIs de extração: `Queue::takeElement(Waiting*)` e `Queue::takeFirst()` para transferência explícita de ownership ao dequeuer. 
- `Queue::removeElement(Waiting*)` agora remove e destrói o `Waiting` (mantendo uma operação destrutiva conveniente). 
- `Queue::_clearOwnedWaitings()` implementada e chamada em `~Queue()` e `_initBetweenReplications()` para garantir destruição de remanescentes; destrutor agora também `delete _list`. 
- `Queue::first()` tornou-se segura em lista vazia (retorna `nullptr`); `getAtRank` mantido. 
- Ajustados consumidores imediatos que retiravam itens da fila para usar a nova API e evitar leaks: `Seize` (`_handlerForResourceEvent`), `Wait` (handlers de sinal/condição), `Match` (liberação por `matchSize`). 
- Adicionados testes unitários focados (`source/tests/unit/test_plugins_data_queue_lifecycle.cpp`) e integração no `CMakeLists.txt` de testes para validar comportamentos de lifecycle/ownership e acesso seguro.

### Testing
- Configuração de build com testes: `cmake -S . -B build -G Ninja -DGENESYS_BUILD_TESTS=ON -DGENESYS_BUILD_KERNEL=ON -DGENESYS_BUILD_PARSER=ON -DGENESYS_BUILD_PLUGINS=ON ...` (sucesso). 
- Build das unit tests: `cmake --build build --target genesys_kernel_unit_tests` (sucesso). 
- Execução dos testes focados: `ctest --test-dir build --output-on-failure -R QueueLifecycleTest` retornou 4/4 testes passados. 
- Execução completa de `ctest` indicou que os unit tests passaram; um teste smoke (`smoke_simulator_start`) ficou `Not Run` no ambiente por ausência do executável (informação de ambiente, não falha causada pelas mudanças).

```markdown
- o que você realizou de fato;
  - Corrigi ownership/lifetime de `Queue`/`Waiting` no escopo pedido, adicionando extração explícita (`takeElement`, `takeFirst`), fazendo `removeElement` deletar o `Waiting`, limpando remanescentes em `_initBetweenReplications()` e no destrutor, e liberando `_list` no destrutor.
  - Ajustei os chamadores imediatos que removem itens da fila (`Seize`, `Wait`, `Match`) para usar a extração segura e evitar leaks.
  - Adicionei testes unitários que cobrem acesso seguro em fila vazia, remoção destrutiva, limpeza entre replicações e destruição final, e integrei o teste ao `CMakeLists.txt` de unitários.
  - Commit realizado com as alterações de código e testes.

- o que não realizou;
  - Não alterei `Batch.cpp` nem `Remove.cpp` (fora do escopo/ não estritamente necessário para resolver leaks detectados neste passo).
  - Não implementei lógica de reordenação por `OrderRule` em runtime (proibido neste passo).
  - Não mexi em subsistemas fora do escopo indicado (`Variable`, `Resource`, `Sequence`, `SignalData`).

- por que não realizou;
  - Estas mudanças estavam explicitamente fora do escopo desta etapa ou não eram necessárias para corrigir ownership/lifetime e acesso seguro imediato.

- riscos remanescentes;
  - Fluxos que precisem acessar `Waiting` após dequeuing devem usar `take*` e fazer `delete` quando apropriado; caso contrário haverá dupla-liberação ou leak dependendo do padrão usado.
  - Código externo que dependia implicitamente da antiga semântica (remoção sem destruição) terá de ser revisado se adicionar novos chamadores que leiam `Waiting` após dequeuing.
  - Teste smoke `smoke_simulator_start` não foi executado no ambiente atual por falta do executável, o que é uma limitação de infra e não da alteração.

- observações relevantes;
  - A decisão preserva a premissa funcional: `Queue` é owner enquanto o item está enfileirado; a transferência de ownership é agora explícita e local, mantendo compatibilidade arquitetural.
  - Mantive mudanças pequenas e reversíveis focadas em ownership/lifetime e segurança contra acesso a fila vazia.

- arquivos alterados;
  - `source/plugins/data/Queue.h`
  - `source/plugins/data/Queue.cpp`
  - `source/plugins/components/Seize.cpp`
  - `source/plugins/components/Wait.cpp`
  - `source/plugins/components/Match.cpp`
  - `source/tests/unit/test_plugins_data_queue_lifecycle.cpp` (novo)
  - `source/tests/unit/CMakeLists.txt` (registro do teste)

- comandos executados e resultados resumidos.
  - `cmake -S . -B build -G Ninja -DGENESYS_BUILD_TESTS=ON -DGENESYS_BUILD_KERNEL=ON -DGENESYS_BUILD_PARSER=ON -DGENESYS_BUILD_PLUGINS=ON ...` → configuração bem-sucedida.
  - `cmake --build build --target genesys_kernel_unit_tests` → build concluído com sucesso.
  - `ctest --test-dir build --output-on-failure -R QueueLifecycleTest` → 4/4 testes `QueueLifecycleTest` passaram.
  - `ctest --test-dir build --output-on-failure` → unit tests OK; 1 smoke test ficou `Not Run` por executável ausente no ambiente.
```

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d84f99e8c08321bae56f5911058ea9)