### PR TITLE
test: expand unit coverage for PersistenceRecord, SimulationScenario, and ExperimentManager

### DIFF
--- a/source/tests/unit/test_support_experimentmanager.cpp
+++ b/source/tests/unit/test_support_experimentmanager.cpp
@@ -9,6 +9,21 @@ TraceManager* Simulator::getTraceManager() const {
     return nullptr;
 }
 
+namespace {
+
+class CountingSimulationExperiment : public SimulationExperiment {
+public:
+    ~CountingSimulationExperiment() override {
+        ++destroyedCount;
+    }
+
+    static int destroyedCount;
+};
+
+int CountingSimulationExperiment::destroyedCount = 0;
+
+} // namespace
+
 TEST(SupportExperimentManagerClassTest, StartsWithoutCurrentExperiment) {
     ExperimentManager manager(nullptr);
 
@@ -21,6 +36,8 @@ TEST(SupportExperimentManagerClassTest, NewSimulationExperimentBecomesCurrent) {
     SimulationExperiment* exp = manager.newSimulationExperiment();
     ASSERT_NE(exp, nullptr);
     EXPECT_EQ(manager.current(), exp);
+
+    delete exp;
 }
 
 TEST(SupportExperimentManagerClassTest, InsertAndRemoveWorkWithoutSimulatorTrace) {
@@ -50,4 +67,97 @@ TEST(SupportExperimentManagerClassTest, SaveAndLoadRemainGracefullyUnimplemented
 
     EXPECT_FALSE(manager.saveSimulationExperiment("exp.gen"));
     EXPECT_FALSE(manager.loadSimulationExperiment("exp.gen"));
+}
+
+TEST(SupportExperimentManagerClassTest, SetCurrentUpdatesCurrentPointer) {
+    ExperimentManager manager(nullptr);
+
+    auto* first = new SimulationExperiment();
+    auto* second = new SimulationExperiment();
+    manager.insert(first);
+    manager.insert(second);
+
+    manager.setCurrent(first);
+    EXPECT_EQ(manager.current(), first);
+
+    manager.remove(second);
+    manager.remove(first);
+}
+
+TEST(SupportExperimentManagerClassTest, GetExperimentsReturnsContainerWithInsertions) {
+    ExperimentManager manager(nullptr);
+
+    ASSERT_NE(manager.getExperiments(), nullptr);
+    EXPECT_EQ(manager.getExperiments()->size(), 0u);
+
+    auto* first = new SimulationExperiment();
+    auto* second = new SimulationExperiment();
+    manager.insert(first);
+    manager.insert(second);
+
+    EXPECT_EQ(manager.getExperiments()->size(), 2u);
+
+    manager.remove(second);
+    manager.remove(first);
+}
+
+TEST(SupportExperimentManagerClassTest, NextNavigatesListAfterFront) {
+    ExperimentManager manager(nullptr);
+
+    auto* first = new SimulationExperiment();
+    auto* second = new SimulationExperiment();
+    auto* third = new SimulationExperiment();
+    manager.insert(first);
+    manager.insert(second);
+    manager.insert(third);
+
+    EXPECT_EQ(manager.front(), first);
+    EXPECT_EQ(manager.next(), second);
+    EXPECT_EQ(manager.next(), third);
+    EXPECT_EQ(manager.next(), nullptr);
+
+    manager.remove(second);
+    manager.remove(third);
+    manager.remove(first);
+}
+
+TEST(SupportExperimentManagerClassTest, RemoveNonCurrentPreservesCurrent) {
+    ExperimentManager manager(nullptr);
+
+    auto* first = new SimulationExperiment();
+    auto* second = new SimulationExperiment();
+    manager.insert(first);
+    manager.insert(second);
+    manager.setCurrent(second);
+
+    manager.remove(first);
+
+    EXPECT_EQ(manager.size(), 1u);
+    EXPECT_EQ(manager.current(), second);
+
+    manager.remove(second);
+}
+
+TEST(SupportExperimentManagerClassTest, RemoveDestroysRemovedExperimentOwnership) {
+    CountingSimulationExperiment::destroyedCount = 0;
+    ExperimentManager manager(nullptr);
+
+    auto* counted = new CountingSimulationExperiment();
+    manager.insert(counted);
+
+    manager.remove(counted);
+
+    EXPECT_EQ(CountingSimulationExperiment::destroyedCount, 1);
+}
+
+TEST(SupportExperimentManagerClassTest, ManagerDestructorDestroysRemainingExperiments) {
+    CountingSimulationExperiment::destroyedCount = 0;
+
+    {
+        ExperimentManager manager(nullptr);
+        manager.insert(new CountingSimulationExperiment());
+        manager.insert(new CountingSimulationExperiment());
+    }
+
+    EXPECT_EQ(CountingSimulationExperiment::destroyedCount, 2);
 }

--- a/source/tests/unit/test_support_persistence.cpp
+++ b/source/tests/unit/test_support_persistence.cpp
@@ -30,3 +30,94 @@ TEST(SupportPersistenceClassTest, MissingFieldReturnsEmptyString) {
 
     EXPECT_EQ(fields.loadField("missing", std::string("")), "");
 }
+
+TEST(SupportPersistenceClassTest, SaveFieldSkipsStringDefaultUnlessForced) {
+    FakeModelPersistenceB persistence;
+    PersistenceRecord fields(persistence);
+
+    fields.saveField("name", std::string("default"), std::string("default"), false);
+    EXPECT_EQ(fields.find("name"), fields.end());
+
+    fields.saveField("name", std::string("default"), std::string("default"), true);
+    ASSERT_NE(fields.find("name"), fields.end());
+    EXPECT_EQ(fields.loadField("name", std::string("")), "default");
+}
+
+TEST(SupportPersistenceClassTest, SaveFieldSkipsNumericDefaultUnlessForced) {
+    FakeModelPersistenceB persistence;
+    PersistenceRecord fields(persistence);
+
+    fields.saveField("double", 2.5, 2.5, false);
+    fields.saveField("unsigned", static_cast<unsigned int>(3), static_cast<unsigned int>(3), false);
+    fields.saveField("integer", 4, 4, false);
+    fields.saveField("time", Util::TimeUnit::second, Util::TimeUnit::second, false);
+    EXPECT_EQ(fields.size(), 0u);
+
+    fields.saveField("double", 2.5, 2.5, true);
+    fields.saveField("unsigned", static_cast<unsigned int>(3), static_cast<unsigned int>(3), true);
+    fields.saveField("integer", 4, 4, true);
+    fields.saveField("time", Util::TimeUnit::second, Util::TimeUnit::second, true);
+    EXPECT_EQ(fields.size(), 4u);
+}
+
+TEST(SupportPersistenceClassTest, LoadFieldNumericOverloadsReadStoredValues) {
+    FakeModelPersistenceB persistence;
+    PersistenceRecord fields(persistence);
+
+    fields.saveField("double", 1.25, 0.0, true);
+    fields.saveField("unsigned", static_cast<unsigned int>(17));
+    fields.saveField("integer", -8, 0, true);
+    fields.saveField("time", Util::TimeUnit::minute, Util::TimeUnit::second, true);
+
+    EXPECT_DOUBLE_EQ(fields.loadField("double", 0.0), 1.25);
+    EXPECT_EQ(fields.loadField("unsigned", static_cast<unsigned int>(0)), 17u);
+    EXPECT_EQ(fields.loadField("integer", 0), -8);
+    EXPECT_EQ(fields.loadField("time", Util::TimeUnit::second), Util::TimeUnit::minute);
+}
+
+TEST(SupportPersistenceClassTest, ClearAndFindReflectContainerState) {
+    FakeModelPersistenceB persistence;
+    PersistenceRecord fields(persistence);
+
+    fields.saveField("a", std::string("1"));
+    fields.saveField("b", std::string("2"));
+    ASSERT_NE(fields.find("a"), fields.end());
+    ASSERT_EQ(fields.find("missing"), fields.end());
+
+    fields.clear();
+    EXPECT_EQ(fields.size(), 0u);
+    EXPECT_EQ(fields.find("a"), fields.end());
+    EXPECT_EQ(fields.find("b"), fields.end());
+}
+
+TEST(SupportPersistenceClassTest, NewInstanceReturnsIndependentRecord) {
+    FakeModelPersistenceB persistence;
+    PersistenceRecord fields(persistence);
+    fields.saveField("a", std::string("main"));
+
+    PersistenceRecord* clone = fields.newInstance();
+    ASSERT_NE(clone, nullptr);
+    EXPECT_EQ(clone->size(), 0u);
+
+    clone->saveField("b", std::string("clone"));
+    EXPECT_EQ(fields.find("b"), fields.end());
+    EXPECT_EQ(fields.size(), 1u);
+    EXPECT_EQ(clone->size(), 1u);
+
+    delete clone;
+}
+
+TEST(SupportPersistenceClassTest, InsertRangeCopiesRawPayloadEntries) {
+    FakeModelPersistenceB persistence;
+    PersistenceRecord source(persistence);
+    PersistenceRecord target(persistence);
+
+    source.saveField("alpha", std::string("text"));
+    source.saveField("beta", 12u);
+
+    target.insert(source.begin(), source.end());
+
+    EXPECT_EQ(target.size(), 2u);
+    EXPECT_EQ(target.loadField("alpha", std::string("")), "text");
+    EXPECT_EQ(target.loadField("beta", static_cast<unsigned int>(0)), 12u);
+}

--- a/source/tests/unit/test_support_simulationscenario.cpp
+++ b/source/tests/unit/test_support_simulationscenario.cpp
@@ -16,6 +16,18 @@ TEST(SupportSimulationScenarioClassTest, StartsWithEmptyNamesAndLists) {
     EXPECT_EQ(scenario.getControlValues()->size(), 0u);
 }
 
+TEST(SupportSimulationScenarioClassTest, SettersAndGettersForMetadata) {
+    SimulationScenario scenario;
+
+    scenario.setScenarioName("Scenario A");
+    scenario.setScenarioDescription("Description A");
+    scenario.setModelFilename("model.gen");
+
+    EXPECT_EQ(scenario.getScenarioName(), "Scenario A");
+    EXPECT_EQ(scenario.getScenarioDescription(), "Description A");
+    EXPECT_EQ(scenario.getModelFilename(), "model.gen");
+}
+
 TEST(SupportSimulationScenarioClassTest, StoresControlValuesSafely) {
     SimulationScenario scenario;
 
@@ -26,6 +38,20 @@ TEST(SupportSimulationScenarioClassTest, StoresControlValuesSafely) {
     EXPECT_EQ(scenario.getControlValues()->size(), 2u);
     EXPECT_DOUBLE_EQ(scenario.getControlValue("replications"), 10.0);
     EXPECT_DOUBLE_EQ(scenario.getControlValue("length"), 25.5);
+}
+
+TEST(SupportSimulationScenarioClassTest, SetControlAccumulatesInsertedPairs) {
+    SimulationScenario scenario;
+
+    scenario.setControl("a", 1.0);
+    scenario.setControl("b", 2.0);
+    scenario.setControl("c", 3.0);
+
+    ASSERT_NE(scenario.getControlValues(), nullptr);
+    EXPECT_EQ(scenario.getControlValues()->size(), 3u);
+    EXPECT_DOUBLE_EQ(scenario.getControlValue("a"), 1.0);
+    EXPECT_DOUBLE_EQ(scenario.getControlValue("b"), 2.0);
+    EXPECT_DOUBLE_EQ(scenario.getControlValue("c"), 3.0);
 }
 
 TEST(SupportSimulationScenarioClassTest, CopiesSelectedControlsList) {
@@ -39,6 +65,35 @@ TEST(SupportSimulationScenarioClassTest, CopiesSelectedControlsList) {
 
     ASSERT_NE(scenario.getSelectedControls(), nullptr);
     EXPECT_EQ(scenario.getSelectedControls()->size(), 2u);
+
+    delete controls;
+}
+
+TEST(SupportSimulationScenarioClassTest, ReplacingSelectedControlsKeepsIndependentCopy) {
+    SimulationScenario scenario;
+
+    auto* first = new std::list<std::string>({"x", "y"});
+    scenario.setSelectedControls(first);
+    first->clear();
+
+    auto* second = new std::list<std::string>({"r"});
+    scenario.setSelectedControls(second);
+    second->push_back("s");
+
+    ASSERT_NE(scenario.getSelectedControls(), nullptr);
+    EXPECT_EQ(scenario.getSelectedControls()->size(), 1u);
+    EXPECT_EQ(scenario.getSelectedControls()->front(), "r");
+
+    delete first;
+    delete second;
+}
+
+TEST(SupportSimulationScenarioClassTest, StartSimulationReturnsFalseAndClearsErrorMessage) {
+    SimulationScenario scenario;
+    std::string errorMessage = "previous error";
+
+    EXPECT_FALSE(scenario.startSimulation(nullptr, errorMessage));
+    EXPECT_EQ(errorMessage, "");
 }
 
 TEST(SupportSimulationScenarioClassTest, ThrowsForMissingControlValue) {


### PR DESCRIPTION
### Motivation
- Increase deterministic unit coverage for support-layer classes focusing on state, container semantics and observable ownership. 
- Exercise additional behaviors of `PersistenceRecord` (save/load variants, clear, find, insert, newInstance) that were previously untested. 
- Validate `SimulationScenario` metadata and control accumulation behavior, and `ExperimentManager` navigation and ownership/destruction semantics.

### Description
- Added tests to `source/tests/unit/test_support_persistence.cpp` covering `saveField` default-filter behavior, numeric `loadField` overloads (`double`, `unsigned int`, `int`, `Util::TimeUnit`), `clear()`, `find()`, `newInstance()` and `insert(begin,end)` copying. 
- Added tests to `source/tests/unit/test_support_simulationscenario.cpp` covering setters/getters for name/description/model filename, repeated `setSelectedControls` replacement (independent copy), `setControl` accumulation and observable `startSimulation()` behavior (returns `false` and clears `errorMessage`). 
- Added tests to `source/tests/unit/test_support_experimentmanager.cpp` covering `setCurrent`, `getExperiments`, `next` navigation, removal semantics for current vs non-current experiments, and ownership verification using a `CountingSimulationExperiment` test double to assert destruction on `remove()` and on manager destructor. 
- No changes to production code were made; only unit tests were added/expanded within the scoped files.

### Testing
- Configured and built tests with CMake+Ninja using `cmake -S . -B build/tests-audit -G Ninja -DGENESYS_BUILD_TESTS=ON` and built the three support test targets successfully. 
- Executed targeted tests with `ctest --test-dir build/tests-audit --output-on-failure -R '^(SupportPersistenceClassTest|SupportSimulationScenarioClassTest|SupportExperimentManagerClassTest)\.'` and observed all added and existing tests passing. 
- Executed `ctest --test-dir build/tests-audit --output-on-failure -L unit` and observed the full unit label passing (28/28 tests passed). 
- No production regressions were observed and no production files were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d851e9928483219837ac7838e8bf33)