### PR TITLE
Fix GraphicalModelDataDefinition removal list consistency in ModelGraphicsScene

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
@@ -664,7 +664,8 @@ void ModelGraphicsScene::insertComponent(GraphicalModelComponent* gmc, QList<Gra
 void ModelGraphicsScene::removeGraphicalModelDataDefinition(GraphicalModelDataDefinition* gmdd) {
     //graphically
     removeItem(gmdd);
-    getGraphicalModelComponents()->removeOne(gmdd);
+    // Keep data-definition ownership lists consistent during removal.
+    getGraphicalModelDataDefinitions()->removeOne(gmdd);
     getAllDataDefinitions()->removeOne(gmdd);
     delete(gmdd);
 }


### PR DESCRIPTION
### Motivation
- Correct a structural inconsistency where `removeGraphicalModelDataDefinition(...)` removed the data-definition item from the components list instead of the data-definitions list, which could leave wrong list state and dangling references in the GUI scene.

### Description
- In `source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp` `removeGraphicalModelDataDefinition(...)` now removes the item from `getGraphicalModelDataDefinitions()` (and still removes from `getAllDataDefinitions()`, removes the item from the scene and deletes it), and a short technical English comment was added immediately above the changed line; `destroyDiagram()` was reviewed and left unchanged as it remains coherent with this fix.

### Testing
- Attempted an automated GUI configure/build via CMake (`cmake -S . -B build/gui -G Ninja -DGENESYS_BUILD_GUI_APPLICATION=ON ...`) which is an automated validation step, but configuration failed because Qt `qmake` was not found in PATH, so no compile/unit tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d852933bcc832190679e5682318680)