### PR TITLE
Fix Queue ownership leaks and empty-queue safety

### DIFF
--- a/source/plugins/components/Match.cpp
+++ b/source/plugins/components/Match.cpp
@@ -107,9 +107,9 @@ void Match::_onDispatchEvent(Entity* entity, unsigned int inputPortNumber) {
 			for (Queue* queue : *_queues->list()) {
 				for (i = 0; i < matchSize; i++) {
 					waiting = queue->first();
+					waitingEntity = waiting->getEntity();
 					queue->removeElement(waiting);
 					// @TODO: Actualize STATISTICS about queue/wait time
-					waitingEntity = waiting->getEntity();
 					_parentModel->sendEntityToComponent(waitingEntity, this->getConnectionManager()->getFrontConnection(), 0.0);
 				}
 			}

--- a/source/plugins/components/Seize.cpp
+++ b/source/plugins/components/Seize.cpp
@@ -361,10 +361,12 @@ void Seize::_handlerForResourceEvent(Resource* resource) { //@TODO Resource is u
 			}
 		}
 		if (canSeizeAll) {
+			Entity* waitingEntity = first->getEntity();
+			std::string waitingEntityName = waitingEntity->getName();
 			queue->removeElement(first);
-			//traceSimulation(this, tnow, first->getEntity(), this, "Waiting entity " + first->getEntity()->getName() + " removed from queue and will try to seize the resources");// now seizes " + std::to_string(quantity) + " elements of resource \"" + resource->getName() + "\"");
-			trace("Waiting entity " + first->getEntity()->getName() + " removed from queue and will try to seize the resources"); // now seizes " + std::to_string(quantity) + " elements of resource \"" + resource->getName() + "\"");
-			_parentModel->sendEntityToComponent(first->getEntity(), this); // move waiting entity from queue to this component
+			//traceSimulation(this, tnow, waitingEntity, this, "Waiting entity " + waitingEntityName + " removed from queue and will try to seize the resources");// now seizes " + std::to_string(quantity) + " elements of resource \"" + resource->getName() + "\"");
+			trace("Waiting entity " + waitingEntityName + " removed from queue and will try to seize the resources"); // now seizes " + std::to_string(quantity) + " elements of resource \"" + resource->getName() + "\"");
+			_parentModel->sendEntityToComponent(waitingEntity, this); // move waiting entity from queue to this component
 		}
 		/*
 		if (request->getResource() == resource) {

--- a/source/plugins/components/Wait.cpp
+++ b/source/plugins/components/Wait.cpp
@@ -221,13 +221,14 @@ unsigned int Wait::_handlerForSignalDataEvent(SignalData* signalData) {
 	unsigned int waitLimit = _parentModel->parseExpression(limitExpression);
 	while (_queue->size() > 0 && signalData->remainsToLimit() > 0 &&  freed <= waitLimit) {
 		Waiting* w = _queue->getAtRank(0);
+		Entity* ent = w->getEntity();
+		ModelComponent* sourceComponent = w->geComponent();
 		_queue->removeElement(w);
 		freed++;
 		signalData->decreaseRemainLimit();
-		Entity* ent = w->getEntity();
 		std::string message = getName() + " received " + signalData->getName() + ". " + ent->getName() + " removed from " + _queue->getName() + ". " + std::to_string(freed) + " freed, " + std::to_string(signalData->remainsToLimit()) + " remaining";
 		_parentModel->getTracer()->traceSimulation(this, TraceManager::Level::L8_detailed, _parentModel->getSimulation()->getSimulatedTime(), ent, this, message);
-		_parentModel->sendEntityToComponent(w->getEntity(), w->geComponent()->getConnectionManager()->getFrontConnection());
+		_parentModel->sendEntityToComponent(ent, sourceComponent->getConnectionManager()->getFrontConnection());
 	}
 	return freed;
 }
@@ -239,11 +240,12 @@ void Wait::_handlerForAfterProcessEventEvent(SimulationEvent* event) {
 	if (result) { // condition is true. Remove entities from the queue
 		while (_queue->size() > 0) {
 			Waiting* w = _queue->getAtRank(0);
-			_queue->removeElement(w);
 			Entity* ent = w->getEntity();
+			ModelComponent* sourceComponent = w->geComponent();
+			_queue->removeElement(w);
 			std::string message = getName() + " evaluated condition " + _condition + " as true. " + ent->getName() + " removed from " + _queue->getName();
 			_parentModel->getTracer()->traceSimulation(this, TraceManager::Level::L8_detailed, _parentModel->getSimulation()->getSimulatedTime(), ent, this, message);
-			_parentModel->sendEntityToComponent(w->getEntity(), w->geComponent()->getConnectionManager()->getFrontConnection());
+			_parentModel->sendEntityToComponent(ent, sourceComponent->getConnectionManager()->getFrontConnection());
 		}
 
 	}

--- a/source/plugins/data/Queue.cpp
+++ b/source/plugins/data/Queue.cpp
@@ -62,6 +62,11 @@ Queue::Queue(Model* model, std::string name) : ModelDataDefinition(model, Util::
 }
 
 Queue::~Queue() {
+	for (Waiting* waiting : *_list->list()) {
+		delete waiting;
+	}
+	_list->clear();
+	delete _list;
 	//_parentModel->elements()->remove(Util::TypeOf<StatisticsCollector>(), _cstatNumberInQueue);
 	//_parentModel->elements()->remove(Util::TypeOf<StatisticsCollector>(), _cstatTimeInQueue);
 }
@@ -82,6 +87,9 @@ void Queue::insertElement(Waiting* modeldatum) {
 }
 
 void Queue::removeElement(Waiting* modeldatum) {
+	if (modeldatum == nullptr) {
+		return;
+	}
 	if (_reportStatistics) {
 		double tnow = _parentModel->getSimulation()->getSimulatedTime();
 		double duration = tnow - _lastTimeNumberInQueueChanged;
@@ -91,9 +99,13 @@ void Queue::removeElement(Waiting* modeldatum) {
 		this->_cstatTimeInQueue->getStatistics()->getCollector()->addValue(timeInQueue);
 	}
 	_list->remove(modeldatum);
+	delete modeldatum;
 }
 
 void Queue::_initBetweenReplications() {
+	for (Waiting* waiting : *_list->list()) {
+		delete waiting;
+	}
 	this->_list->clear();
 	_lastTimeNumberInQueueChanged = 0.0;
 }
@@ -103,6 +115,9 @@ unsigned int Queue::size() {
 }
 
 Waiting* Queue::first() {
+	if (_list->size() == 0) {
+		return nullptr;
+	}
 	return _list->front();
 }
 

--- a/source/tests/unit/test_simulator_runtime.cpp
+++ b/source/tests/unit/test_simulator_runtime.cpp
@@ -6,6 +6,7 @@
 #include "kernel/simulator/ModelDataDefinition.h"
 #include "kernel/simulator/Entity.h"
 #include "kernel/simulator/SimulationControlAndResponse.h"
+#include "plugins/data/Queue.h"
 
 namespace {
 struct SimulationStartObserver {
@@ -45,6 +46,7 @@ public:
 
 static unsigned int g_countingControlProbeDestructorCount = 0;
 static unsigned int g_countingChildProbeDestructorCount = 0;
+static unsigned int g_countingWaitingProbeDestructorCount = 0;
 
 // Tracks owned-property deletion through ModelDataDefinition teardown.
 class CountingSimulationControlProbe : public SimulationControl {
@@ -93,6 +95,25 @@ public:
 
     ~CountingChildDataDefinitionProbe() override {
         ++g_countingChildProbeDestructorCount;
+    }
+};
+
+class QueueLifecycleProbe : public Queue {
+public:
+    QueueLifecycleProbe(Model* model, const std::string& name = "") : Queue(model, name) {}
+
+    void InitBetweenReplicationsProbe() {
+        _initBetweenReplications();
+    }
+};
+
+class CountingWaitingProbe final : public Waiting {
+public:
+    CountingWaitingProbe(Entity* entity, double timeStartedWaiting, ModelComponent* thisComponent, unsigned int thisComponentOutputPort = 0)
+        : Waiting(entity, timeStartedWaiting, thisComponent, thisComponentOutputPort) {}
+
+    ~CountingWaitingProbe() override {
+        ++g_countingWaitingProbeDestructorCount;
     }
 };
 }
@@ -387,4 +408,79 @@ TEST(SimulatorRuntimeTest, ModelDataDefinitionDestructorRemovesOwnedPropertyAlso
     EXPECT_EQ(model->getControls()->size(), controlsBefore);
     EXPECT_EQ(model->getResponses()->size(), responsesBefore);
     EXPECT_EQ(g_countingControlProbeDestructorCount, 1u);
+}
+
+TEST(SimulatorRuntimeTest, QueueFirstOnEmptyQueueReturnsNullptr) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    Queue queue(model, "QueueEmpty");
+    queue.setReportStatistics(false);
+
+    EXPECT_EQ(queue.first(), nullptr);
+    EXPECT_EQ(queue.size(), 0u);
+}
+
+TEST(SimulatorRuntimeTest, QueueRemoveElementDeletesOwnedWaiting) {
+    g_countingWaitingProbeDestructorCount = 0;
+
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    Queue queue(model, "QueueRemove");
+    queue.setReportStatistics(false);
+    Entity* entity = model->createEntity("QueueRemoveEntity", true);
+    ASSERT_NE(entity, nullptr);
+
+    auto* waiting = new CountingWaitingProbe(entity, 0.0, nullptr);
+    queue.insertElement(waiting);
+    queue.removeElement(waiting);
+
+    EXPECT_EQ(queue.size(), 0u);
+    EXPECT_EQ(g_countingWaitingProbeDestructorCount, 1u);
+}
+
+TEST(SimulatorRuntimeTest, QueueInitBetweenReplicationsDeletesOwnedWaiting) {
+    g_countingWaitingProbeDestructorCount = 0;
+
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    QueueLifecycleProbe queue(model, "QueueInit");
+    queue.setReportStatistics(false);
+    Entity* entityA = model->createEntity("QueueInitEntityA", true);
+    Entity* entityB = model->createEntity("QueueInitEntityB", true);
+    ASSERT_NE(entityA, nullptr);
+    ASSERT_NE(entityB, nullptr);
+
+    queue.insertElement(new CountingWaitingProbe(entityA, 0.0, nullptr));
+    queue.insertElement(new CountingWaitingProbe(entityB, 0.0, nullptr));
+    queue.InitBetweenReplicationsProbe();
+
+    EXPECT_EQ(queue.size(), 0u);
+    EXPECT_EQ(g_countingWaitingProbeDestructorCount, 2u);
+}
+
+TEST(SimulatorRuntimeTest, QueueDestructorDeletesRemainingOwnedWaiting) {
+    g_countingWaitingProbeDestructorCount = 0;
+
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    Entity* entityA = model->createEntity("QueueDestructorEntityA", true);
+    Entity* entityB = model->createEntity("QueueDestructorEntityB", true);
+    ASSERT_NE(entityA, nullptr);
+    ASSERT_NE(entityB, nullptr);
+
+    auto* queue = new Queue(model, "QueueDestructor");
+    queue->setReportStatistics(false);
+    queue->insertElement(new CountingWaitingProbe(entityA, 0.0, nullptr));
+    queue->insertElement(new CountingWaitingProbe(entityB, 0.0, nullptr));
+    delete queue;
+
+    EXPECT_EQ(g_countingWaitingProbeDestructorCount, 2u);
 }


### PR DESCRIPTION
PLUGINS

### Motivation
- Eliminate ownership/lifetime bugs where `Waiting*` owned by `Queue` were leaked when removed, between replications or at destruction. 
- Prevent unsafe accesses to `List::front()` when a queue is empty, which caused UB in real call paths (notably `Seize`).
- Make a minimal, local change set that preserves existing plugin contracts while ensuring no use-after-free or leaks for `Waiting` instances.

### Description
- `Queue::~Queue()` now deletes any remaining `Waiting*`, clears the list and deletes the `_list` container. 
- `Queue::removeElement(Waiting*)` returns immediately on `nullptr`, updates statistics as before, removes the element from the internal list and deletes the removed `Waiting` to transfer ownership out of the queue safely. 
- `Queue::_initBetweenReplications()` now deletes all `Waiting*` currently in the list before clearing it. 
- `Queue::first()` now checks `_list->size()` and returns `nullptr` when empty to avoid calling `List::front()` on an empty container. 
- Adjusted immediate consumers that previously used `Waiting*` after calling `removeElement` to capture needed data before removal: `Seize::_handlerForResourceEvent`, `Wait::_handlerForSignalDataEvent`, `Wait::_handlerForAfterProcessEventEvent` and `Match::_onDispatchEvent`. 
- Added focused unit tests (integrated in `test_simulator_runtime.cpp`) that validate empty-queue safety, removal deletes owned `Waiting`, `_initBetweenReplications()` deletes waiting items, and destructor deletes remaining waitings.

### Testing
- Configured build with tests, kernel, parser and plugins using `cmake` and built the unit-test target `genesys_kernel_unit_tests` successfully. 
- Executed targeted queue lifecycle tests with `ctest -R "SimulatorRuntimeTest\.Queue"` and all added queue-related tests passed (4/4).
- Ran the broader unit suite excluding smoke tests with `ctest -LE smoke` and observed all unit tests pass (889/889 in that run).

```markdown
- o que você realizou de fato;
  - Corrigi ownership/lifetime da `Queue` para `Waiting*` (remoção, limpeza entre replicações e destrutor), endureci `first()` para retornar `nullptr` em fila vazia, ajustei consumidores imediatos para não usarem `Waiting*` após `removeElement`, e adicionei testes unitários focalizados.
- o que não realizou;
  - Não implementei reordenação dinâmica por `OrderRule` em runtime; não alterei `Variable`, `Resource`, `Sequence`, `SignalData`; não fiz refatoração ampla fora do escopo.
- por que não realizou;
  - Essas alterações estavam explícita e propositadamente fora do escopo desta etapa por serem funcionalmente maiores e de risco para compatibilidade.
- riscos remanescentes;
  - `Queue::removeElement` agora assume e aplica destruição do `Waiting*` removido; qualquer chamador externo que tente usar um ponteiro `Waiting*` após a remoção causará use-after-free; todos os consumidores imediatos conhecidos foram ajustados, mas chamadores não cobertos devem ser revistos se existirem.
- observações relevantes;
  - Mudanças mantêm semântica de que `Queue` é owner dos `Waiting` enquanto os itens estão na fila e transfere/encerra ownership no momento da remoção.
  - Pequenas mudanças locais e reversíveis foram preferidas.
- arquivos alterados;
  - `source/plugins/data/Queue.cpp`
  - `source/plugins/components/Seize.cpp`
  - `source/plugins/components/Wait.cpp`
  - `source/plugins/components/Match.cpp`
  - `source/tests/unit/test_simulator_runtime.cpp`
- comandos executados e resultados resumidos.
  - `cmake -S . -B build -G Ninja -DGENESYS_BUILD_TESTS=ON -DGENESYS_BUILD_KERNEL=ON -DGENESYS_BUILD_PARSER=ON -DGENESYS_BUILD_PLUGINS=ON -DGENESYS_TERMINAL_APPLICATION=OFF -DGENESYS_BUILD_GUI_APPLICATION=OFF -DGENESYS_BUILD_WEB_APPLICATION=OFF` → configure OK.
  - `cmake --build build --target genesys_kernel_unit_tests` → build OK.
  - `ctest --test-dir build -R "SimulatorRuntimeTest\.Queue" --output-on-failure` → all queue lifecycle tests passed.
  - `ctest --test-dir build -LE smoke --output-on-failure` → full unit suite (excluding smoke) passed in the final run.
```

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d851ba677c83218d2adcc131262ed0)