### PR TITLE
GUI: normalize AnimationTransition global flags in simulation start/end events

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/controllers/SimulationEventController.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/SimulationEventController.cpp
@@ -153,6 +153,8 @@ void SimulationEventController::onSimulationStartHandler(SimulationEvent* re) co
     // Log simulation-start handler entry for animation pipeline tracing.
     qInfo() << "GUI SimulationEvent onSimulationStartHandler begin";
     Q_UNUSED(re)
+    // Reset global animation pause state to a known baseline on simulation start.
+    AnimationTransition::setPause(false);
     _callbacks.actualizeActions();
     _simulationProgressBar->setMaximum(
         _simulator->getModelManager()->current()->getSimulation()->getReplicationLength());
@@ -219,6 +221,9 @@ void SimulationEventController::onSimulationEndHandler(SimulationEvent* re) cons
     // Log simulation-end handler entry before paused-animation cleanup.
     qInfo() << "GUI SimulationEvent onSimulationEndHandler begin";
     Q_UNUSED(re)
+    // Force global animation state to stopped and unpaused during terminal cleanup.
+    AnimationTransition::setRunning(false);
+    AnimationTransition::setPause(false);
     // Log paused-animation map size before terminal cleanup.
     qInfo() << "GUI SimulationEvent onSimulationEndHandler pausedMapSizeBeforeCleanup="
             << (_scene->getAnimationPaused() ? _scene->getAnimationPaused()->size() : 0);


### PR DESCRIPTION
### Motivation
- Ensure global animation static flags are consistent at natural simulation start and end to avoid inheriting stale pause/running state from prior runs.
- Make behavior consistent with command handlers that already set `AnimationTransition::setRunning/setPause` for explicit UI commands.
- Prevent paused animations from persisting across simulation lifecycle boundaries and reduce surprising UI animation behavior.

### Description
- In `SimulationEventController::onSimulationStartHandler` added `AnimationTransition::setPause(false)` with a short English comment immediately above to normalize pause baseline at simulation start. 
- In `SimulationEventController::onSimulationEndHandler` added `AnimationTransition::setRunning(false)` and `AnimationTransition::setPause(false)` with a short English comment immediately above to normalize global animation state on natural simulation end. 
- Changes are restricted to `source/applications/gui/qt/GenesysQtGUI/controllers/SimulationEventController.cpp` and do not modify `AnimationTransition.*`, `SimulationCommandController.cpp`, `ModelGraphicsScene.cpp`, `MainWindow`, or build system files.

### Testing
- Inspected the modified diff to confirm only `SimulationEventController.cpp` was changed and that the inserted calls and comments are present, which succeeded. 
- Verified via code search that `SimulationCommandController.cpp` already controls `AnimationTransition::setRunning/setPause` for start/step/pause/resume/stop, which succeeded. 
- Attempted to build the GUI using the repository flow and the `make` target, which failed due to the environment missing the Qt/qmake toolchain (`qmake not found`); CMake configure for non-GUI paths completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d85502aa1483218b2e6edcec91b8d7)