### PR TITLE
Fix ParserDefaultImpl2 sampler ownership edge case

### DIFF
--- a/source/kernel/simulator/ParserDefaultImpl2.cpp
+++ b/source/kernel/simulator/ParserDefaultImpl2.cpp
@@ -18,7 +18,7 @@
 
 // Construct parser wrapper in-place to avoid copying partially initialized driver state.
 ParserDefaultImpl2::ParserDefaultImpl2(Model* model, Sampler_if* sampler, bool throws)
-	: _model(model), _wrapper(model, sampler, throws), _ownsSampler(true) {}
+	: _model(model), _wrapper(model, sampler, throws), _ownsSampler(sampler != nullptr) {}
 
 // Delete sampler only when parser explicitly owns it.
 ParserDefaultImpl2::~ParserDefaultImpl2() {
@@ -31,6 +31,10 @@ ParserDefaultImpl2::~ParserDefaultImpl2() {
 
 void ParserDefaultImpl2::_setSamplerInternal(Sampler_if* sampler, bool ownsSampler) {
 	Sampler_if* currentSampler = _wrapper.getSampler();
+	if (currentSampler == sampler) {
+		_ownsSampler = _ownsSampler || ownsSampler;
+		return;
+	}
 	if (_ownsSampler && currentSampler != nullptr && currentSampler != sampler) {
 		delete currentSampler;
 	}


### PR DESCRIPTION
### Motivation
- Fix a sampler ownership/lifetime edge case in `ParserDefaultImpl2` so a previously-owned sampler is released when replaced and externally-provided samplers are not deleted, with a minimal scoped change.

### Description
- Modified `source/kernel/simulator/ParserDefaultImpl2.cpp` so the constructor sets `_ownsSampler` only when the constructor actually receives a non-null `sampler` (`_ownsSampler = (sampler != nullptr)`).
- Hardened `_setSamplerInternal` to early-return when the new `sampler` pointer equals the currently installed one while preserving the existing ownership state; the previous delete-on-replace behavior when owned is preserved.
- Did not change `genesyspp_driver`, header APIs, or global build logic, and `setSampler()` still defaults to registering the new sampler as non-owned.

### Testing
- Built and ran the unit test binary with `cmake --preset tests-kernel-unit`, `cmake --build build/tests-kernel-unit --target genesys_test_parser_expressions -j4` and `./build/tests-kernel-unit/source/tests/unit/genesys_test_parser_expressions`, and all tests passed.
- Rebuilt with ASan (`cmake --preset asan` / build) and ran `ASAN_OPTIONS=detect_leaks=1 ./build/asan/source/tests/unit/genesys_test_parser_expressions`, and the suite passed with no leak reported in the parser/driver sampler path.
- Rebuilt with UBSan (`cmake --preset ubsan` / build) and ran `./build/ubsan/source/tests/unit/genesys_test_parser_expressions`, and the suite passed with no UBSan reports.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d84f172d84832199f02880f86c2718)