### PR TITLE
Fix file-backed statistics collector state rehydration

### DIFF
--- a/source/kernel/statistics/CollectorDatafileDefaultImpl1.cpp
+++ b/source/kernel/statistics/CollectorDatafileDefaultImpl1.cpp
@@ -23,6 +23,7 @@ CollectorDatafileDefaultImpl1::CollectorDatafileDefaultImpl1() {
 }
 
 void CollectorDatafileDefaultImpl1::clear() {
+	// Reset the backing file and in-memory metadata to an empty collector state.
 	std::ofstream file;
 	try {
 		file.open(_filename, std::ofstream::out | std::ofstream::trunc);
@@ -31,10 +32,12 @@ void CollectorDatafileDefaultImpl1::clear() {
 		throw "ERROR - can't open the file ";
 	}
 	_numElements = 0;
-    _lastValue = std::numeric_limits<double>::quiet_NaN();
+	_lastValue = std::numeric_limits<double>::quiet_NaN();
+	_nextReadIndex = 0;
 }
 
 void CollectorDatafileDefaultImpl1::addValue(double value, double weight) {
+	// Append one binary double value and keep cached metadata in sync.
 	std::ofstream file;
 	try {
 		if (this->_numElements > 0) {
@@ -62,9 +65,10 @@ unsigned long CollectorDatafileDefaultImpl1::numElements() {
 }
 
 double CollectorDatafileDefaultImpl1::getValue(unsigned int num) {
+	// Read a value by zero-based position with strict bounds validation.
 	std::ifstream file;
 	double value;
-	if (num > _numElements) {
+	if (num >= _numElements) {
 		throw "ERROR - num greater than numElements";
 	}
 	try {
@@ -80,10 +84,15 @@ double CollectorDatafileDefaultImpl1::getValue(unsigned int num) {
 }
 
 double CollectorDatafileDefaultImpl1::getNextValue() {
-	return 0.0; // @TODO:
+	// Read the next sequential value and advance the internal read cursor.
+	double value = getValue(_nextReadIndex);
+	_nextReadIndex++;
+	return value;
 }
 
 void CollectorDatafileDefaultImpl1::seekFirstValue() {
+	// Rewind sequential reads to the first stored element.
+	_nextReadIndex = 0;
 }
 
 std::string CollectorDatafileDefaultImpl1::getDataFilename() {
@@ -91,7 +100,27 @@ std::string CollectorDatafileDefaultImpl1::getDataFilename() {
 }
 
 void CollectorDatafileDefaultImpl1::setDataFilename(std::string filename) {
+	// Bind to a file and rebuild cached metadata from persisted binary doubles.
 	_filename = filename;
+	_numElements = 0;
+	_lastValue = std::numeric_limits<double>::quiet_NaN();
+	_nextReadIndex = 0;
+
+	std::ifstream file(_filename, std::ifstream::binary | std::ifstream::ate);
+	if (!file.is_open()) {
+		return;
+	}
+
+	std::streampos size = file.tellg();
+	if (size <= 0) {
+		return;
+	}
+
+	_numElements = static_cast<unsigned int>(size / static_cast<std::streampos>(sizeof (double)));
+	if (_numElements > 0) {
+		file.seekg(static_cast<std::streamoff>((_numElements - 1) * sizeof (double)), std::ifstream::beg);
+		file.read(reinterpret_cast<char*> (&_lastValue), sizeof (double));
+	}
 }
 
 void CollectorDatafileDefaultImpl1::setAddValueHandler(CollectorAddValueHandler addValueHandler) {

--- a/source/kernel/statistics/CollectorDatafileDefaultImpl1.h
+++ b/source/kernel/statistics/CollectorDatafileDefaultImpl1.h
@@ -14,6 +14,7 @@
 #ifndef COLLECTORDATAFILEDEFAULTIMPL1_H
 #define COLLECTORDATAFILEDEFAULTIMPL1_H
 
+#include <limits>
 #include <string>
 
 #include "CollectorDatafile_if.h"
@@ -55,9 +56,11 @@ public:
 	/*! \brief Registers callback invoked whenever the collector is cleared. */
 	virtual void setClearHandler(CollectorClearHandler clearHandler) override;
 private:
+	// Cache file metadata and sequential read position to avoid stale state.
 	std::string _filename;
-	double _lastValue;
-	unsigned int _numElements;
+	double _lastValue = std::numeric_limits<double>::quiet_NaN();
+	unsigned int _numElements = 0;
+	unsigned int _nextReadIndex = 0;
 };
 
 #endif /* COLLECTORDATAFILEDEFAULTIMPL1_H */

--- a/source/kernel/statistics/StatisticsDataFileDefaultImpl.cpp
+++ b/source/kernel/statistics/StatisticsDataFileDefaultImpl.cpp
@@ -87,6 +87,8 @@ bool StatisticsDatafileDefaultImpl1::_hasNewValue() {
 }
 
 unsigned int StatisticsDatafileDefaultImpl1::numElements() {
+	// Synchronize cached size with the collector before exposing the count.
+	_hasNewValue();
 	return _numElements;
 }
 


### PR DESCRIPTION
KERNEL

### Motivation
- File-backed collector metadata and sequential-read flow were incomplete and could produce stale/incorrect statistics when binding to an existing data file.
- Minimal, safe fixes were needed to rehydrate metadata, provide a working sequential reader, and keep the statistics cache coherent without changing public interfaces.

### Description
- Initialize collector metadata in the header: set `_lastValue` to `std::numeric_limits<double>::quiet_NaN()` and `_numElements` to `0`, and add a sequential read cursor `_nextReadIndex`.
- Implement `getNextValue()` to read the element at the internal cursor and advance the cursor, and implement `seekFirstValue()` to reset the cursor to zero.
- Tighten `getValue(unsigned int num)` bounds check to `num >= _numElements`.
- Implement `setDataFilename(std::string)` to rebuild `_numElements`, `_lastValue`, and reset the read cursor when an existing binary double file is assigned; handle missing/empty files safely.
- Make `StatisticsDatafileDefaultImpl1::numElements()` call `_hasNewValue()` to synchronize the cached `_numElements` with the collector before returning.
- Changes are confined to the allowed files under `source/kernel/statistics` and preserve existing public interfaces.

### Testing
- Ran CMake configuration: `cmake --preset debug-kernel` and it configured successfully.
- Built the kernel target: `cmake --build build/debug-kernel --target genesys_kernel -j4` and the build completed successfully.
- No unit tests were executed per phase constraints.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d859444870832190938d9f5130a643)