### PR TITLE
docs(parser): formalize sampler ownership and add edge-case test for reassignment

### DIFF
--- a/source/kernel/simulator/ParserDefaultImpl2.cpp
+++ b/source/kernel/simulator/ParserDefaultImpl2.cpp
@@ -32,6 +32,7 @@ ParserDefaultImpl2::~ParserDefaultImpl2() {
 void ParserDefaultImpl2::_setSamplerInternal(Sampler_if* sampler, bool ownsSampler) {
 	Sampler_if* currentSampler = _wrapper.getSampler();
 	if (currentSampler == sampler) {
+		// Preserve existing ownership if pointer is unchanged; never downgrade ownership.
 		_ownsSampler = _ownsSampler || ownsSampler;
 		return;
 	}

--- a/source/kernel/simulator/ParserDefaultImpl2.h
+++ b/source/kernel/simulator/ParserDefaultImpl2.h
@@ -24,13 +24,33 @@
 
 class ParserDefaultImpl2 : public Parser_if {
 public:
+	/*!
+	 * \brief Creates parser wrapper bound to a model and an initial sampler.
+	 *
+	 * The constructor stores \p sampler in the internal driver and marks it as
+	 * parser-owned when non-null. This preserves current model behavior where the
+	 * parser starts with an internally managed sampler instance.
+	 */
 	ParserDefaultImpl2(Model* model, Sampler_if* sampler, bool throws = false);
-	// Release parser-owned sampler instance created for expression evaluation.
+	/*!
+	 * \brief Destroys parser wrapper and releases only parser-owned sampler.
+	 *
+	 * The destructor deletes the current sampler only when ownership is flagged as
+	 * internal. Samplers installed through setSampler(...) are non-owned by default
+	 * and therefore not deleted at destruction time.
+	 */
 	virtual ~ParserDefaultImpl2();
 public:
 	virtual double parse(const std::string expression) override; // may throw exception
     virtual double parse(const std::string expression, bool& success, std::string& errorMessage) override;
     virtual std::string getErrorMessage() override;
+	/*!
+	 * \brief Replaces parser sampler with an externally-owned sampler.
+	 *
+	 * If the parser currently owns a previous sampler, that previous sampler is
+	 * released before binding the new pointer. The provided sampler pointer is then
+	 * tracked as non-owned.
+	 */
 	virtual void setSampler(Sampler_if* _sampler) override;
 	virtual Sampler_if* getSampler() const override;
 	virtual genesyspp_driver getParser() const override;

--- a/source/kernel/simulator/Parser_if.h
+++ b/source/kernel/simulator/Parser_if.h
@@ -52,16 +52,22 @@ public:
     /*! \brief Returns the last error message produced by the parser. */
     virtual std::string getErrorMessage() = 0; // to get error message in the case of thrown exception
 	/*!
-	 * \brief setSampler
-	 * \param sampler
+	 * \brief Sets the sampler used by stochastic language functions.
+	 * \param sampler Pointer to sampler instance that must outlive parser usage unless
+	 *        an implementation-specific ownership transfer is explicitly documented.
+	 *
+	 * This interface does not enforce ownership transfer. Concrete parser
+	 * implementations may own a sampler created/provided at construction time, but
+	 * samplers passed through \c setSampler are expected to be externally owned by
+	 * default unless documented otherwise by the implementation.
 	 */
-	/*! \brief Sets the random sampler used by stochastic language functions. */
 	virtual void setSampler(Sampler_if* sampler) = 0;
 	/*!
-	 * \brief getSampler
-	 * \return
+	 * \brief Returns the sampler currently associated with the parser.
+	 *
+	 * The returned pointer is non-owning. Callers must consult concrete parser
+	 * documentation for lifetime/ownership details of the underlying instance.
 	 */
-	/*! \brief Returns the sampler currently associated with the parser. */
 	virtual Sampler_if* getSampler() const = 0;
 	// ...? // TODO: Implement a method to get the TOKENS parsed. Example: If parsing "nq(queue1) < var1" return a list containing something like "fNQ tLPAR eQUEUE tRPAR tLESS eVARIABLE"
 	/*!

--- a/source/tests/unit/test_parser_expressions.cpp
+++ b/source/tests/unit/test_parser_expressions.cpp
@@ -285,3 +285,23 @@ TEST_F(ParserExpressionsTest, ParserDefaultImpl2SetSamplerDeletesPreviousOwnedSa
     EXPECT_FALSE(externalDestroyed);
     EXPECT_EQ(destroyedCounter, 1);
 }
+
+TEST_F(ParserExpressionsTest, ParserDefaultImpl2SetSamplerSameExternalPointerDoesNotDeleteIt) {
+    int destroyedCounter = 0;
+    bool externalDestroyed = false;
+
+    auto* initiallyOwnedSampler = new CountingSampler(&destroyedCounter);
+    CountingSampler externalSampler(&destroyedCounter, &externalDestroyed);
+
+    {
+        ParserDefaultImpl2 parser(model, initiallyOwnedSampler, false);
+        parser.setSampler(&externalSampler);
+        parser.setSampler(&externalSampler);
+        EXPECT_EQ(parser.getSampler(), &externalSampler);
+        EXPECT_EQ(destroyedCounter, 1);
+        EXPECT_FALSE(externalDestroyed);
+    }
+
+    EXPECT_FALSE(externalDestroyed);
+    EXPECT_EQ(destroyedCounter, 1);
+}


### PR DESCRIPTION
### Motivation
- Make the sampler ownership/lifetime semantics explicit in the parser API and the default parser implementation to prevent ambiguous ownership assumptions. 
- Record the actual behavior of `ParserDefaultImpl2` (constructor-owned initial sampler; `setSampler(...)` non-owning by default) and avoid accidental deletion regressions on pointer reassignments. 

### Description
- Documented ownership contract in `Parser_if.h`, stating that `setSampler(...)` does not enforce ownership transfer and that `getSampler()` returns a non-owning pointer. 
- Added explicit header documentation to `ParserDefaultImpl2.h` clarifying that the constructor marks a non-null initial sampler as parser-owned and that the destructor only deletes internally-owned samplers. 
- Added a small explanatory comment in `ParserDefaultImpl2::_setSamplerInternal(...)` to preserve existing ownership when the sampler pointer is unchanged. 
- Added a focused regression test in `source/tests/unit/test_parser_expressions.cpp` that reassigns the same external sampler pointer to verify it is not deleted and that existing owned->external swap behavior remains correct. 
- Files changed: `source/kernel/simulator/Parser_if.h`, `source/kernel/simulator/ParserDefaultImpl2.h`, `source/kernel/simulator/ParserDefaultImpl2.cpp`, `source/tests/unit/test_parser_expressions.cpp`.

### Testing
- Configured and built test target with `cmake --preset tests-kernel-unit` and `cmake --build build/tests-kernel-unit --target genesys_test_parser_expressions -j4`, then ran `./build/tests-kernel-unit/source/tests/unit/genesys_test_parser_expressions`, and all tests passed. 
- Ran ASan build with `cmake --preset asan`, `cmake --build build/asan --target genesys_test_parser_expressions -j4`, and `ASAN_OPTIONS=detect_leaks=1 ./build/asan/source/tests/unit/genesys_test_parser_expressions`, and all tests passed with no leaks reported. 
- Ran UBSan build with `cmake --preset ubsan`, `cmake --build build/ubsan --target genesys_test_parser_expressions -j4`, and `./build/ubsan/source/tests/unit/genesys_test_parser_expressions`, and all tests passed. 
- The new test verifies the edge case of reassigning the same external sampler pointer and passed in normal/ASan/UBSan runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8592c19e48321b3cb6a3176f047aa)