### PR TITLE
Implement Queue OrderRule insertion behavior and add validation tests

### DIFF
--- a/source/plugins/data/Queue.cpp
+++ b/source/plugins/data/Queue.cpp
@@ -59,6 +59,8 @@ Queue::Queue(Model* model, std::string name) : ModelDataDefinition(model, Util::
     _addProperty(propAttributeName);
     _addProperty(propOrderRule);
 	_addProperty(propOrderRuleInt);
+
+	_configureListComparator();
 }
 
 Queue::~Queue() {
@@ -77,6 +79,7 @@ std::string Queue::show() {
 }
 
 void Queue::insertElement(Waiting* modeldatum) {
+	modeldatum->setArrivalOrder(_nextArrivalOrder++);
 	if (_reportStatistics) {
 		double tnow = _parentModel->getSimulation()->getSimulatedTime();
 		double duration = tnow - _lastTimeNumberInQueueChanged;
@@ -108,6 +111,7 @@ void Queue::_initBetweenReplications() {
 	}
 	this->_list->clear();
 	_lastTimeNumberInQueueChanged = 0.0;
+	_nextArrivalOrder = 0;
 }
 
 unsigned int Queue::size() {
@@ -135,7 +139,6 @@ std::string Queue::getAttributeName() const {
 
 void Queue::setOrderRule(OrderRule _orderRule) {
 	this->_orderRule = _orderRule;
-	//@TODO: SORT THE QUEUE BASED ON QUE RULE. Create comparators
 }
 
 Queue::OrderRule Queue::getOrderRule() const {
@@ -200,7 +203,8 @@ void Queue::_saveInstance(PersistenceRecord *fields, bool saveDefaultValues) {
 }
 
 bool Queue::_check(std::string& errorMessage) {
-	return _parentModel->getDataManager()->check(Util::TypeOf<Attribute>(), _attributeName, "AttributeName", false, errorMessage);
+	const bool attributeMandatory = _orderRule == OrderRule::HIGHESTVALUE || _orderRule == OrderRule::SMALLESTVALUE;
+	return _parentModel->getDataManager()->check(Util::TypeOf<Attribute>(), _attributeName, "AttributeName", attributeMandatory, errorMessage);
 }
 
 void Queue::_createInternalAndAttachedData() {
@@ -221,4 +225,37 @@ ParserChangesInformation * Queue::_getParserChangesInformation() {
 	//changes->getProductionToAdd()->insert(...);
 	//changes->getTokensToAdd()->insert(...);
 	return changes;
+}
+
+void Queue::_configureListComparator() {
+	_list->setSortFunc([this](const Waiting* a, const Waiting* b) {
+		switch (_orderRule) {
+			case Queue::OrderRule::FIFO:
+				return a->getArrivalOrder() < b->getArrivalOrder();
+			case Queue::OrderRule::LIFO:
+				return a->getArrivalOrder() > b->getArrivalOrder();
+			case Queue::OrderRule::HIGHESTVALUE:
+			case Queue::OrderRule::SMALLESTVALUE: {
+				if (_attributeName.empty()) {
+					return a->getArrivalOrder() < b->getArrivalOrder();
+				}
+				Attribute* attribute = dynamic_cast<Attribute*> (_parentModel->getDataManager()->getDataDefinition(Util::TypeOf<Attribute>(), _attributeName));
+				if (attribute == nullptr) {
+					return a->getArrivalOrder() < b->getArrivalOrder();
+				}
+				const Util::identification attributeId = attribute->getId();
+				const double valueA = a->getEntity()->getAttributeValue(attributeId);
+				const double valueB = b->getEntity()->getAttributeValue(attributeId);
+				if (valueA == valueB) {
+					return a->getArrivalOrder() < b->getArrivalOrder();
+				}
+				if (_orderRule == Queue::OrderRule::HIGHESTVALUE) {
+					return valueA > valueB;
+				}
+				return valueA < valueB;
+			}
+			default:
+				return a->getArrivalOrder() < b->getArrivalOrder();
+		}
+	});
 }

--- a/source/plugins/data/Queue.h
+++ b/source/plugins/data/Queue.h
@@ -53,11 +53,18 @@ public:
 	unsigned int geComponentOutputPort() const {
 		return _thisComponentOutputPort;
 	}
+	unsigned long long getArrivalOrder() const {
+		return _arrivalOrder;
+	}
+	void setArrivalOrder(unsigned long long arrivalOrder) {
+		_arrivalOrder = arrivalOrder;
+	}
 private:
 	Entity* _entity;
 	ModelComponent* _thisComponent;
 	double _timeStartedWaiting;
 	unsigned int _thisComponentOutputPort;
+	unsigned long long _arrivalOrder = 0;
 };
 
 /*!
@@ -134,9 +141,11 @@ protected: // could be overriden
 
 private:
 	void _initCStats();
+	void _configureListComparator();
 private:
 	List<Waiting*>* _list = new List<Waiting*>();
 	double _lastTimeNumberInQueueChanged;
+	unsigned long long _nextArrivalOrder = 0;
 private: //1::1
 
 	const struct DEFAULT_VALUES {
@@ -151,4 +160,3 @@ private: // inner internal elements
 };
 
 #endif /* QUEUE_H */
-

--- a/source/tests/unit/test_simulator_runtime.cpp
+++ b/source/tests/unit/test_simulator_runtime.cpp
@@ -109,6 +109,15 @@ public:
     }
 };
 
+class QueueValidationProbe : public Queue {
+public:
+    QueueValidationProbe(Model* model, const std::string& name = "") : Queue(model, name) {}
+
+    bool CheckProbe(std::string& errorMessage) {
+        return _check(errorMessage);
+    }
+};
+
 class CountingWaitingProbe final : public Waiting {
 public:
     CountingWaitingProbe(Entity* entity, double timeStartedWaiting, ModelComponent* thisComponent, unsigned int thisComponentOutputPort = 0)
@@ -602,4 +611,195 @@ TEST(SimulatorRuntimeTest, QueueDestructorDeletesRemainingOwnedWaiting) {
     delete queue;
 
     EXPECT_EQ(g_countingWaitingProbeDestructorCount, 2u);
+}
+
+TEST(SimulatorRuntimeTest, QueueOrderRuleFifoKeepsArrivalOrder) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    Queue queue(model, "QueueFIFO");
+    queue.setReportStatistics(false);
+    queue.setOrderRule(Queue::OrderRule::FIFO);
+
+    Entity* firstEntity = model->createEntity("QueueFIFOEntityA", true);
+    Entity* secondEntity = model->createEntity("QueueFIFOEntityB", true);
+    Entity* thirdEntity = model->createEntity("QueueFIFOEntityC", true);
+    ASSERT_NE(firstEntity, nullptr);
+    ASSERT_NE(secondEntity, nullptr);
+    ASSERT_NE(thirdEntity, nullptr);
+
+    queue.insertElement(new Waiting(firstEntity, 0.0, nullptr));
+    queue.insertElement(new Waiting(secondEntity, 0.0, nullptr));
+    queue.insertElement(new Waiting(thirdEntity, 0.0, nullptr));
+
+    ASSERT_NE(queue.getAtRank(0), nullptr);
+    ASSERT_NE(queue.getAtRank(1), nullptr);
+    ASSERT_NE(queue.getAtRank(2), nullptr);
+    EXPECT_EQ(queue.getAtRank(0)->getEntity(), firstEntity);
+    EXPECT_EQ(queue.getAtRank(1)->getEntity(), secondEntity);
+    EXPECT_EQ(queue.getAtRank(2)->getEntity(), thirdEntity);
+}
+
+TEST(SimulatorRuntimeTest, QueueOrderRuleLifoPlacesLatestArrivalFirst) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    Queue queue(model, "QueueLIFO");
+    queue.setReportStatistics(false);
+    queue.setOrderRule(Queue::OrderRule::LIFO);
+
+    Entity* firstEntity = model->createEntity("QueueLIFOEntityA", true);
+    Entity* secondEntity = model->createEntity("QueueLIFOEntityB", true);
+    Entity* thirdEntity = model->createEntity("QueueLIFOEntityC", true);
+    ASSERT_NE(firstEntity, nullptr);
+    ASSERT_NE(secondEntity, nullptr);
+    ASSERT_NE(thirdEntity, nullptr);
+
+    queue.insertElement(new Waiting(firstEntity, 0.0, nullptr));
+    queue.insertElement(new Waiting(secondEntity, 0.0, nullptr));
+    queue.insertElement(new Waiting(thirdEntity, 0.0, nullptr));
+
+    ASSERT_NE(queue.first(), nullptr);
+    EXPECT_EQ(queue.first()->getEntity(), thirdEntity);
+    EXPECT_EQ(queue.getAtRank(1)->getEntity(), secondEntity);
+    EXPECT_EQ(queue.getAtRank(2)->getEntity(), firstEntity);
+}
+
+TEST(SimulatorRuntimeTest, QueueOrderRuleHighestValueRanksByAttributeDescending) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    auto* priority = new Attribute(model, "Priority");
+    ASSERT_NE(priority, nullptr);
+    const Util::identification priorityId = priority->getId();
+
+    Queue queue(model, "QueueHighestValue");
+    queue.setReportStatistics(false);
+    queue.setAttributeName(priority->getName());
+    queue.setOrderRule(Queue::OrderRule::HIGHESTVALUE);
+
+    Entity* low = model->createEntity("QueueHighestLow", true);
+    Entity* high = model->createEntity("QueueHighestHigh", true);
+    Entity* mid = model->createEntity("QueueHighestMid", true);
+    ASSERT_NE(low, nullptr);
+    ASSERT_NE(high, nullptr);
+    ASSERT_NE(mid, nullptr);
+    low->setAttributeValue(priorityId, 1.0);
+    high->setAttributeValue(priorityId, 9.0);
+    mid->setAttributeValue(priorityId, 5.0);
+
+    queue.insertElement(new Waiting(low, 0.0, nullptr));
+    queue.insertElement(new Waiting(high, 0.0, nullptr));
+    queue.insertElement(new Waiting(mid, 0.0, nullptr));
+
+    EXPECT_EQ(queue.getAtRank(0)->getEntity(), high);
+    EXPECT_EQ(queue.getAtRank(1)->getEntity(), mid);
+    EXPECT_EQ(queue.getAtRank(2)->getEntity(), low);
+
+    delete priority;
+}
+
+TEST(SimulatorRuntimeTest, QueueOrderRuleSmallestValueRanksByAttributeAscending) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    auto* priority = new Attribute(model, "PrioritySmallest");
+    ASSERT_NE(priority, nullptr);
+    const Util::identification priorityId = priority->getId();
+
+    Queue queue(model, "QueueSmallestValue");
+    queue.setReportStatistics(false);
+    queue.setAttributeName(priority->getName());
+    queue.setOrderRule(Queue::OrderRule::SMALLESTVALUE);
+
+    Entity* high = model->createEntity("QueueSmallestHigh", true);
+    Entity* low = model->createEntity("QueueSmallestLow", true);
+    Entity* mid = model->createEntity("QueueSmallestMid", true);
+    ASSERT_NE(high, nullptr);
+    ASSERT_NE(low, nullptr);
+    ASSERT_NE(mid, nullptr);
+    high->setAttributeValue(priorityId, 9.0);
+    low->setAttributeValue(priorityId, 1.0);
+    mid->setAttributeValue(priorityId, 5.0);
+
+    queue.insertElement(new Waiting(high, 0.0, nullptr));
+    queue.insertElement(new Waiting(low, 0.0, nullptr));
+    queue.insertElement(new Waiting(mid, 0.0, nullptr));
+
+    EXPECT_EQ(queue.getAtRank(0)->getEntity(), low);
+    EXPECT_EQ(queue.getAtRank(1)->getEntity(), mid);
+    EXPECT_EQ(queue.getAtRank(2)->getEntity(), high);
+
+    delete priority;
+}
+
+TEST(SimulatorRuntimeTest, QueueOrderRuleAttributeTieUsesFifoTiebreaker) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    auto* priority = new Attribute(model, "PriorityTie");
+    ASSERT_NE(priority, nullptr);
+    const Util::identification priorityId = priority->getId();
+
+    Queue queue(model, "QueueTieFIFO");
+    queue.setReportStatistics(false);
+    queue.setAttributeName(priority->getName());
+    queue.setOrderRule(Queue::OrderRule::HIGHESTVALUE);
+
+    Entity* firstTie = model->createEntity("QueueTieFirst", true);
+    Entity* secondTie = model->createEntity("QueueTieSecond", true);
+    Entity* highest = model->createEntity("QueueTieHighest", true);
+    ASSERT_NE(firstTie, nullptr);
+    ASSERT_NE(secondTie, nullptr);
+    ASSERT_NE(highest, nullptr);
+    firstTie->setAttributeValue(priorityId, 5.0);
+    secondTie->setAttributeValue(priorityId, 5.0);
+    highest->setAttributeValue(priorityId, 7.0);
+
+    queue.insertElement(new Waiting(firstTie, 0.0, nullptr));
+    queue.insertElement(new Waiting(secondTie, 0.0, nullptr));
+    queue.insertElement(new Waiting(highest, 0.0, nullptr));
+
+    EXPECT_EQ(queue.getAtRank(0)->getEntity(), highest);
+    EXPECT_EQ(queue.getAtRank(1)->getEntity(), firstTie);
+    EXPECT_EQ(queue.getAtRank(2)->getEntity(), secondTie);
+
+    delete priority;
+}
+
+TEST(SimulatorRuntimeTest, QueueCheckFailsWhenAttributeRuleHasNoAttributeName) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    QueueValidationProbe queue(model, "QueueCheckMissingAttr");
+    queue.setOrderRule(Queue::OrderRule::HIGHESTVALUE);
+
+    std::string errorMessage;
+    EXPECT_FALSE(queue.CheckProbe(errorMessage));
+    EXPECT_FALSE(errorMessage.empty());
+}
+
+TEST(SimulatorRuntimeTest, QueueCheckPassesWhenAttributeRuleHasValidAttributeName) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    auto* priority = new Attribute(model, "PriorityCheck");
+    ASSERT_NE(priority, nullptr);
+
+    QueueValidationProbe queue(model, "QueueCheckValidAttr");
+    queue.setOrderRule(Queue::OrderRule::SMALLESTVALUE);
+    queue.setAttributeName(priority->getName());
+
+    std::string errorMessage;
+    EXPECT_TRUE(queue.CheckProbe(errorMessage));
+    EXPECT_TRUE(errorMessage.empty());
+
+    delete priority;
 }


### PR DESCRIPTION
PLUGINS

### Motivation
- Finish implementing `OrderRule` semantics for the `Queue` plugin so ordering is enforced at insertion time for all supported rules. 
- Ensure deterministic FIFO tiebreaking for attribute-based ordering when entities arrive at the same simulated time. 
- Validate `attributeName` is required when attribute-based rules are selected.

### Description
- Added an `arrivalOrder` sequence to `Waiting` and a `_nextArrivalOrder` counter in `Queue`, and stamped each `Waiting` on `insertElement()` to ensure deterministic arrival ordering. 
- Configured a comparator on the internal `List<Waiting*>` via `_configureListComparator()` (called from the constructor) to implement `FIFO`, `LIFO`, `HIGHESTVALUE` and `SMALLESTVALUE` ordering and to resolve attribute ties with FIFO. 
- Updated `_check()` so `attributeName` is mandatory only when `_orderRule` is `HIGHESTVALUE` or `SMALLESTVALUE`. 
- Added unit tests in `source/tests/unit/test_simulator_runtime.cpp` that cover FIFO, LIFO, HIGHESTVALUE, SMALLESTVALUE, attribute tie FIFO tiebreaker, and `_check()` failure/success cases; introduced a small probe to expose `_check()` for testing.

### Testing
- Built tests with `cmake` and `ninja` and compiled the `genesys_test_simulator_runtime` target successfully. 
- Ran queue-focused unit tests with `ctest --test-dir build -R "SimulatorRuntimeTest.*Queue" --output-on-failure`, and all added Queue tests passed (11/11 passed for the Queue regex). 
- A full `ctest -LE smoke` run surfaced several pre-existing `*_NOT_BUILT` targets in this configuration; those are unrelated to the new Queue logic and stem from target availability in this build configuration.

```markdown
- o que você realizou de fato;
  - Implementei ordenação na inserção da `Queue` para `FIFO`, `LIFO`, `HIGHESTVALUE` e `SMALLESTVALUE` com desempate FIFO para regras por atributo.
  - Adicionei marcador interno de ordem de chegada (`arrivalOrder`) em `Waiting` e contador `_nextArrivalOrder` em `Queue` com reset entre replicações.
  - Atualizei `_check()` para exigir `attributeName` apenas quando a regra depende de atributo.
  - Adicionei os testes unitários obrigatórios no arquivo `source/tests/unit/test_simulator_runtime.cpp`.
  - Compilei e executei os testes específicos de Queue com sucesso.

- o que não realizou;
  - Não implementei reordenação dinâmica em `setOrderRule()` ou `setAttributeName()`.
  - Não alterei outros componentes fora do escopo (por exemplo `Seize.cpp`, `Wait.cpp`, etc.).
  - Não corrigi ou forcei a construção de alvos marcados como `*_NOT_BUILT` no `ctest -LE smoke` (preexistente).

- por que não realizou;
  - Reordenação dinâmica e alterações amplas foram explicitamente fora do escopo do requisito.
  - Os `*_NOT_BUILT` refletem configuração/escopo de build e não uma falha nas mudanças introduzidas.

- riscos remanescentes;
  - O comparador por atributo procura o `Attribute` por nome durante comparação, o que tem custo adicional se a fila for muito grande; pode ser otimizado no futuro se necessário.
  - A comparação de empate usa igualdade direta de `double`, adequada para casos testados mas que pode requerer tolerância se valores não exatos forem esperados.

- observações relevantes;
  - `setOrderRule()` e `setAttributeName()` permanecem como configurações sem reordenação em runtime conforme a restrição.
  - Desempate FIFO é garantido mesmo para inserções com o mesmo tempo simulado graças ao contador monotônico.

- arquivos alterados;
  - `source/plugins/data/Queue.h`
  - `source/plugins/data/Queue.cpp`
  - `source/tests/unit/test_simulator_runtime.cpp`

- comandos executados e resultados resumidos.
  - `cmake -S . -B build -G Ninja -DGENESYS_BUILD_TESTS=ON -DGENESYS_BUILD_KERNEL=ON -DGENESYS_BUILD_PARSER=ON -DGENESYS_BUILD_PLUGINS=ON -DGENESYS_TERMINAL_APPLICATION=OFF -DGENESYS_BUILD_GUI_APPLICATION=OFF -DGENESYS_BUILD_WEB_APPLICATION=OFF` : configure succeeded.
  - `cmake --build build --target genesys_test_simulator_runtime` : build succeeded.
  - `ctest --test-dir build -R "SimulatorRuntimeTest.*Queue" --output-on-failure` : all Queue-focused tests passed (11/11).
  - `ctest --test-dir build -LE smoke --output-on-failure` : reported several `*_NOT_BUILT` tests (pre-existing configuration limitation), not caused by the changes.
```

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d85b75e83c832187dca5179372fc13)