### PR TITLE
Stage 5: add synchronous simulation run/step API endpoints

### DIFF
--- a/source/applications/web/README.md
+++ b/source/applications/web/README.md
@@ -2,7 +2,7 @@
 
 First functional implementation of the **Web** application type for GenESyS.
 
-## Current Stage 4 scope
+## Current Stage 5 scope
 - CMake executable: `genesys_webhook` (enabled with `-DGENESYS_BUILD_WEB_APPLICATION=ON`).
 - Layered architecture for HTTP transport, API routing, session/token, and simulator service.
 - Stateful session management with one `Simulator` per session and per-session workspace directories.
@@ -16,6 +16,8 @@ First functional implementation of the **Web** application type for GenESyS.
   - `POST /api/v1/models/load` (requires `Authorization: Bearer <token>`)
   - `GET /api/v1/simulation/status` (requires `Authorization: Bearer <token>`)
   - `POST /api/v1/simulation/config` (requires `Authorization: Bearer <token>`)
+  - `POST /api/v1/simulation/run` (requires `Authorization: Bearer <token>`)
+  - `POST /api/v1/simulation/step` (requires `Authorization: Bearer <token>`)
 
 ## How to run
 ```bash
@@ -39,3 +41,7 @@ For Stage 3 model persistence:
 For Stage 4 simulation configuration:
 - `POST /api/v1/simulation/config` currently uses a minimal contract parser without external JSON libraries.
 - All configuration fields are required in the request body: `numberOfReplications`, `replicationLength`, `warmUpPeriod`, `pauseOnEvent`, `pauseOnReplication`, `initializeStatistics`, `initializeSystem`.
+
+For Stage 5 simulation execution:
+- `POST /api/v1/simulation/run` and `POST /api/v1/simulation/step` are synchronous wrappers over `ModelSimulation::start()` and `ModelSimulation::step()`.
+- This stage intentionally does not introduce asynchronous/background simulation control endpoints.

--- a/source/applications/web/api/ApiRouter.cpp
+++ b/source/applications/web/api/ApiRouter.cpp
@@ -206,6 +206,62 @@ HttpResponse ApiRouter::handle(const HttpRequest& request) const {
         };
     }
 
+    if (request.path == "/api/v1/simulation/run") {
+        if (request.method != "POST") {
+            return _jsonError(405, "METHOD_NOT_ALLOWED", "Only POST is allowed for /api/v1/simulation/run");
+        }
+
+        const std::string token = _extractBearerToken(request);
+        if (token.empty()) {
+            return _jsonError(401, "UNAUTHORIZED", "Missing or invalid Bearer token");
+        }
+
+        const auto result = _simulatorService.runSimulation(token);
+        if (!result.success) {
+            if (result.invalidToken) {
+                return _jsonError(401, "UNAUTHORIZED", "Invalid or expired session token");
+            }
+            if (result.missingCurrentModel) {
+                return _jsonError(409, "NO_CURRENT_MODEL", "No current model available to run simulation");
+            }
+            return _jsonError(500, "INTERNAL_ERROR", "Unable to run simulation");
+        }
+
+        return HttpResponse{
+            200,
+            "application/json",
+            "{\"ok\":true,\"data\":" + _simulationStatusDataJson(result.status) + "}"
+        };
+    }
+
+    if (request.path == "/api/v1/simulation/step") {
+        if (request.method != "POST") {
+            return _jsonError(405, "METHOD_NOT_ALLOWED", "Only POST is allowed for /api/v1/simulation/step");
+        }
+
+        const std::string token = _extractBearerToken(request);
+        if (token.empty()) {
+            return _jsonError(401, "UNAUTHORIZED", "Missing or invalid Bearer token");
+        }
+
+        const auto result = _simulatorService.stepSimulation(token);
+        if (!result.success) {
+            if (result.invalidToken) {
+                return _jsonError(401, "UNAUTHORIZED", "Invalid or expired session token");
+            }
+            if (result.missingCurrentModel) {
+                return _jsonError(409, "NO_CURRENT_MODEL", "No current model available to step simulation");
+            }
+            return _jsonError(500, "INTERNAL_ERROR", "Unable to step simulation");
+        }
+
+        return HttpResponse{
+            200,
+            "application/json",
+            "{\"ok\":true,\"data\":" + _simulationStatusDataJson(result.status) + "}"
+        };
+    }
+
     return _jsonError(404, "NOT_FOUND", "Route not found");
 }
 

--- a/source/applications/web/service/SimulatorSessionService.cpp
+++ b/source/applications/web/service/SimulatorSessionService.cpp
@@ -172,6 +172,76 @@ SimulatorSessionService::SimulationConfigResult SimulatorSessionService::configu
     return result;
 }
 
+SimulatorSessionService::SimulationActionResult SimulatorSessionService::runSimulation(const std::string& accessToken) {
+    SessionContext* session = _sessionManager.getSessionByToken(accessToken);
+    if (session == nullptr || session->simulator == nullptr) {
+        return SimulationActionResult{false, true, false, SimulationStatusResult{}};
+    }
+
+    std::scoped_lock lock(session->mutex);
+    ModelManager* modelManager = session->simulator->getModelManager();
+    if (modelManager == nullptr) {
+        return SimulationActionResult{false, false, true, SimulationStatusResult{}};
+    }
+
+    Model* model = modelManager->current();
+    if (model == nullptr) {
+        return SimulationActionResult{false, false, true, SimulationStatusResult{}};
+    }
+
+    ModelSimulation* simulation = model->getSimulation();
+    if (simulation == nullptr) {
+        return SimulationActionResult{false, false, true, SimulationStatusResult{}};
+    }
+
+    try {
+        simulation->start();
+    } catch (...) {
+        return SimulationActionResult{false, false, false, SimulationStatusResult{}};
+    }
+
+    SimulationActionResult result{};
+    result.success = true;
+    result.status.success = true;
+    _populateSimulationStatusFromModel(model, result.status);
+    return result;
+}
+
+SimulatorSessionService::SimulationActionResult SimulatorSessionService::stepSimulation(const std::string& accessToken) {
+    SessionContext* session = _sessionManager.getSessionByToken(accessToken);
+    if (session == nullptr || session->simulator == nullptr) {
+        return SimulationActionResult{false, true, false, SimulationStatusResult{}};
+    }
+
+    std::scoped_lock lock(session->mutex);
+    ModelManager* modelManager = session->simulator->getModelManager();
+    if (modelManager == nullptr) {
+        return SimulationActionResult{false, false, true, SimulationStatusResult{}};
+    }
+
+    Model* model = modelManager->current();
+    if (model == nullptr) {
+        return SimulationActionResult{false, false, true, SimulationStatusResult{}};
+    }
+
+    ModelSimulation* simulation = model->getSimulation();
+    if (simulation == nullptr) {
+        return SimulationActionResult{false, false, true, SimulationStatusResult{}};
+    }
+
+    try {
+        simulation->step();
+    } catch (...) {
+        return SimulationActionResult{false, false, false, SimulationStatusResult{}};
+    }
+
+    SimulationActionResult result{};
+    result.success = true;
+    result.status.success = true;
+    _populateSimulationStatusFromModel(model, result.status);
+    return result;
+}
+
 SimulatorSessionService::ModelPersistenceResult SimulatorSessionService::saveCurrentModel(
     const std::string& accessToken,
     const std::string& filename

--- a/source/applications/web/service/SimulatorSessionService.h
+++ b/source/applications/web/service/SimulatorSessionService.h
@@ -80,6 +80,13 @@ public:
         SimulationStatusResult status;
     };
 
+    struct SimulationActionResult {
+        bool success = false;
+        bool invalidToken = false;
+        bool missingCurrentModel = false;
+        SimulationStatusResult status;
+    };
+
     explicit SimulatorSessionService(SessionManager& sessionManager);
 
     CreateSessionResult createSession();
@@ -88,6 +95,8 @@ public:
     bool tryGetCurrentModelInfo(const std::string& accessToken, ModelInfoResult& outInfo);
     SimulationStatusResult getSimulationStatus(const std::string& accessToken);
     SimulationConfigResult configureSimulation(const std::string& accessToken, const SimulationConfigInput& input);
+    SimulationActionResult runSimulation(const std::string& accessToken);
+    SimulationActionResult stepSimulation(const std::string& accessToken);
     ModelPersistenceResult saveCurrentModel(const std::string& accessToken, const std::string& filename);
     ModelPersistenceResult loadModel(const std::string& accessToken, const std::string& filename);
 

--- a/source/tests/unit/test_web_api_router.cpp
+++ b/source/tests/unit/test_web_api_router.cpp
@@ -391,6 +391,62 @@ TEST(WebApiRouterTest, SimulationConfigWithoutTokenReturnsUnauthorized) {
     EXPECT_NE(response.body.find("\"ok\":false"), std::string::npos);
 }
 
+TEST(WebApiRouterTest, SimulationRunWithoutTokenReturnsUnauthorized) {
+    ApiRouterFixture fixture;
+
+    HttpRequest request;
+    request.method = "POST";
+    request.path = "/api/v1/simulation/run";
+
+    const HttpResponse response = fixture.router.handle(request);
+
+    EXPECT_EQ(response.status, 401);
+    EXPECT_NE(response.body.find("\"ok\":false"), std::string::npos);
+}
+
+TEST(WebApiRouterTest, SimulationStepWithoutTokenReturnsUnauthorized) {
+    ApiRouterFixture fixture;
+
+    HttpRequest request;
+    request.method = "POST";
+    request.path = "/api/v1/simulation/step";
+
+    const HttpResponse response = fixture.router.handle(request);
+
+    EXPECT_EQ(response.status, 401);
+    EXPECT_NE(response.body.find("\"ok\":false"), std::string::npos);
+}
+
+TEST(WebApiRouterTest, SimulationRunWithoutCurrentModelReturnsConflict) {
+    ApiRouterFixture fixture;
+    const std::string token = createSessionAndGetToken(fixture.router);
+
+    HttpRequest request;
+    request.method = "POST";
+    request.path = "/api/v1/simulation/run";
+    request.headers["authorization"] = "Bearer " + token;
+
+    const HttpResponse response = fixture.router.handle(request);
+
+    EXPECT_EQ(response.status, 409);
+    EXPECT_NE(response.body.find("\"NO_CURRENT_MODEL\""), std::string::npos);
+}
+
+TEST(WebApiRouterTest, SimulationStepWithoutCurrentModelReturnsConflict) {
+    ApiRouterFixture fixture;
+    const std::string token = createSessionAndGetToken(fixture.router);
+
+    HttpRequest request;
+    request.method = "POST";
+    request.path = "/api/v1/simulation/step";
+    request.headers["authorization"] = "Bearer " + token;
+
+    const HttpResponse response = fixture.router.handle(request);
+
+    EXPECT_EQ(response.status, 409);
+    EXPECT_NE(response.body.find("\"NO_CURRENT_MODEL\""), std::string::npos);
+}
+
 TEST(WebApiRouterTest, SimulationConfigWithoutCurrentModelReturnsConflict) {
     ApiRouterFixture fixture;
     const std::string token = createSessionAndGetToken(fixture.router);
@@ -460,6 +516,72 @@ TEST(WebApiRouterTest, SimulationStatusAndConfigFlowUpdatesValues) {
     EXPECT_NE(updatedStatusResponse.body.find("\"pauseOnReplication\":true"), std::string::npos);
     EXPECT_NE(updatedStatusResponse.body.find("\"initializeStatistics\":false"), std::string::npos);
     EXPECT_NE(updatedStatusResponse.body.find("\"initializeSystem\":false"), std::string::npos);
+}
+
+TEST(WebApiRouterTest, SimulationStepWithCurrentModelReturnsUpdatedStatusEnvelope) {
+    ApiRouterFixture fixture;
+    const std::string token = createSessionAndGetToken(fixture.router);
+
+    HttpRequest createModelRequest;
+    createModelRequest.method = "POST";
+    createModelRequest.path = "/api/v1/models";
+    createModelRequest.headers["authorization"] = "Bearer " + token;
+    ASSERT_EQ(fixture.router.handle(createModelRequest).status, 201);
+
+    HttpRequest configRequest;
+    configRequest.method = "POST";
+    configRequest.path = "/api/v1/simulation/config";
+    configRequest.headers["authorization"] = "Bearer " + token;
+    configRequest.body =
+        "{\"numberOfReplications\":1,\"replicationLength\":1.0,\"warmUpPeriod\":0.0,"
+        "\"pauseOnEvent\":false,\"pauseOnReplication\":false,\"initializeStatistics\":true,\"initializeSystem\":true}";
+    ASSERT_EQ(fixture.router.handle(configRequest).status, 200);
+
+    HttpRequest stepRequest;
+    stepRequest.method = "POST";
+    stepRequest.path = "/api/v1/simulation/step";
+    stepRequest.headers["authorization"] = "Bearer " + token;
+
+    const HttpResponse response = fixture.router.handle(stepRequest);
+
+    EXPECT_EQ(response.status, 200);
+    EXPECT_NE(response.body.find("\"ok\":true"), std::string::npos);
+    EXPECT_NE(response.body.find("\"hasCurrentModel\":true"), std::string::npos);
+    EXPECT_NE(response.body.find("\"isRunning\":"), std::string::npos);
+    EXPECT_NE(response.body.find("\"simulatedTime\":"), std::string::npos);
+}
+
+TEST(WebApiRouterTest, SimulationRunWithCurrentModelReturnsUpdatedStatusEnvelope) {
+    ApiRouterFixture fixture;
+    const std::string token = createSessionAndGetToken(fixture.router);
+
+    HttpRequest createModelRequest;
+    createModelRequest.method = "POST";
+    createModelRequest.path = "/api/v1/models";
+    createModelRequest.headers["authorization"] = "Bearer " + token;
+    ASSERT_EQ(fixture.router.handle(createModelRequest).status, 201);
+
+    HttpRequest configRequest;
+    configRequest.method = "POST";
+    configRequest.path = "/api/v1/simulation/config";
+    configRequest.headers["authorization"] = "Bearer " + token;
+    configRequest.body =
+        "{\"numberOfReplications\":1,\"replicationLength\":1.0,\"warmUpPeriod\":0.0,"
+        "\"pauseOnEvent\":false,\"pauseOnReplication\":false,\"initializeStatistics\":true,\"initializeSystem\":true}";
+    ASSERT_EQ(fixture.router.handle(configRequest).status, 200);
+
+    HttpRequest runRequest;
+    runRequest.method = "POST";
+    runRequest.path = "/api/v1/simulation/run";
+    runRequest.headers["authorization"] = "Bearer " + token;
+
+    const HttpResponse response = fixture.router.handle(runRequest);
+
+    EXPECT_EQ(response.status, 200);
+    EXPECT_NE(response.body.find("\"ok\":true"), std::string::npos);
+    EXPECT_NE(response.body.find("\"hasCurrentModel\":true"), std::string::npos);
+    EXPECT_NE(response.body.find("\"isRunning\":false"), std::string::npos);
+    EXPECT_NE(response.body.find("\"simulatedTime\":"), std::string::npos);
 }
 
 TEST(WebApiRouterTest, SimulationConfigWithInvalidBodyReturnsBadRequest) {


### PR DESCRIPTION
### Motivation
- Provide a minimal, synchronous remote execution surface for simulations (run/step) operating on the current model in a session. 
- Keep simulation control strictly synchronous and encapsulated in the service layer, avoiding any asynchronous/background job or distributed control.

### Description
- Added `SimulationActionResult` and service methods `runSimulation(const std::string&)` and `stepSimulation(const std::string&)` to `SimulatorSessionService`, which call `ModelSimulation::start()` and `ModelSimulation::step()` respectively and return updated `SimulationStatusResult` with error flags for invalid token or missing model. (`source/applications/web/service/SimulatorSessionService.h`, `.cpp`)
- Added authenticated API routes in `ApiRouter` for `POST /api/v1/simulation/run` and `POST /api/v1/simulation/step` with correct method checks and error mapping (`405`, `401`, `409`, `500`) and reusing the existing simulation status JSON serializer. (`source/applications/web/api/ApiRouter.cpp`)
- Extended unit tests in `source/tests/unit/test_web_api_router.cpp` to cover unauthorized requests, missing-current-model (`409`), and happy-path flows for both `step` and `run` returning the expected envelope. (`source/tests/unit/test_web_api_router.cpp`)
- Updated `source/applications/web/README.md` to document Stage 5 endpoints and explicitly note the synchronous execution nature.

### Testing
- Ran configuration: `cmake -S . -B build/web-debug -G Ninja -DGENESYS_BUILD_WEB_APPLICATION=ON`, which succeeded.
- Attempted build: `cmake --build build/web-debug --target genesys_webhook genesys_test_web_api_router`, which failed at link time due to a pre-existing unresolved symbol (`SinkModelComponent`) unrelated to these changes; therefore test binaries were not produced.
- Could not run `ctest` for the `web_api_router` suite because linking failed, so runtime tests were not executed in this environment.

```markdown
## Stage 5 execution report

### What I completed
- Implemented `POST /api/v1/simulation/run` and `POST /api/v1/simulation/step` in the API router with Bearer authentication and proper error mappings.
- Added `runSimulation(...)` and `stepSimulation(...)` to `SimulatorSessionService` to synchronously invoke `ModelSimulation::start()` and `ModelSimulation::step()` and return serialized simulation status.
- Added unit tests for unauthorized, missing-current-model (`409`), and happy-path flows for both endpoints, and updated the web README to Stage 5.

### What I could not complete
- I could not run the unit tests end-to-end because the build failed at link time before test execution.

### Why anything remains incomplete
- The linker failed due to an unrelated pre-existing undefined reference to `SinkModelComponent` while linking `genesys_webhook` and the test executable, preventing test execution in this environment.

### Validation performed
- Ran `cmake -S . -B build/web-debug -G Ninja -DGENESYS_BUILD_WEB_APPLICATION=ON` (configure succeeded).
- Ran `cmake --build build/web-debug --target genesys_webhook genesys_test_web_api_router` (build failed at link stage due to unresolved `SinkModelComponent` symbols).
- Attempted `ctest --test-dir build/web-debug --output-on-failure -R web_api_router` but tests could not run because the binaries were not produced.

### Risks remaining
- Until the repository/environment linker issue is resolved and tests executed, runtime integration of the new endpoints cannot be fully verified by CI.
- The endpoints rely on synchronous kernel behavior; any future kernel changes to make simulation execution asynchronous would require revisiting this API surface.

### Files changed
- `source/applications/web/service/SimulatorSessionService.h`
- `source/applications/web/service/SimulatorSessionService.cpp`
- `source/applications/web/api/ApiRouter.cpp`
- `source/tests/unit/test_web_api_router.cpp`
- `source/applications/web/README.md`
```

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d85bd3c9a88321b0c1ee54feb0a9f2)