### PR TITLE
tests: align `genesys_tests` smoke dependency with aggregate target

### DIFF
--- a/source/tests/CMakeLists.txt
+++ b/source/tests/CMakeLists.txt
@@ -12,5 +12,5 @@ add_custom_target(genesys_tests
 )
 
 if(GENESYS_BUILD_SMOKE_TESTS)
-    add_dependencies(genesys_tests genesys_smoke_simulator_start)
+    add_dependencies(genesys_tests genesys_smoke_tests)
 endif()


### PR DESCRIPTION
### Motivation
- Ensure top-level test aggregator is coherent by depending on the smoke aggregate (`genesys_smoke_tests`) instead of a leaf executable, so a full `genesys_tests` build reliably constructs the complete smoke suite and `ctest` discovery reflects the full suite.

### Description
- Adjusted `source/tests/CMakeLists.txt` to replace `add_dependencies(genesys_tests genesys_smoke_simulator_start)` with `add_dependencies(genesys_tests genesys_smoke_tests)`, with no production-code changes.

### Testing
- Reconfigured with `cmake -S . -B build/tests-audit -G Ninja -DGENESYS_BUILD_TESTS=ON`, built `cmake --build build/tests-audit --target genesys_tests`, and ran `ctest --test-dir build/tests-audit --output-on-failure`, `ctest --test-dir build/tests-audit --output-on-failure -L unit` and `ctest --test-dir build/tests-audit --output-on-failure -L smoke`, observing a successful build and test run (full build: 922 tests total — 921 `unit` + 1 `smoke` — all passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d85be9d64c8321b4f26bf19e00e153)