### PR TITLE
Kernel phase 3: simplify checker and reporter temporary structures

### DIFF
--- a/source/kernel/simulator/ModelCheckerDefaultImpl1.cpp
+++ b/source/kernel/simulator/ModelCheckerDefaultImpl1.cpp
@@ -18,6 +18,7 @@
 #include "Simulator.h"
 
 #include <assert.h>
+#include <unordered_set>
 
 //using namespace GenesysKernel;
 
@@ -104,6 +105,7 @@ bool ModelCheckerDefaultImpl1::checkConnected() {
 			if (plugin->getPluginInfo()->isSource() || plugin->getPluginInfo()->isReceiveTransfer()) { //(dynamic_cast<SourceModelComponent*> (comp) != nullptr) {
 				// it is a source component OR it can receive enetities from transfer
 				bool drenoFound = false;
+				// Keep recursive traversal state entirely in stack-owned bookkeeping objects.
 				_recursiveConnectedTo(pluginManager, comp, &visited, &unconnected, &drenoFound);
 				if (!drenoFound)
 					resultAll = false;
@@ -233,45 +235,48 @@ bool ModelCheckerDefaultImpl1::checkOrphaned() {
 	_model->getTracer()->trace("Checking Orphaned DataDefinitions", TraceManager::Level::L7_internal);
 	Util::IncIndent();
 	{
-		// Track orphan candidates in automatic storage to prevent per-check leaks.
-		std::list<ModelDataDefinition*> orphaned;
+		// Track orphan candidates by pointer identity to make pruning deterministic and iteration-safe.
+		std::unordered_set<ModelDataDefinition*> orphaned;
 		// Start by including all elements as orphaned
 		// Use a value snapshot of type names when enumerating initial orphan candidates.
 		std::list<std::string> allTypes = _model->getDataManager()->getDataDefinitionClassnames();
 		for (std::string ddtypename : allTypes) {
 			for (ModelDataDefinition* element : *_model->getDataManager()->getDataDefinitionList(ddtypename)->list()) {
-				orphaned.insert(orphaned.end(), element);
+				orphaned.insert(element);
 			}
 		}
-		// now exclude all those are refered by someone.
-		ModelDataDefinition* mdd;
+		// Remove every referenced data definition from orphan candidates while preserving trace semantics.
+		auto removeReferenced = [&](ModelDataDefinition* owner) {
+			for (std::pair<std::string, ModelDataDefinition*> pairInternal : *owner->getInternalData()) {
+				ModelDataDefinition* mdd = pairInternal.second;
+				orphaned.erase(mdd);
+				_model->getTracer()->trace("(" + owner->getClassname() + ") " + owner->getName() + " <#>--> " + "(" + mdd->getClassname() + ") " + mdd->getName());
+			}
+			for (std::pair<std::string, ModelDataDefinition*> pairAttached : *owner->getAttachedData()) {
+				ModelDataDefinition* mdd = pairAttached.second;
+				orphaned.erase(mdd);
+				_model->getTracer()->trace("(" + owner->getClassname() + ") " + owner->getName() + " < >--> " + "(" + mdd->getClassname() + ") " + mdd->getName());
+			}
+		};
 		// ... by someone (ModelDataDefinition).
 		// Use another value snapshot because orphan pruning may observe changes made during checking.
 		std::list<std::string> referencedTypes = _model->getDataManager()->getDataDefinitionClassnames();
 		for (std::string ddtypename : referencedTypes) {
 			for (ModelDataDefinition* element : *_model->getDataManager()->getDataDefinitionList(ddtypename)->list()) {
-				for (std::pair<std::string, ModelDataDefinition*> pairInternal : *element->getInternalData()) {
-					mdd = pairInternal.second;
-					orphaned.remove(mdd);
-					_model->getTracer()->trace("(" + element->getClassname() + ") " + element->getName() + " <#>--> " + "(" + mdd->getClassname() + ") " + mdd->getName());
-				}
-				for (std::pair<std::string, ModelDataDefinition*> pairAttached : *element->getAttachedData()) {
-					mdd = pairAttached.second;
-					orphaned.remove(mdd);
-					_model->getTracer()->trace("(" + element->getClassname() + ") " + element->getName() + " < >--> " + "(" + mdd->getClassname() + ") " + mdd->getName());
-				}
+				removeReferenced(element);
 			}
 		}
 		// ... by someone (ModelComponent).
 		for (ModelComponent* component : *_model->getComponentManager()->getAllComponents()) {
+			// Remove all component-owned references from orphan candidates before final deletion pass.
 			for (std::pair<std::string, ModelDataDefinition*> pairInternal : *component->getInternalData()) {
-				mdd = pairInternal.second;
-				orphaned.remove(mdd);
+				ModelDataDefinition* mdd = pairInternal.second;
+				orphaned.erase(mdd);
 				_model->getTracer()->trace("(" + component->getClassname() + ") " + component->getName() + " <#>--> " + "(" + mdd->getClassname() + ") " + mdd->getName());
 			}
 			for (std::pair<std::string, ModelDataDefinition*> pairAttached : *component->getAttachedData()) {
-				mdd = pairAttached.second;
-				orphaned.remove(mdd);
+				ModelDataDefinition* mdd = pairAttached.second;
+				orphaned.erase(mdd);
 				_model->getTracer()->trace("(" + component->getClassname() + ") " + component->getName() + " < >--> " + "(" + mdd->getClassname() + ") " + mdd->getName());
 			}
 		}

--- a/source/kernel/simulator/SimulationReporterDefaultImpl1.cpp
+++ b/source/kernel/simulator/SimulationReporterDefaultImpl1.cpp
@@ -15,9 +15,30 @@
 #include <assert.h>
 #include <iomanip>
 #include <iostream>
+#include <map>
+#include <list>
 #include "Counter.h"
 
 //using namespace GenesysKernel;
+
+namespace {
+using GroupedStats = std::map<std::string, std::map<std::string, std::list<ModelDataDefinition*> > >;
+
+// Build a parent-type/parent-name index for statistics and counters using stack-owned containers.
+static GroupedStats groupStatsByParent(const std::list<ModelDataDefinition*>& items, const std::string& statisticsType, const std::string& counterType) {
+	GroupedStats grouped;
+	for (ModelDataDefinition* item : items) {
+		if (item->getClassname() == statisticsType) {
+			StatisticsCollector* cstat = dynamic_cast<StatisticsCollector*> (item);
+			grouped[cstat->getParent()->getClassname()][cstat->getParent()->getName()].push_back(item);
+		} else if (item->getClassname() == counterType) {
+			Counter* counter = dynamic_cast<Counter*> (item);
+			grouped[counter->getParent()->getClassname()][counter->getParent()->getName()].push_back(item);
+		}
+	}
+	return grouped;
+}
+}
 
 SimulationReporterDefaultImpl1::SimulationReporterDefaultImpl1(ModelSimulation* simulation, Model* model, List<ModelDataDefinition*>* statsCountersSimulation) {
 	_simulation = simulation;
@@ -57,30 +78,8 @@ void SimulationReporterDefaultImpl1::showReplicationStatistics() {
 	std::list<ModelDataDefinition*> counters(*(_model->getDataManager()->getDataDefinitionList(UtilTypeOfCounter)->list()));
 	statisticsAndCounters.merge(counters);
 	//statisticsAndCounters->insert(counters->list()->begin(), counters->list()->end());
-	// Group report items by parent type and parent name with automatic storage containers.
-	std::map<std::string, std::map<std::string, std::list<ModelDataDefinition*> > > mapMapTypeStat;
-
-	for (ModelDataDefinition* cstatOrCounter : statisticsAndCounters) {
-		std::string parentName, parentTypename;
-		//std::cout << statOrCnt->getName() << ": " << statOrCnt->getTypename() << std::endl;
-		if (cstatOrCounter->getClassname() == UtilTypeOfStatisticsCollector) {
-			StatisticsCollector* cstat = dynamic_cast<StatisticsCollector*> (cstatOrCounter);
-			parentName = cstat->getParent()->getName();
-			parentTypename = cstat->getParent()->getClassname();
-		} else {
-			if (cstatOrCounter->getClassname() == UtilTypeOfCounter) {
-				Counter* counter = dynamic_cast<Counter*> (cstatOrCounter);
-				parentName = counter->getParent()->getName();
-				parentTypename = counter->getParent()->getClassname();
-
-			}
-		}
-		// look for key=parentTypename
-		// Insert into nested maps/lists via references to avoid heap-allocated pairs and lists.
-		std::list<ModelDataDefinition*>& listStatAndCount = mapMapTypeStat[parentTypename][parentName];
-		listStatAndCount.insert(listStatAndCount.end(), cstatOrCounter);
-		//_model->getTraceManager()->traceReport(parentTypename + " -> " + parentName + " -> " + stat->show());
-	}
+	// Reuse a shared grouping routine to keep ownership/lifetime logic identical across reports.
+	GroupedStats mapMapTypeStat = groupStatsByParent(statisticsAndCounters, UtilTypeOfStatisticsCollector, UtilTypeOfCounter);
 	//
 	//
 	// now runs over that map of maps showing the statistics
@@ -158,31 +157,8 @@ void SimulationReporterDefaultImpl1::showSimulationStatistics() {//List<Statisti
 	// runs over all elements and list the statistics for each one, and then the statistics with no parent
 	// COPY the list of statistics and counters into a single new list
 	//std::list<ModelDataDefinition*>* statisticsAndCounters = //new std::list<ModelDataDefinition*>(*(this->_statsCountersSimulation->list()));
-	// Group simulation-level stats and counters in local containers without heap-allocated nodes.
-	std::map<std::string, std::map<std::string, std::list<ModelDataDefinition*> > > mapMapTypeStat;
-
-	for (std::list<ModelDataDefinition*>::iterator it = _statsCountersSimulation->list()->begin(); it != _statsCountersSimulation->list()->end(); it++) {
-		std::string parentName, parentTypename;
-		ModelDataDefinition* statOrCnt = (*it);
-		//std::cout << statOrCnt->getName() << ": " << statOrCnt->getTypename() << std::endl;
-		if ((*it)->getClassname() == UtilTypeOfStatisticsCollector) {
-			StatisticsCollector* stat = dynamic_cast<StatisticsCollector*> (statOrCnt);
-			parentName = stat->getParent()->getName();
-			parentTypename = stat->getParent()->getClassname();
-		} else {
-			if ((*it)->getClassname() == UtilTypeOfCounter) {
-				Counter* cnt = dynamic_cast<Counter*> (statOrCnt);
-				parentName = cnt->getParent()->getName();
-				parentTypename = cnt->getParent()->getClassname();
-
-			}
-		}
-		// look for key=parentTypename
-		// Insert into grouped lists using map references to avoid manual heap lifecycle.
-		std::list<ModelDataDefinition*>& listStat = mapMapTypeStat[parentTypename][parentName];
-		listStat.insert(listStat.end(), statOrCnt);
-		//_model->getTraceManager()->traceReport(parentTypename + " -> " + parentName + " -> " + stat->show());
-	}
+	// Apply the same grouping flow used by replication reports to reduce structural divergence.
+	GroupedStats mapMapTypeStat = groupStatsByParent(*_statsCountersSimulation->list(), UtilTypeOfStatisticsCollector, UtilTypeOfCounter);
 	// now runs over that map of maps showing the statistics
 	//int w = 12;
 	Util::IncIndent();


### PR DESCRIPTION
KERNEL

### Motivation
- Reduce fragility and ownership/lifetime risk in temporary traversal/pruning structures used by the model checker and reporter while preserving observable behavior. 
- Remove duplicated map/list assembly logic in replication/simulation report generation to make ownership of temporaries clearer and identical across flows.

### Description
- In `ModelCheckerDefaultImpl1.cpp` replaced the ephemeral `std::list`-based orphan candidate container with a pointer-identity `std::unordered_set<ModelDataDefinition*>` to make removals deterministic and iteration-safe, and added a small local `removeReferenced` lambda to consolidate repeated internal/attached reference pruning logic.
- In `ModelCheckerDefaultImpl1.cpp` left `checkConnected()` algorithm unchanged but added a clarifying comment and ensured traversal bookkeeping stays stack-owned (no signature changes).
- In `SimulationReporterDefaultImpl1.cpp` added a static helper `groupStatsByParent` in an anonymous namespace to build the parent-type/parent-name grouping for statistics and counters, and reused it in both `showReplicationStatistics()` and `showSimulationStatistics()` to remove duplicated grouping code.
- All changes are limited to the two requested `.cpp` files, keep public signatures untouched, and include short English comments immediately above each altered logical block as required.

### Testing
- Configured the debug kernel build with `cmake --preset debug-kernel` and built the kernel target with `cmake --build build/debug-kernel --target genesys_kernel -j4`.
- The build completed successfully and recompiled the modified translation units (including `ModelCheckerDefaultImpl1.cpp` and `SimulationReporterDefaultImpl1.cpp`).
- No unit or runtime tests were run (explicitly out of scope); only compilation validation was performed and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d85cccde2c8321beafdec844925634)