### PR TITLE
Replace qobject_cast with dynamic_cast in ModelGraphicsScene helper

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
@@ -72,7 +72,8 @@ ModelGraphicsView* sceneParentModelGraphicsView(ModelGraphicsScene* scene) {
     if (scene == nullptr) {
         return nullptr;
     }
-    return qobject_cast<ModelGraphicsView*>(scene->parent());
+    // Use RTTI because ModelGraphicsView does not provide Qt meta-object casting.
+    return dynamic_cast<ModelGraphicsView*>(scene->parent());
 }
 }
 


### PR DESCRIPTION
### Motivation
- Fix compile error caused by using `qobject_cast<ModelGraphicsView*>` when `ModelGraphicsView` does not declare `Q_OBJECT`, which makes `qobject_cast` invalid.

### Description
- In `source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp` replaced the specialized cast `qobject_cast<ModelGraphicsView*>(scene->parent())` with `dynamic_cast<ModelGraphicsView*>(scene->parent())` and added a short technical comment immediately above the changed line; no other files were modified.

### Testing
- Attempted to build the GUI with `source/applications/gui/qt/GenesysQtGUI/build_qtgui.sh --config Debug --jobs 2`, but the build could not run because `qmake` is not available in `PATH`; code inspection verifies that `sceneParentModelGraphicsView(...)` no longer uses `qobject_cast` and the change is restricted to the single file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d85fdeb5f883218673630f0f0ebb2c)