### PR TITLE
Fix Variable lifecycle/reset semantics and complete Variable runtime tests

### DIFF
--- a/source/plugins/data/Variable.cpp
+++ b/source/plugins/data/Variable.cpp
@@ -27,10 +27,21 @@ ModelDataDefinition* Variable::NewInstance(Model* model, std::string name) {
 
 Variable::Variable(Model* model, std::string name) : ModelDataDefinition(model, Util::TypeOf<Variable>(), name) {
 	setName(name);
-	_parentModel->getControls()->insert(new SimulationControlDouble(
-						std::bind(&Variable::getInitialValue, this, ""),
-						std::bind(&Variable::setInitialValue, this, std::placeholders::_1, ""),
-						Util::TypeOf<Variable>(), name, "InitialValue", ""));
+	SimulationControlDouble* propInitialValue = new SimulationControlDouble(
+			std::bind(&Variable::getInitialValue, this, ""),
+			std::bind(&Variable::setInitialValue, this, std::placeholders::_1, ""),
+			Util::TypeOf<Variable>(), getName(), "InitialValue", "");
+	_parentModel->getControls()->insert(propInitialValue);
+	_addProperty(propInitialValue);
+}
+
+Variable::~Variable() {
+	delete _dimensionSizes;
+	_dimensionSizes = nullptr;
+	delete _values;
+	_values = nullptr;
+	delete _initialValues;
+	_initialValues = nullptr;
 }
 
 std::string Variable::show() {
@@ -38,9 +49,11 @@ std::string Variable::show() {
 	for (std::pair<std::string, double> var : * this->_values) {
 		text += var.first + "=" + Util::StrTruncIfInt(std::to_string(var.second)) + ", ";
 	}
-	text = text.substr(0, text.length() - 2);
+	if (!this->_values->empty()) {
+		text = text.substr(0, text.length() - 2);
+	}
 	text += "}";
-	return ModelDataDefinition::show();
+	return ModelDataDefinition::show() + ", " + text;
 }
 
 PluginInformation* Variable::GetPluginInformation() {
@@ -142,8 +155,8 @@ bool Variable::_loadInstance(PersistenceRecord *fields) {
 		}
 		nv = fields->loadField("values", 0);
 		for (unsigned int i = 0; i < nv; i++) {
-			pos = fields->loadField("valuePos" + Util::StrIndex(i), 0);
-			value = fields->loadField("value" + Util::StrIndex(i), 0);
+			pos = fields->loadField("valuePos" + Util::StrIndex(i), "");
+			value = fields->loadField("value" + Util::StrIndex(i), 0.0);
 			this->_initialValues->emplace(pos, value);
 		}
 	}
@@ -151,11 +164,14 @@ bool Variable::_loadInstance(PersistenceRecord *fields) {
 }
 
 void Variable::_saveInstance(PersistenceRecord *fields, bool saveDefaultValues) {
+	ModelDataDefinition::_saveInstance(fields, saveDefaultValues);
 	unsigned int i = 0;
 	fields->saveField("dimensions", _dimensionSizes->size(), 0u, saveDefaultValues);
 	for (unsigned int dimension : *_dimensionSizes) {
 		fields->saveField("dimension" + Util::StrIndex(i), dimension, 1u, saveDefaultValues);
+		i++;
 	}
+	i = 0;
 	fields->saveField("values", _initialValues->size(), 0);
 	for (std::map<std::string, double>::iterator it = _initialValues->begin(); it != _initialValues->end(); it++, i++) {
 		fields->saveField("valuePos" + Util::StrIndex(i), (*it).first, "0", saveDefaultValues);
@@ -169,8 +185,7 @@ bool Variable::_check(std::string& errorMessage) {
 }
 
 void Variable::_initBetweenReplications() {
-	this->_values->clear();
-	this->_values = this->_initialValues;
+	*this->_values = *this->_initialValues;
 }
 
 ModelDataDefinition* Variable::get_scope() {

--- a/source/plugins/data/Variable.h
+++ b/source/plugins/data/Variable.h
@@ -90,7 +90,7 @@ Initial Value Variable value at the start of the simulation.
 class Variable : public ModelDataDefinition {
 public:
     Variable(Model* model, std::string name = "");
-    virtual ~Variable() = default;
+    virtual ~Variable() override;
 public:
     virtual std::string show() override;
 public: //static

--- a/source/tests/unit/test_simulator_runtime.cpp
+++ b/source/tests/unit/test_simulator_runtime.cpp
@@ -8,7 +8,9 @@
 #include "kernel/simulator/Attribute.h"
 #include "kernel/simulator/TraceManager.h"
 #include "kernel/simulator/SimulationControlAndResponse.h"
+#include "kernel/simulator/Persistence.h"
 #include "plugins/data/Queue.h"
+#include "plugins/data/Variable.h"
 
 namespace {
 struct SimulationStartObserver {
@@ -116,6 +118,33 @@ public:
     bool CheckProbe(std::string& errorMessage) {
         return _check(errorMessage);
     }
+};
+
+class VariableLifecycleProbe : public Variable {
+public:
+    VariableLifecycleProbe(Model* model, const std::string& name = "") : Variable(model, name) {}
+
+    void InitBetweenReplicationsProbe() {
+        _initBetweenReplications();
+    }
+
+    void SaveInstanceProbe(PersistenceRecord* fields, bool saveDefaultValues = false) {
+        _saveInstance(fields, saveDefaultValues);
+    }
+
+    bool LoadInstanceProbe(PersistenceRecord* fields) {
+        return _loadInstance(fields);
+    }
+};
+
+class FakeModelPersistenceRuntime : public ModelPersistence_if {
+public:
+    bool save(std::string) override { return false; }
+    bool load(std::string) override { return false; }
+    bool hasChanged() override { return false; }
+    bool getOption(ModelPersistence_if::Options) override { return false; }
+    void setOption(ModelPersistence_if::Options, bool) override {}
+    std::string getFormatedField(PersistenceRecord*) override { return ""; }
 };
 
 class CountingWaitingProbe final : public Waiting {
@@ -802,4 +831,112 @@ TEST(SimulatorRuntimeTest, QueueCheckPassesWhenAttributeRuleHasValidAttributeNam
     EXPECT_TRUE(errorMessage.empty());
 
     delete priority;
+}
+
+TEST(SimulatorRuntimeTest, VariableInitBetweenReplicationsCopiesWithoutAliasingInitialValues) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    VariableLifecycleProbe variable(model, "VariableResetNoAlias");
+    variable.setInitialValue(10.0, "idx");
+    variable.InitBetweenReplicationsProbe();
+
+    variable.setValue(77.0, "idx");
+
+    EXPECT_DOUBLE_EQ(variable.getValue("idx"), 77.0);
+    EXPECT_DOUBLE_EQ(variable.getInitialValue("idx"), 10.0);
+}
+
+TEST(SimulatorRuntimeTest, VariableInitBetweenReplicationsRestoresCurrentValueFromInitial) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    VariableLifecycleProbe variable(model, "VariableResetRestores");
+    variable.setInitialValue(21.5, "slot");
+    variable.setValue(3.0, "slot");
+
+    variable.InitBetweenReplicationsProbe();
+
+    EXPECT_DOUBLE_EQ(variable.getValue("slot"), 21.5);
+}
+
+TEST(SimulatorRuntimeTest, VariableSavePersistsMultipleDimensionsWithIncreasingIndexes) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    VariableLifecycleProbe variable(model, "VariablePersistDimensions");
+    variable.insertDimentionSize(3u);
+    variable.insertDimentionSize(5u);
+    variable.insertDimentionSize(7u);
+
+    FakeModelPersistenceRuntime persistence;
+    PersistenceRecord fields(persistence);
+    variable.SaveInstanceProbe(&fields, true);
+
+    EXPECT_EQ(fields.loadField("dimensions", 0u), 3u);
+    EXPECT_EQ(fields.loadField("dimension[0]", 0u), 3u);
+    EXPECT_EQ(fields.loadField("dimension[1]", 0u), 5u);
+    EXPECT_EQ(fields.loadField("dimension[2]", 0u), 7u);
+}
+
+TEST(SimulatorRuntimeTest, VariableSaveAndLoadPreservesInitialValues) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    VariableLifecycleProbe source(model, "VariablePersistValuesSource");
+    source.setInitialValue(4.25, "");
+    source.setInitialValue(8.5, "1,1");
+
+    FakeModelPersistenceRuntime persistence;
+    PersistenceRecord fields(persistence);
+    source.SaveInstanceProbe(&fields, true);
+
+    VariableLifecycleProbe loaded(model, "VariablePersistValuesLoaded");
+    ASSERT_TRUE(loaded.LoadInstanceProbe(&fields));
+
+    EXPECT_DOUBLE_EQ(loaded.getInitialValue(""), 4.25);
+    EXPECT_DOUBLE_EQ(loaded.getInitialValue("1,1"), 8.5);
+}
+
+TEST(SimulatorRuntimeTest, VariableLoadedCurrentAndInitialContainersRemainIndependentAfterReset) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    VariableLifecycleProbe source(model, "VariableContainerIndependenceSource");
+    source.setInitialValue(12.0, "shared");
+
+    FakeModelPersistenceRuntime persistence;
+    PersistenceRecord fields(persistence);
+    source.SaveInstanceProbe(&fields, true);
+
+    VariableLifecycleProbe loaded(model, "VariableContainerIndependenceLoaded");
+    ASSERT_TRUE(loaded.LoadInstanceProbe(&fields));
+    loaded.InitBetweenReplicationsProbe();
+
+    ASSERT_NE(loaded.getValues(), nullptr);
+    EXPECT_DOUBLE_EQ(loaded.getValue("shared"), 12.0);
+    loaded.setValue(44.0, "shared");
+    EXPECT_DOUBLE_EQ(loaded.getValue("shared"), 44.0);
+    EXPECT_DOUBLE_EQ(loaded.getInitialValue("shared"), 12.0);
+    loaded.setInitialValue(66.0, "shared");
+    EXPECT_DOUBLE_EQ(loaded.getInitialValue("shared"), 66.0);
+    EXPECT_DOUBLE_EQ(loaded.getValue("shared"), 44.0);
+}
+
+TEST(SimulatorRuntimeTest, VariableShowIncludesVariableSpecificValues) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    VariableLifecycleProbe variable(model, "VariableShowDetails");
+    variable.setValue(3.14, "pi");
+
+    const std::string shown = variable.show();
+    EXPECT_NE(shown.find("values:{"), std::string::npos);
+    EXPECT_NE(shown.find("pi="), std::string::npos);
 }


### PR DESCRIPTION
### Motivation
- The `Variable` plugin had pointer-aliasing and ownership bugs that caused lost containers, leaks and incorrect reset semantics across replications.
- Persistence saving/loading missed superclass fields and wrote dimension entries with a fixed index, leading to data loss on multi-dimension variables.
- `show()` discarded the variable-specific rendered text and constructor-created control did not follow the class property lifecycle conventions.

### Description
- Added an explicit destructor to `Variable` that releases owned containers `_dimensionSizes`, `_values` and `_initialValues`, removing leaks (files changed: `Variable.h`, `Variable.cpp`).
- Fixed `_initBetweenReplications()` to copy contents (`* _values = * _initialValues`) instead of aliasing pointers and leaking, preserving independence between current and initial state (`Variable.cpp`).
- Corrected `_saveInstance()` to call `ModelDataDefinition::_saveInstance(...)`, increment dimension index while saving multiple dimensions, and reset local index for saving values to match `_loadInstance()` behavior (`Variable.cpp`).
- Fixed `_loadInstance()` default types to read `valuePos` as string and `value` as double to avoid truncation/`stoi` errors; updated `show()` to include the variable-specific value string; and registered the `SimulationControlDouble` created in the constructor via `_addProperty(...)` so the base destructor manages it (`Variable.cpp`, `Variable.h`).
- Added test probes and unit tests to `source/tests/unit/test_simulator_runtime.cpp` to validate reset-without-aliasing, reset-restore, multi-dimension persistence, values round-trip, container independence, and `show()` content.

### Testing
- Built tests with: `cmake -S . -B build -G Ninja -DGENESYS_BUILD_TESTS=ON -DGENESYS_BUILD_KERNEL=ON -DGENESYS_BUILD_PARSER=ON -DGENESYS_BUILD_PLUGINS=ON -DGENESYS_TERMINAL_APPLICATION=OFF -DGENESYS_BUILD_GUI_APPLICATION=OFF -DGENESYS_BUILD_WEB_APPLICATION=OFF` which configured successfully.
- Built the runtime tests target: `cmake --build build --target genesys_test_simulator_runtime` which completed successfully.
- Ran the Variable-focused tests: `ctest --test-dir build -R "SimulatorRuntimeTest.*Variable" --output-on-failure` and the six added/updated Variable tests passed (100% for the filtered set).
- Note: `ctest --test-dir build -LE smoke` reported several `*_NOT_BUILT` entries in this build profile (unrelated to the Variable changes); these reflect targets not produced by the selected build invocation and are not regressions in the plugin changes.

- o que você realizou de fato;
  - Corrigi `Variable` (lifecycle, reset entre replicações, persistência save/load, `show()`) e adicionei os testes unitários exigidos.
- o que não realizou;
  - Não alterei classes fora do escopo proibido (`Queue`, `Resource`, `Sequence`, `SignalData`) nem redesenhei arquitetura global.
- por que não realizou;
  - Mantive o escopo solicitado e o encapsulamento existente; mudanças fora do escopo teriam sido mais invasivas.
- riscos remanescentes;
  - A classe ainda usa alocação manual (`new/delete`) para containers; usar RAII (smart pointers/containers por valor) seria mais robusto e pode ser considerado em futura refatoração.
- observações relevantes;
  - O `SimulationControlDouble` criado no construtor agora é registrado via `_addProperty(...)` para alinhar com o ciclo de vida padrão da base.
- arquivos alterados;
  - `source/plugins/data/Variable.h`
  - `source/plugins/data/Variable.cpp`
  - `source/tests/unit/test_simulator_runtime.cpp`
- comandos executados e resultados resumidos.
  - `cmake -S . -B build -G Ninja ...` => configure success.
  - `cmake --build build --target genesys_test_simulator_runtime` => build success.
  - `ctest --test-dir build -R "SimulatorRuntimeTest.*Variable" --output-on-failure` => all Variable tests passed.
  - `ctest --test-dir build -LE smoke --output-on-failure` => reported unrelated `*_NOT_BUILT` entries in this build profile.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d86172597c8321bb3abe89b9ab8c70)