### PR TITLE
Fix cache invalidation and sorted-file lifecycle in file-backed statistics

### DIFF
--- a/source/kernel/statistics/StatisticsDataFileDefaultImpl.cpp
+++ b/source/kernel/statistics/StatisticsDataFileDefaultImpl.cpp
@@ -47,43 +47,59 @@ Collector_if* StatisticsDatafileDefaultImpl1::getCollector() const {
 	return this->_collector;
 }
 
+// Reset all memoized statistics so future getters recompute from current collector data.
+void StatisticsDatafileDefaultImpl1::_invalidateCachedResults() {
+	_maxCalculated = false;
+	_minCalculated = false;
+	_averageCalculated = false;
+	_varianceCalculated = false;
+	_modeCalculated = false;
+	_medianeCalculated = false;
+	_stddeviationCalculated = false;
+	_variationCoefCalculated = false;
+	_halfWidthConfidenceIntervalCalculated = false;
+	_newSampleSizeCalculated = false;
+	_quartilCalculated = false;
+	_decilCalculated = false;
+	_centilCalculated = false;
+	_histogramNumClassesCalculated = false;
+	_histogramClassLowerLimitCalculated = false;
+	_histogramClassFrequencyCalculated = false;
+	_proportionCalculed = false;
+}
+
+// Drop sorted-file binding so a future sort rebuilds against the active source file.
+void StatisticsDatafileDefaultImpl1::_resetSortedFileState() {
+	_fileSorted = false;
+	_fileSortedCreated = false;
+	_sortedSourceFilename.clear();
+}
+
 void StatisticsDatafileDefaultImpl1::setCollector(Collector_if* collector) {
 	if (_collector == collector) {
 		return;
 	}
+	// Release previous collector when owned and fully invalidate cached state for the new source.
 	if (_ownsCollector) {
 		delete _collector;
 	}
 	_collector = static_cast<CollectorDatafile_if*> (collector);
 	_ownsCollector = false;
+	_numElements = 0;
+	_invalidateCachedResults();
+	_resetSortedFileState();
 }
 
 bool StatisticsDatafileDefaultImpl1::_hasNewValue() {
-	if (_numElements < _collector->numElements()) {
-		_numElements = _collector->numElements();
-		_maxCalculated = false;
-		_minCalculated = false;
-		_averageCalculated = false;
-		_varianceCalculated = false;
-		_modeCalculated = false;
-		_medianeCalculated = false;
-		_stddeviationCalculated = false;
-		_variationCoefCalculated = false;
-		_halfWidthConfidenceIntervalCalculated = false;
-		_newSampleSizeCalculated = false;
-		_quartilCalculated = false;
-		_decilCalculated = false;
-		_centilCalculated = false;
-		_histogramNumClassesCalculated = false;
-		_histogramClassLowerLimitCalculated = false;
-		_histogramClassFrequencyCalculated = false;
-		_proportionCalculed = false;
+	// Invalidate caches whenever collector size diverges in any direction (growth, shrink, reset).
+	const unsigned long currentNumElements = _collector->numElements();
+	if (_numElements != currentNumElements) {
+		_numElements = currentNumElements;
+		_invalidateCachedResults();
 		_fileSorted = false;
 		return true;
-	} else {
-		return false;
 	}
-
+	return false;
 }
 
 unsigned int StatisticsDatafileDefaultImpl1::numElements() {
@@ -330,18 +346,27 @@ unsigned int StatisticsDatafileDefaultImpl1::histogramClassFrequency(unsigned sh
 }
 
 void StatisticsDatafileDefaultImpl1::_sortFile() {
-
+	// Rebind and recreate the sorted collector file when the source filename changes.
+	const std::string sourceFilename = _collector->getDataFilename();
+	if (_sortedSourceFilename != sourceFilename) {
+		_resetSortedFileState();
+		_sortedSourceFilename = sourceFilename;
+	}
 	if (!_fileSortedCreated) {
-		_collectorSorted->setDataFilename(_collector->getDataFilename() + "_sorted");
+		_collectorSorted->setDataFilename(sourceFilename + "_sorted");
 		_collectorSorted->clear();
 		_fileSortedCreated = true;
 	}
-
+	// Ensure sorted mirror content tracks source size, including shrink/reset scenarios.
+	if (_collectorSorted->numElements() > _collector->numElements()) {
+		_collectorSorted->clear();
+	}
 	if (_collectorSorted->numElements() < _collector->numElements()) {
 		for (unsigned long position = _collectorSorted->numElements(); position < _collector->numElements(); position++) {
 			_collectorSorted->addValue(_collector->getValue(position));
 		}
 	}
+	// Sort the refreshed mirror file and mark sorted state as valid for this source filename.
 	sort->setDataFilename(_collectorSorted->getDataFilename());
 	sort->sort();
 	_fileSorted = true;

--- a/source/kernel/statistics/StatisticsDataFileDefaultImpl.h
+++ b/source/kernel/statistics/StatisticsDataFileDefaultImpl.h
@@ -18,6 +18,7 @@
 #include "SorttFile.h"
 #include <limits.h>
 #include <map>
+#include <string>
 
 typedef double valueType;
 
@@ -81,6 +82,10 @@ public:
 	/*! \brief Returns absolute frequency of histogram class \p classNum. */
 	virtual unsigned int histogramClassFrequency(unsigned short classNum) override;
 private:
+	/*! \brief Invalidates calculated statistics to force recomputation from source data. */
+	void _invalidateCachedResults();
+	/*! \brief Resets sorted-file lifecycle state bound to the current source filename. */
+	void _resetSortedFileState();
 	/*! \brief Sorts collector file if required by order-based metrics. */
 	void _sortFile();
 	/*! \brief Checks whether source data changed since last cached computation. */
@@ -100,6 +105,7 @@ private:
 	std::map<double, double> _z;
 	bool _fileSorted = false;
 	bool _fileSortedCreated = false;
+	std::string _sortedSourceFilename;
 	//unsigned long _numElements = 0;
 	bool _numElementsCalculated = false;
 	double _max = INT_MIN;


### PR DESCRIPTION
### Motivation
- The file-backed statistics implementation kept cached results and a sorted-file mirror tied to stale collector state, causing incorrect results after collector swap, dataset shrink/reset, or filename changes.  
- The goal is a minimal, API-preserving fix so cached metrics and the sorted mirror are invalidated and rebuilt when the underlying data source changes.

### Description
- Added two small private helpers: `_invalidateCachedResults()` to clear memoized statistic flags and `_resetSortedFileState()` to drop sorted-file lifecycle binding, plus a `_sortedSourceFilename` field to track the source filename.  
- `setCollector(...)` now preserves `_ownsCollector`, swaps the collector, resets `_numElements`, invalidates cached statistics and resets sorted-file state to avoid carrying stale state from the previous collector.  
- `_hasNewValue()` now detects any divergence in element count (`!=`) and on mismatch syncs `_numElements`, invalidates caches and clears the sorted flag (previous behavior only detected growth).  
- `_sortFile()` now tracks the collector data filename and, when it changes, resets the sorted-file lifecycle, sets the sorted collector filename from the tracked source, and handles shrink/reset by clearing the mirror if it has more elements than the source before refilling and sorting.
- Short technical comments in English were added immediately above each modified logical block as requested.

### Testing
- Configured and generated build files with `cmake --preset debug-kernel`.  
- Built the kernel target with `cmake --build ./build/debug-kernel --target genesys_kernel -j4` and the build completed successfully.  
- No unit or runtime tests were executed (per scope); verification limited to successful compilation of the kernel target.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d866a51a888321bb48e0fc98d0b0fa)