### PR TITLE
Fix Resource recheck/persistence/lifecycle bugs and add runtime tests

### DIFF
--- a/source/plugins/data/Resource.cpp
+++ b/source/plugins/data/Resource.cpp
@@ -98,6 +98,28 @@ Resource::Resource(Model* model, std::string name) : ModelDataDefinition(model, 
     _addProperty(propCapacitySchedule);
 }
 
+Resource::~Resource() {
+    if (_resourceEventHandlers != nullptr) {
+        for (SortedResourceEventHandler* sreh : *_resourceEventHandlers->list()) {
+            delete sreh;
+        }
+        _resourceEventHandlers->clear();
+        delete _resourceEventHandlers;
+        _resourceEventHandlers = nullptr;
+    }
+
+    if (_failures != nullptr) {
+        for (Failure* failure : *_failures->list()) {
+            if (failure != nullptr) {
+                failure->falingResources()->remove(this);
+            }
+        }
+        _failures->clear();
+        delete _failures;
+        _failures = nullptr;
+    }
+}
+
 std::string Resource::show() {
     return ModelDataDefinition::show() +
             ",capacity=" + Util::StrTruncIfInt(std::to_string(_capacity)) +
@@ -191,7 +213,7 @@ void Resource::_active() {
 //
 
 void Resource::setResourceState(ResourceState _resourceState) {
-    _resourceState = _resourceState;
+    this->_resourceState = _resourceState;
 }
 
 Resource::ResourceState Resource::getResourceState() const {
@@ -210,7 +232,7 @@ unsigned int Resource::getCapacity() const {
 }
 
 void Resource::setCostBusyTimeUnit(double _costBusyTimeUnit) {
-    _costBusyTimeUnit = _costBusyTimeUnit;
+    this->_costBusyTimeUnit = _costBusyTimeUnit;
 }
 
 double Resource::getCostBusyTimeUnit() const {
@@ -218,7 +240,7 @@ double Resource::getCostBusyTimeUnit() const {
 }
 
 void Resource::setCostIdleTimeUnit(double _costIdleTimeUnit) {
-    _costIdleTimeUnit = _costIdleTimeUnit;
+    this->_costIdleTimeUnit = _costIdleTimeUnit;
 }
 
 double Resource::getCostIdleTimeUnit() const {
@@ -226,7 +248,7 @@ double Resource::getCostIdleTimeUnit() const {
 }
 
 void Resource::setCostPerUse(double _costPerUse) {
-    _costPerUse = _costPerUse;
+    this->_costPerUse = _costPerUse;
 }
 
 double Resource::getCostPerUse() const {
@@ -290,7 +312,7 @@ void Resource::removeFailure(Failure* failure) {
 }
 
 void Resource::setCapacitySchedule(Schedule* _capacitySchedule) {
-    _capacitySchedule = _capacitySchedule;
+    this->_capacitySchedule = _capacitySchedule;
 }
 
 Schedule* Resource::getCapacitySchedule() const {
@@ -342,8 +364,25 @@ bool Resource::_loadInstance(PersistenceRecord *fields) {
         _costIdleTimeUnit = fields->loadField("costIdleTimeUnit", DEFAULT.cost);
         _costPerUse = fields->loadField("costPerUse", DEFAULT.cost);
         _resourceState = static_cast<Resource::ResourceState> (fields->loadField("resourceState", static_cast<int> (DEFAULT.resourceState)));
+
+        std::string scheduleName = fields->loadField("capacitySchedule", std::string(""));
+        _capacitySchedule = static_cast<Schedule*> (_parentModel->getDataManager()->getDataDefinition(Util::TypeOf<Schedule>(), scheduleName));
+
+        for (Failure* failure : *_failures->list()) {
+            if (failure != nullptr) {
+                failure->falingResources()->remove(this);
+            }
+        }
+        _failures->clear();
+        unsigned int failuresSize = fields->loadField("failures", 0u);
+        for (unsigned int i = 0; i < failuresSize; i++) {
+            std::string failureName = fields->loadField("failure" + Util::StrIndex(i), std::string(""));
+            Failure* failure = static_cast<Failure*> (_parentModel->getDataManager()->getDataDefinition(Util::TypeOf<Failure>(), failureName));
+            if (failure != nullptr) {
+                insertFailure(failure);
+            }
+        }
     }
-    //@TODO: Save failures
     return res;
 }
 
@@ -354,7 +393,13 @@ void Resource::_saveInstance(PersistenceRecord *fields, bool saveDefaultValues) 
     fields->saveField("costIdleTimeUnit", _costIdleTimeUnit, DEFAULT.cost, saveDefaultValues);
     fields->saveField("costPerUse", _costPerUse, DEFAULT.cost, saveDefaultValues);
     fields->saveField("resourceState", static_cast<int> (_resourceState), static_cast<int> (DEFAULT.resourceState), saveDefaultValues);
-    //@TODO: load failures
+    fields->saveField("capacitySchedule", _capacitySchedule != nullptr ? _capacitySchedule->getName() : std::string(""), std::string(""), saveDefaultValues);
+    fields->saveField("failures", _failures->size(), 0u, saveDefaultValues);
+    unsigned int i = 0;
+    for (Failure* failure : *_failures->list()) {
+        fields->saveField("failure" + Util::StrIndex(i), failure != nullptr ? failure->getName() : std::string(""), std::string(""), saveDefaultValues);
+        i++;
+    }
 }
 
 bool Resource::_check(std::string& errorMessage) {
@@ -369,6 +414,19 @@ bool Resource::_check(std::string& errorMessage) {
     if (_costBusyTimeUnit < 0 || _costIdleTimeUnit < 0 || _costPerUse < 0) {
         errorMessage += "Resource costs must be non-negative. ";
         resultAll = false;
+    }
+    if (_capacitySchedule != nullptr) {
+        bool scheduleOk = _parentModel->getDataManager()->check(Util::TypeOf<Schedule>(), _capacitySchedule, getName() + ".CapacitySchedule", errorMessage);
+        if (scheduleOk) {
+            scheduleOk &= ModelDataDefinition::Check(_capacitySchedule, errorMessage);
+        }
+        resultAll &= scheduleOk;
+    }
+    for (Failure* failure : *_failures->list()) {
+        resultAll &= _parentModel->getDataManager()->check(Util::TypeOf<Failure>(), failure, getName() + ".Failure", errorMessage);
+        if (failure != nullptr) {
+            resultAll &= ModelDataDefinition::Check(failure, errorMessage);
+        }
     }
     return resultAll;
 }
@@ -407,9 +465,42 @@ void Resource::_createInternalAndAttachedData() {
         _parentModel->getOnEventManager()->addOnReplicationEndHandler(this, &Resource::_onReplicationEnd);
     } else if (!_reportStatistics && _cstatTimeSeized != nullptr) {
         _internalDataClear();
+        _cstatTimeSeized = nullptr;
+        _cstatTimeFailed = nullptr;
+        _cstatProportionSeized = nullptr;
+        _cstatCapacityUtilization = nullptr;
+        _counterTotalTimeSeized = nullptr;
+        _counterTotalTimeFailed = nullptr;
+        _counterNumSeizes = nullptr;
+        _counterNumReleases = nullptr;
+        _counterTotalCostPerUse = nullptr;
+        _counterTotalCostBusy = nullptr;
+        _counterTotalCostIdle = nullptr;
     }
+
+    const std::string scheduleKey = getName() + ".CapacitySchedule";
+    if (_capacitySchedule != nullptr) {
+        _attachedDataInsert(scheduleKey, _capacitySchedule);
+    } else {
+        _attachedDataRemove(scheduleKey);
+    }
+
+    std::map<std::string, ModelDataDefinition*>* attachedData = getAttachedData();
+    std::list<std::string> staleFailureKeys;
+    const std::string failurePrefix = getName() + ".Failure.";
+    for (const auto& pair : *attachedData) {
+        if (pair.first.rfind(failurePrefix, 0) == 0) {
+            staleFailureKeys.push_back(pair.first);
+        }
+    }
+    for (const std::string& key : staleFailureKeys) {
+        _attachedDataRemove(key);
+    }
+
     for (Failure* failure : *_failures->list()) {
-        _attachedDataInsert(getName() + "." + failure->getName(), failure);
+        if (failure != nullptr) {
+            _attachedDataInsert(failurePrefix + failure->getName(), failure);
+        }
     }
 }
 

--- a/source/plugins/data/Resource.h
+++ b/source/plugins/data/Resource.h
@@ -104,7 +104,7 @@ public:
 public:
 	//Resource(Model* model);
 	Resource(Model* model, std::string name = "");
-	virtual ~Resource() = default;
+	virtual ~Resource() override;
 public:
 	virtual std::string show() override;
 public: // static
@@ -151,6 +151,7 @@ private: //methods
 	void _active();
 	void _checkFailByCount();
 	friend class Failure;
+	friend class ResourceTestProbe;
 
 private:
 
@@ -188,14 +189,13 @@ private: // internal elements
 	StatisticsCollector* _cstatTimeFailed = nullptr;
 	StatisticsCollector* _cstatProportionSeized = nullptr;
 	StatisticsCollector* _cstatCapacityUtilization = nullptr;
-	Counter* _counterTotalTimeSeized;
-	Counter* _counterTotalTimeFailed;
-	Counter* _counterNumSeizes;
-	Counter* _counterNumReleases;
-	Counter* _counterTotalCostPerUse;
-	Counter* _counterTotalCostBusy;
-	Counter* _counterTotalCostIdle;
+	Counter* _counterTotalTimeSeized = nullptr;
+	Counter* _counterTotalTimeFailed = nullptr;
+	Counter* _counterNumSeizes = nullptr;
+	Counter* _counterNumReleases = nullptr;
+	Counter* _counterTotalCostPerUse = nullptr;
+	Counter* _counterTotalCostBusy = nullptr;
+	Counter* _counterTotalCostIdle = nullptr;
 };
 
 #endif /* RESOURCE_H */
-

--- a/source/tests/unit/test_simulator_runtime.cpp
+++ b/source/tests/unit/test_simulator_runtime.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include <algorithm>
+#include <memory>
 
 #include "kernel/simulator/Simulator.h"
 #include "kernel/simulator/Model.h"
@@ -11,6 +12,26 @@
 #include "kernel/simulator/Persistence.h"
 #include "plugins/data/Queue.h"
 #include "plugins/data/Variable.h"
+#include "plugins/data/Resource.h"
+#include "plugins/data/Failure.h"
+#include "plugins/data/Schedule.h"
+
+class ResourceTestProbe {
+public:
+    static bool HasStatisticsInternals(const Resource& resource) {
+        return resource._cstatTimeSeized != nullptr &&
+               resource._cstatTimeFailed != nullptr &&
+               resource._cstatProportionSeized != nullptr &&
+               resource._cstatCapacityUtilization != nullptr &&
+               resource._counterTotalTimeSeized != nullptr &&
+               resource._counterTotalTimeFailed != nullptr &&
+               resource._counterNumSeizes != nullptr &&
+               resource._counterNumReleases != nullptr &&
+               resource._counterTotalCostPerUse != nullptr &&
+               resource._counterTotalCostBusy != nullptr &&
+               resource._counterTotalCostIdle != nullptr;
+    }
+};
 
 namespace {
 struct SimulationStartObserver {
@@ -126,6 +147,27 @@ public:
 
     void InitBetweenReplicationsProbe() {
         _initBetweenReplications();
+    }
+
+    void SaveInstanceProbe(PersistenceRecord* fields, bool saveDefaultValues = false) {
+        _saveInstance(fields, saveDefaultValues);
+    }
+
+    bool LoadInstanceProbe(PersistenceRecord* fields) {
+        return _loadInstance(fields);
+    }
+};
+
+class ResourceProbe : public Resource {
+public:
+    ResourceProbe(Model* model, const std::string& name = "") : Resource(model, name) {}
+
+    bool CheckProbe(std::string& errorMessage) {
+        return _check(errorMessage);
+    }
+
+    void CreateInternalAndAttachedDataProbe() {
+        _createInternalAndAttachedData();
     }
 
     void SaveInstanceProbe(PersistenceRecord* fields, bool saveDefaultValues = false) {
@@ -939,4 +981,204 @@ TEST(SimulatorRuntimeTest, VariableShowIncludesVariableSpecificValues) {
     const std::string shown = variable.show();
     EXPECT_NE(shown.find("values:{"), std::string::npos);
     EXPECT_NE(shown.find("pi="), std::string::npos);
+}
+
+TEST(SimulatorRuntimeTest, ResourceSettersUpdateState) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    ResourceProbe resource(model, "ResourceSetterCheck");
+    Schedule schedule(model, "ResourceSetterSchedule");
+
+    resource.setResourceState(Resource::ResourceState::FAILED);
+    resource.setCostBusyTimeUnit(11.25);
+    resource.setCostIdleTimeUnit(7.5);
+    resource.setCostPerUse(3.5);
+    resource.setCapacitySchedule(&schedule);
+
+    EXPECT_EQ(resource.getResourceState(), Resource::ResourceState::FAILED);
+    EXPECT_DOUBLE_EQ(resource.getCostBusyTimeUnit(), 11.25);
+    EXPECT_DOUBLE_EQ(resource.getCostIdleTimeUnit(), 7.5);
+    EXPECT_DOUBLE_EQ(resource.getCostPerUse(), 3.5);
+    EXPECT_EQ(resource.getCapacitySchedule(), &schedule);
+}
+
+TEST(SimulatorRuntimeTest, ResourceCheckFailsForInvalidConfiguration) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    ResourceProbe capacityZero(model, "ResourceCheckCapacityZero");
+    capacityZero.setCapacity(0u);
+    std::string errorMessage;
+    EXPECT_FALSE(capacityZero.CheckProbe(errorMessage));
+
+    ResourceProbe negativeCost(model, "ResourceCheckNegativeCost");
+    negativeCost.setCostPerUse(-1.0);
+    errorMessage.clear();
+    EXPECT_FALSE(negativeCost.CheckProbe(errorMessage));
+
+    Schedule invalidSchedule(model, "ResourceCheckInvalidSchedule");
+    ResourceProbe invalidScheduleResource(model, "ResourceCheckWithInvalidSchedule");
+    invalidScheduleResource.setCapacitySchedule(&invalidSchedule);
+    errorMessage.clear();
+    EXPECT_FALSE(invalidScheduleResource.CheckProbe(errorMessage));
+
+    Failure invalidFailure(model, "ResourceCheckInvalidFailure");
+    invalidFailure.setFailureType(Failure::FailureType::COUNT);
+    invalidFailure.setCountExpression(")");
+    ResourceProbe invalidFailureResource(model, "ResourceCheckWithInvalidFailure");
+    invalidFailureResource.insertFailure(&invalidFailure);
+    errorMessage.clear();
+    EXPECT_FALSE(invalidFailureResource.CheckProbe(errorMessage));
+}
+
+TEST(SimulatorRuntimeTest, ResourceCheckPassesForValidConfiguration) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    Schedule schedule(model, "ResourceCheckValidSchedule");
+    schedule.getSchedulableItems()->insert(new SchedulableItem("2", 10.0));
+
+    Failure failure(model, "ResourceCheckValidFailure");
+    failure.setFailureType(Failure::FailureType::COUNT);
+    failure.setCountExpression("3");
+    failure.setDownTimeExpression("1");
+
+    ResourceProbe resource(model, "ResourceCheckValid");
+    resource.setCapacity(2u);
+    resource.setCostBusyTimeUnit(1.0);
+    resource.setCostIdleTimeUnit(0.0);
+    resource.setCostPerUse(0.5);
+    resource.setCapacitySchedule(&schedule);
+    resource.insertFailure(&failure);
+
+    std::string errorMessage;
+    EXPECT_TRUE(resource.CheckProbe(errorMessage));
+    EXPECT_TRUE(errorMessage.empty());
+}
+
+TEST(SimulatorRuntimeTest, ResourceSaveAndLoadPreservesCapacityScheduleReference) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    Schedule schedule(model, "ResourcePersistSchedule");
+    ResourceProbe source(model, "ResourcePersistScheduleSource");
+    source.setCapacitySchedule(&schedule);
+
+    FakeModelPersistenceRuntime persistence;
+    PersistenceRecord fields(persistence);
+    source.SaveInstanceProbe(&fields, true);
+
+    ResourceProbe loaded(model, "ResourcePersistScheduleLoaded");
+    ASSERT_TRUE(loaded.LoadInstanceProbe(&fields));
+
+    EXPECT_EQ(loaded.getCapacitySchedule(), &schedule);
+}
+
+TEST(SimulatorRuntimeTest, ResourceSaveAndLoadPreservesFailuresReferenceList) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    Failure failureA(model, "ResourcePersistFailureA");
+    Failure failureB(model, "ResourcePersistFailureB");
+    ResourceProbe source(model, "ResourcePersistFailureSource");
+    source.insertFailure(&failureA);
+    source.insertFailure(&failureB);
+
+    FakeModelPersistenceRuntime persistence;
+    PersistenceRecord fields(persistence);
+    source.SaveInstanceProbe(&fields, true);
+
+    ResourceProbe loaded(model, "ResourcePersistFailureLoaded");
+    ASSERT_TRUE(loaded.LoadInstanceProbe(&fields));
+    loaded.CreateInternalAndAttachedDataProbe();
+
+    auto* attached = loaded.getAttachedData();
+    const std::string keyPrefix = loaded.getName() + ".Failure.";
+    ASSERT_EQ(attached->count(keyPrefix + "ResourcePersistFailureA"), 1u);
+    ASSERT_EQ(attached->count(keyPrefix + "ResourcePersistFailureB"), 1u);
+    EXPECT_EQ(attached->at(keyPrefix + "ResourcePersistFailureA"), &failureA);
+    EXPECT_EQ(attached->at(keyPrefix + "ResourcePersistFailureB"), &failureB);
+}
+
+TEST(SimulatorRuntimeTest, ResourceRecheckKeepsAttachedDataConsistent) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    Schedule scheduleA(model, "ResourceRecheckScheduleA");
+    Schedule scheduleB(model, "ResourceRecheckScheduleB");
+    Failure failureA(model, "ResourceRecheckFailureA");
+    Failure failureB(model, "ResourceRecheckFailureB");
+
+    ResourceProbe resource(model, "ResourceRecheckAttached");
+    resource.setCapacitySchedule(&scheduleA);
+    resource.insertFailure(&failureA);
+    resource.CreateInternalAndAttachedDataProbe();
+
+    auto* attached = resource.getAttachedData();
+    ASSERT_EQ(attached->at("ResourceRecheckAttached.CapacitySchedule"), &scheduleA);
+    ASSERT_EQ(attached->at("ResourceRecheckAttached.Failure.ResourceRecheckFailureA"), &failureA);
+
+    resource.removeFailure(&failureA);
+    resource.insertFailure(&failureB);
+    resource.setCapacitySchedule(&scheduleB);
+    resource.CreateInternalAndAttachedDataProbe();
+
+    EXPECT_EQ(attached->at("ResourceRecheckAttached.CapacitySchedule"), &scheduleB);
+    EXPECT_EQ(attached->at("ResourceRecheckAttached.Failure.ResourceRecheckFailureB"), &failureB);
+    EXPECT_EQ(attached->count("ResourceRecheckAttached.Failure.ResourceRecheckFailureA"), 0u);
+
+    resource.setCapacitySchedule(nullptr);
+    resource.removeFailure(&failureB);
+    resource.CreateInternalAndAttachedDataProbe();
+
+    EXPECT_EQ(attached->count("ResourceRecheckAttached.CapacitySchedule"), 0u);
+    EXPECT_EQ(attached->count("ResourceRecheckAttached.Failure.ResourceRecheckFailureB"), 0u);
+}
+
+TEST(SimulatorRuntimeTest, ResourceToggleReportStatisticsClearsAndRecreatesInternalPointersSafely) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    ResourceProbe resource(model, "ResourceToggleStats");
+    resource.setReportStatistics(true);
+    resource.CreateInternalAndAttachedDataProbe();
+    EXPECT_TRUE(ResourceTestProbe::HasStatisticsInternals(resource));
+
+    resource.setReportStatistics(false);
+    resource.CreateInternalAndAttachedDataProbe();
+    EXPECT_FALSE(ResourceTestProbe::HasStatisticsInternals(resource));
+
+    resource.setReportStatistics(true);
+    resource.CreateInternalAndAttachedDataProbe();
+    EXPECT_TRUE(ResourceTestProbe::HasStatisticsInternals(resource));
+}
+
+TEST(SimulatorRuntimeTest, ResourceDestructorCleansOwnedHandlersContainers) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    std::weak_ptr<int> weakCapture;
+    {
+        auto* resource = new ResourceProbe(model, "ResourceDestructorLifecycle");
+        auto capture = std::make_shared<int>(42);
+        weakCapture = capture;
+
+        Resource::ResourceEventHandler handler = [capture](Resource*) {
+            (void)capture;
+        };
+        resource->addReleaseResourceEventHandler(handler, nullptr, 1u);
+        ASSERT_FALSE(weakCapture.expired());
+        delete resource;
+    }
+
+    EXPECT_TRUE(weakCapture.expired());
 }


### PR DESCRIPTION
PLUGINS

### Motivation
- Close multiple correctness and lifecycle bugs in `Resource` that break rechecks, persistence and ownership, and cause dangling pointers when toggling statistics. 
- Ensure attached-data semantics used by `checkOrphaned()` remain coherent after repeated `Model::check()` calls. 
- Provide unit-test coverage validating setters, persistence, recheck idempotence, statistics toggling and destructor behavior.

### Description
- Fixed broken setters so they correctly mutate instance state for `setResourceState`, `setCostBusyTimeUnit`, `setCostIdleTimeUnit`, `setCostPerUse`, and `setCapacitySchedule`.
- Added an explicit `Resource` destructor that deletes owned `SortedResourceEventHandler*` entries, deletes the `_resourceEventHandlers` list, detaches this resource from each `Failure` back-reference and deletes the `_failures` list without deleting `Failure*` objects.
- Implemented persistence for `_capacitySchedule` and `_failures`: `save` writes schedule name and failures list; `load` rebinds schedule and failure references using `ModelDataManager` and reinstates back-references.
- Made `_createInternalAndAttachedData()` idempotent for repeated checks by attaching/removing the schedule attachment, attaching all current failures, and removing stale failure attached-data keys; also nulls internal-statistics pointers after `_internalDataClear()` when statistics are disabled.
- Hardened `_check()` to validate: capacity > 0, non-negative costs, configured `_capacitySchedule` exists and passes its own check, and each configured `Failure*` exists and passes its own check.
- Initialized internal counter pointers to `nullptr` in the header and added a small friend/test probe to inspect internal pointer state for unit tests.
- Added unit-test probes and eight tests in `source/tests/unit/test_simulator_runtime.cpp` covering setters, invalid/valid `_check()`, schedule and failures persistence, attached-data idempotence on recheck, statistics toggle pointer clearing/recreation, and destructor lifecycle for owned handler containers.

### Testing
- Ran configuration and build with tests/plugins enabled using `cmake` and `cmake --build`, and built `genesys_test_simulator_runtime` successfully.
- Executed targeted tests with `ctest --test-dir build -R "SimulatorRuntimeTest.*Resource" --output-on-failure` and all Resource-focused tests passed (8/8 passed).
- Ran broader `ctest --test-dir build -LE smoke --output-on-failure`; several unrelated tests are reported as `*_NOT_BUILT` in this environment but Resource-focused tests remain green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8759534b883219cfc70edcbe60e32)