### PR TITLE
Fix index calculations for quartile/decile/percentile in StatisticsDataFileDefaultImpl

### DIFF
--- a/source/kernel/statistics/StatisticsDataFileDefaultImpl.cpp
+++ b/source/kernel/statistics/StatisticsDataFileDefaultImpl.cpp
@@ -260,13 +260,14 @@ double StatisticsDatafileDefaultImpl1::quartil(unsigned short num) {
 		else {
 			if (!_fileSorted) _sortFile();
 
-			valueType quartil, tmpValue, tmpValue2;
-
-			unsigned long position = floor(num * _collectorSorted->numElements() / 4) - 1;
-			tmpValue = _collectorSorted->getValue(position);
-			//tmpValue2 = _collectorSorted->getValue(position + 1);
-
-			_quartil = tmpValue; //(tmpValue + tmpValue2) / 2;
+			// Compute quartile rank with floating-point arithmetic and clamp to valid zero-based index.
+			const unsigned long sampleSize = _collectorSorted->numElements();
+			const double rawRank = floor((static_cast<double>(num) * sampleSize) / 4.0);
+			unsigned long position = (rawRank <= 1.0) ? 0 : static_cast<unsigned long>(rawRank - 1.0);
+			if (position >= sampleSize) {
+				position = sampleSize - 1;
+			}
+			_quartil = _collectorSorted->getValue(position);
 			_quartilCalculated = true;
 			_lastQuartilNum = num;
 		}
@@ -279,7 +280,13 @@ double StatisticsDatafileDefaultImpl1::decil(unsigned short num) {
 		if (num == 5) _decil = mediane();
 		else {
 			if (!_fileSorted) _sortFile();
-			unsigned long position = ceil(num * _collectorSorted->numElements() / 10);
+			// Use nearest-rank index converted to zero-based and clamp to avoid out-of-range access.
+			const unsigned long sampleSize = _collectorSorted->numElements();
+			const double rawRank = ceil((static_cast<double>(num) * sampleSize) / 10.0);
+			unsigned long position = (rawRank <= 1.0) ? 0 : static_cast<unsigned long>(rawRank - 1.0);
+			if (position >= sampleSize) {
+				position = sampleSize - 1;
+			}
 			_decil = _collectorSorted->getValue(position);
 			_decilCalculated = true;
 			_lastDecilNum = num;
@@ -293,7 +300,13 @@ double StatisticsDatafileDefaultImpl1::centil(unsigned short num) {
 		if (num == 50) _centil = mediane();
 		else {
 			if (!_fileSorted) _sortFile();
-			unsigned long position = ceil(num * _collectorSorted->numElements() / 100);
+			// Use nearest-rank index converted to zero-based and clamp to avoid out-of-range access.
+			const unsigned long sampleSize = _collectorSorted->numElements();
+			const double rawRank = ceil((static_cast<double>(num) * sampleSize) / 100.0);
+			unsigned long position = (rawRank <= 1.0) ? 0 : static_cast<unsigned long>(rawRank - 1.0);
+			if (position >= sampleSize) {
+				position = sampleSize - 1;
+			}
 			_centil = _collectorSorted->getValue(position);
 			_centilCalculated = true;
 			_lastCentilNum = num;


### PR DESCRIPTION
### Motivation
- Correct local index/rank inconsistencies in order-statistics methods that risk out-of-range `getValue(position)` access and incorrect ranks for small samples.
- Preserve the class convention of zero-based `getValue(position)` access and avoid integer-division before `ceil`/`floor`.

### Description
- Adjusted `quartil(unsigned short)`, `decil(unsigned short)`, and `centil(unsigned short)` to compute ranks using floating-point arithmetic, convert nearest-rank to zero-based indices (`rank-1`), and clamp indices to `[0, n-1]` before calling `getValue(position)`.
- Kept `mediane()` logic unchanged and did not modify histogram methods except for ensuring no collateral changes.
- Added short technical English comments immediately above each altered block explaining the purpose of the change.
- Changes are limited to `source/kernel/statistics/StatisticsDataFileDefaultImpl.cpp` and preserve the public API.

### Testing
- Configured build with `cmake --preset debug-kernel` and built the kernel with `cmake --build build/debug-kernel --target genesys_kernel -j4`.
- Build completed successfully; no automated tests were run (per instructions).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d87a9e71148321aecb97eff75b9f9c)