### PR TITLE
Fix Sequence: ownership, persistence namespacing, attached-data recheck and validation

### DIFF
--- a/source/plugins/data/Sequence.cpp
+++ b/source/plugins/data/Sequence.cpp
@@ -30,8 +30,20 @@ ModelDataDefinition* Sequence::NewInstance(Model* model, std::string name) {
 Sequence::Sequence(Model* model, std::string name) : ModelDataDefinition(model, Util::TypeOf<Sequence>(), name) {
 }
 
+Sequence::~Sequence() {
+	if (_steps != nullptr) {
+		for (SequenceStep* step : *_steps->list()) {
+			delete step;
+		}
+		_steps->clear();
+		delete _steps;
+		_steps = nullptr;
+	}
+}
+
 std::string Sequence::show() {
 	std::string msg = ModelDataDefinition::show();
+	msg += ",steps=" + std::to_string(_steps != nullptr ? _steps->size() : 0u);
 	return msg;
 }
 
@@ -82,15 +94,81 @@ void Sequence::_saveInstance(PersistenceRecord *fields, bool saveDefaultValues) 
 }
 
 bool Sequence::_check(std::string& errorMessage) {
-	_attachedAttributesInsert({"Entity.Sequence", "Entity.SequenceStep"});
-	int i = 0;
+	bool resultAll = true;
+	unsigned int i = 0;
 	for (SequenceStep* step : *_steps->list()) {
-		_attachedDataInsert("StepStation" + Util::StrIndex(i), step->getStation());
-		_attachedDataInsert("StepLabel" + Util::StrIndex(i), step->getLabel());
+		const std::string stepPrefix = getName() + ".Step" + Util::StrIndex(i);
+		if (step == nullptr) {
+			errorMessage += stepPrefix + " is null. ";
+			resultAll = false;
+			i++;
+			continue;
+		}
+		Station* station = step->getStation();
+		Label* label = step->getLabel();
+		const bool hasStation = station != nullptr;
+		const bool hasLabel = label != nullptr;
+		if (!hasStation && !hasLabel) {
+			errorMessage += stepPrefix + " must reference a Station or a Label. ";
+			resultAll = false;
+		}
+		if (hasStation && hasLabel) {
+			errorMessage += stepPrefix + " cannot reference both Station and Label simultaneously. ";
+			resultAll = false;
+		}
+		if (hasStation) {
+			bool stationOk = _parentModel->getDataManager()->check(Util::TypeOf<Station>(), station, stepPrefix + ".Station", errorMessage);
+			if (stationOk) {
+				stationOk &= ModelDataDefinition::Check(station, errorMessage);
+			}
+			resultAll &= stationOk;
+		}
+		if (hasLabel) {
+			bool labelOk = _parentModel->getDataManager()->check(Util::TypeOf<Label>(), label, stepPrefix + ".Label", errorMessage);
+			if (labelOk) {
+				labelOk &= ModelDataDefinition::Check(label, errorMessage);
+			}
+			resultAll &= labelOk;
+		}
+
+		unsigned int assignmentIndex = 0;
+		for (Assignment* assignment : *step->getAssignments()) {
+			if (assignment == nullptr) {
+				errorMessage += stepPrefix + ".Assignment" + Util::StrIndex(assignmentIndex) + " is null. ";
+				resultAll = false;
+			} else if (assignment->getDestination().empty()) {
+				errorMessage += stepPrefix + ".Assignment" + Util::StrIndex(assignmentIndex) + " destination cannot be empty. ";
+				resultAll = false;
+			}
+			assignmentIndex++;
+		}
 		i++;
 	}
-	errorMessage += "";
-	return true;
+	return resultAll;
+}
+
+void Sequence::_createInternalAndAttachedData() {
+	_attachedAttributesInsert({"Entity.Sequence", "Entity.SequenceStep"});
+
+	std::map<std::string, ModelDataDefinition*>* attachedData = getAttachedData();
+	std::list<std::string> staleStepKeys;
+	for (const auto& pair : *attachedData) {
+		if (pair.first.rfind("StepStation", 0) == 0 || pair.first.rfind("StepLabel", 0) == 0) {
+			staleStepKeys.push_back(pair.first);
+		}
+	}
+	for (const std::string& key : staleStepKeys) {
+		_attachedDataRemove(key);
+	}
+
+	unsigned int i = 0;
+	for (SequenceStep* step : *_steps->list()) {
+		if (step != nullptr) {
+			_attachedDataInsert("StepStation" + Util::StrIndex(i), step->getStation());
+			_attachedDataInsert("StepLabel" + Util::StrIndex(i), step->getLabel());
+		}
+		i++;
+	}
 }
 
 SequenceStep::SequenceStep(Station* station, std::list<Assignment*>* assignments) {
@@ -136,6 +214,17 @@ SequenceStep::SequenceStep(Model* model, std::string stationOrLabelName, bool is
 		_assignments = new std::list<Assignment*>();
 }
 
+SequenceStep::~SequenceStep() {
+	if (_assignments != nullptr) {
+		for (Assignment* assignment : *_assignments) {
+			delete assignment;
+		}
+		_assignments->clear();
+		delete _assignments;
+		_assignments = nullptr;
+	}
+}
+
 bool SequenceStep::_loadInstance(PersistenceRecord *fields, unsigned int parentIndex) {
 	bool res = true;
 	std::string num = Util::StrIndex(parentIndex);
@@ -152,7 +241,10 @@ bool SequenceStep::_loadInstance(PersistenceRecord *fields, unsigned int parentI
 		unsigned int assignmentsSize = fields->loadField("stepAssignments" + num, DEFAULT.assignmentsSize);
 		for (unsigned short i = 0; i < assignmentsSize; i++) {
 			Assignment* assm = new Assignment("", "");
-			assm->loadInstance(fields, i);
+			const std::string assignmentIndex = num + "_" + Util::StrIndex(i);
+			assm->setDestination(fields->loadField("assignDest" + assignmentIndex, ""));
+			assm->setExpression(fields->loadField("assignExpr" + assignmentIndex, ""));
+			assm->setAttributeNotVariable(fields->loadField("assignIsAttrib" + assignmentIndex, true));
 			_assignments->insert(_assignments->end(), assm);
 		}
 	} catch (...) {
@@ -172,7 +264,10 @@ void SequenceStep::_saveInstance(PersistenceRecord *fields, unsigned int parentI
 	fields->saveField("stepAssignments" + num, _assignments->size(), DEFAULT.assignmentsSize);
 	unsigned short i = 0;
 	for (Assignment* assm : *_assignments) {
-		assm->saveInstance(fields, i, saveDefaultValues);
+		const std::string assignmentIndex = num + "_" + Util::StrIndex(i);
+		fields->saveField("assignDest" + assignmentIndex, assm != nullptr ? assm->getDestination() : std::string(""), std::string(""), saveDefaultValues);
+		fields->saveField("assignExpr" + assignmentIndex, assm != nullptr ? assm->getExpression() : std::string(""), std::string(""), saveDefaultValues);
+		fields->saveField("assignIsAttrib" + assignmentIndex, assm != nullptr ? assm->isAttributeNotVariable() : true, true, saveDefaultValues);
 		i++;
 	}
 }

--- a/source/plugins/data/Sequence.h
+++ b/source/plugins/data/Sequence.h
@@ -26,6 +26,7 @@ public:
 	SequenceStep(Station* station, std::list<Assignment*>* assignments = nullptr);
 	SequenceStep(Label* label, std::list<Assignment*>* assignments = nullptr);
 	SequenceStep(Model* model, std::string stationOrLabelName, bool isStation = true, std::list<Assignment*>* assignments = nullptr);
+	virtual ~SequenceStep() override;
 public: // virtual
 
 	virtual bool _loadInstance(PersistenceRecord *fields, unsigned int parentIndex);
@@ -84,7 +85,7 @@ public:
 
 public:
 	Sequence(Model* model, std::string name = "");
-	virtual ~Sequence() = default;
+	virtual ~Sequence() override;
 public:
 	virtual std::string show() override;
 public: // static 
@@ -97,6 +98,7 @@ protected:
 	virtual bool _loadInstance(PersistenceRecord *fields) override;
 	virtual void _saveInstance(PersistenceRecord *fields, bool saveDefaultValues) override;
 	virtual bool _check(std::string& errorMessage) override;
+	virtual void _createInternalAndAttachedData() override;
 private:
 	List<SequenceStep*>* _steps = new List<SequenceStep*>();
 };

--- a/source/tests/unit/test_simulator_runtime.cpp
+++ b/source/tests/unit/test_simulator_runtime.cpp
@@ -15,6 +15,7 @@
 #include "plugins/data/Resource.h"
 #include "plugins/data/Failure.h"
 #include "plugins/data/Schedule.h"
+#include "plugins/data/Sequence.h"
 
 class ResourceTestProbe {
 public:
@@ -72,6 +73,7 @@ public:
 static unsigned int g_countingControlProbeDestructorCount = 0;
 static unsigned int g_countingChildProbeDestructorCount = 0;
 static unsigned int g_countingWaitingProbeDestructorCount = 0;
+static unsigned int g_countingSequenceStepProbeDestructorCount = 0;
 
 // Tracks owned-property deletion through ModelDataDefinition teardown.
 class CountingSimulationControlProbe : public SimulationControl {
@@ -176,6 +178,41 @@ public:
 
     bool LoadInstanceProbe(PersistenceRecord* fields) {
         return _loadInstance(fields);
+    }
+};
+
+class SequenceProbe : public Sequence {
+public:
+    SequenceProbe(Model* model, const std::string& name = "") : Sequence(model, name) {}
+
+    bool CheckProbe(std::string& errorMessage) {
+        return _check(errorMessage);
+    }
+
+    void CreateInternalAndAttachedDataProbe() {
+        _createInternalAndAttachedData();
+    }
+
+    void SaveInstanceProbe(PersistenceRecord* fields, bool saveDefaultValues = false) {
+        _saveInstance(fields, saveDefaultValues);
+    }
+
+    bool LoadInstanceProbe(PersistenceRecord* fields) {
+        return _loadInstance(fields);
+    }
+
+    void AttachDataProbe(const std::string& key, ModelDataDefinition* data) {
+        _attachedDataInsert(key, data);
+    }
+};
+
+class CountingSequenceStepProbe : public SequenceStep {
+public:
+    CountingSequenceStepProbe(Station* station, std::list<Assignment*>* assignments = nullptr)
+        : SequenceStep(station, assignments) {}
+
+    ~CountingSequenceStepProbe() override {
+        ++g_countingSequenceStepProbeDestructorCount;
     }
 };
 
@@ -1181,4 +1218,159 @@ TEST(SimulatorRuntimeTest, ResourceDestructorCleansOwnedHandlersContainers) {
     }
 
     EXPECT_TRUE(weakCapture.expired());
+}
+
+TEST(SimulatorRuntimeTest, SequenceDestructorDeletesOwnedSteps) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    g_countingSequenceStepProbeDestructorCount = 0;
+    Station station(model, "SequenceLifecycleStation");
+    auto* sequence = new SequenceProbe(model, "SequenceLifecycle");
+    sequence->getSteps()->insert(new CountingSequenceStepProbe(&station));
+    sequence->getSteps()->insert(new CountingSequenceStepProbe(&station));
+
+    delete sequence;
+    EXPECT_EQ(g_countingSequenceStepProbeDestructorCount, 2u);
+}
+
+TEST(SimulatorRuntimeTest, SequenceStepDestructorOwnsAndDeletesAssignments) {
+    std::list<Assignment*>* assignments = new std::list<Assignment*>();
+    assignments->push_back(new Assignment("Entity.a", "1", true));
+    assignments->push_back(new Assignment("Entity.b", "2", true));
+    SequenceStep* step = new SequenceStep(static_cast<Station*>(nullptr), assignments);
+
+    delete step;
+    SUCCEED();
+}
+
+TEST(SimulatorRuntimeTest, SequenceSaveAndLoadPreservesAssignmentsPerStepWithoutCollision) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    Station stationA(model, "SequencePersistStationA");
+    Station stationB(model, "SequencePersistStationB");
+    SequenceProbe source(model, "SequencePersistAssignmentsSource");
+    auto* stepA = new SequenceStep(&stationA);
+    stepA->getAssignments()->push_back(new Assignment("Entity.stepA", "11", true));
+    stepA->getAssignments()->push_back(new Assignment("Entity.stepA2", "12", true));
+    auto* stepB = new SequenceStep(&stationB);
+    stepB->getAssignments()->push_back(new Assignment("Entity.stepB", "21", true));
+    source.getSteps()->insert(stepA);
+    source.getSteps()->insert(stepB);
+
+    FakeModelPersistenceRuntime persistence;
+    PersistenceRecord fields(persistence);
+    source.SaveInstanceProbe(&fields, true);
+
+    SequenceProbe loaded(model, "SequencePersistAssignmentsLoaded");
+    ASSERT_TRUE(loaded.LoadInstanceProbe(&fields));
+    ASSERT_EQ(loaded.getSteps()->size(), 2u);
+
+    auto loadedSteps = loaded.getSteps()->list();
+    auto it = loadedSteps->begin();
+    SequenceStep* loadedStepA = *it++;
+    SequenceStep* loadedStepB = *it++;
+
+    ASSERT_EQ(loadedStepA->getAssignments()->size(), 2u);
+    ASSERT_EQ(loadedStepB->getAssignments()->size(), 1u);
+    EXPECT_EQ(loadedStepA->getAssignments()->front()->getDestination(), "Entity.stepA");
+    EXPECT_EQ(loadedStepA->getAssignments()->back()->getDestination(), "Entity.stepA2");
+    EXPECT_EQ(loadedStepB->getAssignments()->front()->getDestination(), "Entity.stepB");
+    EXPECT_EQ(loadedStepB->getAssignments()->front()->getExpression(), "21");
+}
+
+TEST(SimulatorRuntimeTest, SequenceSaveAndLoadPreservesStationAndLabelPerStep) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    Station station(model, "SequencePersistStation");
+    Label label(model, "SequencePersistLabel");
+    SequenceProbe source(model, "SequencePersistRoutingSource");
+    source.getSteps()->insert(new SequenceStep(&station));
+    source.getSteps()->insert(new SequenceStep(&label));
+
+    FakeModelPersistenceRuntime persistence;
+    PersistenceRecord fields(persistence);
+    source.SaveInstanceProbe(&fields, true);
+
+    SequenceProbe loaded(model, "SequencePersistRoutingLoaded");
+    ASSERT_TRUE(loaded.LoadInstanceProbe(&fields));
+    ASSERT_EQ(loaded.getSteps()->size(), 2u);
+
+    auto steps = loaded.getSteps()->list();
+    auto it = steps->begin();
+    SequenceStep* loadedStationStep = *it++;
+    SequenceStep* loadedLabelStep = *it++;
+    EXPECT_EQ(loadedStationStep->getStation(), &station);
+    EXPECT_EQ(loadedStationStep->getLabel(), nullptr);
+    EXPECT_EQ(loadedLabelStep->getStation(), nullptr);
+    EXPECT_EQ(loadedLabelStep->getLabel(), &label);
+}
+
+TEST(SimulatorRuntimeTest, SequenceRecheckRemovesObsoleteAttachedData) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    Station stationA(model, "SequenceRecheckStationA");
+    Station stationB(model, "SequenceRecheckStationB");
+    Label labelA(model, "SequenceRecheckLabelA");
+    SequenceProbe sequence(model, "SequenceRecheck");
+    sequence.getSteps()->insert(new SequenceStep(&stationA));
+    sequence.getSteps()->insert(new SequenceStep(&stationB));
+    sequence.CreateInternalAndAttachedDataProbe();
+
+    auto* attached = sequence.getAttachedData();
+    EXPECT_EQ(attached->count("StepLabel[0]"), 0u);
+    sequence.AttachDataProbe("StepStation[77]", &stationA);
+    ASSERT_EQ(attached->count("StepStation[77]"), 1u);
+
+    SequenceStep* obsoleteStep = sequence.getSteps()->list()->back();
+    sequence.getSteps()->remove(obsoleteStep);
+    delete obsoleteStep;
+    SequenceStep* firstStationStep = sequence.getSteps()->front();
+    sequence.getSteps()->remove(firstStationStep);
+    delete firstStationStep;
+    sequence.getSteps()->insert(new SequenceStep(&labelA));
+    sequence.CreateInternalAndAttachedDataProbe();
+
+    EXPECT_EQ(attached->count("StepStation[77]"), 0u);
+    EXPECT_EQ(attached->count("StepStation[1]"), 0u);
+    ASSERT_EQ(attached->count("StepLabel[0]"), 1u);
+    EXPECT_EQ(attached->at("StepLabel[0]"), &labelA);
+}
+
+TEST(SimulatorRuntimeTest, SequenceCheckFailsForEmptyStep) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    SequenceProbe sequence(model, "SequenceInvalid");
+    sequence.getSteps()->insert(new SequenceStep(static_cast<Station*>(nullptr)));
+
+    std::string errorMessage;
+    EXPECT_FALSE(sequence.CheckProbe(errorMessage));
+    EXPECT_NE(errorMessage.find("must reference a Station or a Label"), std::string::npos);
+}
+
+TEST(SimulatorRuntimeTest, SequenceCheckPassesForValidSteps) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    Station station(model, "SequenceValidStation");
+    SequenceProbe sequence(model, "SequenceValid");
+    auto* stationStep = new SequenceStep(&station);
+    stationStep->getAssignments()->push_back(new Assignment("Entity.valid", "1", true));
+    sequence.getSteps()->insert(stationStep);
+    Station station2(model, "SequenceValidStation2");
+    sequence.getSteps()->insert(new SequenceStep(&station2));
+
+    std::string errorMessage;
+    EXPECT_TRUE(sequence.CheckProbe(errorMessage));
+    EXPECT_TRUE(errorMessage.empty());
 }


### PR DESCRIPTION
PLUGINS

### Motivation
- Eliminate memory leaks and ownership issues in `Sequence`/`SequenceStep` by ensuring owned children are destroyed.  
- Fix persisted assignment collisions across steps so saved/loaded assignments remain namespaced per step.  
- Move attached-data maintenance to the proper lifecycle hook and make rechecks idempotent while adding minimum semantic validation to `_check()`.

### Description
- Added explicit `Sequence::~Sequence()` and `SequenceStep::~SequenceStep()` that delete owned objects and containers to fix lifecycle/ownership leaks.  
- Namespaced assignment persistence using a composite key of step index + assignment index (e.g. `assignDest[step]_[assign]`) in both save and load paths to avoid collisions.  
- Implemented `Sequence::_createInternalAndAttachedData()` and removed attached-data mutation from `_check()`; the implementation removes stale `StepStation[...]` / `StepLabel[...]` keys before reinserting current attachments.  
- Hardened `Sequence::_check()` to validate non-null steps, require exactly one of Station or Label per step, validate referenced Station/Label via the `ModelDataManager` and `ModelDataDefinition::Check`, and perform minimal assignment coherence checks.  
- Improved `Sequence::show()` to include step count and added targeted unit tests and probes to exercise lifecycle, persistence and recheck behavior.

### Testing
- Configured and built tests and plugins with `cmake` and `ninja`, then built the runtime test executable; build succeeded.  
- Ran focused Sequence tests: `ctest -R "SimulatorRuntimeTest.*Sequence"` and all new/updated Sequence tests passed (7/7).  
- Ran broader smoke-level ctest; some unrelated test targets show `*_NOT_BUILT` under this environment configuration, but Sequence-focused tests passed.

```markdown
- o que você realizou de fato;
  - Corrigi `Sequence` integralmente no escopo solicitado: destrutores para `Sequence` e `SequenceStep`, persistência namespaced de assignments por passo, implementação de `_createInternalAndAttachedData()` com remoção de dados obsoletos, reforço de `_check()` e melhoria de `show()`, e inclusão de testes unitários focados em Sequence.
- o que não realizou;
  - Não alterei classes fora do escopo proibido (`Queue`, `Variable`, `Resource`, `SignalData`) e não refatorei infraestrutura global de persistência ou a API pública de `Assignment` além do necessário local em `SequenceStep`.
- por que não realizou;
  - Itens listados como proibidos na tarefa e para manter mudanças mínimas e seguras concentradas em `Sequence`.
- riscos remanescentes;
  - A instrumentação de destrutores de `Assignment` não foi alterada (os testes verificam ausência de leaks por execução e contagem de destrutores de `SequenceStep`), portanto rastreamento fino de destruição de `Assignment` depende da cobertura atual.
  - Mudança na convenção de campos persistidos (`assignDest[step]_[assign]`) é localizada em `SequenceStep` e compatível com o mecanismo de persistência, mas ferramentas externas que esperassem o antigo layout devem ser atualizadas.
- observações relevantes;
  - A regra aplicada em `_check()` exige "exatamente um entre Station e Label" por passo, por coerência semântica observada no código; se a semântica real do domínio permitir ambos, isso deve ser documentado e ajustado posteriormente.
  - Foram adicionados helpers de teste (`SequenceProbe`, `CountingSequenceStepProbe`) para acessar hooks protegidos de maneira segura.
- arquivos alterados;
  - `source/plugins/data/Sequence.h`
  - `source/plugins/data/Sequence.cpp`
  - `source/tests/unit/test_simulator_runtime.cpp`
- comandos executados e resultados resumidos.
  - `cmake -S . -B build -G Ninja -DGENESYS_BUILD_TESTS=ON -DGENESYS_BUILD_KERNEL=ON -DGENESYS_BUILD_PARSER=ON -DGENESYS_BUILD_PLUGINS=ON ...` → configuração OK.
  - `cmake --build build --target genesys_test_simulator_runtime` → build OK.
  - `ctest --test-dir build -R "SimulatorRuntimeTest.*Sequence" --output-on-failure` → all Sequence tests passed (7/7).
  - `ctest --test-dir build -LE smoke --output-on-failure` → smoke run shows unrelated `*_NOT_BUILT` entries in this environment; Sequence tests remain green.
```

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d87bf9f3648321945550d70eab4ea8)