### PR TITLE
docs: revalidate phase2 kernel/simulator inventory (WiP20261)

### DIFF
--- a/documentation/phase2-kernel-simulator-inventory.md
+++ b/documentation/phase2-kernel-simulator-inventory.md
@@ -1,5 +1,12 @@
 # Phase 2 — Inventário técnico do kernel/simulator (2026-1)
 
+## Audit Status (WiP20261)
+- Branch audited: `WiP20261` (requested scope).
+- Working branch in local checkout during this audit: `work`.
+- Audit scope: `source/kernel/simulator` phase-2 inventory revalidated against current code.
+- Status legend: `DONE`, `PARTIAL`, `OPEN`, `UNCERTAIN`, `SUPERSEDED`.
+- Audit intent: preserve historical context from the original inventory while reclassifying each major finding based on current code evidence.
+
 ## Escopo analisado
 - Pacote: `source/kernel/simulator`
 - Classes foco desta fase:
@@ -12,85 +19,122 @@
 ## 1) Mapa de ownership/lifetime (estado atual)
 
 ### 1.1 Model
-**Confirmado no código**
+**Texto histórico (inventário original)**
 - `Model` aloca em heap e mantém ponteiros crus para quase todos os subsistemas (`_eventManager`, `_modeldataManager`, `_componentManager`, `_simulation`, `_parser`, `_modelChecker`, `_modelPersistence`, `_futureEvents`, `_controls`, `_responses`, `_modelInfo`).
-- O destrutor está como `= default` no header, sem lógica de liberação explícita.
+- O destrutor estava descrito como `= default` no header, sem lógica de liberação explícita.
 
-**Implicação**
-- A semântica de ownership é “Model possui tudo”, mas a destruição atual não deixa isso explícito.
-- Forte indício de vazamento por ciclo de vida longo do processo (ou limpezas incompletas em cenários de criação/destruição de múltiplos modelos).
+### Audit status
+- Classificação do achado “`Model` com destrutor default + múltiplas alocações”: **SUPERSEDED**.
+- Classificação do risco de teardown hoje: **PARTIAL**.
+
+### Evidence
+- `Model.h` declara destrutor virtual explícito (`virtual ~Model();`).
+- `Model.cpp` implementa destrutor explícito com teardown estruturado: `_destroyFutureEvents`, `_destroyTransientEntities`, `_destroyComponents`, `_destroyModelDataDefinitions`, seguido da destruição dos serviços/containers owned.
+- `Model::clear()` também aplica rotina explícita de limpeza.
+
+### Remaining gaps
+- Ainda há uso intenso de ponteiros crus e ownership implícito em várias associações; embora o teardown exista, não há migração ampla para RAII/smart pointers.
 
 ### 1.2 ModelSimulation
-**Confirmado no código**
+**Texto histórico (inventário original)**
 - `ModelSimulation` cria controles com `new` e insere em `Model::getControls()`.
-- Também mantém membros alocados dinamicamente no próprio header (`_cstatsAndCountersSimulation`, `_cstatsAndCountersMapSimulation`, `_breakpointsOnTime`, `_breakpointsOnComponent`, `_breakpointsOnEntity`).
-- Método `_createSimulationEvent()` cria `SimulationEvent*` com `new` e retorna ponteiro cru sem ownership explícito.
+- Mantém membros alocados dinamicamente no header (`_cstatsAndCountersSimulation`, `_cstatsAndCountersMapSimulation`, `_breakpointsOnTime`, `_breakpointsOnComponent`, `_breakpointsOnEntity`).
+- O inventário original apontava `_createSimulationEvent()` retornando `SimulationEvent*` cru sem ownership explícito.
 
-**Implicação**
-- Ownership de `SimulationEvent` é ambíguo (forte indício de leak em callbacks/event handlers).
-- Alocações no header e ausência de destrutor customizado aumentam risco de leak.
+### Audit status
+- Classificação do achado “`ModelSimulation::_createSimulationEvent` com ownership indefinido”: **DONE**.
+- Classificação do achado “`ModelSimulation` sem estratégia explícita de teardown”: **SUPERSEDED**.
+- Classificação de risco residual de lifetime em `ModelSimulation`: **PARTIAL**.
+
+### Evidence
+- Em `ModelSimulation.h`, assinatura atual de `_createSimulationEvent` é `std::unique_ptr<SimulationEvent>`.
+- Em `ModelSimulation.cpp`, implementação cria e retorna `std::unique_ptr<SimulationEvent>` e chamadas usam `.get()` apenas para notificação, preservando ownership local.
+- `ModelSimulation` possui destrutor explícito removendo/deletando controles owned, estruturas auxiliares, breakpoints e reporter owned.
+
+### Remaining gaps
+- Parte da classe ainda depende de alocações manuais e flags de ownership (`_ownsSimulationReporter`), sem unificação completa de política de ownership.
 
 ### 1.3 PluginManager
-**Confirmado no código**
-- `_plugins` e `_pluginConnector` são criados com `new` e não há destrutor explícito para liberar recursos.
-- `insert()` retorna `plugin` mesmo quando `_insert(plugin)` falha; o próprio código já comenta risco de uso após liberação.
+**Texto histórico (inventário original)**
+- `_plugins` e `_pluginConnector` são criados com `new`.
+- O inventário antigo apontava ausência de destrutor explícito e retorno potencialmente inválido em `insert()` quando `_insert` falha.
 
-**Implicação**
-- Bug potencial de ponteiro inválido (use-after-free) para chamadores de `insert()`.
-- Lifecycle de plugin connector e lista de plugins depende de side effects externos.
+### Audit status
+- Classificação do achado “`PluginManager::insert` pode retornar ponteiro inválido”: **DONE**.
+- Classificação do achado “`PluginManager` sem teardown explícito”: **SUPERSEDED**.
+- Classificação do risco de robustez em auto-carga/parsing de lista de plugins: **OPEN**.
+
+### Evidence
+- `PluginManager::insert` conecta plugin e, se `_insert(plugin)` falhar, força `plugin = nullptr` antes do retorno; em exceção retorna `nullptr`.
+- `PluginManager` possui destrutor explícito liberando plugins e `_pluginConnector`.
+- `autoInsertPlugins` ainda faz tratamento manual de caracteres de controle no início da linha (`while (line[0] > 126 || line[0] < 32)`) sem normalização completa da linha.
+
+### Remaining gaps
+- O hardening de parsing/normalização no carregamento de arquivo de plugins permanece candidato real de backlog.
 
 ### 1.4 TraceManager
-**Confirmado no código**
-- Diversas listas de handlers e `_errorMessages` são alocadas com `new`.
-- `traceError(...)` não adiciona mensagens em `_errorMessages`, apesar de expor `errorMessages()`.
+**Texto histórico (inventário original)**
+- Estruturas de handlers e `_errorMessages` alocadas com `new`.
+- O inventário antigo dizia que `traceError(...)` não alimentava `_errorMessages`.
+- Também sugeria ausência de teardown efetivo.
 
-**Implicação**
-- API sugere buffer de erros, mas não o alimenta (inconsistência funcional).
-- Forte indício de leak por ausência de destrutor explicitando limpeza.
+### Audit status
+- Classificação do achado “`TraceManager::errorMessages()` não populada por `traceError`”: **DONE**.
+- Classificação do achado “`TraceManager` sem teardown efetivo”: **SUPERSEDED**.
+- Classificação de risco residual de ownership: **PARTIAL**.
 
----
+### Evidence
+- Ambos overloads de `traceError` inserem texto em `_errorMessages`.
+- `TraceManager` possui destrutor explícito liberando listas de handlers, regras de exceção e `_errorMessages`.
+- Há cobertura de teste unitário para armazenamento de mensagens de erro em `source/tests/unit/test_support_tracemanager.cpp`.
 
-## 2) Top 10 riscos priorizados (Fase 2)
-
-### P0 (alto impacto / provável)
-1. **`PluginManager::insert` pode retornar ponteiro inválido** quando `_insert(plugin)` falha e destrói o plugin.
-2. **`ModelSimulation::_createSimulationEvent` com ownership indefinido** (alocação heap sem contrato de destruição).
-3. **`Model::hasChanged` usa `&=` em cascata**, podendo mascarar mudanças (lógica aparentemente invertida para agregação de flags).
-4. **`Model::createEntity` ignora parâmetro `insertIntoModel`** e sempre cria com `true`.
-
-### P1 (médio)
-5. **`Model` com destrutor default + múltiplas alocações** (ownership implícito e difícil de auditar).
-6. **`ModelSimulation` com alocações em membros sem estratégia explícita de teardown**.
-7. **`PluginManager` sem teardown explícito de `_pluginConnector` e `_plugins`**.
-8. **`TraceManager::errorMessages()` expõe estrutura não populada por `traceError`**.
-
-### P2 (baixo/moderado)
-9. **`PluginManager::autoInsertPlugins` trata BOM/caracteres de controle manualmente** sem normalização robusta da linha inteira.
-10. **TODOs críticos no fluxo de simulação/report** que podem ocultar comportamento incompleto em cenários avançados.
+### Remaining gaps
+- Estrutura ainda centrada em ponteiros crus e listas alocadas manualmente; teardown existe, mas RAII integral ainda não foi adotado.
 
 ---
 
-## 3) Backlog imediato (3 primeiras entregas com teste)
+## 2) Top 10 riscos priorizados (Fase 2) — Reaudit
 
-### Task A (P0) — Corrigir retorno de `PluginManager::insert`
-- Ajustar `insert()` para retornar `nullptr` quando `_insert(plugin)` falhar.
-- Garantir contrato claro: retorno não nulo implica plugin válido/registrado.
-- **Teste de regressão sugerido**: simular plugin inválido e verificar retorno `nullptr` + ausência na lista.
+### Reclassificação dos itens históricos
+1. **`PluginManager::insert` pode retornar ponteiro inválido** → **DONE**.
+2. **`ModelSimulation::_createSimulationEvent` com ownership indefinido** → **DONE**.
+3. **`Model::hasChanged` usa `&=` em cascata** → **DONE** (agregação atual com `||`).
+4. **`Model::createEntity` ignora parâmetro `insertIntoModel`** → **OPEN** (implementação ainda cria `new Entity(this, name, true)`).
+5. **`Model` com destrutor default + múltiplas alocações** → **SUPERSEDED** (destrutor explícito implementado).
+6. **`ModelSimulation` com alocações sem estratégia explícita de teardown** → **SUPERSEDED** (destrutor explícito implementado).
+7. **`PluginManager` sem teardown explícito** → **SUPERSEDED** (destrutor explícito implementado).
+8. **`TraceManager::errorMessages()` não populada por `traceError`** → **DONE**.
+9. **`PluginManager::autoInsertPlugins` com normalização frágil de linha/BOM** → **OPEN**.
+10. **TODOs críticos no fluxo de simulação/report** → **UNCERTAIN** (há TODOs, mas impacto operacional atual requer validação direcionada por teste comportamental).
 
-### Task B (P0) — Tornar ownership de `SimulationEvent` explícito
-- Opção mínima segura: converter `_createSimulationEvent` para retorno por valor (se viável sem quebra) ou adotar destruição explícita no mesmo frame de notificação.
-- **Teste de regressão sugerido**: validar que notificações continuam com estado correto (paused/running/time) em start/pause/step.
-
-### Task C (P0/P1) — Corrigir lógica de `Model::hasChanged`
-- Substituir cadeia com `&=` por agregação OR (`||`) com semântica “qualquer subsistema mudou”.
-- **Teste de regressão sugerido**: marcar mudança em apenas 1 subsistema e esperar `true`.
+### Validade atual do “Top 10” original
+- O top 10 histórico **não permanece válido como lista de prioridade atual**: a maior parte dos itens P0/P1 foi corrigida ou superada por mudanças posteriores.
+- Itens realmente vivos após reauditoria concentram-se em:
+  - `Model::createEntity` e contrato de `insertIntoModel`.
+  - Robustez de parsing em `autoInsertPlugins`.
+  - TODOs com possível impacto em cenários avançados (ainda sem confirmação de severidade).
 
 ---
 
-## 4) Estratégia de execução recomendada
-1. **Fixes de contrato (Task A e C) primeiro**: menor impacto arquitetural e alto ganho de segurança.
-2. **Depois ownership/eventos (Task B)**: requer mapeamento de listeners e validação em testes de suporte/runtime.
-3. **Por fim hardening de teardown (Model/ModelSimulation/PluginManager/TraceManager)** com migração incremental para RAII/regra do zero.
+## 3) Backlog imediato (Task A/B/C) — Reaudit
+
+### Situação do backlog histórico
+- **Task A (corrigir retorno de `PluginManager::insert`)** → **DONE**.
+- **Task B (ownership explícito de `SimulationEvent`)** → **DONE**.
+- **Task C (corrigir `Model::hasChanged`)** → **DONE**.
+
+### Novo foco recomendado para backlog imediato
+- **Task A2 (OPEN)** — Corrigir/confirmar contrato de `Model::createEntity(name, insertIntoModel)` para respeitar o parâmetro recebido.
+- **Task B2 (OPEN)** — Hardening de `PluginManager::autoInsertPlugins` (normalização robusta de linha, BOM e espaços de controle).
+- **Task C2 (UNCERTAIN)** — Converter TODOs de simulação/report em casos de teste focados para medir risco real antes de classificar severidade.
+
+---
+
+## 4) Estratégia de execução recomendada (revisada)
+1. **Contrato funcional primeiro (OPEN):** fechar `createEntity(insertIntoModel)` com teste de regressão específico.
+2. **Robustez de entrada (OPEN):** endurecer parsing de `autoInsertPlugins` e cobrir com testes de arquivo contendo BOM/linhas anômalas.
+3. **Risco exploratório orientado por teste (UNCERTAIN):** transformar TODOs críticos em hipóteses testáveis antes de qualquer refatoração maior.
+4. **Evolução técnica incremental (PARTIAL):** migrar gradualmente para RAII onde ainda existe teardown manual em classes core.
 
 ## 5) Checkpoints de validação
 - Build:
@@ -98,12 +142,32 @@
   - `cmake --build --preset debug --target genesys_kernel genesys_tests -j4`
 - Testes:
   - `ctest --preset debug`
-  - novos testes de regressão para A/B/C
+  - incluir regressões para `createEntity(insertIntoModel)` e `autoInsertPlugins`
 - Sanitizers:
   - `cmake --preset asan && cmake --build --preset asan --target genesys_tests -j4`
   - `ctest --preset asan`
 
-## 6) Classificação de confiabilidade
-- **Confirmado no código**: alocações em heap com ponteiros crus nas classes foco; retorno potencialmente inválido em `PluginManager::insert`; inconsistência funcional de `TraceManager::errorMessages`.
-- **Forte indício**: leaks associados a eventos/listas sem teardown explícito.
-- **Hipótese a validar**: impacto completo de mudar ownership de `SimulationEvent` sobre todos os listeners existentes.
+## 6) Classificação de confiabilidade (revisada)
+- **Confirmado no código (DONE/SUPERSEDED):**
+  - `PluginManager::insert` já retorna `nullptr` em falha de `_insert`.
+  - `_createSimulationEvent` usa `std::unique_ptr<SimulationEvent>`.
+  - `Model::hasChanged` agrega por `||`.
+  - `Model`, `ModelSimulation`, `PluginManager` e `TraceManager` possuem destrutores explícitos com teardown relevante.
+  - `TraceManager::traceError` alimenta `_errorMessages` em ambos overloads.
+- **Confirmado no código (OPEN):**
+  - `Model::createEntity` ainda ignora o parâmetro `insertIntoModel` na chamada efetiva do construtor de `Entity`.
+  - Normalização em `PluginManager::autoInsertPlugins` permanece limitada a tratamento manual de primeiro caractere.
+- **Cobertura de regressão já existente (parcial):**
+  - `TraceManager` já possui testes unitários cobrindo armazenamento em `errorMessages`.
+  - `Model::hasChanged` possui teste de comportamento no runtime unitário.
+- **Hipótese a validar (UNCERTAIN):**
+  - Severidade prática dos TODOs remanescentes no fluxo de simulação/report em cenários avançados.
+
+## Remaining Work
+- **OPEN**
+  - `Model::createEntity(name, insertIntoModel)` respeitar o parâmetro recebido e não forçar `true`.
+  - Hardening de `PluginManager::autoInsertPlugins` para normalização robusta de entrada.
+- **PARTIAL**
+  - Evolução incremental para RAII/smart pointers em áreas ainda dependentes de teardown manual.
+- **UNCERTAIN**
+  - Impacto real dos TODOs do fluxo de simulação/report (necessita validação orientada por teste).


### PR DESCRIPTION
### Motivation
- Bring the Phase‑2 kernel/simulator inventory document up to date with the current codebase while preserving the original historical context. 
- Provide an explicit, auditable layer for branch `WiP20261` that reclassifies legacy findings using the requested statuses. 
- Focus the audit on ownership/lifetime, event ownership and teardown risks in `Model`, `ModelSimulation`, `PluginManager` and `TraceManager`. 
- Restrict the change to documentation only and avoid any source edits.

### Description
- Added an `## Audit Status (WiP20261)` header and audit legend and preserved the original inventory structure while inserting per-item audit subsections. 
- Reclassified the required legacy items (e.g. `PluginManager::insert`, `_createSimulationEvent`, `Model::hasChanged`, `Model::createEntity`, destructors/teardown, `TraceManager::errorMessages`) with statuses `DONE`, `PARTIAL`, `OPEN`, `UNCERTAIN`, or `SUPERSEDED` based on current source inspection. 
- Updated the Top‑10 risks, immediate backlog (Task A/B/C) and the recommended execution strategy to reflect the code as now implemented. 
- Added the mandatory `## Remaining Work` section listing only items with `OPEN`, `PARTIAL` or `UNCERTAIN` status; confirmed that only `documentation/phase2-kernel-simulator-inventory.md` was modified.

### Testing
- No automated test suite was executed as part of this documentation-only change. 
- Validation was performed by inspecting the current source and relevant unit tests, including `Model(.h/.cpp)`, `ModelSimulation(.h/.cpp)`, `PluginManager(.h/.cpp)`, `TraceManager(.h/.cpp)` and unit tests `test_support_tracemanager.cpp` and `test_simulator_runtime.cpp` to confirm behavioral/coverage evidence for the reclassifications. 
- Confirmed locally that only the target `.md` file was changed and the document content is coherent with the inspected sources.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d87f66fa20832192fa54492b54832c)