### PR TITLE
Fix SignalData lifecycle, recheck stale handlers, and runtime tests

### DIFF
--- a/source/plugins/components/Wait.cpp
+++ b/source/plugins/components/Wait.cpp
@@ -191,6 +191,13 @@ bool Wait::_check(std::string& errorMessage) {
 }
 
 void Wait::_createInternalAndAttachedData() {
+	SignalData* previouslyAttachedSignalData = nullptr;
+	std::map<std::string, ModelDataDefinition*>* attachedData = getAttachedData();
+	std::map<std::string, ModelDataDefinition*>::iterator attachedSignalDataIt = attachedData->find("SignalData");
+	if (attachedSignalDataIt != attachedData->end()) {
+		previouslyAttachedSignalData = dynamic_cast<SignalData*>(attachedSignalDataIt->second);
+	}
+
 	// internal
 	PluginManager* pm = _parentModel->getParentSimulator()->getPluginManager();
 	if (_queue == nullptr) {
@@ -198,6 +205,10 @@ void Wait::_createInternalAndAttachedData() {
 	}
 	_internalDataInsert("Queue", _queue);
 	//attached
+	if (previouslyAttachedSignalData != nullptr && (_waitType != Wait::WaitType::WaitForSignal || previouslyAttachedSignalData != _signalData)) {
+		previouslyAttachedSignalData->removeSignalDataEventHandler(this);
+	}
+
 	if (_waitType == Wait::WaitType::WaitForSignal) {
 		if (_signalData == nullptr) {
 			_signalData = pm->newInstance<SignalData>(_parentModel);

--- a/source/plugins/data/SignalData.cpp
+++ b/source/plugins/data/SignalData.cpp
@@ -29,6 +29,15 @@ ModelDataDefinition* SignalData::NewInstance(Model* model, std::string name) {
 SignalData::SignalData(Model* model, std::string name) : ModelDataDefinition(model, Util::TypeOf<SignalData>(), name) {
 }
 
+SignalData::~SignalData() {
+	for (PairSignalDataEventHandler* handler : *_signalDataEventHandlers->list()) {
+		delete handler;
+	}
+	_signalDataEventHandlers->clear();
+	delete _signalDataEventHandlers;
+	_signalDataEventHandlers = nullptr;
+}
+
 //public
 
 std::string SignalData::show() {
@@ -51,6 +60,30 @@ void SignalData::addSignalDataEventHandler(SignalDataEventHandler eventHandler, 
 	}
 	PairSignalDataEventHandler* pairEventHandler = new PairSignalDataEventHandler(eventHandler, component);
 	_signalDataEventHandlers->insert(pairEventHandler);
+}
+
+void SignalData::removeSignalDataEventHandler(ModelComponent* component) {
+	if (_signalDataEventHandlers == nullptr) {
+		return;
+	}
+	std::list<PairSignalDataEventHandler*>* handlers = _signalDataEventHandlers->list();
+	for (std::list<PairSignalDataEventHandler*>::iterator it = handlers->begin(); it != handlers->end(); ++it) {
+		PairSignalDataEventHandler* pairEventHandler = *it;
+		if (pairEventHandler->second == component) {
+			delete pairEventHandler;
+			handlers->erase(it);
+			return;
+		}
+	}
+}
+
+bool SignalData::hasSignalDataEventHandler(ModelComponent* component) const {
+	for (PairSignalDataEventHandler* pairEventHandler : *_signalDataEventHandlers->list()) {
+		if (pairEventHandler->second == component) {
+			return true;
+		}
+	}
+	return false;
 }
 
 // public static
@@ -97,17 +130,16 @@ void SignalData::_saveInstance(PersistenceRecord *fields, bool saveDefaultValues
 // protected virtual -- could be overriden
 
 bool SignalData::_check(std::string& errorMessage) {
-	bool resultAll = true;
-	//!@TODO
-	resultAll &= _signalDataEventHandlers->size() > 0;
-	if (!resultAll) {
-		traceError("There is no handler added to SignalData "+this->getName());
+	if (_signalDataEventHandlers->size() == 0) {
+		errorMessage = "SignalData \"" + this->getName() + "\" requires at least one event handler";
+		traceError(errorMessage);
+		return false;
 	}
-	//resultAll &= _quantityExpression != "";
-	return resultAll;
+	return true;
 }
 
 void SignalData::_initBetweenReplications() {
+	_remainsToLimit = 0;
 }
 
 //void SignalData::_createInternalAndAttachedData() {}

--- a/source/plugins/data/SignalData.h
+++ b/source/plugins/data/SignalData.h
@@ -27,7 +27,7 @@ public:
 	}
 public:
 	SignalData(Model* model, std::string name = "");
-	virtual ~SignalData() = default;
+	virtual ~SignalData() override;
 public: // static
 	static ModelDataDefinition* LoadInstance(Model* model, PersistenceRecord *fields);
 	static PluginInformation* GetPluginInformation();
@@ -37,6 +37,8 @@ public: //virtual
 public:
 	unsigned int generateSignal(double signalValue, unsigned int limit);
 	void addSignalDataEventHandler(SignalDataEventHandler eventHandler, ModelComponent* component);
+	void removeSignalDataEventHandler(ModelComponent* component);
+	bool hasSignalDataEventHandler(ModelComponent* component) const;
 	unsigned int remainsToLimit() const;
 	void decreaseRemainLimit();
 
@@ -51,10 +53,9 @@ protected: // could be overriden .
 private: // methods
 	unsigned int  _notifySignalDataEventHandlers(); //!< Notify observer classes that some of the resource capacity has been released. It is useful for allocation components (such as Seize) to know when an entity waiting into a queue can try to seize the resource again
 private: //1::1
-	unsigned int _remainsToLimit;
+	unsigned int _remainsToLimit = 0;
 private: //1::n
 	List<PairSignalDataEventHandler*>* _signalDataEventHandlers = new List<PairSignalDataEventHandler*>();
 };
 
 #endif /* SIGNALDATA_H */
-

--- a/source/tests/unit/test_simulator_runtime.cpp
+++ b/source/tests/unit/test_simulator_runtime.cpp
@@ -16,6 +16,8 @@
 #include "plugins/data/Failure.h"
 #include "plugins/data/Schedule.h"
 #include "plugins/data/Sequence.h"
+#include "plugins/data/SignalData.h"
+#include "plugins/components/Wait.h"
 
 class ResourceTestProbe {
 public:
@@ -203,6 +205,28 @@ public:
 
     void AttachDataProbe(const std::string& key, ModelDataDefinition* data) {
         _attachedDataInsert(key, data);
+    }
+};
+
+class SignalDataProbe : public SignalData {
+public:
+    SignalDataProbe(Model* model, const std::string& name = "") : SignalData(model, name) {}
+
+    bool CheckProbe(std::string& errorMessage) {
+        return _check(errorMessage);
+    }
+
+    void InitBetweenReplicationsProbe() {
+        _initBetweenReplications();
+    }
+};
+
+class WaitProbe : public Wait {
+public:
+    WaitProbe(Model* model, const std::string& name = "") : Wait(model, name) {}
+
+    void CreateInternalAndAttachedDataProbe() {
+        _createInternalAndAttachedData();
     }
 };
 
@@ -1372,5 +1396,115 @@ TEST(SimulatorRuntimeTest, SequenceCheckPassesForValidSteps) {
 
     std::string errorMessage;
     EXPECT_TRUE(sequence.CheckProbe(errorMessage));
+    EXPECT_TRUE(errorMessage.empty());
+}
+
+TEST(SimulatorRuntimeTest, SignalDataDestructorHandlesOwnedHandlersLifecycle) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    auto* signal = new SignalDataProbe(model, "SignalLifecycle");
+    Wait waitA(model, "SignalLifecycleWaitA");
+    Wait waitB(model, "SignalLifecycleWaitB");
+    signal->addSignalDataEventHandler([](SignalData*) { return 0u; }, &waitA);
+    signal->addSignalDataEventHandler([](SignalData*) { return 0u; }, &waitB);
+
+    EXPECT_TRUE(signal->hasSignalDataEventHandler(&waitA));
+    EXPECT_TRUE(signal->hasSignalDataEventHandler(&waitB));
+    EXPECT_NO_THROW(delete signal);
+}
+
+TEST(SimulatorRuntimeTest, SignalDataInitBetweenReplicationsResetsRemainsToLimit) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    SignalDataProbe signal(model, "SignalReset");
+    Wait wait(model, "SignalResetWait");
+    signal.addSignalDataEventHandler([](SignalData*) { return 0u; }, &wait);
+
+    signal.generateSignal(0.0, 3);
+    signal.decreaseRemainLimit();
+    ASSERT_EQ(signal.remainsToLimit(), 2u);
+
+    signal.InitBetweenReplicationsProbe();
+    EXPECT_EQ(signal.remainsToLimit(), 0u);
+}
+
+TEST(SimulatorRuntimeTest, SignalDataAddHandlerDoesNotDuplicateSameComponent) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    SignalDataProbe signal(model, "SignalNoDuplicate");
+    Wait wait(model, "SignalNoDuplicateWait");
+    signal.addSignalDataEventHandler([](SignalData*) { return 1u; }, &wait);
+    signal.addSignalDataEventHandler([](SignalData*) { return 10u; }, &wait);
+
+    EXPECT_EQ(signal.generateSignal(0.0, 10), 1u);
+}
+
+TEST(SimulatorRuntimeTest, SignalDataRemoveHandlerByComponentRemovesOwnedRegistration) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    SignalDataProbe signal(model, "SignalRemove");
+    Wait wait(model, "SignalRemoveWait");
+    signal.addSignalDataEventHandler([](SignalData*) { return 2u; }, &wait);
+    ASSERT_TRUE(signal.hasSignalDataEventHandler(&wait));
+
+    signal.removeSignalDataEventHandler(&wait);
+    EXPECT_FALSE(signal.hasSignalDataEventHandler(&wait));
+    EXPECT_EQ(signal.generateSignal(0.0, 10), 0u);
+}
+
+TEST(SimulatorRuntimeTest, WaitRecheckUpdatesSignalDataHandlersWhenSignalChangesOrTypeChanges) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    SignalDataProbe signalA(model, "SignalRecheckA");
+    SignalDataProbe signalB(model, "SignalRecheckB");
+    WaitProbe wait(model, "WaitRecheck");
+    wait.setWaitType(Wait::WaitType::WaitForSignal);
+    wait.setSignalData(&signalA);
+    wait.CreateInternalAndAttachedDataProbe();
+    ASSERT_TRUE(signalA.hasSignalDataEventHandler(&wait));
+
+    wait.setSignalData(&signalB);
+    wait.CreateInternalAndAttachedDataProbe();
+    EXPECT_FALSE(signalA.hasSignalDataEventHandler(&wait));
+    EXPECT_TRUE(signalB.hasSignalDataEventHandler(&wait));
+
+    wait.setWaitType(Wait::WaitType::InfiniteHold);
+    wait.CreateInternalAndAttachedDataProbe();
+    EXPECT_FALSE(signalB.hasSignalDataEventHandler(&wait));
+}
+
+TEST(SimulatorRuntimeTest, SignalDataCheckFailsWithoutHandlers) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    SignalDataProbe signal(model, "SignalCheckInvalid");
+    std::string errorMessage;
+    EXPECT_FALSE(signal.CheckProbe(errorMessage));
+    EXPECT_FALSE(errorMessage.empty());
+    EXPECT_NE(errorMessage.find("requires at least one event handler"), std::string::npos);
+}
+
+TEST(SimulatorRuntimeTest, SignalDataCheckPassesWithValidHandler) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    SignalDataProbe signal(model, "SignalCheckValid");
+    Wait wait(model, "SignalCheckWait");
+    signal.addSignalDataEventHandler([](SignalData*) { return 0u; }, &wait);
+
+    std::string errorMessage;
+    EXPECT_TRUE(signal.CheckProbe(errorMessage));
     EXPECT_TRUE(errorMessage.empty());
 }


### PR DESCRIPTION
PLUGINS

### Motivation
- Close lifecycle and recheck bugs in `SignalData` that caused memory leaks and stale handlers during repeated model checks and between replications. 
- Ensure dynamic state `_remainsToLimit` is initialized and reset between replications so signal consumption behaves predictably.

### Description
- Implemented explicit `SignalData` destructor that deletes all owned `PairSignalDataEventHandler*`, clears the list and deletes the handler container. 
- Initialized `_remainsToLimit` in the header and reset it in `_initBetweenReplications()` to zero. 
- Added `removeSignalDataEventHandler(ModelComponent*)` and `hasSignalDataEventHandler(ModelComponent*)` to safely remove and query handlers owned by `SignalData`. 
- Strengthened `_check()` to fail with a clear `errorMessage` when no handlers are registered. 
- Updated `Wait::_createInternalAndAttachedData()` to remove obsolete handlers from a previously attached `SignalData` when the `Wait` changes type or the attached `SignalData` (making rechecks idempotent). 
- Added focused unit tests in `test_simulator_runtime.cpp` covering destructor lifecycle, reset between replications, handler deduplication, handler removal, `Wait` recheck behavior, and `_check()` pass/fail cases for `SignalData`.

### Testing
- Ran CMake configure and built `genesys_test_simulator_runtime` successfully. 
- Executed targeted tests with `ctest -R "SimulatorRuntimeTest.*SignalData"` and all 7 new/targeted tests passed. 
- Ran broader `ctest -LE smoke`; the environment reported some `_NOT_BUILT` entries unrelated to these changes (environment/build configuration), while the unit tests compiled and runnable passed.

```markdown
- o que você realizou de fato;
  - Corrigi ownership e lifecycle de `SignalData` (destrutor explícito), inicializei e resetei `_remainsToLimit`, adicionei API para remoção/consulta de handlers, reforcei `_check()` e atualizei `Wait::_createInternalAndAttachedData()` para remover handlers obsoletos; adicionei testes unitários cobrindo os cenários exigidos.
- o que não realizou;
  - Não alterei a semântica de `signalValue` em `generateSignal(double signalValue, unsigned int limit)`; o parâmetro permanece sem uso funcional explícito nesta etapa.
- por que não realizou;
  - Não existe base clara e segura no código atual para mudar o comportamento de `signalValue` sem efeitos colaterais fora do escopo desta correção localizada.
- riscos remanescentes;
  - A verificação do destrutor foi por comportamento observável (no-throw e liberação de estruturas), não por análise com ferramentas de leak (ASan/Valgrind) nesta execução; leaks residuais não detectados por testes unitários específicos podem permanecer.
  - Alguns testes do conjunto maior aparecem como `_NOT_BUILT` no ambiente de CI local, o que é um artefato da configuração de build e não das mudanças aplicadas.
- observações relevantes;
  - A correção de rechecagem em `Wait` é local e minimalista: usa os dados anexados previamente para remover o handler antigo ao trocar `SignalData` ou tipo de espera, preservando idempotência de rechecagens repetidas.
  - A alteração mantém comportamento preservado de `generateSignal` quanto ao `signalValue` conforme solicitado.
- arquivos alterados;
  - `source/plugins/data/SignalData.h`
  - `source/plugins/data/SignalData.cpp`
  - `source/plugins/components/Wait.cpp`
  - `source/tests/unit/test_simulator_runtime.cpp`
- comandos executados e resultados resumidos.
  - `cmake -S . -B build -G Ninja -DGENESYS_BUILD_TESTS=ON -DGENESYS_BUILD_KERNEL=ON -DGENESYS_BUILD_PARSER=ON -DGENESYS_BUILD_PLUGINS=ON -DGENESYS_TERMINAL_APPLICATION=OFF -DGENESYS_BUILD_GUI_APPLICATION=OFF -DGENESYS_BUILD_WEB_APPLICATION=OFF` => configure OK.
  - `cmake --build build --target genesys_test_simulator_runtime` => build OK.
  - `ctest --test-dir build -R "SimulatorRuntimeTest.*SignalData" --output-on-failure` => 7/7 SignalData-related tests passed.
  - `ctest --test-dir build -LE smoke --output-on-failure` => broader run reports some `_NOT_BUILT` tests (environment); compiled tests including new ones passed.
```

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d881afb9f4832183872e5bf457f203)