### PR TITLE
docs: re-audit kernel memory-leak review for WiP20261

### DIFF
--- a/documentation/kernel-memory-leak-review-2026-03-30.md
+++ b/documentation/kernel-memory-leak-review-2026-03-30.md
@@ -1,117 +1,148 @@
 # Revisão de possíveis leaks de memória no pacote `source/kernel` (2026-03-30)
 
-## Escopo e método
+## Audit Status (WiP20261)
+- Branch audited: `WiP20261`
+- Audit scope: revisão do documento de leaks revalidada contra o estado atual do kernel
+- Status legend: `DONE`, `PARTIAL`, `OPEN`, `UNCERTAIN`, `SUPERSEDED`
+- Data desta reauditoria documental: `2026-04-10`
 
-- Busca textual por alocações manuais (`new`) e liberações (`delete`) em `source/kernel`.
-- Inspeção manual de classes com ponteiros proprietários (`owner`) e destrutor `= default`.
-- Foco principal: risco de vazamento por ausência de `delete`, substituição de ponteiro sem liberar antigo e falta de RAII.
+## Escopo e método da reauditoria
 
-## Achados principais (alto risco)
+- Leitura do documento histórico original e reclassificação item a item.
+- Revalidação direta dos pontos no código atual (headers + implementações) das classes citadas.
+- Foco em ownership real no estado atual: destrutores, ponteiros owner, substituição de ponteiros e limpeza global.
+- Esta atualização preserva o valor histórico dos achados, mas distingue explicitamente o que era risco em 2026-03-30 e o que permanece risco **hoje**.
+
+## Achados principais auditados
 
 ### 1) `SimulationScenario` acumula alocações sem desalocação
 
-**Evidências**
-- A classe possui múltiplos membros alocados com `new` e destrutor default (`virtual ~SimulationScenario() = default`).
-- `setSelectedControls()` cria uma nova lista e sobrescreve `_selectedControls` sem liberar a anterior.
-- `setControl()` aloca `pair` com `new` e apenas armazena na lista.
+**Registro histórico (2026-03-30)**
+- O review anterior apontava destrutor default, alocações com `new` e possível leak incremental em `setSelectedControls()`.
 
-**Risco**
-- Vazamento persistente por cenário criado.
-- Vazamento incremental a cada chamada de `setSelectedControls()`.
+### Audit status
+`PARTIAL`
 
-**Solução sugerida**
-- Curto prazo: implementar destrutor explícito liberando `_selectedControls`, `_selectedResponses`, `_controlValues`, `_responseValues` e os elementos apontados pelas listas de `pair`.
-- Médio prazo: migrar para RAII (`std::list<std::pair<std::string,double>>` por valor, e listas por valor em vez de ponteiros).
+### Evidence
+- `SimulationScenario` agora declara destrutor explícito (`virtual ~SimulationScenario();`) e implementa cleanup de `_controlValues`, `_responseValues`, `_selectedControls`, `_selectedResponses`, incluindo deleção dos `pair` internos nas listas de valores.
+- `setSelectedControls()` foi atualizado para copiar a lista recebida, liberar `_selectedControls` anterior e substituir o ponteiro, removendo o leak incremental antes descrito.
+- Ainda há alocação dinâmica em `setControl()` (`new std::pair<...>`), mas os objetos passam a ser desalocados no destrutor.
+
+### Remaining gaps
+- Embora o leak principal tenha sido mitigado, a classe permanece com ownership manual por ponteiros crus e sem RAII por valor/`unique_ptr`.
+- Não há limpeza pontual de itens em ciclos longos antes da destruição do objeto (trade-off de memória de runtime, mesmo sem leak no shutdown).
 
 ---
 
 ### 2) `ModelSimulation` possui objetos owner alocados com `new` sem destruição explícita
 
-**Evidências**
-- Membros `_simulationReporter`, `_cstatsAndCountersSimulation`, `_cstatsAndCountersMapSimulation`, `_breakpointsOnTime`, `_breakpointsOnComponent`, `_breakpointsOnEntity` são alocados com `new`.
-- Destrutor da classe é `= default`.
+**Registro histórico (2026-03-30)**
+- O review anterior descrevia destrutor default com múltiplos members owner alocados por `new`.
 
-**Risco**
-- Vazamento por instância de `ModelSimulation` (objetos de longa vida do kernel).
+### Audit status
+`PARTIAL`
 
-**Solução sugerida**
-- Curto prazo: destrutor explícito com `delete` de todos os owners.
-- Melhor prática: trocar membros para `std::unique_ptr<>` (ou ainda melhor, membros por valor quando possível).
+### Evidence
+- `ModelSimulation` hoje declara destrutor explícito e libera `_ownedControls`, `_cstatsAndCountersSimulation` (com deleção dos elementos), `_cstatsAndCountersMapSimulation`, `_breakpointsOnTime`, `_breakpointsOnComponent`, `_breakpointsOnEntity`.
+- O reporter (`_simulationReporter`) também é desalocado quando `_ownsSimulationReporter` é verdadeiro.
+- Há lógica explícita para remover controles da lista do modelo antes de deletá-los, reduzindo risco de dangling internos.
+
+### Remaining gaps
+- Ownership ainda depende de disciplina manual (`new`/`delete` + flags de ownership), mantendo superfície de risco de regressão.
+- Migração para RAII continua recomendada para diminuir risco futuro de double free/use-after-free em evolução de código.
 
 ---
 
 ### 3) `TraceManager` aloca várias listas e `_errorMessages` sem destrutor explícito
 
-**Evidências**
-- Diversos handlers são `new List<...>()` no header.
-- `_errorMessages` é alocado no construtor.
-- Destrutor é `= default`.
+**Registro histórico (2026-03-30)**
+- O review anterior apontava destrutor default e leak provável em handlers/listas auxiliares.
 
-**Risco**
-- Vazamento por ciclo de vida do `Simulator`.
+### Audit status
+`DONE`
 
-**Solução sugerida**
-- Curto prazo: adicionar destrutor para liberar todos os members owner.
-- Médio prazo: usar composição por valor (`List<T> _traceHandlers;`) ou `std::unique_ptr<List<T>>` quando necessário.
+### Evidence
+- `TraceManager` agora declara destrutor virtual explícito.
+- Implementação atual destrói explicitamente `_traceHandlers`, `_traceErrorHandlers`, `_traceReportHandlers`, `_traceSimulationHandlers`, handlers-method correspondentes, `_traceSimulationExceptionRule` e `_errorMessages`.
+
+### Remaining gaps
+- Nenhum leak direto do achado histórico permaneceu demonstrável neste ponto.
+- O backlog arquitetural de RAII ainda pode existir como melhoria, mas não como pendência deste leak específico.
 
 ---
 
 ### 4) `ModelManager` mantém `_models` com `new` e destrutor default
 
-**Evidências**
-- `_models` é alocado com `new` no header.
-- Destrutor `= default`.
-- A remoção individual (`remove`) faz `delete model`, porém não há cleanup global no encerramento do manager.
+**Registro histórico (2026-03-30)**
+- O review anterior indicava falta de cleanup global, com risco sobre `_models` e modelos remanescentes.
 
-**Risco**
-- Vazamento da estrutura `_models` e potencialmente de modelos remanescentes não removidos explicitamente.
+### Audit status
+`DONE`
 
-**Solução sugerida**
-- Implementar destrutor que itera e destrói modelos restantes e em seguida destrói `_models`.
-- Alternativa robusta: `List<std::unique_ptr<Model>>`.
+### Evidence
+- `ModelManager` agora declara destrutor virtual explícito.
+- Destrutor atual percorre `_models` e destrói modelos remanescentes.
+- Também trata o caso de `_currentModel` “destacado” (não pertencente a `_models`) e o desaloca.
+- Depois libera `_models` e neutraliza ponteiros.
+
+### Remaining gaps
+- O risco principal descrito no review antigo foi efetivamente eliminado no estado atual.
 
 ---
 
 ### 5) `StatisticsDatafileDefaultImpl1` tem owners com `new` e destrutor default
 
-**Evidências**
-- `_collector`, `_collectorSorted` e `sort` são alocados com `new`.
-- Destrutor default.
+**Registro histórico (2026-03-30)**
+- O documento antigo citava `StatisticsDatafileDefaultImpl1` com `_collector`, `_collectorSorted` e `sort` alocados com `new`.
 
-**Risco**
-- Vazamento em cada instância do coletor estatístico.
+### Audit status
+`SUPERSEDED`
 
-**Solução sugerida**
-- Criar destrutor liberando os três ponteiros owner.
-- Evolução: substituir por `std::unique_ptr`.
+### Evidence
+- No estado atual auditado, não foi encontrado artefato `StatisticsDatafileDefaultImpl1` no repositório.
+- O artefato relacionado existente é `CollectorDatafileDefaultImpl1`.
+- Em `CollectorDatafileDefaultImpl1`, os membros são por valor (`_filename`, `_lastValue`, `_numElements`, `_nextReadIndex`) e não reproduzem o padrão de owners com `new` descrito no texto histórico.
+- O destrutor default da implementação atual não implica, por si só, o risco específico anteriormente descrito.
+
+### Remaining gaps
+- Não há evidência, no snapshot atual, de leak equivalente ao claim histórico dessa seção.
+- Sem histórico de rename/refactor no próprio documento, não é possível afirmar com 100% de certeza se houve renomeação direta da classe antiga ou substituição arquitetural completa.
 
 ---
 
 ### 6) `SamplerDefaultImpl1` aloca `_param` com `new` e destrutor default
 
-**Evidências**
-- `_param = new DefaultImpl1RNG_Parameters();` no header.
-- Destrutor default.
+**Registro histórico (2026-03-30)**
+- O review anterior descrevia `_param` como owner sem destruição explícita.
 
-**Risco**
-- Vazamento de parâmetros de RNG em cada instância do sampler.
+### Audit status
+`PARTIAL`
 
-**Solução sugerida**
-- Liberar `_param` no destrutor.
-- Preferível: armazenar `DefaultImpl1RNG_Parameters` por valor ou `std::unique_ptr<RNG_Parameters>` com ownership explícito.
+### Evidence
+- `SamplerDefaultImpl1` agora declara destrutor explícito e libera `_param` quando `_ownsParam` é verdadeiro.
+- `setRNGparameters()` também libera `_param` previamente owned antes de substituir por parâmetro externo e ajustar `_ownsParam=false`.
 
-## Recomendações de hardening (priorizadas)
+### Remaining gaps
+- Ownership ainda é manual (ponteiro cru + flag `_ownsParam`), mantendo risco de manutenção futura.
+- RAII por `std::unique_ptr<RNG_Parameters>` (ou objeto por valor onde possível) continua sendo recomendação válida de hardening.
 
-1. **Padronizar ownership**: owner deve ser `std::unique_ptr` (ou valor), observer deve ser ponteiro cru/referência.
-2. **Eliminar `new` em inicialização de atributo** quando a classe pode conter o objeto por valor.
-3. **Regra de projeto**: toda classe com ponteiro owner precisa de um dos dois:
-   - destrutor explícito com liberação, ou
-   - smart pointer com deleção automática.
-4. **Executar sanitizers no CI** para detectar regressões:
-   - `-fsanitize=address,leak,undefined`
-   - suíte mínima de smoke tests e unit tests.
-5. **Adicionar checklist de PR**: “introduziu `new`? Onde está o owner e a estratégia de liberação?”.
+## Recomendações de hardening (estado atual)
 
-## Resumo executivo
+1. Manter prioridade na migração gradual de owners manuais para RAII (`std::unique_ptr` ou composição por valor).
+2. Para classes ainda em `PARTIAL` (`SimulationScenario`, `ModelSimulation`, `SamplerDefaultImpl1`), reduzir ponteiros owner crus como backlog técnico explícito.
+3. Preservar regra de projeto: novo `new` deve vir com ownership claro e estratégia de liberação verificável.
+4. Continuar uso de sanitizers (ASan/LSan/UBSan) em CI para prevenir regressões de leak/lifetime.
 
-Há sinais concretos de risco de leak no kernel, principalmente em classes com muitos members alocados com `new` e destrutor default. O caminho mais seguro é migrar gradualmente para RAII (`std::unique_ptr`/valor), começando por `SimulationScenario`, `ModelSimulation`, `TraceManager`, `ModelManager`, `StatisticsDatafileDefaultImpl1` e `SamplerDefaultImpl1`.
+## Resumo executivo reclassificado
+
+- Itens antes tratados como “alto risco atual” em `TraceManager` e `ModelManager` foram **corrigidos** no estado atual (`DONE`).
+- `SimulationScenario`, `ModelSimulation` e `SamplerDefaultImpl1` não sustentam mais o leak direto descrito originalmente, mas ainda dependem de ownership manual (`PARTIAL`).
+- O item de `StatisticsDatafileDefaultImpl1` foi **superado por mudança posterior/obsolescência de artefato** (`SUPERSEDED`), com equivalente atual (`CollectorDatafileDefaultImpl1`) sem o padrão de leak descrito.
+- No recorte auditado deste documento, não houve item classificado como `OPEN`.
+
+## Remaining Work
+
+- `PARTIAL` — `SimulationScenario`: migrar ownership manual de listas/pares para RAII por valor ou smart pointers, reduzindo risco de regressão.
+- `PARTIAL` — `ModelSimulation`: reduzir owners manuais (`new`/`delete`) e flags de ownership para modelo RAII.
+- `PARTIAL` — `SamplerDefaultImpl1`: trocar ponteiro cru `_param` + `_ownsParam` por contrato RAII explícito.
+- `UNCERTAIN` — rastreabilidade histórica entre `StatisticsDatafileDefaultImpl1` (documento antigo) e `CollectorDatafileDefaultImpl1` (estado atual): confirmar por histórico de commits/refactor quando necessário.


### PR DESCRIPTION
### Motivation
- Update the historical `documentation/kernel-memory-leak-review-2026-03-30.md` so the review reflects the current kernel state on branch `WiP20261` without changing any source code.
- Reclassify previously reported leak findings into `DONE`/`PARTIAL`/`OPEN`/`UNCERTAIN`/`SUPERSEDED` categories based on current headers/implementations.

### Description
- Transformed the old review into an evidence-based re-audit, adding an `## Audit Status (WiP20261)` header, legend and date, and preserving historical notes while adding `Audit status`, `Evidence` and `Remaining gaps` for each finding. 
- Reclassified the six mandated items: `TraceManager` and `ModelManager` -> `DONE`; `SimulationScenario`, `ModelSimulation`, `SamplerDefaultImpl1` -> `PARTIAL`; `StatisticsDatafileDefaultImpl1` -> `SUPERSEDED` (mapped to current `CollectorDatafileDefaultImpl1` with uncertainty noted).
- Added a final `## Remaining Work` section that lists only `PARTIAL` and `UNCERTAIN` items and recommended RAII hardening steps for remaining manual-ownership sites.
- Change is documentation-only and limited to `documentation/kernel-memory-leak-review-2026-03-30.md`.

### Testing
- Confirmed the modified file content and diff of `documentation/kernel-memory-leak-review-2026-03-30.md` to ensure only the intended document was changed and the new audit sections are present. (inspection/read-only checks)
- Re-inspected the referenced source files (`SimulationScenario`, `ModelSimulation`, `TraceManager`, `ModelManager`, `CollectorDatafileDefaultImpl1`, `SamplerDefaultImpl1`) to collect the evidence cited in the document. (static file reads)
- No unit/integration tests were run because this is a documentation-only change; no build or runtime effects are expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d881e833f88321a90e215f53954fe2)