### PR TITLE
Fix Delay recheck lifecycle dangling statistics pointer

### DIFF
--- a/source/plugins/components/Delay.cpp
+++ b/source/plugins/components/Delay.cpp
@@ -153,20 +153,23 @@ bool Delay::_check(std::string& errorMessage) {
 }
 
 void Delay::_createInternalAndAttachedData() {
-	if (_reportStatistics && _cstatWaitTime == nullptr) {
-		_attachedAttributesInsert({"Entity.Total" + Util::StrAllocation(_allocation)+"Time"});
-		_cstatWaitTime = new StatisticsCollector(_parentModel, getName() + "." + "DelayTime", this);
-		_internalDataInsert("DelayTime", _cstatWaitTime);
-		// include StatisticsCollector needed in EntityType
-		//ModelDataManager* elements = _parentModel->getDataManager();
-		//std::list<ModelDataDefinition*>* enttypes = elements->getDataDefinitionList(Util::TypeOf<EntityType>())->list();
-		//for (ModelDataDefinition* modeldatum : *enttypes) {
-		//	EntityType* enttype = static_cast<EntityType*> (modeldatum);
-		//	if (modeldatum->isReportStatistics())
-		//		enttype->addGetStatisticsCollector(enttype->getName() + ".DelayTime");
-		//}
-	} else {
+	if (_reportStatistics) {
+		if (_cstatWaitTime == nullptr) {
+			_attachedAttributesInsert({"Entity.Total" + Util::StrAllocation(_allocation)+"Time"});
+			_cstatWaitTime = new StatisticsCollector(_parentModel, getName() + "." + "DelayTime", this);
+			_internalDataInsert("DelayTime", _cstatWaitTime);
+			// include StatisticsCollector needed in EntityType
+			//ModelDataManager* elements = _parentModel->getDataManager();
+			//std::list<ModelDataDefinition*>* enttypes = elements->getDataDefinitionList(Util::TypeOf<EntityType>())->list();
+			//for (ModelDataDefinition* modeldatum : *enttypes) {
+			//	EntityType* enttype = static_cast<EntityType*> (modeldatum);
+			//	if (modeldatum->isReportStatistics())
+			//		enttype->addGetStatisticsCollector(enttype->getName() + ".DelayTime");
+			//}
+		}
+	} else if (_cstatWaitTime != nullptr) {
 		_internalDataClear();
+		_cstatWaitTime = nullptr;
 		// @TODO remove StatisticsCollector needed in EntityType
 	}
 }

--- a/source/plugins/components/Delay.h
+++ b/source/plugins/components/Delay.h
@@ -82,9 +82,9 @@ private:
 	Util::TimeUnit _delayTimeUnit = DEFAULT.delayTimeUnit;
 	Util::AllocationType _allocation = DEFAULT.allocation;
 private: // inner internal elements
+	friend class DelayProbe;
 	StatisticsCollector* _cstatWaitTime = nullptr;
 };
 //enable_this_owner(Delay, DelayExpression);
 
 #endif /* DELAY_H */
-

--- a/source/tests/unit/test_simulator_runtime.cpp
+++ b/source/tests/unit/test_simulator_runtime.cpp
@@ -17,7 +17,25 @@
 #include "plugins/data/Schedule.h"
 #include "plugins/data/Sequence.h"
 #include "plugins/data/SignalData.h"
+#include "plugins/components/Delay.h"
 #include "plugins/components/Wait.h"
+
+class DelayProbe : public Delay {
+public:
+    DelayProbe(Model* model, const std::string& name = "") : Delay(model, name) {}
+
+    void CreateInternalAndAttachedDataProbe() {
+        _createInternalAndAttachedData();
+    }
+
+    StatisticsCollector* WaitTimeStatisticsCollectorProbe() const {
+        return _cstatWaitTime;
+    }
+
+    void AddWaitTimeValueProbe(double waitTime) {
+        _cstatWaitTime->getStatistics()->getCollector()->addValue(waitTime);
+    }
+};
 
 class ResourceTestProbe {
 public:
@@ -1481,6 +1499,93 @@ TEST(SimulatorRuntimeTest, WaitRecheckUpdatesSignalDataHandlersWhenSignalChanges
     wait.setWaitType(Wait::WaitType::InfiniteHold);
     wait.CreateInternalAndAttachedDataProbe();
     EXPECT_FALSE(signalB.hasSignalDataEventHandler(&wait));
+}
+
+TEST(SimulatorRuntimeTest, DelayCreateInternalInitiallyCreatesStatisticsCollectorWhenEnabled) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    DelayProbe delay(model, "DelayCreateStats");
+    delay.setReportStatistics(true);
+    delay.CreateInternalAndAttachedDataProbe();
+
+    EXPECT_NE(delay.WaitTimeStatisticsCollectorProbe(), nullptr);
+}
+
+TEST(SimulatorRuntimeTest, DelayRecheckWithStatisticsEnabledIsIdempotentAndPreservesInternalCollector) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    DelayProbe delay(model, "DelayIdempotentStats");
+    delay.setReportStatistics(true);
+    delay.CreateInternalAndAttachedDataProbe();
+    StatisticsCollector* firstCollector = delay.WaitTimeStatisticsCollectorProbe();
+    ASSERT_NE(firstCollector, nullptr);
+
+    delay.CreateInternalAndAttachedDataProbe();
+    EXPECT_EQ(delay.WaitTimeStatisticsCollectorProbe(), firstCollector);
+    EXPECT_NE(delay.WaitTimeStatisticsCollectorProbe()->getStatistics(), nullptr);
+}
+
+TEST(SimulatorRuntimeTest, DelayRecheckWithStatisticsDisabledClearsInternalCollectorPointer) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    DelayProbe delay(model, "DelayDisableStats");
+    delay.setReportStatistics(true);
+    delay.CreateInternalAndAttachedDataProbe();
+    ASSERT_NE(delay.WaitTimeStatisticsCollectorProbe(), nullptr);
+
+    delay.setReportStatistics(false);
+    delay.CreateInternalAndAttachedDataProbe();
+    EXPECT_EQ(delay.WaitTimeStatisticsCollectorProbe(), nullptr);
+}
+
+TEST(SimulatorRuntimeTest, DelayRecheckCanRecreateCollectorAfterDisablingAndReenablingStatistics) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    DelayProbe delay(model, "DelayRecreateStats");
+    delay.setReportStatistics(true);
+    delay.CreateInternalAndAttachedDataProbe();
+    ASSERT_NE(delay.WaitTimeStatisticsCollectorProbe(), nullptr);
+
+    delay.setReportStatistics(false);
+    delay.CreateInternalAndAttachedDataProbe();
+    ASSERT_EQ(delay.WaitTimeStatisticsCollectorProbe(), nullptr);
+
+    delay.setReportStatistics(true);
+    delay.CreateInternalAndAttachedDataProbe();
+    StatisticsCollector* recreatedCollector = delay.WaitTimeStatisticsCollectorProbe();
+    ASSERT_NE(recreatedCollector, nullptr);
+    EXPECT_NE(recreatedCollector->getStatistics(), nullptr);
+}
+
+TEST(SimulatorRuntimeTest, DelayCollectorAccessPathRemainsValidAcrossStatisticsRecheckSequence) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    DelayProbe delay(model, "DelayCollectorPath");
+    delay.setReportStatistics(true);
+    delay.CreateInternalAndAttachedDataProbe();
+    delay.CreateInternalAndAttachedDataProbe();
+
+    delay.setReportStatistics(false);
+    delay.CreateInternalAndAttachedDataProbe();
+    ASSERT_EQ(delay.WaitTimeStatisticsCollectorProbe(), nullptr);
+
+    delay.setReportStatistics(true);
+    delay.CreateInternalAndAttachedDataProbe();
+    ASSERT_NE(delay.WaitTimeStatisticsCollectorProbe(), nullptr);
+    ASSERT_NE(delay.WaitTimeStatisticsCollectorProbe()->getStatistics(), nullptr);
+    ASSERT_NE(delay.WaitTimeStatisticsCollectorProbe()->getStatistics()->getCollector(), nullptr);
+
+    EXPECT_NO_THROW(delay.AddWaitTimeValueProbe(1.5));
 }
 
 TEST(SimulatorRuntimeTest, SignalDataCheckFailsWithoutHandlers) {


### PR DESCRIPTION
### Motivation
- A dangling `_cstatWaitTime` pointer in `Delay` could occur after model rechecks because `_internalDataClear()` destroyed the internal `StatisticsCollector` without nulling the member, causing a segfault at dispatch when accessing `getStatistics()`.
- The change aims for a minimal, localized fix to make rechecks idempotent and ensure safe cleanup of the Delay internal statistics collector.

### Description
- Updated `Delay::_createInternalAndAttachedData()` to only create the `StatisticsCollector` when `_reportStatistics == true` and `_cstatWaitTime == nullptr`, to preserve existing internals on repeated rechecks, and to call `_internalDataClear()` only when statistics are disabled and an existing collector is present.
- After clearing internals, explicitly set `_cstatWaitTime = nullptr` to avoid dangling pointers.
- Added a `friend class DelayProbe;` declaration in `Delay.h` and a `DelayProbe` test probe in `test_simulator_runtime.cpp` to access internals for unit testing without changing production semantics.
- Added unit tests exercising the full toggle/recheck sequence and a functional access path that mirrors the pre-crash usage (`StatisticsCollector::getStatistics()->getCollector()->addValue(...)`).

### Testing
- Configured and built the tests with CMake and Ninja (`GENESYS_BUILD_TESTS=ON`, `GENESYS_BUILD_KERNEL=ON`, `GENESYS_BUILD_PLUGINS=ON`) and built `genesys_test_simulator_runtime` successfully.
- Ran Delay-focused tests with CTest: `ctest -R "SimulatorRuntimeTest.*Delay"` and all Delay tests passed (5/5).
- Ran broader smoke run (`ctest -LE smoke`); the run shows several `*_NOT_BUILT` tests due to build configuration, but the modified Delay-related tests executed and passed.

```markdown
- o que você realizou de fato;
  - Corrigi o ciclo de vida do `Delay` em `_createInternalAndAttachedData()` para ser idempotente em rechecagens, preservando o collector quando habilitado e limpando + zerando o ponteiro quando desabilitado.
  - Adicionei `DelayProbe` (probe de teste) e testes unitários que cobrem criação, rechecagem idempotente, desligar/religar estatísticas e acesso funcional ao collector para reproduzir o caminho do crash.
  - Compilei e executei os testes relevantes; os testes de Delay passaram.

- o que não realizou;
  - Não alterei `StatisticsCollector` nem refatorei outros componentes fora do `Delay`.
  - Não auditei outros componentes por possíveis problemas semelhantes nesta etapa.

- por que não realizou;
  - Alterar `StatisticsCollector` ou outros componentes estava explicitamente proibido e fora do escopo desta correção localizada.
  - O objetivo era uma correção mínima e segura apenas em `Delay` com cobertura de teste.

- riscos remanescentes;
  - Outros componentes podem ter lógica de rechecagem similar que gere dangling pointers, e não foram verificados aqui.
  - A alteração depende do comportamento de `_internalDataClear()` e da garantia de que ele destrói os objetos gerenciados; se essa semântica mudar, será necessária revisão.

- observações relevantes;
  - A correção é localizada, não altera a semântica externa do `Delay` e evita o uso de ponteiro pendente na simulação.
  - A prova funcional adicionada chama `addValue(...)` no collector para garantir que o caminho que gerava o segfault ficou seguro.

- arquivos alterados;
  - `source/plugins/components/Delay.h`
  - `source/plugins/components/Delay.cpp`
  - `source/tests/unit/test_simulator_runtime.cpp`

- comandos executados e resultados resumidos.
  - `cmake -S . -B build -G Ninja -DGENESYS_BUILD_TESTS=ON -DGENESYS_BUILD_KERNEL=ON -DGENESYS_BUILD_PARSER=ON -DGENESYS_BUILD_PLUGINS=ON -DGENESYS_TERMINAL_APPLICATION=OFF -DGENESYS_BUILD_GUI_APPLICATION=OFF -DGENESYS_BUILD_WEB_APPLICATION=OFF` — configuração bem-sucedida.
  - `cmake --build build --target genesys_test_simulator_runtime` — build bem-sucedido do alvo de testes.
  - `ctest --test-dir build -R "SimulatorRuntimeTest.*Delay" --output-on-failure` — executou 5 testes Delay com 5/5 aprovados.
  - `ctest --test-dir build -LE smoke --output-on-failure` — executado; vários testes aparecem como `*_NOT_BUILT` nesta configuração, mas os testes em que aplicamos alterações passaram.
```

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d88aa2d3cc83218db7177936fc9df4)