### PR TITLE
Fix confidence level precision and invalid z lookup behavior

### DIFF
--- a/source/kernel/statistics/StatisticsDataFileDefaultImpl.cpp
+++ b/source/kernel/statistics/StatisticsDataFileDefaultImpl.cpp
@@ -14,6 +14,7 @@
 #include "StatisticsDataFileDefaultImpl.h"
 #include "../TraitsKernel.h"
 #include <math.h>
+#include <cmath>
 #include <limits>
 
 StatisticsDatafileDefaultImpl1::StatisticsDatafileDefaultImpl1() {
@@ -204,11 +205,12 @@ double StatisticsDatafileDefaultImpl1::variationCoef() {
 }
 
 double StatisticsDatafileDefaultImpl1::_getNormalProbability(double confidenceLevel) {
+	// Return NaN for unsupported confidence levels to avoid silent use of invalid z-values.
 	auto search = _z.find(confidenceLevel);
 	if (search != _z.end()) {
 		return search->second;
 	} else {
-		return 0.0;
+		return std::numeric_limits<double>::quiet_NaN();
 	}
 }
 
@@ -218,7 +220,7 @@ double StatisticsDatafileDefaultImpl1::halfWidthConfidenceInterval() {
 		double z = _getNormalProbability(_confidenceLevel);
 		// Return NaN for undefined interval width when sample size or deviation is invalid.
 		const double stddev = stddeviation();
-		if (_numElements == 0 || std::isnan(stddev)) {
+		if (_numElements == 0 || std::isnan(stddev) || !std::isfinite(z)) {
 			_halfWidthConfidenceInterval = std::numeric_limits<double>::quiet_NaN();
 		} else {
 			_halfWidthConfidenceInterval = z * stddev / sqrt(_numElements);
@@ -256,7 +258,12 @@ double StatisticsDatafileDefaultImpl1::confidenceLevel() {
 }
 
 void StatisticsDatafileDefaultImpl1::setConfidenceLevel(double confidencelevel) {
-	_confidenceLevel = round(confidencelevel * 100.0) / 100.0;
+	// Preserve supported table precision while rejecting out-of-range confidence levels.
+	if (confidencelevel > 0.0 && confidencelevel <= 1.0) {
+		_confidenceLevel = confidencelevel;
+	} else {
+		_confidenceLevel = std::numeric_limits<double>::quiet_NaN();
+	}
 }
 
 double StatisticsDatafileDefaultImpl1::mode() {


### PR DESCRIPTION
KERNEL

### Motivation
- The previous implementation rounded `confidenceLevel` to 2 decimal places which prevented exact map lookups for supported `_z` keys like `0.975` and `0.995`, and `_getNormalProbability` returned `0.0` silently for missing keys which could produce misleading results.
- The change aims to remove the silent failure mode with minimal API-surface changes and preserve inferential math correctness by making invalid inputs explicit.

### Description
- Updated `source/kernel/statistics/StatisticsDataFileDefaultImpl.cpp` to stop rounding `confidenceLevel` and instead accept values in `(0,1]` or store `NaN` when out of range, preserving the public signature of `setConfidenceLevel`.
- Changed `_getNormalProbability` to return `std::numeric_limits<double>::quiet_NaN()` for unsupported keys and made `halfWidthConfidenceInterval()` treat non-finite `z` values as invalid so it returns `NaN`; `newSampleSize()` behavior remains protected by its existing guards.

### Testing
- Performed an OOB compilation validation using `cmake --preset debug-kernel` and then `cmake --build build/debug-kernel --target genesys_kernel -j4` and the build completed successfully with the modified translation unit recompiled.
- No automated tests were executed as requested; only compilation was run and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d88e9895148321b42bfe2756c8d6d5)