### PR TITLE
Reconcile Delay Entity.Total*Time attached attributes on recheck and add tests

### DIFF
--- a/source/plugins/components/Delay.cpp
+++ b/source/plugins/components/Delay.cpp
@@ -152,10 +152,42 @@ bool Delay::_check(std::string& errorMessage) {
 	return _parentModel->checkExpression(_delayExpression, "Delay expression", errorMessage);
 }
 
+std::vector<std::string> Delay::_allAllocationAttachedAttributeNames() const {
+	return {
+		_allocationAttachedAttributeName(Util::AllocationType::ValueAdded),
+		_allocationAttachedAttributeName(Util::AllocationType::NonValueAdded),
+		_allocationAttachedAttributeName(Util::AllocationType::Transfer),
+		_allocationAttachedAttributeName(Util::AllocationType::Wait),
+		_allocationAttachedAttributeName(Util::AllocationType::Others)
+	};
+}
+
+std::string Delay::_allocationAttachedAttributeName(Util::AllocationType allocation) const {
+	return "Entity.Total" + Util::StrAllocation(allocation) + "Time";
+}
+
+void Delay::_reconcileAllocationAttachedAttributes() {
+	std::vector<std::string> allocationAttributes = _allAllocationAttachedAttributeNames();
+	if (_reportStatistics) {
+		const std::string currentAllocationAttribute = _allocationAttachedAttributeName(_allocation);
+		for (const std::string& allocationAttribute : allocationAttributes) {
+			if (allocationAttribute != currentAllocationAttribute) {
+				_attachedDataRemove(allocationAttribute);
+			}
+		}
+		_attachedAttributesInsert({currentAllocationAttribute});
+	} else {
+		for (const std::string& allocationAttribute : allocationAttributes) {
+			_attachedDataRemove(allocationAttribute);
+		}
+	}
+}
+
 void Delay::_createInternalAndAttachedData() {
+	_reconcileAllocationAttachedAttributes();
+
 	if (_reportStatistics) {
 		if (_cstatWaitTime == nullptr) {
-			_attachedAttributesInsert({"Entity.Total" + Util::StrAllocation(_allocation)+"Time"});
 			_cstatWaitTime = new StatisticsCollector(_parentModel, getName() + "." + "DelayTime", this);
 			_internalDataInsert("DelayTime", _cstatWaitTime);
 			// include StatisticsCollector needed in EntityType

--- a/source/plugins/components/Delay.h
+++ b/source/plugins/components/Delay.h
@@ -15,6 +15,7 @@
 #define DELAY_H
 
 #include <string>
+#include <vector>
 #include "../../kernel/simulator/ModelComponent.h"
 #include "../../kernel/simulator/Plugin.h"
 
@@ -81,6 +82,10 @@ private:
 	std::string _delayExpression = DEFAULT.delayExpression;
 	Util::TimeUnit _delayTimeUnit = DEFAULT.delayTimeUnit;
 	Util::AllocationType _allocation = DEFAULT.allocation;
+private:
+	std::vector<std::string> _allAllocationAttachedAttributeNames() const;
+	std::string _allocationAttachedAttributeName(Util::AllocationType allocation) const;
+	void _reconcileAllocationAttachedAttributes();
 private: // inner internal elements
 	friend class DelayProbe;
 	StatisticsCollector* _cstatWaitTime = nullptr;

--- a/source/tests/unit/test_simulator_runtime.cpp
+++ b/source/tests/unit/test_simulator_runtime.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include <algorithm>
 #include <memory>
+#include <vector>
 
 #include "kernel/simulator/Simulator.h"
 #include "kernel/simulator/Model.h"
@@ -34,6 +35,10 @@ public:
 
     void AddWaitTimeValueProbe(double waitTime) {
         _cstatWaitTime->getStatistics()->getCollector()->addValue(waitTime);
+    }
+
+    bool HasAttachedDataProbe(const std::string& key) const {
+        return getAttachedData()->find(key) != getAttachedData()->end();
     }
 };
 
@@ -277,6 +282,30 @@ public:
         ++g_countingWaitingProbeDestructorCount;
     }
 };
+
+std::vector<std::string> DelayAllocationAttributeNames() {
+    return {
+        "Entity.TotalValueAddedTime",
+        "Entity.TotalNonValueAddedTime",
+        "Entity.TotalTransferTime",
+        "Entity.TotalWaitTime",
+        "Entity.TotalOthersTime"
+    };
+}
+
+std::string DelayAllocationAttributeName(Util::AllocationType allocation) {
+    return "Entity.Total" + Util::StrAllocation(allocation) + "Time";
+}
+
+size_t CountAttachedDelayAllocationAttributes(const DelayProbe& delay) {
+    size_t count = 0;
+    for (const std::string& attributeName : DelayAllocationAttributeNames()) {
+        if (delay.HasAttachedDataProbe(attributeName)) {
+            ++count;
+        }
+    }
+    return count;
+}
 }
 
 TEST(SimulatorRuntimeTest, CanConstructSimulatorAndAccessManagers) {
@@ -1511,6 +1540,99 @@ TEST(SimulatorRuntimeTest, DelayCreateInternalInitiallyCreatesStatisticsCollecto
     delay.CreateInternalAndAttachedDataProbe();
 
     EXPECT_NE(delay.WaitTimeStatisticsCollectorProbe(), nullptr);
+}
+
+TEST(SimulatorRuntimeTest, DelayAttachedAttributeUsesInitialAllocationWhenStatisticsAreEnabled) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    DelayProbe delay(model, "DelayInitialAllocationAttached");
+    delay.setReportStatistics(true);
+    delay.setAllocation(Util::AllocationType::Wait);
+    delay.CreateInternalAndAttachedDataProbe();
+
+    EXPECT_TRUE(delay.HasAttachedDataProbe("Entity.TotalWaitTime"));
+    EXPECT_EQ(CountAttachedDelayAllocationAttributes(delay), 1u);
+}
+
+TEST(SimulatorRuntimeTest, DelayRecheckWithAllocationChangeKeepsOnlyCurrentAttachedAttribute) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    DelayProbe delay(model, "DelayAllocationRecheck");
+    delay.setReportStatistics(true);
+    delay.setAllocation(Util::AllocationType::Wait);
+    delay.CreateInternalAndAttachedDataProbe();
+    ASSERT_TRUE(delay.HasAttachedDataProbe("Entity.TotalWaitTime"));
+
+    delay.setAllocation(Util::AllocationType::Transfer);
+    delay.CreateInternalAndAttachedDataProbe();
+    EXPECT_FALSE(delay.HasAttachedDataProbe("Entity.TotalWaitTime"));
+    EXPECT_TRUE(delay.HasAttachedDataProbe("Entity.TotalTransferTime"));
+    EXPECT_EQ(CountAttachedDelayAllocationAttributes(delay), 1u);
+}
+
+TEST(SimulatorRuntimeTest, DelayRecheckWithStatisticsDisabledRemovesAllAllocationAttachedAttributes) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    DelayProbe delay(model, "DelayDisableStatisticsAttached");
+    delay.setReportStatistics(true);
+    delay.setAllocation(Util::AllocationType::Transfer);
+    delay.CreateInternalAndAttachedDataProbe();
+    ASSERT_TRUE(delay.HasAttachedDataProbe("Entity.TotalTransferTime"));
+
+    delay.setReportStatistics(false);
+    delay.CreateInternalAndAttachedDataProbe();
+    EXPECT_EQ(CountAttachedDelayAllocationAttributes(delay), 0u);
+    EXPECT_EQ(delay.WaitTimeStatisticsCollectorProbe(), nullptr);
+}
+
+TEST(SimulatorRuntimeTest, DelayRecheckReenableStatisticsWithDifferentAllocationCreatesSingleExpectedAttachedAttribute) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    DelayProbe delay(model, "DelayReenableDifferentAllocation");
+    delay.setReportStatistics(true);
+    delay.setAllocation(Util::AllocationType::Wait);
+    delay.CreateInternalAndAttachedDataProbe();
+    ASSERT_TRUE(delay.HasAttachedDataProbe("Entity.TotalWaitTime"));
+
+    delay.setReportStatistics(false);
+    delay.CreateInternalAndAttachedDataProbe();
+    ASSERT_EQ(CountAttachedDelayAllocationAttributes(delay), 0u);
+
+    delay.setAllocation(Util::AllocationType::Others);
+    delay.setReportStatistics(true);
+    delay.CreateInternalAndAttachedDataProbe();
+    EXPECT_TRUE(delay.HasAttachedDataProbe("Entity.TotalOthersTime"));
+    EXPECT_FALSE(delay.HasAttachedDataProbe("Entity.TotalWaitTime"));
+    EXPECT_EQ(CountAttachedDelayAllocationAttributes(delay), 1u);
+}
+
+TEST(SimulatorRuntimeTest, DelayRecheckKeepsComponentConsistentForDispatchPathsAfterAllocationChanges) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    DelayProbe delay(model, "DelayConsistentDispatchAfterRecheck");
+    delay.setReportStatistics(true);
+    delay.setAllocation(Util::AllocationType::ValueAdded);
+    delay.CreateInternalAndAttachedDataProbe();
+    ASSERT_NE(delay.WaitTimeStatisticsCollectorProbe(), nullptr);
+
+    delay.setAllocation(Util::AllocationType::Transfer);
+    delay.CreateInternalAndAttachedDataProbe();
+    ASSERT_TRUE(delay.HasAttachedDataProbe(DelayAllocationAttributeName(Util::AllocationType::Transfer)));
+    ASSERT_EQ(CountAttachedDelayAllocationAttributes(delay), 1u);
+    ASSERT_NE(delay.WaitTimeStatisticsCollectorProbe(), nullptr);
+    ASSERT_NE(delay.WaitTimeStatisticsCollectorProbe()->getStatistics(), nullptr);
+    ASSERT_NE(delay.WaitTimeStatisticsCollectorProbe()->getStatistics()->getCollector(), nullptr);
+    EXPECT_NO_THROW(delay.AddWaitTimeValueProbe(2.0));
 }
 
 TEST(SimulatorRuntimeTest, DelayRecheckWithStatisticsEnabledIsIdempotentAndPreservesInternalCollector) {


### PR DESCRIPTION
PLUGINS

### Motivation
- Closing the remaining semantic bug in `Delay` where attached attributes `Entity.Total<Allocation>Time` were only added on initial creation and not reconciled on model recheck, leaving stale attached data when `AllocationType` or `reportStatistics` change. 
- Ensure model-check lifecycle is correct for repeated calls to `_createInternalAndAttachedData()` during modelling/rechecking without reintroducing the prior segfault fix.

### Description
- Added private helpers in `Delay` to enumerate allocation attribute names, build the attribute name for a given `AllocationType`, and reconcile attached attributes: `_allAllocationAttachedAttributeNames()`, `_allocationAttachedAttributeName(...)`, and `_reconcileAllocationAttachedAttributes()` in `Delay.h`/`Delay.cpp`.
- Call `_reconcileAllocationAttachedAttributes()` at the start of `_createInternalAndAttachedData()` so that attached attributes are idempotently reconciled on every recheck and only the correct `Entity.Total*Time` remains when `reportStatistics==true`, and all such attributes are removed when `reportStatistics==false`.
- Preserve the existing safe lifecycle for `_cstatWaitTime` (collector created only if needed and cleared with `_cstatWaitTime = nullptr`).
- Added unit tests and test probes in `source/tests/unit/test_simulator_runtime.cpp` to cover: initial allocation attach, allocation swap with statistics enabled, disabling statistics removes all allocation attributes, reenabling with a different allocation, and functional consistency of the collector path after rechecks.

### Testing
- Configured build with tests and plugins enabled using `cmake -S . -B build -G Ninja -DGENESYS_BUILD_TESTS=ON -DGENESYS_BUILD_KERNEL=ON -DGENESYS_BUILD_PARSER=ON -DGENESYS_BUILD_PLUGINS=ON -DGENESYS_TERMINAL_APPLICATION=OFF -DGENESYS_BUILD_GUI_APPLICATION=OFF -DGENESYS_BUILD_WEB_APPLICATION=OFF` which completed successfully.
- Built the runtime tests via `cmake --build build --target genesys_test_simulator_runtime` which completed successfully.
- Ran Delay-focused tests with `ctest --test-dir build -R "SimulatorRuntimeTest.*Delay" --output-on-failure` and the Delay tests passed (10/10 passed).
- Ran broader smoke suite `ctest --test-dir build -LE smoke --output-on-failure` and observed unrelated `*_NOT_BUILT` entries causing some Not Run results; these are artifacts of the current build profile and do not indicate failure of the changed Delay tests.

```markdown
- o que você realizou de fato;
  - Corrigi a reconciliação de attached attributes de allocation no `Delay` em rechecagens sucessivas.
  - Garanti comportamento obrigatório:
    - com `reportStatistics == true`: mantém apenas o attached attribute da allocation atual;
    - com `reportStatistics == false`: remove todos os `Entity.Total*Time` do `Delay`.
  - Preservei a correção anterior do ciclo de vida de `_cstatWaitTime` (sem reintroduzir dangling pointer).
  - Adicionei testes unitários cobrindo os 5 cenários obrigatórios desta etapa.
  - Commit realizado: `a90aa8da`.
  - PR registrada via ferramenta `make_pr`.

- o que não realizou;
  - Não alterei `StatisticsCollector`.
  - Não refatorei outros componentes além de `Delay`.
  - Não mudei arquitetura global de model checking.
  - Não capturei screenshot (sem mudança de frontend/componente visual).

- por que não realizou;
  - Fora do escopo permitido/proibido definido para esta etapa.
  - Não houve alteração visual que justificasse screenshot.

- riscos remanescentes;
  - O `ctest -LE smoke` inclui entradas `*_NOT_BUILT`; isso pode confundir leitura de “falha geral” mesmo com suíte-alvo validada.
  - A correção está focada no ciclo modelagem/rechecagem (como solicitado), não em reconfiguração estrutural durante simulação.

- observações relevantes;
  - O comportamento agora é idempotente sob rechecagem com troca de `AllocationType` e toggle de `reportStatistics`.
  - Os testes novos e os já existentes de `Delay` passaram no filtro `SimulatorRuntimeTest.*Delay`.

- arquivos alterados;
  - `source/plugins/components/Delay.h`
  - `source/plugins/components/Delay.cpp`
  - `source/tests/unit/test_simulator_runtime.cpp`

- comandos executados e resultados resumidos.
  - `cmake -S . -B build -G Ninja ...` → sucesso.
  - `cmake --build build --target genesys_test_simulator_runtime` → sucesso.
  - `ctest --test-dir build -R "SimulatorRuntimeTest.*Delay" --output-on-failure` → 10/10 testes passaram.
  - `ctest --test-dir build -LE smoke --output-on-failure` → falhas por executáveis `*_NOT_BUILT` ausentes no perfil atual.
```

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d88e9c0e548321a5fc274b526c0b00)