### PR TITLE
GUI: make property browser infrastructure binding strictly one-time

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/propertyeditor/ObjectPropertyBrowser.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/propertyeditor/ObjectPropertyBrowser.cpp
@@ -116,13 +116,15 @@ void ObjectPropertyBrowser::_ensureBrowserInfrastructure() {
         _enumFactory = new QtEnumEditorFactory(this);
     }
 
-    if (_variantManager != nullptr && _variantFactory != nullptr) {
-        // Bind variant manager/factory one time to avoid repeated reconfiguration.
+    // Bind manager/factory pairs only once to keep browser infrastructure idempotent.
+    if (!_browserInfrastructureBound
+        && _variantManager != nullptr
+        && _variantFactory != nullptr
+        && _enumManager != nullptr
+        && _enumFactory != nullptr) {
         setFactoryForManager(_variantManager, _variantFactory);
-    }
-    if (_enumManager != nullptr && _enumFactory != nullptr) {
-        // Bind enum manager/factory one time to avoid repeated reconfiguration.
         setFactoryForManager(_enumManager, _enumFactory);
+        _browserInfrastructureBound = true;
     }
 }
 

--- a/source/applications/gui/qt/GenesysQtGUI/propertyeditor/ObjectPropertyBrowser.h
+++ b/source/applications/gui/qt/GenesysQtGUI/propertyeditor/ObjectPropertyBrowser.h
@@ -123,6 +123,8 @@ private:
 
     QtVariantEditorFactory* _variantFactory = nullptr;
     QtEnumEditorFactory* _enumFactory = nullptr;
+    // Track whether factories were already bound to managers in the browser.
+    bool _browserInfrastructureBound = false;
 
     QMap<QtProperty*, Binding> _bindings;
     QMap<QtProperty*, QStringList> _enumNames;


### PR DESCRIPTION
### Motivation
- Prevent repeated structural re-registration of factories/managers by `_ensureBrowserInfrastructure()` which can touch sensitive parts of `QtAbstractPropertyBrowser` during cleanup/rebuild cycles.
- Ensure managers and factories are created and connected only once and that `setFactoryForManager(...)` is invoked a single time to avoid runtime instability.

### Description
- Added a private flag `// Track whether factories were already bound to managers in the browser.` `bool _browserInfrastructureBound = false;` to `ObjectPropertyBrowser.h` to record first-time binding.
- Modified `_ensureBrowserInfrastructure()` in `ObjectPropertyBrowser.cpp` to keep one-time creation and signal connections for managers/factories but perform `setFactoryForManager(...)` only when `_browserInfrastructureBound` is `false`, then set it to `true` after binding.
- Left manager/factory creation and signal connections to occur only when the corresponding pointers are null, and preserved `CommitAwareVariantEditorFactory` behavior.
- Kept `_clearAll()` behavior unchanged as transient-content cleanup and allowed it to call `_ensureBrowserInfrastructure()` defensively without causing re-registration.

### Testing
- Reopened and inspected both modified files to confirm the `_browserInfrastructureBound` flag exists and the `setFactoryForManager(...)` calls are guarded by that flag; inspection succeeded.
- Verified the patch diff is restricted to the two targeted files and the changes are limited to the described additions/guarding; verification succeeded.
- Searched the two files for `_browserInfrastructureBound`, `_ensureBrowserInfrastructure`, `setFactoryForManager`, and `_clearAll(` to confirm idempotent binding behavior; searches returned the expected guarded usages.
- Attempted to run a GUI build prerequisite check but `qmake` is not available in the environment, so a full compile/run test could not be performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d89921ad44832192e977b5521ed700)