### PR TITLE
HYPTEST-1 alignment: proportion-difference CI and coherent one-population p-values

### DIFF
--- a/source/tools/ARCHITECTURE_tools.md
+++ b/source/tools/ARCHITECTURE_tools.md
@@ -25,6 +25,7 @@ The `tools` package provides domain-support services for statistical analysis an
 
 ### Hypothesis testing
 - Maintain current contract and refine implementation completeness, especially two-population methods.
+- HYPTEST-1 alignment keeps the current pooled-vs-Welch heuristic, but documents it as a TODO while consolidating one-population p-value coherence and the two-proportion-difference confidence interval formula.
 
 ### Distribution abstractions
 - Introduce `Distribution_if` and specialized continuous/discrete interfaces.

--- a/source/tools/HypothesisTesterDefaultImpl1.cpp
+++ b/source/tools/HypothesisTesterDefaultImpl1.cpp
@@ -42,6 +42,19 @@ double chi2CdfApproximation(double chi2, double degreesOfFreedom) {
 	return clampProbability(normalCdf(transformed));
 }
 
+double chi2CdfByIntegration(double chi2, double degreesOfFreedom) {
+	if (chi2 <= 0.0) {
+		return 0.0;
+	}
+	if (degreesOfFreedom <= 0.0 || !std::isfinite(degreesOfFreedom)) {
+		throw std::invalid_argument("chi2CdfByIntegration requires positive finite degreesOfFreedom");
+	}
+	// Use numerical integration of the chi-square PDF to keep p-values coherent with chi-square quantiles.
+	SolverDefaultImpl1 integrator(1e-6, 10000);
+	const double integral = integrator.integrate(0.0, chi2, ProbabilityDistributionBase::chi2, degreesOfFreedom);
+	return clampProbability(integral);
+}
+
 void validateConfidenceLevel(double confidenceLevel) {
 	if (!(confidenceLevel > 0.0 && confidenceLevel < 1.0)) {
 		throw std::invalid_argument("confidenceLevel must be in (0,1)");
@@ -139,6 +152,7 @@ HypothesisTester_if::ConfidenceInterval HypothesisTesterDefaultImpl1::averageDif
 	double correctConf = (1.0 - confidenceLevel) / 2.0;
 	double e0;
 	HypothesisTester_if::ConfidenceInterval varIC = varianceRatioConfidenceInterval(pow(stddev1, 2), n1, pow(stddev2, 2), n2, confidenceLevel);
+	// @TODO: Equal-variance selection is currently indirect, based on whether the variance-ratio CI contains 1.0; revisit with an explicit pooled-vs-Welch policy.
 	if ((varIC.inferiorLimit() <= 1.0 && varIC.superiorLimit() >= 1.0) || (varIC.inferiorLimit() >= 1.0 && varIC.superiorLimit() <= 1.0)) { // test variances ratio
 		// equal variances
 		const double pooledVariance = (((n1 - 1) * stddev1 * stddev1) + ((n2 - 1) * stddev2 * stddev2)) / (n1 + n2 - 2);
@@ -155,18 +169,21 @@ HypothesisTester_if::ConfidenceInterval HypothesisTesterDefaultImpl1::averageDif
 }
 
 HypothesisTester_if::ConfidenceInterval HypothesisTesterDefaultImpl1::proportionDifferenceConfidenceInterval(double avg1, double stddev1, unsigned int n1, double avg2, double stddev2, unsigned int n2, double confidenceLevel) {
-	if (n1 < 2 || n2 < 2 || stddev1 < 0.0 || stddev2 < 0.0) {
-		throw std::invalid_argument("proportionDifferenceConfidenceInterval requires n1,n2 >= 2 and stddev1,stddev2 >= 0");
+	// Legacy signature compatibility: avg1/avg2 are interpreted as p1/p2 and stddev1/stddev2 are intentionally unused.
+	(void) stddev1;
+	(void) stddev2;
+	const double prop1 = avg1;
+	const double prop2 = avg2;
+	if (n1 < 2 || n2 < 2 || prop1 < 0.0 || prop1 > 1.0 || prop2 < 0.0 || prop2 > 1.0) {
+		throw std::invalid_argument("proportionDifferenceConfidenceInterval requires n1,n2 >= 2 and 0 <= p1,p2 <= 1");
 	}
-	constexpr auto epsilon = std::numeric_limits<double>::epsilon();
-	const double denominator = std::sqrt((stddev1 * stddev1) / n1 + (stddev2 * stddev2) / n2);
-	if (denominator <= epsilon) {
-		return HypothesisTester_if::ConfidenceInterval(avg1 - avg2, avg1 - avg2, 0.0);
-	}
-	double correctConf = (1.0 - confidenceLevel) / 2.0;
-	double critic = -ProbabilityDistribution::inverseTStudent(correctConf, 0.0, 1.0, std::min(n1, n2) - 1);
-	double e0 = critic * denominator;
-	return HypothesisTester_if::ConfidenceInterval(avg1 - avg2 - e0, avg1 - avg2 + e0, e0);
+	validateConfidenceLevel(confidenceLevel);
+	// Use the classical CI for p1 - p2 with normal quantile z_(1-alpha/2), as required by the adopted formalism.
+	const double alpha = 1.0 - confidenceLevel;
+	const double critic = ProbabilityDistribution::inverseNormal(1.0 - alpha / 2.0, 0.0, 1.0);
+	const double standardError = std::sqrt(prop1 * (1.0 - prop1) / n1 + prop2 * (1.0 - prop2) / n2);
+	const double e0 = critic * standardError;
+	return HypothesisTester_if::ConfidenceInterval((prop1 - prop2) - e0, (prop1 - prop2) + e0, e0);
 }
 
 HypothesisTester_if::ConfidenceInterval HypothesisTesterDefaultImpl1::varianceRatioConfidenceInterval(double var1, unsigned int n1, double var2, unsigned int n2, double confidenceLevel) {
@@ -259,7 +276,10 @@ HypothesisTester_if::TestResult HypothesisTesterDefaultImpl1::testAverage(double
 		acceptSupLimit = ProbabilityDistribution::inverseTStudent(1.0 - significanceLevel, 0.0, 1.0, n - 1);
 	}
 	double testStat = (avgSample - avg) / (stddev / sqrt(n));
-	const double cdf = normalCdf(testStat); // normal approximation
+	// Use Student-t CDF for p-value consistency with the t-based critical limits above.
+	const double cdf = studentTCdf(testStat, n - 1);
+	// Historical reference: the previous implementation used a normal approximation for p-value.
+	// const double cdf = normalCdf(testStat); // normal approximation
 	double pvalue;
 	if (comp == HypothesisTester_if::H1Comparition::LESS_THAN) {
 		pvalue = cdf;
@@ -303,7 +323,10 @@ HypothesisTester_if::TestResult HypothesisTesterDefaultImpl1::testVariance(doubl
 	const double significanceLevel = 1.0 - confidenceLevel;
 	const double dof = n - 1;
 	const double testStat = (dof * var) / vartest;
-	const double cdf = chi2CdfApproximation(testStat, dof);
+	// Use integrated chi-square CDF for p-value coherence with inverseChi2-based acceptance limits.
+	const double cdf = chi2CdfByIntegration(testStat, dof);
+	// Historical reference: Wilson-Hilferty approximation kept commented for technical traceability.
+	// const double cdf = chi2CdfApproximation(testStat, dof);
 	double pValue;
 	double acceptInfLim = -std::numeric_limits<double>::infinity();
 	double acceptSupLim = std::numeric_limits<double>::infinity();
@@ -331,6 +354,7 @@ HypothesisTester_if::TestResult HypothesisTesterDefaultImpl1::testAverage(double
 	const double var1 = stddev1 * stddev1;
 	const double var2 = stddev2 * stddev2;
 	HypothesisTester_if::ConfidenceInterval varIC = varianceRatioConfidenceInterval(var1, n1, var2, n2, confidenceLevel);
+	// @TODO: Equal-variance selection is currently indirect, based on whether the variance-ratio CI contains 1.0; revisit with an explicit pooled-vs-Welch policy.
 	const bool equalVariances = (varIC.inferiorLimit() <= 1.0 && varIC.superiorLimit() >= 1.0);
 	const double diff = avg1 - avg2;
 	double testStat;

--- a/source/tools/README_tools.md
+++ b/source/tools/README_tools.md
@@ -36,5 +36,6 @@ The `source/tools` package hosts statistical and numerical support abstractions 
 
 - **Fitting**: interface defined; `FitterDefaultImpl` is functional for uniform/triangular/normal/exponential/erlang/beta/weibull with binary dataset loading and SSE-CDF comparison and is now the default `TraitsTools<Fitter_if>` binding (FITTER-3). `FitterDummyImpl` remains available as legacy placeholder.
 - **Hypothesis testing**: functional baseline exists in `HypothesisTesterDefaultImpl1`, with known partial areas.
+  - HYPTEST-1 alignment update: proportion-difference CI now follows the classical two-proportion formula, and one-population average/variance tests now compute p-values with Student-t/chi-square-coherent CDF paths.
 - **Probability distributions**: mathematical static base and inverse façade available, with internal numeric dependencies.
 - **Numerical solvers**: legacy `Solver_if` + `SolverDefaultImpl1` remain the compatible baseline.


### PR DESCRIPTION
### Motivation
- Align the two-proportions confidence-interval implementation with the classical formula from the reference material while keeping public signatures stable.
- Make one-population tests coherent by computing p-values with the same distributional formalism used for acceptance limits (Student-t for means and chi-square for variances).
- Preserve existing pooled-vs-Welch decision logic but add an explicit `@TODO` documenting the heuristic and its limitation.

### Description
- Implemented classical two-proportion CI in `proportionDifferenceConfidenceInterval(...)` while preserving the legacy signature and treating `avg1/avg2` as `p1/p2` and ignoring `stddev1/stddev2` for compatibility, with validation for `n1,n2 >= 2`, proportions in `[0,1]` and `confidenceLevel` in `(0,1)` and using `ProbabilityDistribution::inverseNormal(1-alpha/2,0,1)` for the z-quantile.
- Replaced the one-population mean p-value computation to use `studentTCdf(testStat, n-1)` and left the old `normalCdf(testStat)` line commented with an English historical note.
- Replaced the one-population variance p-value computation to use an integrated chi-square CDF `chi2CdfByIntegration(...)` that numerically integrates `ProbabilityDistributionBase::chi2` via `SolverDefaultImpl1`, and left the prior `chi2CdfApproximation(...)` call commented for traceability.
- Added small English `@TODO` comments at the two points where pooled vs. Welch is chosen (CI and 2-pop mean test) documenting that the current decision is indirect (based on whether the variance-ratio CI contains `1.0`) and should be revisited with an explicit policy; preserved existing logic unchanged.
- Added required explanatory comments before each modified block and kept historical lines commented nearby as requested.
- Updated minimal documentation notes in `source/tools/README_tools.md` and `source/tools/ARCHITECTURE_tools.md` to record the HYPTEST-1 alignment.
- Files inspected: `HypothesisTester_if.h`, `HypothesisTesterDefaultImpl1.h`, `HypothesisTesterDefaultImpl1.cpp`, `ProbabilityDistribution.h`, `ProbabilityDistributionBase.h`, `SolverDefaultImpl1.h`, `README_tools.md`, `ARCHITECTURE_tools.md`.
- Files modified: `source/tools/HypothesisTesterDefaultImpl1.cpp`, `source/tools/README_tools.md`, `source/tools/ARCHITECTURE_tools.md`; branch used/created: `WiP20261` (created from local state).

### Testing
- Confirmed repository state with `git status --short --branch` and `git diff --name-only` after changes and committed the patch.
- Built a minimal reproducible driver (`/tmp/hyptest_alignment_driver.cpp`) with `g++` linking `HypothesisTesterDefaultImpl1.cpp`, `ProbabilityDistribution.cpp`, `ProbabilityDistributionBase.cpp`, `SolverDefaultImpl1.cpp`, `StatisticsDataFileDefaultImpl.cpp`, `CollectorDatafileDefaultImpl1.cpp` and `SorttFile.cpp` and the build completed successfully.
- Executed the driver and validated the required scenarios: two-proportion CI with `p1=0.60,n1=100,p2=0.45,n2=120,confidence=0.95` produced finite bounds, positive half-width and center ≈ `0.15`; one-pop mean tests produced one non-rejection (`p≈0.6216`) and one rejection (`p≈0.00099`); one-pop variance tests produced one non-rejection (`p≈0.9233`) and one rejection (`p≈0.00077`), and the driver printed `ALL_CHECKS_OK`.
- Rebuilt and ran the same driver with sanitizers (`-fsanitize=address,undefined`) and the run also completed and returned `ALL_CHECKS_OK`.
- No automated unit-test suite was modified; the validation is a small reproducible driver and sanitizer run that both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d904aba58c8321af25234971d25df2)