### PR TITLE
GUI: add class and file-level Doxygen docs for refactored GUI architecture

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/controllers/DialogUtilityController.h
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/DialogUtilityController.h
@@ -13,7 +13,24 @@ namespace Ui {
 class MainWindow;
 }
 
-// Move remaining dialog and utility orchestration into a dedicated Phase 11 controller.
+// Document the dialog and utility controller extracted from remaining MainWindow actions.
+/**
+ * @brief Controller that orchestrates auxiliary dialogs and utility actions.
+ *
+ * This Phase-11 controller gathers non-core menu/toolbar actions that were still in
+ * MainWindow, such as About dialogs, breakpoint utilities, optimization/preferences dialogs,
+ * data analyzer launch flow, and parallelization toggles.
+ *
+ * Responsibilities:
+ * - execute dialog-driven utility actions delegated from MainWindow wrappers;
+ * - access shared UI/simulator state through narrow injected callbacks/references;
+ * - keep compatibility behavior for debug breakpoints and auxiliary tooling actions.
+ *
+ * Boundaries:
+ * - it does not own simulator/model lifecycle;
+ * - it does not manage scene command pipeline or property editor internals;
+ * - it acts as a controller-level compatibility wrapper, not as a domain service.
+ */
 class DialogUtilityController {
 public:
     // Inject only narrow dependencies required by Phase 11 dialog and utility workflows.

--- a/source/applications/gui/qt/GenesysQtGUI/controllers/EditCommandController.h
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/EditCommandController.h
@@ -11,7 +11,24 @@ class GraphicalModelComponent;
 class GraphicalConnection;
 class QGraphicsItemGroup;
 
-// Phase 9 controller that centralizes edit/clipboard command orchestration.
+// Document edit command orchestration extracted from MainWindow wrappers.
+/**
+ * @brief Controller for edit/clipboard/grouping command orchestration in the scene.
+ *
+ * This Phase-9 controller keeps MainWindow slots as compatibility wrappers while centralizing
+ * clipboard buffers, grouping operations, and undo-aware edit command dispatch against the
+ * current graphical scene.
+ *
+ * Responsibilities:
+ * - execute undo/redo/cut/copy/paste/delete/group/ungroup command flows;
+ * - preserve legacy clipboard structures used by graphical components and drawings;
+ * - trigger action refresh callbacks after command execution.
+ *
+ * Boundaries:
+ * - it does not own scene lifetime (resolved from injected graphics view);
+ * - it does not persist clipboard state across sessions;
+ * - it does not manage simulation events, model lifecycle, or property-editor synchronization.
+ */
 class EditCommandController {
 public:
     // Inject only narrow dependencies required by edit command behavior.

--- a/source/applications/gui/qt/GenesysQtGUI/controllers/ModelInspectorController.h
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/ModelInspectorController.h
@@ -6,7 +6,25 @@
 class Simulator;
 class ModelGraphicsView;
 
-// Encapsulate Phase 3 model-inspection and tree/scene synchronization logic.
+// Document the controller boundary for model-inspection and tree/scene synchronization.
+/**
+ * @brief Controller for model inspection views and scene-selection synchronization.
+ *
+ * In the refactored GUI architecture, this controller receives delegated callbacks from
+ * MainWindow to keep model-inspector responsibilities outside the composition root while
+ * preserving the existing UI contract. It synchronizes Components/Data Definitions trees
+ * with the current kernel model and keeps tree-to-scene selection behavior consistent.
+ *
+ * Responsibilities:
+ * - refresh model component and data-definition trees from Simulator state;
+ * - manage in-place rename flow for editable data-definition names;
+ * - propagate current tree selection to the graphical scene and viewport.
+ *
+ * Boundaries:
+ * - it does not create/destroy models or files (model lifecycle remains elsewhere);
+ * - it does not own scene command logic, undo/redo, or simulation commands;
+ * - it does not act as a persistence or export service.
+ */
 class ModelInspectorController {
 public:
     // Inject only the narrow dependencies required by the model-inspector workflow.

--- a/source/applications/gui/qt/GenesysQtGUI/controllers/ModelLifecycleController.h
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/ModelLifecycleController.h
@@ -14,7 +14,25 @@ namespace Ui {
 class MainWindow;
 }
 
-// Encapsulate Phase 7 model/application lifecycle orchestration with narrow dependencies.
+// Document model lifecycle orchestration delegated by MainWindow compatibility wrappers.
+/**
+ * @brief Controller for model/application lifecycle flows delegated from MainWindow.
+ *
+ * This controller centralizes lifecycle actions (new/open/save/close/check/configure/exit)
+ * while MainWindow remains the composition root and compatibility façade. It uses explicit
+ * callback injection to invoke existing UI update and persistence routines without changing
+ * signatures or ownership.
+ *
+ * Responsibilities:
+ * - orchestrate user-triggered lifecycle actions and guard pending-change confirmations;
+ * - coordinate model load/save paths through injected serializer callbacks;
+ * - trigger UI/tab/action refreshes required after lifecycle transitions.
+ *
+ * Boundaries:
+ * - it does not directly implement file formats (delegated to services);
+ * - it does not own simulator/model objects;
+ * - it does not manage scene tools, property editor internals, or simulation traces.
+ */
 class ModelLifecycleController {
 public:
     // Group callback dependencies to keep constructor arguments focused and explicit.

--- a/source/applications/gui/qt/GenesysQtGUI/controllers/PluginCatalogController.h
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/PluginCatalogController.h
@@ -13,7 +13,24 @@ class QString;
 class QTreeWidget;
 class QTreeWidgetItem;
 
-// Encapsulate Phase 5 plugin-catalog and plugin-palette UI behavior.
+// Document the plugin-catalog controller extracted from MainWindow UI code.
+/**
+ * @brief Controller responsible for plugin catalog presentation and plugin palette behavior.
+ *
+ * This controller encapsulates the plugin-tree behavior used by MainWindow wrappers, keeping
+ * plugin browsing and insertion affordances consistent while reducing direct widget logic in
+ * the MainWindow compatibility façade.
+ *
+ * Responsibilities:
+ * - populate plugin entries grouped by category with legacy color conventions;
+ * - provide compatibility helpers for fake-plugin insertion paths;
+ * - react to plugin-tree click/double-click events delegated by MainWindow.
+ *
+ * Boundaries:
+ * - it does not load plugin binaries or manage kernel plugin lifecycle;
+ * - it does not own textual model synchronization beyond delegated editor insertions;
+ * - it is a UI controller layer, not a persistence/export service.
+ */
 class PluginCatalogController {
 public:
     // Inject only the dependencies required to manage plugin catalog UI behavior.

--- a/source/applications/gui/qt/GenesysQtGUI/controllers/PropertyEditorController.h
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/PropertyEditorController.h
@@ -12,7 +12,24 @@ class DataComponentProperty;
 class DataComponentEditor;
 class ComboBoxEnum;
 
-// Encapsulate Phase 6 property-editor and scene-selection orchestration outside MainWindow.
+// Document the property-editor controller and post-commit synchronization pipeline.
+/**
+ * @brief Controller that orchestrates property editor state and scene-selection coupling.
+ *
+ * This Phase-6 extraction isolates property editor wiring from MainWindow while preserving
+ * the existing compatibility façade methods. It coordinates selection-driven property binding
+ * and the deferred refresh cascade required after property commits.
+ *
+ * Responsibilities:
+ * - synchronize current scene selection into PropertyEditorGenesys/ObjectPropertyBrowser;
+ * - execute post-edit refresh callbacks for model language, trees, C++ export, and tabs;
+ * - coalesce heavy refresh requests to avoid re-entrant UI update storms.
+ *
+ * Boundaries:
+ * - it does not own property objects/editors lifetime (maps are injected);
+ * - it does not alter undo/redo infrastructure or scene command orchestration;
+ * - it does not persist models or execute simulation commands.
+ */
 class PropertyEditorController {
 public:
     // Inject only the property-editor dependencies needed by the Phase 6 flow.

--- a/source/applications/gui/qt/GenesysQtGUI/controllers/SceneToolController.h
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/SceneToolController.h
@@ -10,7 +10,23 @@ namespace Ui {
 class MainWindow;
 }
 
-// Move scene/view/drawing command orchestration into a dedicated Phase 10 controller.
+// Document the scene tooling controller that receives delegated UI commands.
+/**
+ * @brief Controller for scene visualization, drawing tools, alignment, and zoom orchestration.
+ *
+ * MainWindow delegates many menu/toolbar wrappers to this Phase-10 controller to keep the
+ * compatibility façade thin while concentrating scene-tool behavior in a dedicated component.
+ *
+ * Responsibilities:
+ * - handle grid/ruler/guides/snap toggles and zoom commands;
+ * - orchestrate drawing/connection modes and alignment actions;
+ * - coordinate animation toggles and scene-display filters through injected callbacks.
+ *
+ * Boundaries:
+ * - it does not own MainWindow or scene/view lifetime;
+ * - it does not perform model persistence/export/simulation lifecycle work;
+ * - it relies on injected references for shared UI state (zoom, first-click connection state).
+ */
 class SceneToolController {
 public:
     // Inject only narrow dependencies required by scene and tool command handlers.

--- a/source/applications/gui/qt/GenesysQtGUI/controllers/SimulationCommandController.h
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/SimulationCommandController.h
@@ -6,8 +6,23 @@
 
 class SimulationController;
 
+// Document simulation command orchestration delegated by MainWindow slots.
 /**
- * @brief Phase 8 controller for UI-level simulation command orchestration.
+ * @brief Controller that orchestrates UI simulation commands over SimulationController guards.
+ *
+ * This class sits between MainWindow compatibility slots and the low-level simulation
+ * readiness controller. It coordinates command intent (start/step/pause/resume/stop), command
+ * logging, and action refresh callbacks while preserving the existing UI trigger surface.
+ *
+ * Responsibilities:
+ * - execute simulation command flows delegated from MainWindow;
+ * - use SimulationController precondition checks before unsafe commands;
+ * - invoke injected callbacks for console command logging and action-state refresh.
+ *
+ * Boundaries:
+ * - it does not own simulation state or kernel event wiring;
+ * - it does not render trace/event widgets;
+ * - it is a controller/orchestration layer, not a persistence or synchronization service.
  */
 class SimulationCommandController {
 public:

--- a/source/applications/gui/qt/GenesysQtGUI/controllers/SimulationController.h
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/SimulationController.h
@@ -7,16 +7,27 @@ class QWidget;
 class Simulator;
 class ModelSimulation;
 
+// Document the simulation precondition controller role in the refactored GUI architecture.
 /**
- * @brief Thin controller responsible for simulation-command preconditions in GUI.
+ * @brief Controller that validates simulation command readiness for MainWindow wrappers.
  *
- * This class centralizes guard logic previously duplicated across simulation actions
- * (`start`, `step`, `pause`, `resume`, `stop`) in MainWindow.
+ * This controller is part of the incremental extraction that keeps MainWindow as a
+ * compatibility façade while moving simulation-command orchestration behind smaller
+ * collaborators. It centralizes precondition checks shared by start/step/pause/resume/stop
+ * flows, including model availability and model-text synchronization guards.
  *
- * It deliberately avoids owning simulation model state; ownership remains in Simulator.
+ * Responsibilities:
+ * - verify that the current model and its ModelSimulation are available;
+ * - execute callback-based readiness checks delegated by MainWindow;
+ * - return a single command-ready decision used by higher-level command controllers.
  *
- * @todo Evolve this controller to encapsulate command execution itself
- *       (not only readiness validation), reducing MainWindow responsibilities further.
+ * Boundaries:
+ * - it does not own simulation state or lifecycle (owned by Simulator);
+ * - it does not execute GUI commands directly (handled by SimulationCommandController);
+ * - it does not update widgets, tabs, or trace outputs.
+ *
+ * Dependencies are injected narrowly (owner widget + simulator + callbacks) to preserve
+ * existing ownership and enable incremental compatibility without changing slot signatures.
  */
 class SimulationController {
 public:

--- a/source/applications/gui/qt/GenesysQtGUI/controllers/SimulationEventController.h
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/SimulationEventController.h
@@ -17,7 +17,26 @@ class QTextEdit;
 class QTabWidget;
 class QAction;
 
-// Encapsulate Phase 4 simulation-event handling and handler registration.
+// Document the controller that bridges kernel simulation events to GUI updates.
+/**
+ * @brief Controller for simulation event callbacks, UI updates, and handler wiring.
+ *
+ * This controller concentrates event-reaction logic previously embedded in MainWindow and
+ * keeps compatibility by exposing methods invoked from MainWindow wrappers. It also provides
+ * the event-registration entry point used to wire kernel OnEventManager callbacks to those
+ * wrappers without changing the existing signal/slot surface.
+ *
+ * Responsibilities:
+ * - react to model-check, replication, simulation, process, and entity events;
+ * - update progress/status widgets and debug tables through injected UI dependencies;
+ * - trigger delegated refresh callbacks for actions, debug panes, and scene synchronization;
+ * - register handlers through MainWindow compatibility façade ownership.
+ *
+ * Boundaries:
+ * - it does not own MainWindow or widget lifetime;
+ * - it does not execute simulation commands (handled by command controllers);
+ * - it does not perform persistence/export/model-language synchronization.
+ */
 class SimulationEventController {
 public:
     // Group callback dependencies to keep constructor explicit and narrow.

--- a/source/applications/gui/qt/GenesysQtGUI/controllers/TraceConsoleController.h
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/TraceConsoleController.h
@@ -5,7 +5,24 @@
 
 class QTextEdit;
 
-// Encapsulate Phase 4 trace rendering for console/simulation/report widgets.
+// Document the trace rendering bridge used by MainWindow simulator callbacks.
+/**
+ * @brief Controller that routes simulator trace events to GUI text widgets.
+ *
+ * This controller is the Phase-4 extraction for trace presentation. MainWindow keeps
+ * compatibility handlers registered in the kernel trace manager and delegates rendering to
+ * this class, reducing direct UI formatting logic in the façade.
+ *
+ * Responsibilities:
+ * - render regular/error traces to the main console pane;
+ * - render simulation traces to the simulation output pane;
+ * - render report traces to the reports pane.
+ *
+ * Boundaries:
+ * - it does not subscribe handlers by itself (registration stays in MainWindow/event layer);
+ * - it does not change simulation flow, model state, or controller orchestration;
+ * - it acts as a UI bridge, not as a domain service.
+ */
 class TraceConsoleController {
 public:
     // Inject narrow text-output dependencies used by trace handlers.

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
@@ -1,3 +1,13 @@
+// Document this compilation unit as the MainWindow composition-root partition.
+/**
+ * @file mainwindow.cpp
+ * @brief Composition-root partition of MainWindow implementation.
+ *
+ * This file contains central MainWindow construction, initialization, and wiring logic,
+ * including creation of extracted controllers/services and baseline UI setup. It does not
+ * define a new class; it is a physical partition of the same MainWindow implementation used
+ * as a compatibility façade in the incremental refactoring.
+ */
 #include "mainwindow.h"
 #include "ui_mainwindow.h"
 

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.h
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.h
@@ -41,10 +41,25 @@ class EditCommandController;
 class SceneToolController;
 class DialogUtilityController;
 
+// Document MainWindow as composition root and incremental compatibility façade.
 /**
- * @brief Main Qt window of Genesys GUI.
+ * @brief Main Qt window that composes controllers/services and preserves legacy GUI entry points.
  *
- * Acts as the final composition root and compatibility façade for extracted controllers/services.
+ * MainWindow remains the composition root of GenesysQtGUI: it owns the generated UI, wires
+ * extracted controllers/services, and exposes the original Qt slot surface expected by actions,
+ * widgets, and kernel callback registration. In the refactored architecture it primarily acts as
+ * a compatibility façade that delegates operational responsibilities to focused collaborators.
+ *
+ * Responsibilities:
+ * - bootstrap UI construction and dependency wiring for controllers/services;
+ * - host compatibility wrappers used by menus/toolbars/scene callbacks;
+ * - coordinate cross-cutting state that still spans multiple controllers.
+ *
+ * Boundaries:
+ * - detailed domain workflows (simulation commands, lifecycle, persistence, scene tools,
+ *   property editing, trace/event rendering) are delegated to dedicated controller/service
+ *   classes whenever extraction already exists;
+ * - MainWindow does not replace kernel ownership semantics.
  */
 class MainWindow : public QMainWindow {
 	Q_OBJECT

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow_controller.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow_controller.cpp
@@ -1,3 +1,12 @@
+// Document this compilation unit as the controller-wrapper partition of MainWindow.
+/**
+ * @file mainwindow_controller.cpp
+ * @brief Controller-delegation partition of MainWindow implementation.
+ *
+ * This file groups menu/toolbar/widget slot wrappers that delegate behavior to extracted
+ * controllers (for example lifecycle, simulation command, edit, scene tool, and dialog utility
+ * controllers). It does not define a new class; it is a thematic partition of MainWindow.
+ */
 #include "mainwindow.h"
 #include "ui_mainwindow.h"
 // Include the Phase 3 controller interface required by compatibility wrappers.

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow_modelrepresentations.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow_modelrepresentations.cpp
@@ -1,3 +1,13 @@
+// Document this compilation unit as the model-representation partition of MainWindow.
+/**
+ * @file mainwindow_modelrepresentations.cpp
+ * @brief Model representation/persistence wrapper partition of MainWindow implementation.
+ *
+ * This file groups MainWindow wrappers related to textual synchronization, Graphviz and C++
+ * exports, graphical persistence/serialization, and graphical model reconstruction through
+ * extracted services/controllers. It does not define a new class; it is a thematic partition
+ * of MainWindow.
+ */
 #include "mainwindow.h"
 #include "ui_mainwindow.h"
 // Include the Phase 3 controller interface required by compatibility wrappers.

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow_scene.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow_scene.cpp
@@ -1,3 +1,12 @@
+// Document this compilation unit as the scene-synchronization partition of MainWindow.
+/**
+ * @file mainwindow_scene.cpp
+ * @brief Scene callback and scene synchronization partition of MainWindow implementation.
+ *
+ * This file concentrates scene-related callbacks, selection/focus/zoom bridging, and wrappers
+ * that synchronize scene state with UI elements such as actions and the property editor
+ * controller. It does not define a new class; it is a thematic partition of MainWindow.
+ */
 #include "mainwindow.h"
 #include "ui_mainwindow.h"
 // Include the Phase 6 controller type so member calls compile with a complete class definition.

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow_simulator.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow_simulator.cpp
@@ -1,3 +1,13 @@
+// Document this compilation unit as the simulator-callback partition of MainWindow.
+/**
+ * @file mainwindow_simulator.cpp
+ * @brief Simulator trace/event wrapper partition of MainWindow implementation.
+ *
+ * This file centralizes MainWindow compatibility wrappers for simulator traces and simulation
+ * event callbacks, delegating rendering and reactions to TraceConsoleController and
+ * SimulationEventController (plus plugin-catalog related delegation where applicable). It does
+ * not define a new class; it is a thematic partition of MainWindow.
+ */
 #include "mainwindow.h"
 #include "ui_mainwindow.h"
 // Include dedicated Phase 4 controllers used by simulator compatibility wrappers.

--- a/source/applications/gui/qt/GenesysQtGUI/services/CppModelExporter.h
+++ b/source/applications/gui/qt/GenesysQtGUI/services/CppModelExporter.h
@@ -6,7 +6,23 @@
 class QPlainTextEdit;
 class Simulator;
 
-// This Phase-1 service encapsulates generation of C++ model code shown in the GUI editor.
+// Document the service that generates C++ model representation text.
+/**
+ * @brief Service responsible for C++ code representation of the current simulation model.
+ *
+ * The refactoring keeps C++ representation generation outside MainWindow by delegating this
+ * concern to a dedicated service. MainWindow wrappers call into this class when model or UI
+ * state changes require regeneration.
+ *
+ * Responsibilities:
+ * - format indented C++ output lines used by exporter routines;
+ * - rebuild the full C++ representation shown in the GUI code pane.
+ *
+ * Boundaries:
+ * - it does not compile or execute generated code;
+ * - it does not persist files directly;
+ * - it does not manage lifecycle/simulation/scene controller flows.
+ */
 class CppModelExporter {
 public:
     // MainWindow provides explicit dependencies once, keeping wrappers thin and stable.

--- a/source/applications/gui/qt/GenesysQtGUI/services/GraphicalModelBuilder.h
+++ b/source/applications/gui/qt/GenesysQtGUI/services/GraphicalModelBuilder.h
@@ -14,7 +14,24 @@ class ModelComponent;
 class GraphicalModelComponent;
 template<typename T> class List;
 
-// Rebuild graphical components and links from an already loaded kernel model.
+// Document the service that rebuilds graphical scene artifacts from kernel models.
+/**
+ * @brief Service that reconstructs graphical components/connections from kernel model data.
+ *
+ * This builder is used after model loading to recreate the scene representation while keeping
+ * MainWindow as a compatibility façade. It acts as a model-representation bridge between the
+ * kernel component graph and GUI graphical items.
+ *
+ * Responsibilities:
+ * - recursively create graphical nodes/connections for component branches;
+ * - generate a full scene representation from model source components;
+ * - apply plugin-category visual metadata needed during reconstruction.
+ *
+ * Boundaries:
+ * - it does not persist files or parse textual model language;
+ * - it does not manage selection/property editor/simulation command flows;
+ * - it operates as a reconstruction service, not a controller.
+ */
 class GraphicalModelBuilder {
 public:
     // Keep builder dependencies narrow and explicit for Phase 2 extraction.

--- a/source/applications/gui/qt/GenesysQtGUI/services/GraphicalModelSerializer.h
+++ b/source/applications/gui/qt/GenesysQtGUI/services/GraphicalModelSerializer.h
@@ -15,7 +15,24 @@ class QSlider;
 class QAction;
 class ModelGraphicsView;
 
-// Persist and restore graphical-model state for Phase 2 extraction.
+// Document persistence responsibilities for textual and graphical GUI model data.
+/**
+ * @brief Persistence service for saving/loading graphical and textual model representations.
+ *
+ * This Phase-2 extraction removes serialization concerns from MainWindow while preserving file
+ * compatibility through wrapper delegation. It bridges GUI state (scene/view/actions/editors)
+ * and kernel model loading/saving workflows.
+ *
+ * Responsibilities:
+ * - save textual model content with the existing line-based format;
+ * - save full graphical .gui state sections used by legacy compatibility;
+ * - load persisted model files and restore graphical/editor UI state via callbacks.
+ *
+ * Boundaries:
+ * - it does not own widgets or simulator lifetime;
+ * - it does not run simulation commands or trace rendering;
+ * - it coordinates persistence/serialization only.
+ */
 class GraphicalModelSerializer {
 public:
     // Capture only the narrow GUI/kernel dependencies required for persistence behavior.

--- a/source/applications/gui/qt/GenesysQtGUI/services/GraphvizModelExporter.h
+++ b/source/applications/gui/qt/GenesysQtGUI/services/GraphvizModelExporter.h
@@ -11,7 +11,24 @@ class QCheckBox;
 class Simulator;
 class ModelDataDefinition;
 
-// This Phase-1 service encapsulates Graphviz DOT generation and PNG rendering for model representation.
+// Document the service used to export graphical model representations via Graphviz.
+/**
+ * @brief Service that builds DOT content and renders model images for the GUI.
+ *
+ * This service encapsulates Graphviz-oriented model representation logic extracted from
+ * MainWindow. It keeps image-generation behavior stable while MainWindow exposes compatibility
+ * wrappers used by actions and tabs.
+ *
+ * Responsibilities:
+ * - normalize identifiers for DOT compatibility;
+ * - build hierarchical DOT fragments from model/data-definition traversal;
+ * - generate and display model images after ensuring text/model synchronization.
+ *
+ * Boundaries:
+ * - it does not own model synchronization policy (uses injected callback);
+ * - it does not manage simulation commands, traces, or lifecycle actions;
+ * - it provides export/representation service behavior, not controller orchestration.
+ */
 class GraphvizModelExporter {
 public:
     // MainWindow provides explicit dependencies once, keeping wrappers thin and stable.

--- a/source/applications/gui/qt/GenesysQtGUI/services/ModelLanguageSynchronizer.h
+++ b/source/applications/gui/qt/GenesysQtGUI/services/ModelLanguageSynchronizer.h
@@ -7,7 +7,24 @@ class QWidget;
 class QPlainTextEdit;
 class Simulator;
 
-// This Phase-1 service encapsulates synchronization between the textual model editor and kernel model state.
+// Document the service boundary for textual model representation synchronization.
+/**
+ * @brief Service layer that synchronizes textual model language with kernel model state.
+ *
+ * This service was extracted from MainWindow representation code to isolate text/model
+ * synchronization concerns. MainWindow remains the composition root and delegates wrapper
+ * methods to this class.
+ *
+ * Responsibilities:
+ * - generate/update the textual model representation from current Simulator model;
+ * - parse/apply textual edits back into simulator model state;
+ * - notify MainWindow via callback when model creation/loading side effects are required.
+ *
+ * Boundaries:
+ * - it does not own simulator or editor widgets;
+ * - it does not handle graphical persistence, Graphviz export, or C++ code export;
+ * - it is a synchronization service, not a controller.
+ */
 class ModelLanguageSynchronizer {
 public:
     // MainWindow provides explicit dependencies once, keeping wrappers thin and stable.


### PR DESCRIPTION
### Motivation
- Provide complete, consistent Doxygen class-level documentation for the extracted GUI controllers and services so the incremental refactor is easier to understand and maintain.
- Clarify the role of `MainWindow` and the thematic `mainwindow*.cpp` partitions as a composition root and compatibility façade to guide future extraction steps.
- Keep changes strictly non-functional and localized to comments/documentation to avoid regressions during documentation work.

### Description
- Added or replaced class-level Doxygen blocks for the requested controllers in `controllers/` to document responsibilities, boundaries, ownership and relation to `MainWindow` (11 headers modified).
- Added or replaced class-level Doxygen blocks for the requested services in `services/` to document synchronization, export, persistence and builder responsibilities (5 headers modified).
- Expanded `MainWindow` class-level Doxygen to describe its role as composition root and compatibility façade, and added `@file` Doxygen headers to the five `mainwindow*.cpp` partitions to explain their thematic responsibilities (6 files modified).
- All edits were comment-only and editorial; no signatures, logic, includes, or runtime behavior were changed and the diff is limited to the scoped files (22 files changed). 

### Testing
- Ran a targeted marker scan with `rg -n "@brief|@file|@class"` across the modified controllers, services and `mainwindow*` files and confirmed the expected Doxygen markers are present; scan succeeded.
- Verified the working-tree diff for the scoped files with `git diff -- <files>` and inspected the diff to ensure changes are comment/documentation-only; verification succeeded.
- Confirmed repository status with `git status --short` to ensure only intended files were modified; check succeeded.
- No build was performed in this environment because a build directory/configuration was not present, so compilation checks were not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d907c6798c8321b747ee02d4e6f8c2)