### PR TITLE
Corrige Failure: ownership, links bidirecionais e persistência

### DIFF
--- a/source/plugins/data/Failure.cpp
+++ b/source/plugins/data/Failure.cpp
@@ -90,6 +90,23 @@ Failure::Failure(Model* model, std::string name) : ModelDataDefinition(model, Ut
 	_addProperty(propFalingResources);
 }
 
+Failure::~Failure() {
+	if (_falingResources != nullptr) {
+		while (!_falingResources->empty()) {
+			Resource* resource = _falingResources->front();
+			if (resource != nullptr) {
+				resource->removeFailure(this);
+			} else {
+				_falingResources->pop_front();
+			}
+		}
+		delete _falingResources;
+		_falingResources = nullptr;
+	}
+	delete _releaseCounts;
+	_releaseCounts = nullptr;
+}
+
 std::string Failure::show() {
 	return ModelDataDefinition::show() +
 			"";
@@ -215,8 +232,22 @@ bool Failure::_loadInstance(PersistenceRecord *fields) {
 			_upTimeTimeUnit = static_cast<Util::TimeUnit>(fields->loadField("upTimeTimeUnit", static_cast<int>(DEFAULT.upTimeTimeUnit)));
 			_downTimeExpression = fields->loadField("downTimeExpression", DEFAULT.downTimeExpression);
 			_downTimeTimeUnit = static_cast<Util::TimeUnit>(fields->loadField("downTimeTimeUnit", static_cast<int>(DEFAULT.downTimeTimeUnit)));
-			// Possible extension for attached resources:
-			// unsigned int numResources = fields->loadField("failingResources", 0u);
+			while (!_falingResources->empty()) {
+				Resource* resource = _falingResources->front();
+				if (resource != nullptr) {
+					resource->removeFailure(this);
+				} else {
+					_falingResources->pop_front();
+				}
+			}
+			unsigned int failingResourcesSize = fields->loadField("failingResources", 0u);
+			for (unsigned int i = 0; i < failingResourcesSize; i++) {
+				std::string resourceName = fields->loadField("failingResource" + Util::StrIndex(i), std::string(""));
+				Resource* resource = static_cast<Resource*> (_parentModel->getDataManager()->getDataDefinition(Util::TypeOf<Resource>(), resourceName));
+				if (resource != nullptr) {
+					addResource(resource);
+				}
+			}
 		} catch (...) {
 		}
 	}
@@ -235,8 +266,12 @@ void Failure::_saveInstance(PersistenceRecord *fields, bool saveDefaultValues) {
 	fields->saveField("upTimeTimeUnit", static_cast<int>(_upTimeTimeUnit), static_cast<int>(DEFAULT.upTimeTimeUnit), saveDefaultValues);
 	fields->saveField("downTimeExpression", _downTimeExpression, DEFAULT.downTimeExpression, saveDefaultValues);
 	fields->saveField("downTimeTimeUnit", static_cast<int>(_downTimeTimeUnit), static_cast<int>(DEFAULT.downTimeTimeUnit), saveDefaultValues);
-	// Possible extension for attached resources:
-	// fields->saveField("failingResources", _falingResources->size(), 0u, saveDefaultValues);
+	fields->saveField("failingResources", _falingResources->size(), 0u, saveDefaultValues);
+	unsigned int i = 0;
+	for (Resource* resource : *_falingResources->list()) {
+		fields->saveField("failingResource" + Util::StrIndex(i), resource != nullptr ? resource->getName() : std::string(""), std::string(""), saveDefaultValues);
+		i++;
+	}
 }
 
 bool Failure::_check(std::string& errorMessage) {
@@ -276,11 +311,21 @@ List<Resource*>*Failure::falingResources() const{
 }
 
 void Failure::addResource(Resource* newResource){
-	_falingResources->insert(newResource);
+	if (newResource == nullptr) {
+		return;
+	}
+	if (_falingResources->find(newResource) == _falingResources->list()->end()) {
+		newResource->insertFailure(this);
+	}
 }
 
 void Failure::removeResource(Resource* resource){
-	_falingResources->remove(resource);
+	if (resource == nullptr) {
+		return;
+	}
+	if (_falingResources->find(resource) != _falingResources->list()->end()) {
+		resource->removeFailure(this);
+	}
 }
 
 // private (internal!!) simulation event handlers
@@ -306,4 +351,3 @@ void Failure::_onFailureFailEventHandler(void* resourcePtr){
 	// schedule next resource activation
 	_scheduleActivation(resource);
 }
-

--- a/source/plugins/data/Failure.h
+++ b/source/plugins/data/Failure.h
@@ -80,7 +80,7 @@ public:
 	static std::string convertEnumToStr(FailureRule rule);
 public:
 	Failure(Model* model, std::string name = "");
-	virtual ~Failure() = default;
+	virtual ~Failure() override;
 public: // static
 	static ModelDataDefinition* LoadInstance(Model* model, PersistenceRecord *fields);
 	static PluginInformation* GetPluginInformation();
@@ -146,4 +146,3 @@ private:
 };
 
 #endif /* FAILURE_H */
-

--- a/source/tests/unit/test_simulator_runtime.cpp
+++ b/source/tests/unit/test_simulator_runtime.cpp
@@ -57,6 +57,14 @@ public:
                resource._counterTotalCostBusy != nullptr &&
                resource._counterTotalCostIdle != nullptr;
     }
+
+    static bool HasFailure(const Resource& resource, const Failure* failure) {
+        return std::find(resource._failures->list()->begin(), resource._failures->list()->end(), failure) != resource._failures->list()->end();
+    }
+
+    static size_t FailureCount(const Resource& resource) {
+        return resource._failures->size();
+    }
 };
 
 namespace {
@@ -250,6 +258,23 @@ public:
 
     void CreateInternalAndAttachedDataProbe() {
         _createInternalAndAttachedData();
+    }
+};
+
+class FailureProbe : public Failure {
+public:
+    FailureProbe(Model* model, const std::string& name = "") : Failure(model, name) {}
+
+    void SaveInstanceProbe(PersistenceRecord* fields, bool saveDefaultValues = false) {
+        _saveInstance(fields, saveDefaultValues);
+    }
+
+    bool LoadInstanceProbe(PersistenceRecord* fields) {
+        return _loadInstance(fields);
+    }
+
+    void InitBetweenReplicationsProbe() {
+        _initBetweenReplications();
     }
 };
 
@@ -1289,6 +1314,109 @@ TEST(SimulatorRuntimeTest, ResourceDestructorCleansOwnedHandlersContainers) {
     }
 
     EXPECT_TRUE(weakCapture.expired());
+}
+
+TEST(SimulatorRuntimeTest, FailureDestructorReleasesOwnedContainersAndDetachesResources) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    ResourceProbe resourceA(model, "FailureLifecycleResourceA");
+    ResourceProbe resourceB(model, "FailureLifecycleResourceB");
+
+    auto* failure = new FailureProbe(model, "FailureLifecycle");
+    failure->addResource(&resourceA);
+    failure->addResource(&resourceB);
+
+    ASSERT_TRUE(ResourceTestProbe::HasFailure(resourceA, failure));
+    ASSERT_TRUE(ResourceTestProbe::HasFailure(resourceB, failure));
+    ASSERT_EQ(ResourceTestProbe::FailureCount(resourceA), 1u);
+    ASSERT_EQ(ResourceTestProbe::FailureCount(resourceB), 1u);
+
+    delete failure;
+
+    EXPECT_EQ(ResourceTestProbe::FailureCount(resourceA), 0u);
+    EXPECT_EQ(ResourceTestProbe::FailureCount(resourceB), 0u);
+}
+
+TEST(SimulatorRuntimeTest, FailureAddResourceMaintainsBidirectionalAssociationWithoutDuplicates) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    FailureProbe failure(model, "FailureBidirectionalAdd");
+    ResourceProbe resource(model, "FailureBidirectionalAddResource");
+
+    failure.addResource(&resource);
+    failure.addResource(&resource); // duplicate attempt
+
+    EXPECT_EQ(failure.falingResources()->size(), 1u);
+    EXPECT_EQ(failure.falingResources()->getAtRank(0), &resource);
+    EXPECT_TRUE(ResourceTestProbe::HasFailure(resource, &failure));
+    EXPECT_EQ(ResourceTestProbe::FailureCount(resource), 1u);
+}
+
+TEST(SimulatorRuntimeTest, FailureRemoveResourceMaintainsBidirectionalAssociation) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    FailureProbe failure(model, "FailureBidirectionalRemove");
+    ResourceProbe resource(model, "FailureBidirectionalRemoveResource");
+    failure.addResource(&resource);
+    ASSERT_EQ(failure.falingResources()->size(), 1u);
+    ASSERT_TRUE(ResourceTestProbe::HasFailure(resource, &failure));
+
+    failure.removeResource(&resource);
+
+    EXPECT_EQ(failure.falingResources()->size(), 0u);
+    EXPECT_EQ(ResourceTestProbe::FailureCount(resource), 0u);
+    EXPECT_FALSE(ResourceTestProbe::HasFailure(resource, &failure));
+}
+
+TEST(SimulatorRuntimeTest, FailureSaveAndLoadPreservesFalingResourcesBidirectionally) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    ResourceProbe resourceA(model, "FailurePersistResourceA");
+    ResourceProbe resourceB(model, "FailurePersistResourceB");
+    FailureProbe source(model, "FailurePersistSource");
+    source.addResource(&resourceA);
+    source.addResource(&resourceB);
+
+    FakeModelPersistenceRuntime persistence;
+    PersistenceRecord fields(persistence);
+    source.SaveInstanceProbe(&fields, true);
+
+    FailureProbe loaded(model, "FailurePersistLoaded");
+    ASSERT_TRUE(loaded.LoadInstanceProbe(&fields));
+    ASSERT_EQ(loaded.falingResources()->size(), 2u);
+    EXPECT_TRUE(std::find(loaded.falingResources()->list()->begin(), loaded.falingResources()->list()->end(), &resourceA) != loaded.falingResources()->list()->end());
+    EXPECT_TRUE(std::find(loaded.falingResources()->list()->begin(), loaded.falingResources()->list()->end(), &resourceB) != loaded.falingResources()->list()->end());
+    EXPECT_TRUE(ResourceTestProbe::HasFailure(resourceA, &loaded));
+    EXPECT_TRUE(ResourceTestProbe::HasFailure(resourceB, &loaded));
+}
+
+TEST(SimulatorRuntimeTest, FailureInitBetweenReplicationsSchedulesByFalingResourcesList) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    FailureProbe failure(model, "FailureInitSchedule");
+    ResourceProbe resourceA(model, "FailureInitResourceA");
+    ResourceProbe resourceB(model, "FailureInitResourceB");
+    failure.setFailureType(Failure::FailureType::TIME);
+    failure.setUpTimeExpression("1");
+    failure.setDownTimeExpression("1");
+    failure.addResource(&resourceA);
+    failure.addResource(&resourceB);
+
+    const unsigned int eventsBefore = model->getFutureEvents()->size();
+    failure.InitBetweenReplicationsProbe();
+    const unsigned int eventsAfter = model->getFutureEvents()->size();
+
+    EXPECT_EQ(eventsAfter - eventsBefore, 2u);
 }
 
 TEST(SimulatorRuntimeTest, SequenceDestructorDeletesOwnedSteps) {


### PR DESCRIPTION
PLUGINS

### Motivation
- Corrigir vazamentos e ownership em `Failure` removendo containers owned e evitando destruir `Resource*` non-owner.
- Garantir consistência bidirecional entre `Failure` e `Resource` independentemente do lado que configura a relação.
- Implementar persistência da lista de recursos associados para que load/save e `_initBetweenReplications()` funcionem corretamente.

### Description
- Adiciona destrutor explícito `Failure::~Failure()` que limpa `_releaseCounts` e `_falingResources` e desfaz links com `Resource` chamando `Resource::removeFailure()` sem destruir os `Resource*` (non-owner). (`source/plugins/data/Failure.h`, `source/plugins/data/Failure.cpp`)
- Atualiza `Failure::addResource()` e `Failure::removeResource()` para delegar ao lado `Resource` (`insertFailure`/`removeFailure`) com guards contra `nullptr` e evitando duplicatas/remoções inválidas. (`source/plugins/data/Failure.cpp`)
- Implementa persistência de `_falingResources` em `_saveInstance()` (salva contagem + nomes indexados) e em `_loadInstance()` (limpa associações antigas, carrega nomes e reconstroi links bidirecionais). (`source/plugins/data/Failure.cpp`)
- Adiciona testes unitários focados em `Failure` no arquivo de testes existente para cobrir lifecycle, add/remove bidirecional, persistência round-trip, e agendamento em `_initBetweenReplications()`. (`source/tests/unit/test_simulator_runtime.cpp`)

### Testing
- Executado `cmake` com flags de teste/plug-ins e o projeto foi configurado com sucesso.
- Build do alvo `genesys_test_simulator_runtime` foi realizado com sucesso via `cmake --build build --target genesys_test_simulator_runtime`.
- Executado `ctest --test-dir build -R "SimulatorRuntimeTest.*Failure" --output-on-failure` e os testes relacionados a `Failure` passaram: 6/6 testes passaram.
- Executado `ctest --test-dir build -LE smoke --output-on-failure`; a execução falhou por múltiplos alvos marcados `*_NOT_BUILT` (infra/targets não construídos nesta configuração) e não por regressões nas mudanças aplicadas.

```markdown
- o que você realizou de fato;
  - implementei `Failure::~Failure()` para liberar containers owned e desfazer links com `Resource` sem deletar `Resource*`;
  - corrigi `Failure::addResource`/`Failure::removeResource` para garantir associação bidirecional consistente evitando duplicatas;
  - implementei persistência de `_falingResources` em `_saveInstance`/`_loadInstance` (contagem + nomes indexados) e reconstituição bidirecional no load;
  - adicionei testes unitários cobrindo lifecycle, add/remove bidirecional, persistência e `_initBetweenReplications` scheduling.
- o que não realizou;
  - não alterei `Resource.h/.cpp` nem outros plugins/componentes fora do escopo permitido;
  - não alterei arquitetura ampla ou outros ModelDataDefinition além de `Failure`.
- por que não realizou;
  - o escopo solicitado era limitado a correções localizadas em `Failure` e nos testes associados e exigia evitar alterações em `Resource` salvo necessidade mínima (não necessária).
- riscos remanescentes;
  - `_loadInstance()` ainda engole exceções silenciosamente (comportamento pré-existente) o que pode dificultar diagnóstico em falhas de persistência;
  - alguns alvos de teste permanecem `NOT_BUILT` na configuração de smoke, limitando cobertura completa da suíte, embora não relacionados às mudanças feitas.
- observações relevantes;
  - a solução delega operações ao lado `Resource` para manter um único caminho de alteração da relação e evitar recursão/duplicação;
  - destrutor limpa a lista e chama `Resource::removeFailure()` para manter consistência sem destruir recursos.
- arquivos alterados;
  - `source/plugins/data/Failure.h`
  - `source/plugins/data/Failure.cpp`
  - `source/tests/unit/test_simulator_runtime.cpp`
- comandos executados e resultados resumidos.
  - `cmake -S . -B build -G Ninja -DGENESYS_BUILD_TESTS=ON -DGENESYS_BUILD_KERNEL=ON -DGENESYS_BUILD_PARSER=ON -DGENESYS_BUILD_PLUGINS=ON -DGENESYS_TERMINAL_APPLICATION=OFF -DGENESYS_BUILD_GUI_APPLICATION=OFF -DGENESYS_BUILD_WEB_APPLICATION=OFF` → configuração concluída com sucesso;
  - `cmake --build build --target genesys_test_simulator_runtime` → build concluído com sucesso;
  - `ctest --test-dir build -R "SimulatorRuntimeTest.*Failure" --output-on-failure` → todos os testes de Failure passaram (6/6 passados);
  - `ctest --test-dir build -LE smoke --output-on-failure` → alguns testes reportados como `*_NOT_BUILT` (falha de execução por metas não construídas, não por regressão nas mudanças aplicadas).
```

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d908cd5ff88321a9e03481ded59512)