### PR TITLE
GUI: add method-level Doxygen docs for refactored GUI API surface

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/controllers/DialogUtilityController.h
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/DialogUtilityController.h
@@ -33,7 +33,7 @@ class MainWindow;
  */
 class DialogUtilityController {
 public:
-    // Inject only narrow dependencies required by Phase 11 dialog and utility workflows.
+    /** @brief Builds the utility controller that backs legacy MainWindow dialog wrappers. */
     DialogUtilityController(MainWindow* ownerWidget,
                             Simulator* simulator,
                             Ui::MainWindow* ui,
@@ -51,20 +51,35 @@ public:
                             int& parallelizationBatchSize,
                             QString& lastDataAnalyzerPath);
 
+    /** @brief Opens the About dialog while preserving legacy action routing. */
     void onActionAboutAboutTriggered();
+    /** @brief Opens the license dialog from the compatibility façade action slot. */
     void onActionAboutLicenceTriggered();
+    /** @brief Opens the get-involved/help contribution dialog flow. */
     void onActionAboutGetInvolvedTriggered();
+    /** @brief Runs find workflow for the currently focused text editor pane. */
     void onActionEditFindTriggered();
+    /** @brief Runs replace workflow for the currently focused text editor pane. */
     void onActionEditReplaceTriggered();
+    /** @brief Opens parser grammar checker utility without altering model state. */
     void onActionToolsParserGrammarCheckerTriggered();
+    /** @brief Opens optimization settings dialog and stores lightweight preferences. */
     void onActionToolsOptimizatorTriggered();
+    /** @brief Launches data analyzer workflow using persisted last-path compatibility state. */
     void onActionToolsDataAnalyzerTriggered();
+    /** @brief Opens view configuration dialog and applies delegated scene/UI refreshes. */
     void onActionViewConfigureTriggered();
+    /** @brief Opens simulator preferences utility dialog. */
     void onActionSimulatorPreferencesTriggered();
+    /** @brief Opens plugin manager dialog from the compatibility action surface. */
     void onActionSimulatorsPluginManagerTriggered();
+    /** @brief Inserts a breakpoint entry based on current scene selection. */
     void onPushButtonBreakpointInsertClicked();
+    /** @brief Removes selected breakpoint entries and refreshes debug breakpoint pane. */
     void onPushButtonBreakpointRemoveClicked();
+    /** @brief Exports current debug/trace context using legacy push-button route. */
     void onPushButtonExportClicked();
+    /** @brief Opens parallelization configuration and persists run-preference flags. */
     void onActionParallelizationTriggered();
 
 private:

--- a/source/applications/gui/qt/GenesysQtGUI/controllers/EditCommandController.h
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/EditCommandController.h
@@ -31,7 +31,7 @@ class QGraphicsItemGroup;
  */
 class EditCommandController {
 public:
-    // Inject only narrow dependencies required by edit command behavior.
+    /** @brief Creates the edit-command controller used by MainWindow compatibility slots. */
     EditCommandController(Simulator* simulator,
                           ModelGraphicsView* graphicsView,
                           std::function<void()> actualizeActions,
@@ -41,30 +41,30 @@ public:
                           QList<QGraphicsItem*>** drawCopy,
                           QList<QGraphicsItemGroup*>** groupCopy);
 
-    // Delegate undo command handling without changing scene undo semantics.
+    /** @brief Delegates undo command handling without changing scene undo semantics. */
     void onActionEditUndoTriggered() const;
-    // Delegate redo command handling without changing scene undo semantics.
+    /** @brief Delegates redo command handling without changing scene undo semantics. */
     void onActionEditRedoTriggered() const;
-    // Delegate cut command handling while preserving copy buffers.
+    /** @brief Delegates cut command handling while preserving compatibility copy buffers. */
     void onActionEditCutTriggered() const;
-    // Delegate copy command handling while preserving copy buffers.
+    /** @brief Delegates copy command handling while preserving compatibility copy buffers. */
     void onActionEditCopyTriggered() const;
-    // Delegate paste command handling while preserving copy buffers.
+    /** @brief Delegates paste command handling while preserving compatibility copy buffers. */
     void onActionEditPasteTriggered() const;
-    // Delegate delete command handling while preserving undo integration.
+    /** @brief Delegates delete command handling while preserving undo integration. */
     void onActionEditDeleteTriggered() const;
-    // Delegate group command handling through scene grouping APIs.
+    /** @brief Delegates group command handling through scene grouping APIs. */
     void onActionEditGroupTriggered() const;
-    // Delegate ungroup command handling through scene grouping APIs.
+    /** @brief Delegates ungroup command handling through scene grouping APIs. */
     void onActionEditUngroupTriggered() const;
-    // Delegate view-group command handling through scene grouping APIs.
+    /** @brief Delegates view-group command handling through scene grouping APIs. */
     void onActionViewGroupTriggered() const;
-    // Delegate view-ungroup command handling through scene grouping APIs.
+    /** @brief Delegates view-ungroup command handling through scene grouping APIs. */
     void onActionViewUngroupTriggered() const;
 
-    // Keep clipboard filtering helper behavior used by copy/cut workflows.
+    /** @brief Stores eligible selected items in compatibility clipboard structures. */
     void saveItemForCopy(QList<GraphicalModelComponent*>* gmcList, QList<GraphicalConnection*>* connList) const;
-    // Keep deep-copy helper behavior used by paste workflows.
+    /** @brief Performs deep-copy preparation for subsequent paste command execution. */
     void helpCopy() const;
 
 private:

--- a/source/applications/gui/qt/GenesysQtGUI/controllers/ModelInspectorController.h
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/ModelInspectorController.h
@@ -27,21 +27,21 @@ class ModelGraphicsView;
  */
 class ModelInspectorController {
 public:
-    // Inject only the narrow dependencies required by the model-inspector workflow.
+    /** @brief Creates the model-inspector delegated controller. */
     ModelInspectorController(Simulator* simulator,
                              QTreeWidget* componentsTree,
                              QTreeWidget* dataDefinitionsTree,
                              ModelGraphicsView* graphicsView);
 
-    // Synchronize the Components tree with the current model state.
+    /** @brief Synchronizes the Components tree from the current model representation. */
     void actualizeModelComponents(bool force) const;
-    // Synchronize the Data Definitions tree with the current model state.
+    /** @brief Synchronizes the Data Definitions tree from current model data definitions. */
     void actualizeModelDataDefinitions(bool force) const;
-    // Start in-place edition for a data-definition name when column is editable.
+    /** @brief Starts in-place rename editing for editable data-definition entries. */
     void beginDataDefinitionNameEdit(QTreeWidgetItem* item, int column) const;
-    // Apply renamed data-definition names back into the current model.
+    /** @brief Commits edited data-definition names back to the kernel model. */
     void applyDataDefinitionNameChange(QTreeWidgetItem* item, int column) const;
-    // Synchronize tree selection with graphical scene selection and viewport.
+    /** @brief Synchronizes tree selection with scene selection and viewport focus. */
     void syncSelectedComponentTreeItemToScene() const;
 
 private:

--- a/source/applications/gui/qt/GenesysQtGUI/controllers/ModelLifecycleController.h
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/ModelLifecycleController.h
@@ -52,7 +52,7 @@ public:
         std::function<void(const char*)> disconnectSceneSignals;
     };
 
-    // Inject only the state and callbacks required by lifecycle flows.
+    /** @brief Creates the lifecycle orchestration controller used by MainWindow wrappers. */
     ModelLifecycleController(QWidget* ownerWidget,
                              Simulator* simulator,
                              Ui::MainWindow* ui,
@@ -62,16 +62,25 @@ public:
                              bool* loaded,
                              Callbacks callbacks);
 
-    // Expose lifecycle actions used by MainWindow compatibility wrappers.
+    /** @brief Starts the new-model lifecycle flow and reinitializes GUI/model state. */
     void onActionModelNewTriggered() const;
+    /** @brief Starts model-open flow with persistence loading and UI synchronization. */
     void onActionModelOpenTriggered() const;
+    /** @brief Starts model-save flow for graphical/text representations. */
     void onActionModelSaveTriggered() const;
+    /** @brief Closes current model after pending-change checks and cleanup orchestration. */
     void onActionModelCloseTriggered() const;
+    /** @brief Opens model information dialog for the current model context. */
     void onActionModelInformationTriggered() const;
+    /** @brief Runs model-check workflow as a delegated lifecycle operation. */
     void onActionModelCheckTriggered() const;
+    /** @brief Opens simulation configuration workflow anchored to lifecycle façade. */
     void onActionSimulationConfigureTriggered() const;
+    /** @brief Executes application-exit flow with pending-change confirmation semantics. */
     void onActionSimulatorExitTriggered() const;
+    /** @brief Indicates whether current model/text state has unsaved changes. */
     bool hasPendingModelChanges() const;
+    /** @brief Requests exit confirmation preserving compatibility prompt behavior. */
     bool confirmApplicationExit() const;
 
 private:

--- a/source/applications/gui/qt/GenesysQtGUI/controllers/PluginCatalogController.h
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/PluginCatalogController.h
@@ -33,19 +33,19 @@ class QTreeWidgetItem;
  */
 class PluginCatalogController {
 public:
-    // Inject only the dependencies required to manage plugin catalog UI behavior.
+    /** @brief Creates the plugin-catalog controller used by MainWindow compatibility slots. */
     PluginCatalogController(Simulator* simulator,
                             QTreeWidget* pluginsTree,
                             QPlainTextEdit* modelTextEditor,
                             std::map<std::string, QColor>* pluginCategoryColor);
 
-    // Populate plugin-tree entries while preserving legacy visual behavior.
+    /** @brief Inserts one plugin entry into the categorized plugin tree representation. */
     void insertPluginUI(Plugin* plugin) const;
-    // Keep fake plugin insertion extension point for compatibility.
+    /** @brief Inserts compatibility fake plugins used by legacy GUI flows. */
     void insertFakePlugins() const;
-    // Handle plugin-tree double-click behavior delegated from MainWindow.
+    /** @brief Handles plugin double-click by delegating insertion/selection behavior. */
     void handlePluginItemDoubleClicked(QTreeWidgetItem* item, int column) const;
-    // Handle plugin-tree single-click behavior delegated from MainWindow.
+    /** @brief Handles plugin single-click behavior without mutating model lifecycle state. */
     void handlePluginItemClicked(QTreeWidgetItem* item, int column) const;
 
 private:

--- a/source/applications/gui/qt/GenesysQtGUI/controllers/PropertyEditorController.h
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/PropertyEditorController.h
@@ -32,7 +32,7 @@ class ComboBoxEnum;
  */
 class PropertyEditorController {
 public:
-    // Inject only the property-editor dependencies needed by the Phase 6 flow.
+    /** @brief Creates the property-editor controller and its synchronization callbacks. */
     PropertyEditorController(ObjectPropertyBrowser* propertyBrowser,
                              ModelGraphicsView* graphicsView,
                              PropertyEditorGenesys* propertyGenesys,
@@ -47,13 +47,13 @@ public:
                              std::function<void()> actualizeTabPanes,
                              std::function<void()> actualizeActions);
 
-    // Synchronize current scene selection into the property editor safely.
+    /** @brief Synchronizes current scene selection into property editor bindings. */
     void sceneSelectionChanged() const;
-    // Execute the post-edit model/UI update cascade safely.
+    /** @brief Executes post-commit synchronization across model representations and panes. */
     void onPropertyEditorModelChanged() const;
-    // Clear property editor selection and bindings defensively.
+    /** @brief Clears property editor selection/bindings during lifecycle resets. */
     void clearPropertyEditorSelection() const;
-    // Report whether post-commit stabilization/refresh is still running or queued.
+    /** @brief Reports whether the deferred global refresh pipeline is active. */
     bool isPostCommitPipelineActive() const;
 
 private:

--- a/source/applications/gui/qt/GenesysQtGUI/controllers/SceneToolController.h
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/SceneToolController.h
@@ -29,7 +29,9 @@ class MainWindow;
  */
 class SceneToolController {
 public:
-    // Inject only narrow dependencies required by scene and tool command handlers.
+    /**
+     * @brief Builds the scene-tool delegated controller used by MainWindow compatibility slots.
+     */
     SceneToolController(ModelGraphicsView* graphicsView,
                         Ui::MainWindow* ui,
                         std::function<ModelGraphicsScene*()> currentScene,
@@ -42,39 +44,73 @@ public:
                         int& zoomValue,
                         bool& firstClickShowConnection);
 
+    /** @brief Toggles grid visibility and requests scene redraw updates. */
     void onActionShowGridTriggered();
+    /** @brief Toggles ruler visibility through the delegated scene callback path. */
     void onActionShowRuleTriggered();
+    /** @brief Toggles guide visibility and keeps tab/action synchronization. */
     void onActionShowGuidesTriggered();
+    /** @brief Toggles snap behavior on the current scene without changing tool wiring. */
     void onActionShowSnapTriggered();
+    /** @brief Applies incremental zoom-in and updates shared zoom state. */
     void onActionZoomInTriggered();
+    /** @brief Applies incremental zoom-out and updates shared zoom state. */
     void onActionZoomOutTriggered();
+    /** @brief Fits the current graphical model in view and re-synchronizes zoom widgets. */
     void onActionZoomAllTriggered();
+    /** @brief Synchronizes slider-originated zoom changes with scene/view scale. */
     void onHorizontalSliderZoomGraphicalValueChanged(int value);
+    /** @brief Activates line drawing mode as a compatibility façade wrapper. */
     void onActionDrawLineTriggered();
+    /** @brief Activates rectangle drawing mode as a compatibility façade wrapper. */
     void onActionDrawRectangleTriggered();
+    /** @brief Activates ellipse drawing mode as a compatibility façade wrapper. */
     void onActionDrawEllipseTriggered();
+    /** @brief Activates text drawing mode as a compatibility façade wrapper. */
     void onActionDrawTextTriggered();
+    /** @brief Activates polygon drawing mode as a compatibility façade wrapper. */
     void onActionDrawPoligonTriggered();
+    /** @brief Toggles simulated-time animation overlays in the current scene. */
     void onActionAnimateSimulatedTimeTriggered();
+    /** @brief Toggles variable animation overlays in the current scene. */
     void onActionAnimateVariableTriggered();
+    /** @brief Toggles counter animation overlays in the current scene. */
     void onActionAnimateCounterTriggered();
+    /** @brief Activates connection-creation mode and resets first-click compatibility state. */
     void onActionConnectTriggered();
+    /** @brief Aligns selected graphical items to the left boundary. */
     void onActionArranjeLeftTriggered();
+    /** @brief Aligns selected graphical items to the right boundary. */
     void onActionArranjeRightTriggered();
+    /** @brief Aligns selected graphical items to the top boundary. */
     void onActionArranjeTopTriggered();
+    /** @brief Aligns selected graphical items to the bottom boundary. */
     void onActionArranjeBototmTriggered();
+    /** @brief Aligns selected graphical items to horizontal center. */
     void onActionArranjeCenterTriggered();
+    /** @brief Aligns selected graphical items to vertical middle. */
     void onActionArranjeMiddleTriggered();
+    /** @brief Toggles graphical simulation visualization mode and action state. */
     void onActionActivateGraphicalSimulationTriggered();
+    /** @brief Applies animation-speed slider values to scene animation pacing. */
     void onHorizontalSliderAnimationSpeedValueChanged(int value);
+    /** @brief Toggles diagram overlays and refreshes model-image representation. */
     void onActionDiagramsTriggered();
+    /** @brief Selects all graphical items in the active scene context. */
     void onActionSelectAllTriggered();
+    /** @brief Toggles rendering of internal elements and triggers representation refresh. */
     void onActionShowInternalElementsTriggered();
+    /** @brief Toggles rendering of attached elements and triggers representation refresh. */
     void onActionShowAttachedElementsTriggered();
+    /** @brief Bridges checkbox state changes to the show-elements action wrapper. */
     void onCheckBoxShowElementsStateChanged(int arg1);
+    /** @brief Bridges checkbox state changes to the show-internals action wrapper. */
     void onCheckBoxShowInternalsStateChanged(int arg1);
+    /** @brief Bridges recursive-render checkbox changes to model-image refresh workflow. */
     void onCheckBoxShowRecursiveStateChanged(int arg1);
+    /** @brief Bridges level-annotation checkbox changes to model-image refresh workflow. */
     void onCheckBoxShowLevelsStateChanged(int arg1);
+    /** @brief Toggles interactive connection-hint visibility in scene callback wiring. */
     void onActionGModelShowConnectTriggered();
 
 private:

--- a/source/applications/gui/qt/GenesysQtGUI/controllers/SimulationEventController.h
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/SimulationEventController.h
@@ -48,7 +48,7 @@ public:
         std::function<void(SimulationEvent*)> actualizeGraphicalModel;
     };
 
-    // Inject simulator/view/widget dependencies required by legacy event reactions.
+    /** @brief Creates the simulation-event bridge used by MainWindow compatibility handlers. */
     SimulationEventController(Simulator* simulator,
                               ModelGraphicsScene* scene,
                               ModelGraphicsView* graphicsView,
@@ -65,29 +65,29 @@ public:
                               int tabCentralReportsIndex,
                               Callbacks callbacks);
 
-    // Keep model-check success handling behavior equivalent to legacy MainWindow logic.
+    /** @brief Handles model-check success and updates delegated GUI state. */
     void onModelCheckSuccessHandler(ModelEvent* re) const;
-    // Keep replication-start UI updates equivalent to legacy MainWindow logic.
+    /** @brief Handles replication-start event and updates simulation/report panes. */
     void onReplicationStartHandler(SimulationEvent* re) const;
-    // Keep simulation-start UI reset/setup equivalent to legacy MainWindow logic.
+    /** @brief Handles simulation-start event and resets run-scoped UI state. */
     void onSimulationStartHandler(SimulationEvent* re) const;
-    // Keep simulation-paused reaction equivalent to legacy MainWindow logic.
+    /** @brief Handles simulation pause event and refreshes action availability. */
     void onSimulationPausedHandler(SimulationEvent* re) const;
-    // Keep simulation-resume animation continuation behavior equivalent to legacy MainWindow logic.
+    /** @brief Handles simulation resume event and resumes graphical simulation synchronization. */
     void onSimulationResumeHandler(SimulationEvent* re) const;
-    // Keep simulation-end cleanup behavior equivalent to legacy MainWindow logic.
+    /** @brief Handles simulation end event and performs delegated cleanup/refresh. */
     void onSimulationEndHandler(SimulationEvent* re) const;
-    // Keep process-event updates equivalent to legacy MainWindow logic.
+    /** @brief Handles process-event updates for progress tables and scene refresh hooks. */
     void onProcessEventHandler(SimulationEvent* re) const;
-    // Keep entity-create hook compatibility.
+    /** @brief Handles entity-create events for compatibility callback wiring. */
     void onEntityCreateHandler(SimulationEvent* re) const;
-    // Keep entity-remove hook compatibility.
+    /** @brief Handles entity-remove events for compatibility callback wiring. */
     void onEntityRemoveHandler(SimulationEvent* re) const;
-    // Keep entity-move animation behavior equivalent to legacy MainWindow logic.
+    /** @brief Handles entity-move event updates used by graphical simulation animation. */
     void onMoveEntityEvent(SimulationEvent* re) const;
-    // Keep after-process animation updates equivalent to legacy MainWindow logic.
+    /** @brief Handles after-process event updates used by animation/frame synchronization. */
     void onAfterProcessEvent(SimulationEvent* re) const;
-    // Register simulation event handlers on OnEventManager while keeping MainWindow wrappers.
+    /** @brief Registers kernel on-event callbacks through MainWindow compatibility façade wrappers. */
     void setOnEventHandlers(MainWindow* owner) const;
 
 private:

--- a/source/applications/gui/qt/GenesysQtGUI/controllers/TraceConsoleController.h
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/TraceConsoleController.h
@@ -25,18 +25,18 @@ class QTextEdit;
  */
 class TraceConsoleController {
 public:
-    // Inject narrow text-output dependencies used by trace handlers.
+    /** @brief Creates the trace-output bridge used by MainWindow trace wrappers. */
     TraceConsoleController(QTextEdit* console,
                            QTextEdit* simulationText,
                            QTextEdit* reportsText);
 
-    // Render generic simulator traces to the main console text area.
+    /** @brief Renders generic traces to the main console pane. */
     void simulatorTraceHandler(TraceEvent e) const;
-    // Render simulator error traces to the main console text area.
+    /** @brief Renders error traces to the main console pane. */
     void simulatorTraceErrorHandler(TraceErrorEvent e) const;
-    // Render simulation traces to the simulation output text area.
+    /** @brief Renders simulation traces to the simulation output pane. */
     void simulatorTraceSimulationHandler(TraceSimulationEvent e) const;
-    // Render reports traces to the reports output text area.
+    /** @brief Renders reports traces to the reports output pane. */
     void simulatorTraceReportsHandler(TraceEvent e) const;
 
 private:

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.h
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.h
@@ -68,14 +68,21 @@ class MainWindow : public QMainWindow {
     friend class SimulationEventController;
 
 public:
+    /** @brief Builds the composition root, wiring controllers/services and legacy Qt surface. */
 	MainWindow(QWidget *parent = nullptr);
+    /** @brief Releases UI resources while preserving existing Qt ownership semantics. */
 	~MainWindow();
+    /** @brief Returns the current model graphics scene used by delegated controllers/services. */
     ModelGraphicsScene* myScene() const;
 
 public: // to notify changes
+    /** @brief Indicates whether graphical representation has unsaved modifications. */
 	bool graphicalModelHasChanged() const;
+    /** @brief Updates graphical-change flag used by persistence/action synchronization. */
     void setGraphicalModelHasChanged(bool graphicalModelHasChanged);
+    /** @brief Compatibility wrapper that clears currently selected draw tool actions. */
     void unselectDrawIcons();
+    /** @brief Compatibility wrapper that reports whether any draw tool action is selected. */
     bool checkSelectedDrawIcons();
 
 private slots:
@@ -131,6 +138,7 @@ private slots:
 	void on_actionSimulationPause_triggered();
     /** @brief Resumes paused simulation when available. */
 	void on_actionSimulationResume_triggered();
+    /** @brief Compatibility slot that delegates simulation configuration flow to lifecycle controller. */
 	void on_actionSimulationConfigure_triggered();
 
 	void on_actionAboutAbout_triggered();
@@ -153,11 +161,17 @@ private slots:
 	void on_actionSimulatorExit_triggered();
 	void on_actionSimulatorPreferences_triggered();
 
+    /** @brief Delegates new-model lifecycle orchestration while preserving legacy Qt action slot. */
 	void on_actionModelNew_triggered();
+    /** @brief Delegates open-model lifecycle orchestration while preserving legacy Qt action slot. */
 	void on_actionModelOpen_triggered();
+    /** @brief Delegates save-model lifecycle orchestration while preserving legacy Qt action slot. */
 	void on_actionModelSave_triggered();
+    /** @brief Delegates close-model lifecycle orchestration while preserving legacy Qt action slot. */
 	void on_actionModelClose_triggered();
+    /** @brief Delegates model-information dialog flow to lifecycle/dialog compatibility layer. */
 	void on_actionModelInformation_triggered();
+    /** @brief Delegates model-check workflow used as precondition for simulation/export flows. */
 	void on_actionModelCheck_triggered();
 
 	void on_actionConnect_triggered();
@@ -193,7 +207,9 @@ private slots:
 	void on_pushButton_Breakpoint_Remove_clicked();
 	void on_pushButton_Export_clicked();
 
+    /** @brief Synchronizes selection/property editor state after rubber-band scene selection updates. */
 	void on_graphicsView_rubberBandChanged(const QRect &viewportRect, const QPointF &fromScenePoint, const QPointF &toScenePoint);
+    /** @brief Marks model-language representation dirty and updates synchronization-related UI state. */
 	void on_TextCodeEditor_textChanged();
 
     void on_treeWidgetDataDefnitions_itemDoubleClicked(QTreeWidgetItem *item, int column);
@@ -216,6 +232,7 @@ private slots:
     void on_actionParallelization_triggered();
 
     void on_horizontalSlider_ZoomGraphical_actionTriggered(int action);
+    /** @brief Compatibility slot bridging property-editor commit notifications to controller pipeline. */
     void _onPropertyEditorModelChanged();
 
 protected:
@@ -224,21 +241,36 @@ protected:
 private: // VIEW
 
 private: // trace handlers
+    /** @brief Compatibility façade wrapper that delegates generic trace rendering to controller. */
 	void _simulatorTraceHandler(TraceEvent e);
+    /** @brief Compatibility façade wrapper that delegates error trace rendering to controller. */
 	void _simulatorTraceErrorHandler(TraceErrorEvent e);
+    /** @brief Compatibility façade wrapper that delegates simulation trace rendering. */
 	void _simulatorTraceSimulationHandler(TraceSimulationEvent e);
+    /** @brief Compatibility façade wrapper that delegates reports trace rendering. */
 	void _simulatorTraceReportsHandler(TraceEvent e);
 private: // simulator event handlers
+    /** @brief Compatibility wrapper for model-check success event handling delegation. */
 	void _onModelCheckSuccessHandler(ModelEvent* re);
+    /** @brief Compatibility wrapper for replication-start event handling delegation. */
 	void _onReplicationStartHandler(SimulationEvent* re);
+    /** @brief Compatibility wrapper for simulation-start event handling delegation. */
 	void _onSimulationStartHandler(SimulationEvent* re);
+    /** @brief Compatibility wrapper for simulation-pause event handling delegation. */
 	void _onSimulationPausedHandler(SimulationEvent* re);
+    /** @brief Compatibility wrapper for simulation-resume event handling delegation. */
 	void _onSimulationResumeHandler(SimulationEvent* re);
+    /** @brief Compatibility wrapper for simulation-end event handling delegation. */
 	void _onSimulationEndHandler(SimulationEvent* re);
+    /** @brief Compatibility wrapper for process-event handling delegation. */
 	void _onProcessEventHandler(SimulationEvent* re);
+    /** @brief Compatibility wrapper for entity-create handling delegation. */
 	void _onEntityCreateHandler(SimulationEvent* re);
+    /** @brief Compatibility wrapper for entity-remove handling delegation. */
 	void _onEntityRemoveHandler(SimulationEvent* re);
+    /** @brief Compatibility wrapper for move-entity animation event delegation. */
     void _onMoveEntityEvent(SimulationEvent * re);
+    /** @brief Compatibility wrapper for after-process animation event delegation. */
     void _onAfterProcessEvent(SimulationEvent * re);
 private: // model Graphics View handlers
     void _onSceneMouseEvent(QGraphicsSceneMouseEvent* mouseEvent);
@@ -253,48 +285,87 @@ private: // QGraphicsScene Slots
 private: // Similar to QGraphicsScene Slots
 	void sceneGraphicalModelChanged();
 private: // simulator related
+    /** @brief Registers simulator event callbacks while preserving private wrapper surface. */
 	void _setOnEventHandlers();
+    /** @brief Guards command execution with model-check and text/model synchronization preconditions. */
     bool _ensureSimulationReady(bool checkModel = true);
+    /** @brief Returns whether current model exposes a valid ModelSimulation instance. */
     bool _hasCurrentModelSimulation() const;
+    /** @brief Compatibility wrapper delegating plugin-tree insertion to extracted controller. */
 	void _insertPluginUI(Plugin* plugin);
+    /** @brief Compatibility wrapper delegating fake-plugin insertion to extracted controller. */
 	void _insertFakePlugins();
+    /** @brief Compatibility wrapper delegating text-to-model synchronization to service. */
 	bool _setSimulationModelBasedOnText();
+    /** @brief Compatibility wrapper delegating Graphviz image generation to service. */
 	bool _createModelImage();
+    /** @brief Compatibility wrapper delegating DOT name normalization to service. */
 	std::string _adjustDotName(std::string name);
+    /** @brief Compatibility wrapper delegating DOT fragment insertion to service. */
 	void _insertTextInDot(std::string text, unsigned int compLevel, unsigned int compRank, std::map<unsigned int, std::map<unsigned int, std::list<std::string>*>*>* dotmap, bool isNode = false);
+    /** @brief Compatibility wrapper delegating recursive DOT generation to service. */
 	void _recursiveCreateModelGraphicPicture(ModelDataDefinition* componentOrData, std::list<ModelDataDefinition*>* visited, std::map<unsigned int, std::map<unsigned int, std::list<std::string>*>*>* dotmap);
+    /** @brief Compatibility wrapper delegating C++ representation refresh to service. */
 	void _actualizeModelCppCode();
+    /** @brief Compatibility wrapper delegating C++ line formatting to service. */
 	std::string _addCppCodeLine(std::string line, unsigned int indent = 0);
 private: // view
+    /** @brief Initializes scene/view widgets and core scene callback wiring. */
 	void _initModelGraphicsView();
+    /** @brief Connects scene signals using stored QMetaObject connections for lifecycle control. */
     void _connectSceneSignals();
+    /** @brief Disconnects scene signals during lifecycle transitions and shutdown. */
     void _disconnectSceneSignals(const char* context);
+    /** @brief Reinitializes UI state after new/load model lifecycle operations. */
 	void _initUiForNewModel(Model* m);
+    /** @brief Recomputes action enabled/checked states from delegated controller/service state. */
 	void _actualizeActions();
+    /** @brief Refreshes undo view/actions after scene command changes. */
     void _actualizeUndo();
+    /** @brief Synchronizes tab panes that depend on simulation/model representation updates. */
 	void _actualizeTabPanes();
+    /** @brief Compatibility wrapper delegating model-language text refresh to service. */
 	void _actualizeModelSimLanguage();
+    /** @brief Updates text-change flags and related UI hints. */
 	void _actualizeModelTextHasChanged(bool hasChanged);
+    /** @brief Refreshes simulation-events pane based on latest event payload. */
 	void _actualizeSimulationEvents(SimulationEvent * re);
+    /** @brief Refreshes debug variables pane while preserving force-update semantics. */
 	void _actualizeDebugVariables(bool force);
+    /** @brief Refreshes debug entities pane while preserving force-update semantics. */
 	void _actualizeDebugEntities(bool force);
+    /** @brief Refreshes debug breakpoints pane while preserving force-update semantics. */
 	void _actualizeDebugBreakpoints(bool force);
+    /** @brief Compatibility wrapper delegating model-components tree synchronization. */
 	void _actualizeModelComponents(bool force);
+    /** @brief Compatibility wrapper delegating data-definitions tree synchronization. */
 	void _actualizeModelDataDefinitions(bool force);
+    /** @brief Refreshes graphical animation state based on simulation event progression. */
 	void _actualizeGraphicalModel(SimulationEvent * re);
+    /** @brief Appends command text to console, preserving legacy command-log formatting. */
 	void _insertCommandInConsole(std::string text);
+    /** @brief Clears model editors during lifecycle reset and persistence transitions. */
 	void _clearModelEditors();
+    /** @brief Applies smooth zoom transformation used by slider/action wrappers. */
 	void _gentle_zoom(double factor);
+    /** @brief Shows compatibility placeholder message for not-yet-implemented utilities. */
 	void _showMessageNotImplemented();
+    /** @brief Compatibility wrapper delegating recursive graphical rebuild to service. */
     void _recursivalyGenerateGraphicalModelFromModel(ModelComponent* component, List<ModelComponent*>* visited, std::map<ModelComponent*,GraphicalModelComponent*>* map, int *x, int *y, int *ymax, int sequenceInline);
+    /** @brief Compatibility wrapper delegating full graphical model rebuild to service. */
 	void _generateGraphicalModelFromModel();
+    /** @brief Compatibility wrapper delegating clipboard selection filtering to controller. */
     void saveItemForCopy(QList<GraphicalModelComponent*> * gmcList, QList<GraphicalConnection*> * connList);
 	//bool _checkStartSimulation();
 private: // graphical model persistence
+    /** @brief Compatibility wrapper delegating graphical model persistence to service. */
     bool _saveGraphicalModel(QString filename);
+    /** @brief Compatibility wrapper delegating text model persistence to service. */
     bool _saveTextModel(QFile *saveFile, QString data);
+    /** @brief Compatibility wrapper delegating model loading and restoration to service. */
 	Model* _loadGraphicalModel(std::string filename);
 private: //???
+    /** @brief Compatibility wrapper delegating deep-copy helper behavior to edit controller. */
 	void _helpCopy();
 private: // interface and model main elements to join
 	Ui::MainWindow *ui;
@@ -340,8 +411,11 @@ private: // interface and model main elements to join
 private: // attributes to be saved and loaded withing the graphical model
 	int _zoomValue; // todo should be set for each open graphical model, such as view rect, etc
 private: // misc useful
+    /** @brief Helper for legacy bool-check chaining used in compatibility flows. */
     bool _check(bool success = true);
+    /** @brief Delegates pending-change calculation to lifecycle controller compatibility flow. */
 	bool _hasPendingModelChanges() const;
+    /** @brief Delegates application-exit confirmation to lifecycle controller flow. */
 	bool _confirmApplicationExit();
 	bool _textModelHasChanged = false;
 	bool _graphicalModelHasChanged = false;
@@ -349,6 +423,7 @@ private: // misc useful
 	// Avoids duplicated prompts when exit is approved and Qt emits close events during shutdown.
 	bool _closingApproved = false;
 	QString _autoLoadPluginsFilename = "autoloadplugins.txt";
+    /** @brief Validates scene item invariants before executing scene-dependent commands. */
     bool _checkItemsScene();
 	QString _modelfilename;
 	std::map<std::string /*category*/,QColor>* _pluginCategoryColor = new std::map<std::string,QColor>();

--- a/source/applications/gui/qt/GenesysQtGUI/services/CppModelExporter.h
+++ b/source/applications/gui/qt/GenesysQtGUI/services/CppModelExporter.h
@@ -25,10 +25,15 @@ class Simulator;
  */
 class CppModelExporter {
 public:
-    // MainWindow provides explicit dependencies once, keeping wrappers thin and stable.
+    /** @brief Creates the exporter service for the C++ model-representation pane. */
     CppModelExporter(Simulator* simulator, QPlainTextEdit* cppCodeEditor);
 
+    /**
+     * @brief Formats one C++ output line with the requested indentation level.
+     * @return Formatted line that can be appended to the representation buffer.
+     */
     std::string addCppCodeLine(const std::string& line, unsigned int indent = 0) const;
+    /** @brief Rebuilds the full C++ model representation shown in the GUI editor pane. */
     void actualizeModelCppCode() const;
 
 private:

--- a/source/applications/gui/qt/GenesysQtGUI/services/GraphicalModelBuilder.h
+++ b/source/applications/gui/qt/GenesysQtGUI/services/GraphicalModelBuilder.h
@@ -34,14 +34,16 @@ template<typename T> class List;
  */
 class GraphicalModelBuilder {
 public:
-    // Keep builder dependencies narrow and explicit for Phase 2 extraction.
+    /** @brief Creates the reconstruction service used by load/rebuild compatibility flows. */
     GraphicalModelBuilder(Simulator* simulator,
                           ModelGraphicsView* graphicsView,
                           ModelGraphicsScene* scene,
                           std::map<std::string, QColor>* pluginCategoryColor,
                           QTextEdit* console);
 
-    // Recursively create graphical items and connections from one component branch.
+    /**
+     * @brief Recursively rebuilds graphical items and links from one model-component branch.
+     */
     void recursivalyGenerateGraphicalModelFromModel(ModelComponent* component,
                                                     List<ModelComponent*>* visited,
                                                     std::map<ModelComponent*, GraphicalModelComponent*>* map,
@@ -50,7 +52,7 @@ public:
                                                     int* ymax,
                                                     int sequenceInLine);
 
-    // Generate the full graphical model from all source components.
+    /** @brief Rebuilds the full scene model representation from kernel source components. */
     void generateGraphicalModelFromModel();
 
 private:

--- a/source/applications/gui/qt/GenesysQtGUI/services/GraphicalModelSerializer.h
+++ b/source/applications/gui/qt/GenesysQtGUI/services/GraphicalModelSerializer.h
@@ -35,7 +35,7 @@ class ModelGraphicsView;
  */
 class GraphicalModelSerializer {
 public:
-    // Capture only the narrow GUI/kernel dependencies required for persistence behavior.
+    /** @brief Creates the persistence service that backs MainWindow lifecycle wrappers. */
     GraphicalModelSerializer(Simulator* simulator,
                              QWidget* ownerWidget,
                              QPlainTextEdit* modelTextEditor,
@@ -56,11 +56,20 @@ public:
                              std::function<void()> applyShowAttachedElements,
                              std::function<void()> applyDiagramsVisibility);
 
-    // Save textual model representation using the existing line-by-line format.
+    /**
+     * @brief Saves textual model language using the established compatibility format.
+     * @return true when write succeeds.
+     */
     bool saveTextModel(QFile* saveFile, const QString& data) const;
-    // Save full .gui persistence sections without altering file compatibility.
+    /**
+     * @brief Saves full graphical `.gui` persistence sections without format changes.
+     * @return true when serialization succeeds.
+     */
     bool saveGraphicalModel(const QString& filename) const;
-    // Load .gui/.gen files and restore persisted graphical state.
+    /**
+     * @brief Loads `.gui`/`.gen` model files and restores persisted graphical/UI state.
+     * @return Loaded kernel model pointer or nullptr when loading fails.
+     */
     Model* loadGraphicalModel(const std::string& filename) const;
 
 private:

--- a/source/applications/gui/qt/GenesysQtGUI/services/GraphvizModelExporter.h
+++ b/source/applications/gui/qt/GenesysQtGUI/services/GraphvizModelExporter.h
@@ -31,8 +31,9 @@ class ModelDataDefinition;
  */
 class GraphvizModelExporter {
 public:
-    // MainWindow provides explicit dependencies once, keeping wrappers thin and stable.
-    // Receive a narrow callback to preserve text-to-model sync precondition before image export.
+    /**
+     * @brief Creates the Graphviz exporter service used by MainWindow compatibility wrappers.
+     */
     GraphvizModelExporter(Simulator* simulator,
                           QLabel* modelGraphicLabel,
                           QCheckBox* showInternals,
@@ -41,16 +42,32 @@ public:
                           QCheckBox* showLevels,
                           std::function<bool()> ensureModelSynchronized);
 
+    /**
+     * @brief Normalizes identifiers to Graphviz-safe names.
+     * @param name Raw label/name from model representation.
+     * @return DOT-safe identifier preserving compatibility naming intent.
+     */
     std::string adjustDotName(std::string name) const;
+
+    /**
+     * @brief Inserts a DOT line into the hierarchical rank/level map used for image generation.
+     */
     void insertTextInDot(std::string text,
                          unsigned int compLevel,
                          unsigned int compRank,
                          std::map<unsigned int, std::map<unsigned int, std::list<std::string>*>*>* dotmap,
                          bool isNode = false) const;
+    /**
+     * @brief Recursively traverses model/data nodes to build DOT content fragments.
+     */
     void recursiveCreateModelGraphicPicture(ModelDataDefinition* componentOrData,
                                             std::list<ModelDataDefinition*>* visited,
                                             std::map<unsigned int, std::map<unsigned int, std::list<std::string>*>*>* dotmap) const;
-    // Keep image generation API wrapper-friendly while internally invoking synchronization callback.
+
+    /**
+     * @brief Generates and displays the model image after synchronization preconditions.
+     * @return true when DOT generation and image rendering complete successfully.
+     */
     bool createModelImage() const;
 
 private:

--- a/source/applications/gui/qt/GenesysQtGUI/services/ModelLanguageSynchronizer.h
+++ b/source/applications/gui/qt/GenesysQtGUI/services/ModelLanguageSynchronizer.h
@@ -27,14 +27,26 @@ class Simulator;
  */
 class ModelLanguageSynchronizer {
 public:
-    // MainWindow provides explicit dependencies once, keeping wrappers thin and stable.
+    /**
+     * @brief Creates the synchronization service used by MainWindow compatibility wrappers.
+     */
     ModelLanguageSynchronizer(Simulator* simulator,
                               QPlainTextEdit* modelTextEditor,
                               bool* textModelHasChangedFlag,
                               QWidget* ownerWidget,
                               std::function<void()> onModelCreatedOrLoaded);
 
+    /**
+     * @brief Rebuilds textual model representation from the current kernel model.
+     *
+     * This is part of the synchronization bridge used after lifecycle, property, and scene updates.
+     */
     void actualizeModelSimLanguage() const;
+
+    /**
+     * @brief Parses text editor content and applies it to the simulator model.
+     * @return true when synchronization succeeds and model state is valid for downstream workflows.
+     */
     bool setSimulationModelBasedOnText() const;
 
 private:


### PR DESCRIPTION
### Motivation
- Improve developer-facing documentation for the refactored GUI API by adding method-level Doxygen on controllers, services and key MainWindow wrappers to clarify responsibilities, boundaries and compatibility façade intent.
- Make explicit which methods are delegating to extracted controllers/services, which are compatibility wrappers kept for Qt slot surface, and which participate in synchronization/persistence/export flows.

### Description
- Added concise, technical Doxygen comments for public methods and constructors in controller headers: `DialogUtilityController`, `EditCommandController`, `ModelInspectorController`, `ModelLifecycleController`, `PluginCatalogController`, `PropertyEditorController`, `SceneToolController`, `SimulationEventController`, and `TraceConsoleController` to explain delegation and effects.
- Documented service APIs in headers: `ModelLanguageSynchronizer`, `GraphvizModelExporter`, `CppModelExporter`, `GraphicalModelSerializer`, and `GraphicalModelBuilder`, clarifying preconditions, return semantics and responsibility boundaries.
- Annotated MainWindow method surface in `mainwindow.h` (notably private slots, trace/simulation/scene handlers and helper/wiring methods) to indicate which methods are compatibility wrappers, which delegate to controllers/services, and which still contain logic-worthy responsibilities.
- All edits are comment/documentation only; no signatures, logic, ordering, includes, or behavior were changed.

### Testing
- Reopened and inspected each modified header to confirm method-level Doxygen presence and consistent architectural vocabulary across controllers/services and `mainwindow.h`.
- Verified Doxygen tags (`@brief`, `@param`, `@return`) are present where applicable using a code search across the scoped headers.
- Configured the project with the `debug` preset and performed a debug build (non-GUI build profile used by the preset) to ensure no compilation regressions; the build completed successfully.
- Confirmed the diffs are restricted to documentation/comment changes and that no function signatures or implementations were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d910c2d43083219fd453e0d901e4c4)