### PR TITLE
Fix StatisticsDefaultImpl1 collector ownership and online-state validity

### DIFF
--- a/source/kernel/statistics/StatisticsDefaultImpl1.cpp
+++ b/source/kernel/statistics/StatisticsDefaultImpl1.cpp
@@ -12,6 +12,8 @@
  */
 
 #include <complex>
+#include <cmath>
+#include <limits>
 
 #include "StatisticsDefaultImpl1.h"
 #include "../TraitsKernel.h"
@@ -21,29 +23,63 @@
 //using namespace GenesysKernel;
 
 StatisticsDefaultImpl1::StatisticsDefaultImpl1() {
-	//_collector = new TraitsKernel<Statistics_if>::CollectorImplementation();
+	// Create and own the default collector implementation used by online statistics.
 	_collector = new TraitsKernel<Model>::StatisticsCollector_CollectorImplementation();
-	_collector->setAddValueHandler(setCollectorAddValueHandler(&StatisticsDefaultImpl1::collectorAddHandler, this));
-	_collector->setClearHandler(setCollectorClearHandler(&StatisticsDefaultImpl1::collectorClearHandler, this));
-	//_collector->setAddValueHandler(std::bind(&StatisticsDefaultImpl1::collectorAddHandler, this, std::placeholders::_1));
-	this->initStatistics();
+	_ownsCollector = true;
+	this->_bindCollectorHandlers(_collector);
+	this->_resetStateForCurrentCollector();
 }
 
 StatisticsDefaultImpl1::StatisticsDefaultImpl1(Collector_if* collector) {
+	// Bind to an external collector without taking ownership of its lifetime.
 	_collector = collector;
-	_collector->setAddValueHandler(setCollectorAddValueHandler(&StatisticsDefaultImpl1::collectorAddHandler, this));
-	_collector->setClearHandler(setCollectorClearHandler(&StatisticsDefaultImpl1::collectorClearHandler, this));
-	//_collector->setAddValueHandler(std::bind(&StatisticsDefaultImpl1::collectorAddHandler, this, std::placeholders::_1));
+	_ownsCollector = false;
+	this->_bindCollectorHandlers(_collector);
+	this->_resetStateForCurrentCollector();
+}
+
+StatisticsDefaultImpl1::~StatisticsDefaultImpl1() {
+	// Release collector only when this statistics object owns the allocated instance.
+	if (_ownsCollector && _collector != nullptr) {
+		delete _collector;
+	}
+	_collector = nullptr;
+}
+
+void StatisticsDefaultImpl1::_bindCollectorHandlers(Collector_if* collector) {
+	// Reconnect add/clear callbacks so collector events keep statistics in sync.
+	if (collector != nullptr) {
+		collector->setAddValueHandler(setCollectorAddValueHandler(&StatisticsDefaultImpl1::collectorAddHandler, this));
+		collector->setClearHandler(setCollectorClearHandler(&StatisticsDefaultImpl1::collectorClearHandler, this));
+	}
+}
+
+void StatisticsDefaultImpl1::_resetStateForCurrentCollector() {
+	// Reset online accumulators and invalidate metrics if historical values are not reconstructable.
 	this->initStatistics();
+	if (_collector != nullptr && _collector->numElements() > 0) {
+		_onlineStateValid = false;
+		_elems = _collector->numElements();
+	}
 }
 
 void StatisticsDefaultImpl1::collectorAddHandler(double newValue, double newWeight) {
-	_elems = _collector->numElements();
-	if (newValue < _min) {
-		_min = newValue;
+	// Ignore incremental updates while bound to prefilled collector state that cannot be reconstructed.
+	if (!_onlineStateValid || _collector == nullptr) {
+		return;
 	}
-	if (newValue > _max) {
+	_elems = _collector->numElements();
+	// Initialize first-sample bounds explicitly and update bounds for subsequent samples.
+	if (_elems == 1) {
+		_min = newValue;
 		_max = newValue;
+	} else {
+		if (newValue < _min) {
+			_min = newValue;
+		}
+		if (newValue > _max) {
+			_max = newValue;
+		}
 	}
 
 	// alternative 1
@@ -62,38 +98,47 @@ void StatisticsDefaultImpl1::collectorAddHandler(double newValue, double newWeig
 	double oldAverage = _average;
 	_average = oldAverage + (newWeight/_sumWeight)*(newValue-oldAverage);
 	_sumData += newWeight*(newValue-oldAverage)*(newValue-_average);
-	_variance = _sumWeight==1 ? 0 :_sumData/(_sumWeight-1);
-	_unbiasedVariance = _sumWeight==0 ? 0 : _sumData / (_sumWeight-_sumWeightSquare/_sumWeight);
+	// Keep variance caches coherent and return NaN for undefined finite-sample configurations.
+	const double varianceDenominator = _sumWeight - 1.0;
+	// Protect weighted-unbiased denominator calculation against zero accumulated weight.
+	const double unbiasedDenominator = (_sumWeight == 0.0) ? 0.0 : (_sumWeight - _sumWeightSquare / _sumWeight);
+	_variance = (_elems < 2 || varianceDenominator <= 0.0) ? std::numeric_limits<double>::quiet_NaN() : _sumData / varianceDenominator;
+	_unbiasedVariance = (_elems < 2 || unbiasedDenominator <= 0.0) ? std::numeric_limits<double>::quiet_NaN() : _sumData / unbiasedDenominator;
 
 	// alternative 2 (numerical instability)
 	//_average = _average + (newValue - _average)/_elems;  // or bellow
 	//_average = (_average * (elems - 1) + newValue) / elems;  // this approach propagates the numeric error
 	//_variance = (_variance * (elems - 1) + pow(newValue - _average, 2)) / elems;  // this approach propagates the numeric error
 
-	_stddeviation = sqrt(_variance);
-	_variationCoef = (_average != 0 ? _stddeviation / _average : 0.0);
-	_halfWidth = _criticalTn_1 * (_stddeviation / std::sqrt(_elems));
+	// Propagate undefined dispersion and confidence settings as NaN instead of fragile default zeros.
+	_stddeviation = std::isnan(_variance) ? std::numeric_limits<double>::quiet_NaN() : sqrt(_variance);
+	_variationCoef = (_elems == 0 || std::isnan(_stddeviation) || _average == 0.0) ? std::numeric_limits<double>::quiet_NaN() : (_stddeviation / _average);
+	_halfWidth = (_elems == 0 || std::isnan(_stddeviation) || !std::isfinite(_criticalTn_1)) ? std::numeric_limits<double>::quiet_NaN() : _criticalTn_1 * (_stddeviation / std::sqrt(_elems));
 }
 
 void StatisticsDefaultImpl1::collectorClearHandler() {
+	// A collector clear event restores a reconstructable online state from an empty sample.
 	this->initStatistics();
+	_onlineStateValid = true;
 }
 
 void StatisticsDefaultImpl1::initStatistics() {
+	// Reset accumulators to a clean empty-state baseline without using numeric sentinels.
 	_elems = 0;
-	_min = +1e+99; //@TODO: Change by the double min and man
-	_max = -1e+99;
+	_min = std::numeric_limits<double>::quiet_NaN();
+	_max = std::numeric_limits<double>::quiet_NaN();
 	_sumData = 0.0;
 	_sumWeight = 0.0;
 	_sumWeightSquare = 0.0;
 	_sumDataSquare = 0.0;
-	_average = 0.0;
-	_variance = 0.0;
-	_unweightedvariance = 0.0;
-	_unbiasedVariance = 0.0;
-	_stddeviation = 0.0;
-	_variationCoef = 0.0;
-	_halfWidth = 0.0;
+	_average = std::numeric_limits<double>::quiet_NaN();
+	_variance = std::numeric_limits<double>::quiet_NaN();
+	_unweightedvariance = std::numeric_limits<double>::quiet_NaN();
+	_unbiasedVariance = std::numeric_limits<double>::quiet_NaN();
+	_stddeviation = std::numeric_limits<double>::quiet_NaN();
+	_variationCoef = std::numeric_limits<double>::quiet_NaN();
+	_halfWidth = std::numeric_limits<double>::quiet_NaN();
+	_onlineStateValid = true;
 }
 
 unsigned int StatisticsDefaultImpl1::numElements() {
@@ -101,43 +146,78 @@ unsigned int StatisticsDefaultImpl1::numElements() {
 }
 
 double StatisticsDefaultImpl1::min() {
-	if (_elems > 0)
-		return _min;
-	else
-		return 0.0;
+	// Return NaN while online state is invalid or sample is empty.
+	if (!_onlineStateValid || _elems == 0) {
+		return std::numeric_limits<double>::quiet_NaN();
+	}
+	return _min;
 }
 
 double StatisticsDefaultImpl1::max() {
-	if (_elems > 0)
-		return _max;
-	else
-		return 0.0;
+	// Return NaN while online state is invalid or sample is empty.
+	if (!_onlineStateValid || _elems == 0) {
+		return std::numeric_limits<double>::quiet_NaN();
+	}
+	return _max;
 }
 
 double StatisticsDefaultImpl1::average() {
+	// Return NaN when full historical reconstruction is unavailable.
+	if (!_onlineStateValid || _elems == 0) {
+		return std::numeric_limits<double>::quiet_NaN();
+	}
 	return _average;
 }
 
 double StatisticsDefaultImpl1::variance() {
+	// Return NaN when full historical reconstruction is unavailable.
+	if (!_onlineStateValid) {
+		return std::numeric_limits<double>::quiet_NaN();
+	}
 	return _variance;
 }
 
 double StatisticsDefaultImpl1::stddeviation() {
+	// Return NaN when full historical reconstruction is unavailable.
+	if (!_onlineStateValid) {
+		return std::numeric_limits<double>::quiet_NaN();
+	}
 	return _stddeviation;
 }
 
 double StatisticsDefaultImpl1::variationCoef() {
+	// Return NaN when full historical reconstruction is unavailable.
+	if (!_onlineStateValid) {
+		return std::numeric_limits<double>::quiet_NaN();
+	}
 	return _variationCoef;
 }
 
 double StatisticsDefaultImpl1::halfWidthConfidenceInterval() {
+	// Return NaN when full historical reconstruction is unavailable.
+	if (!_onlineStateValid) {
+		return std::numeric_limits<double>::quiet_NaN();
+	}
 	return _halfWidth;
 }
 
 void StatisticsDefaultImpl1::setConfidenceLevel(double confidencelevel) {
-	_confidenceLevel = confidencelevel;
-	//Integrator_if* integrator = new TraitsKernel<Integrator_if>::Implementation();
-	_criticalTn_1 = 1.96; //integrator->integrate()
+	// Accept only supported confidence levels and invalidate inferential constants otherwise.
+	if (confidencelevel <= 0.0 || confidencelevel >= 1.0) {
+		_confidenceLevel = std::numeric_limits<double>::quiet_NaN();
+		_criticalTn_1 = std::numeric_limits<double>::quiet_NaN();
+	} else {
+		auto found = _supportedConfidenceLevels.find(confidencelevel);
+		if (found != _supportedConfidenceLevels.end()) {
+			_confidenceLevel = confidencelevel;
+			_criticalTn_1 = found->second;
+		} else {
+			_confidenceLevel = std::numeric_limits<double>::quiet_NaN();
+			_criticalTn_1 = std::numeric_limits<double>::quiet_NaN();
+		}
+	}
+	// Recompute cached half-width consistently with the current confidence policy.
+	_halfWidth = (!_onlineStateValid || _elems == 0 || std::isnan(_stddeviation) || !std::isfinite(_criticalTn_1)) ? std::numeric_limits<double>::quiet_NaN() : _criticalTn_1 * (_stddeviation / std::sqrt(_elems));
 
 }
 
@@ -146,7 +226,15 @@ double StatisticsDefaultImpl1::confidenceLevel() {
 }
 
 unsigned int StatisticsDefaultImpl1::newSampleSize(double halfWidth) {
-	return 0;
+	// Compute required sample size from current dispersion and reject undefined input scenarios.
+	if (!_onlineStateValid || halfWidth <= 0.0 || !std::isfinite(_criticalTn_1) || std::isnan(_stddeviation) || std::isinf(_stddeviation)) {
+		return 0;
+	}
+	const double ratio = _criticalTn_1 * _stddeviation / halfWidth;
+	if (!std::isfinite(ratio) || ratio < 0.0) {
+		return 0;
+	}
+	return static_cast<unsigned int>(std::ceil(ratio * ratio));
 }
 
 Collector_if* StatisticsDefaultImpl1::getCollector() const {
@@ -154,5 +242,18 @@ Collector_if* StatisticsDefaultImpl1::getCollector() const {
 }
 
 void StatisticsDefaultImpl1::setCollector(Collector_if* collector) {
+	// Transfer collector binding safely, preserving ownership semantics and callback connections.
+	if (_collector == collector) {
+		return;
+	}
+	Collector_if* oldCollector = _collector;
+	const bool oldCollectorOwned = _ownsCollector;
 	this->_collector = collector;
+	_ownsCollector = false;
+	this->_bindCollectorHandlers(_collector);
+	this->_resetStateForCurrentCollector();
+	// Delete previous collector only when this object owned it and the instance actually changed.
+	if (oldCollectorOwned && oldCollector != nullptr) {
+		delete oldCollector;
+	}
 }

--- a/source/kernel/statistics/StatisticsDefaultImpl1.h
+++ b/source/kernel/statistics/StatisticsDefaultImpl1.h
@@ -16,6 +16,7 @@
 
 #include "Statistics_if.h"
 #include "Collector_if.h"
+#include <map>
 //namespace GenesysKernel {
 
 /*!
@@ -30,7 +31,7 @@ public:
 	StatisticsDefaultImpl1(); //!< When constructor is invoked without a Collector, it is taken from Traits<Statistics_if>::CollectorImplementation configuration
 	/*! \brief Creates statistics object bound to an external collector. */
 	StatisticsDefaultImpl1(Collector_if* collector);
-	virtual ~StatisticsDefaultImpl1() = default;
+	virtual ~StatisticsDefaultImpl1() override;
 public:
 	/*! \brief Returns current collector data source. */
 	virtual Collector_if* getCollector() const override;
@@ -64,10 +65,16 @@ private:
 	void collectorAddHandler(double newValue, double newWeight);
 	/*! \brief Callback executed when collector is cleared. */
 	void collectorClearHandler();
+	/*! \brief Binds collector callbacks used by online statistics updates. */
+	void _bindCollectorHandlers(Collector_if* collector);
+	/*! \brief Resets state and invalidates online metrics when collector is prefilled. */
+	void _resetStateForCurrentCollector();
 	/*! \brief Initializes/zeros all internal accumulators and cached metrics. */
 	void initStatistics();
 private:
 	Collector_if* _collector;
+	bool _ownsCollector = false;
+	bool _onlineStateValid = true;
 	unsigned long _elems;
 	double _sumData;
 	double _sumDataSquare;
@@ -84,6 +91,16 @@ private:
 	double _confidenceLevel = 0.95;
 	double _criticalTn_1 = 1.96;
 	double _halfWidth;
+	const std::map<double, double> _supportedConfidenceLevels{
+		{0.50, 0.0},
+		{0.80, 1.282},
+		{0.90, 1.645},
+		{0.95, 1.96},
+		{0.975, 2.06},
+		{0.98, 2.326},
+		{0.99, 2.576},
+		{0.995, 2.807}
+	};
 };
 //namespace\\}
 #endif /* STATISTICSDEFAULTIMPL1_H */


### PR DESCRIPTION
### Motivation
- Prevent memory leak and incorrect online statistics when binding to external collectors that may already contain data, and provide safe behavior for degenerates and confidence-level inference.

### Description
- Added explicit ownership flag `_ownsCollector`, `_onlineStateValid` flag, non-default destructor, and `_supportedConfidenceLevels` map to `StatisticsDefaultImpl1` to manage collector lifetime and confidence z-values.
- Implemented `_bindCollectorHandlers()` and `_resetStateForCurrentCollector()` helpers; constructors and `setCollector()` now reconnect add/clear handlers, enforce ownership policy (default ctor owns, external ctor non-owner), and invalidate online metrics when bound to a prefilled collector (`numElements() > 0`).
- Replaced magic sentinels for min/max with `NaN`-based empty-state semantics, initialize min/max on the first observed element, and ensure incremental updates are ignored while online state is invalid.
- Made degenerate-case behavior deterministic by returning `NaN` for undefined metrics (`min`, `max`, `average`, `variance`, `stddeviation`, `variationCoef`, `halfWidthConfidenceInterval`) when reconstruction is not possible.
- Fixed `setConfidenceLevel()` to validate input and use a small table of supported z-values instead of a fixed `1.96`, and implemented `newSampleSize(double)` with defensive checks using the standard formula `ceil((z*stddev/halfWidth)^2)`, returning `0` for invalid/undefined scenarios.
- Small defensive fixes to weighted variance denominator handling to avoid division-by-zero issues.
- Changes limited to `source/kernel/statistics/StatisticsDefaultImpl1.h` and `source/kernel/statistics/StatisticsDefaultImpl1.cpp` only; short technical comments in English were added immediately above altered code blocks.

### Testing
- Configured project: `cmake --preset debug-kernel` (succeeded).
- Built kernel target: `cmake --build build/debug-kernel --target genesys_kernel -j4` (succeeded; full build completed and linked `genesys_kernel` static libraries).
- No unit tests were added or executed per scope constraints.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d910fd9a8883219cdb29b4ec55d7af)