### PR TITLE
Fix Schedule lifecycle leaks and harden runtime validation

### DIFF
--- a/source/plugins/data/Schedule.cpp
+++ b/source/plugins/data/Schedule.cpp
@@ -13,6 +13,8 @@
 #include "Schedule.h"
 
 #include "../../kernel/simulator/Model.h"
+#include <cmath>
+#include <sstream>
 
 #ifdef PLUGINCONNECT_DYNAMIC
 
@@ -31,24 +33,54 @@ ModelDataDefinition* Schedule::NewInstance(Model* model, std::string name) {
 
 Schedule::Schedule(Model* model, std::string name) : ModelDataDefinition(model, Util::TypeOf<Schedule>(), name) {
 }
+
+Schedule::~Schedule() {
+	for (SchedulableItem* item : *_schedulableItems->list()) {
+		delete item;
+	}
+	delete _schedulableItems;
+}
 //
 //public
 //
 
 std::string Schedule::show() {
-	return ModelDataDefinition::show();
+	std::stringstream ss;
+	ss << ModelDataDefinition::show()
+	   << ",items=" << _schedulableItems->size()
+	   << ",repeatAfterLast=" << (_repeatAfterLast ? "true" : "false");
+	return ss.str();
 }
 
 std::string Schedule::getExpression() {
+	if (_schedulableItems->size() == 0) {
+		return "";
+	}
+
 	double tnow = _parentModel->getSimulation()->getSimulatedTime();
+	double cycleDuration = 0.0;
+	for (SchedulableItem* item : *_schedulableItems->list()) {
+		cycleDuration += item->getDuration();
+	}
+
+	double targetTime = tnow;
+	if (_repeatAfterLast) {
+		if (cycleDuration <= 0.0) {
+			return _schedulableItems->last()->getExpression();
+		}
+		targetTime = std::fmod(tnow, cycleDuration);
+		if (targetTime < 0.0) {
+			targetTime += cycleDuration;
+		}
+	}
+
 	double accumDuration = 0.0;
-	do
-		for (SchedulableItem* item : *_schedulableItems->list()) {
-			if (tnow <= accumDuration + item->getDuration()) {
-				return item->getExpression();
-			}
-			accumDuration += item->getDuration();
-		} while (_repeatAfterLast);
+	for (SchedulableItem* item : *_schedulableItems->list()) {
+		accumDuration += item->getDuration();
+		if (targetTime <= accumDuration) {
+			return item->getExpression();
+		}
+	}
 	return _schedulableItems->last()->getExpression();
 }
 
@@ -103,6 +135,9 @@ bool Schedule::_loadInstance(PersistenceRecord *fields) {
 			 */
 			_repeatAfterLast = fields->loadField("repeatAfterLast", DEFAULT.repeatAfterLast);
 			unsigned int items = fields->loadField("items", 0u);
+			for (SchedulableItem* item : *_schedulableItems->list()) {
+				delete item;
+			}
 			_schedulableItems->clear();
 			for (unsigned int i = 0; i < items; i++) {
 				std::string suffix = Util::StrIndex(i);
@@ -143,6 +178,7 @@ bool Schedule::_check(std::string& errorMessage) {
 	 * \brief Validate that schedule has items and non-negative durations.
 	 */
 	bool resultAll = true;
+	bool hasPositiveDuration = false;
 	if (_schedulableItems->size() == 0) {
 		errorMessage += "Schedule has no schedulable items. ";
 		resultAll = false;
@@ -152,7 +188,14 @@ bool Schedule::_check(std::string& errorMessage) {
 			errorMessage += "Schedule item duration must be >= 0. ";
 			resultAll = false;
 		}
+		if (item->getDuration() > 0.0) {
+			hasPositiveDuration = true;
+		}
 		resultAll &= _parentModel->checkExpression(item->getExpression(), getName() + ".ItemExpression", errorMessage);
+	}
+	if (_repeatAfterLast && !hasPositiveDuration) {
+		errorMessage += "Schedule repeating cycle must contain at least one item with duration > 0. ";
+		resultAll = false;
 	}
 	return resultAll;
 }
@@ -163,14 +206,7 @@ void Schedule::_initBetweenReplications() {
 }
 
 void Schedule::_createInternalAndAttachedData() {
-	if (_reportStatistics) {
-		//if (_internal == nullptr) {
-		//	_internal = new StatisticsCollector(_parentModel, getName() + "." + "NumberInQueue", this); 
-		//	_internelElementsInsert("NumberInQueue", _internal);
-		//}
-	} else { //if (_cstatNumberInQueue != nullptr) {
-		this->_internalDataClear();
-	}
+	// Schedule currently has no internal or attached data to instantiate.
 }
 
 ParserChangesInformation* Schedule::_getParserChangesInformation() {

--- a/source/plugins/data/Schedule.h
+++ b/source/plugins/data/Schedule.h
@@ -68,7 +68,7 @@ private:
 class Schedule : public ModelDataDefinition {
 public:
 	Schedule(Model* model, std::string name = "");
-	virtual ~Schedule() = default;
+	virtual ~Schedule() override;
 public: // static
 	static ModelDataDefinition* LoadInstance(Model* model, PersistenceRecord *fields);
 	static PluginInformation* GetPluginInformation();

--- a/source/tests/unit/test_simulator_runtime.cpp
+++ b/source/tests/unit/test_simulator_runtime.cpp
@@ -8,6 +8,7 @@
 #include "kernel/simulator/ModelDataDefinition.h"
 #include "kernel/simulator/Entity.h"
 #include "kernel/simulator/Attribute.h"
+#include "kernel/simulator/Event.h"
 #include "kernel/simulator/TraceManager.h"
 #include "kernel/simulator/SimulationControlAndResponse.h"
 #include "kernel/simulator/Persistence.h"
@@ -275,6 +276,49 @@ public:
 
     void InitBetweenReplicationsProbe() {
         _initBetweenReplications();
+    }
+};
+
+class ScheduleProbe : public Schedule {
+public:
+    ScheduleProbe(Model* model, const std::string& name = "") : Schedule(model, name) {}
+
+    bool CheckProbe(std::string& errorMessage) {
+        return _check(errorMessage);
+    }
+
+    bool LoadInstanceProbe(PersistenceRecord* fields) {
+        return _loadInstance(fields);
+    }
+
+    void SaveInstanceProbe(PersistenceRecord* fields, bool saveDefaultValues = false) {
+        _saveInstance(fields, saveDefaultValues);
+    }
+
+    void CreateInternalAndAttachedDataProbe() {
+        _createInternalAndAttachedData();
+    }
+
+    void InternalEventNoopProbe(void* parameter) {
+        (void) parameter;
+    }
+};
+
+struct ReplicationStartEventInjector {
+    Model* model = nullptr;
+    ScheduleProbe* owner = nullptr;
+    bool inserted = false;
+    double eventTime = 0.0;
+    std::string description;
+
+    void OnReplicationStart(SimulationEvent*) {
+        if (inserted || model == nullptr || owner == nullptr) {
+            return;
+        }
+        auto* event = new InternalEvent(eventTime, description);
+        event->setEventHandler(owner, &ScheduleProbe::InternalEventNoopProbe, nullptr);
+        model->getFutureEvents()->insert(event);
+        inserted = true;
     }
 };
 
@@ -1114,6 +1158,134 @@ TEST(SimulatorRuntimeTest, VariableShowIncludesVariableSpecificValues) {
     const std::string shown = variable.show();
     EXPECT_NE(shown.find("values:{"), std::string::npos);
     EXPECT_NE(shown.find("pi="), std::string::npos);
+}
+
+TEST(SimulatorRuntimeTest, ScheduleDestructorDeletesOwnedSchedulableItemsSafely) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    auto* schedule = new ScheduleProbe(model, "ScheduleLifecycle");
+    schedule->getSchedulableItems()->insert(new SchedulableItem("1", 1.0));
+    schedule->getSchedulableItems()->insert(new SchedulableItem("2", 2.0));
+
+    EXPECT_NO_THROW(delete schedule);
+}
+
+TEST(SimulatorRuntimeTest, ScheduleLoadInstanceReplacesSchedulableItemsWithoutKeepingOldPointers) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    ScheduleProbe firstPersisted(model, "ScheduleReloadFirst");
+    firstPersisted.setRepeatAfterLast(false);
+    firstPersisted.getSchedulableItems()->insert(new SchedulableItem("stale", 4.0));
+    FakeModelPersistenceRuntime persistence;
+    PersistenceRecord fieldsFirst(persistence);
+    firstPersisted.SaveInstanceProbe(&fieldsFirst, true);
+
+    ScheduleProbe secondPersisted(model, "ScheduleReloadSecond");
+    secondPersisted.setRepeatAfterLast(false);
+    secondPersisted.getSchedulableItems()->insert(new SchedulableItem("11", 3.0));
+    secondPersisted.getSchedulableItems()->insert(new SchedulableItem("22", 5.0, SchedulableItem::Rule::WAIT));
+    PersistenceRecord fieldsSecond(persistence);
+    secondPersisted.SaveInstanceProbe(&fieldsSecond, true);
+
+    ScheduleProbe schedule(model, "ScheduleReloadTarget");
+    ASSERT_TRUE(schedule.LoadInstanceProbe(&fieldsFirst));
+    ASSERT_EQ(schedule.getSchedulableItems()->size(), 1u);
+    ASSERT_EQ(schedule.getSchedulableItems()->getAtRank(0)->getExpression(), "stale");
+
+    ASSERT_TRUE(schedule.LoadInstanceProbe(&fieldsSecond));
+    ASSERT_EQ(schedule.getSchedulableItems()->size(), 2u);
+    EXPECT_EQ(schedule.getSchedulableItems()->getAtRank(0)->getExpression(), "11");
+    EXPECT_DOUBLE_EQ(schedule.getSchedulableItems()->getAtRank(0)->getDuration(), 3.0);
+    EXPECT_EQ(schedule.getSchedulableItems()->getAtRank(1)->getExpression(), "22");
+    EXPECT_DOUBLE_EQ(schedule.getSchedulableItems()->getAtRank(1)->getDuration(), 5.0);
+}
+
+TEST(SimulatorRuntimeTest, ScheduleGetExpressionReturnsSafeFallbackForEmptyList) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    Schedule schedule(model, "ScheduleEmptyExpression");
+    EXPECT_EQ(schedule.getExpression(), "");
+}
+
+TEST(SimulatorRuntimeTest, ScheduleGetExpressionHandlesNonRepeatingAndReturnsLastAfterEnd) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    ScheduleProbe schedule(model, "ScheduleNonRepeatExpression");
+    schedule.setRepeatAfterLast(false);
+    schedule.getSchedulableItems()->insert(new SchedulableItem("1", 2.0));
+    schedule.getSchedulableItems()->insert(new SchedulableItem("2", 3.0));
+
+    EXPECT_EQ(schedule.getExpression(), "1");
+
+    ReplicationStartEventInjector injector{model, &schedule, false, 10.0, "AdvanceTimeForSchedule"};
+    model->getOnEventManager()->addOnReplicationStartHandler(&injector, &ReplicationStartEventInjector::OnReplicationStart);
+    model->getSimulation()->setReplicationLength(20.0);
+    model->getSimulation()->start();
+
+    EXPECT_DOUBLE_EQ(model->getSimulation()->getSimulatedTime(), 10.0);
+    EXPECT_EQ(schedule.getExpression(), "2");
+}
+
+TEST(SimulatorRuntimeTest, ScheduleGetExpressionRepeatsWithPositiveCycleDurations) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    ScheduleProbe schedule(model, "ScheduleRepeatExpression");
+    schedule.setRepeatAfterLast(true);
+    schedule.getSchedulableItems()->insert(new SchedulableItem("1", 2.0));
+    schedule.getSchedulableItems()->insert(new SchedulableItem("2", 3.0));
+
+    EXPECT_EQ(schedule.getExpression(), "1");
+
+    ReplicationStartEventInjector injector{model, &schedule, false, 8.0, "AdvanceTimeForScheduleRepeat"};
+    model->getOnEventManager()->addOnReplicationStartHandler(&injector, &ReplicationStartEventInjector::OnReplicationStart);
+    model->getSimulation()->setReplicationLength(20.0);
+    model->getSimulation()->start();
+
+    EXPECT_DOUBLE_EQ(model->getSimulation()->getSimulatedTime(), 8.0);
+    EXPECT_EQ(schedule.getExpression(), "2");
+}
+
+TEST(SimulatorRuntimeTest, ScheduleCheckFailsForRepeatingCyclesWithZeroTotalDuration) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    ScheduleProbe schedule(model, "ScheduleInvalidZeroCycle");
+    schedule.setRepeatAfterLast(true);
+    schedule.getSchedulableItems()->insert(new SchedulableItem("1", 0.0));
+    schedule.getSchedulableItems()->insert(new SchedulableItem("2", 0.0));
+
+    std::string errorMessage;
+    EXPECT_FALSE(schedule.CheckProbe(errorMessage));
+    EXPECT_NE(errorMessage.find("duration > 0"), std::string::npos);
+}
+
+TEST(SimulatorRuntimeTest, ScheduleCheckPassesForValidRepeatingConfiguration) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    ScheduleProbe schedule(model, "ScheduleValidCheck");
+    schedule.setRepeatAfterLast(true);
+    schedule.getSchedulableItems()->insert(new SchedulableItem("1", 1.0));
+    schedule.getSchedulableItems()->insert(new SchedulableItem("2", 0.0));
+
+    std::string errorMessage;
+    EXPECT_TRUE(schedule.CheckProbe(errorMessage));
+    EXPECT_TRUE(errorMessage.empty());
+    EXPECT_NE(schedule.show().find("items=2"), std::string::npos);
+    EXPECT_NE(schedule.show().find("repeatAfterLast=true"), std::string::npos);
+    EXPECT_NO_THROW(schedule.CreateInternalAndAttachedDataProbe());
 }
 
 TEST(SimulatorRuntimeTest, ResourceSettersUpdateState) {


### PR DESCRIPTION
### Motivation
- Prevent memory leaks and runtime failures in `Schedule` by fixing ownership, reload, and time-expression edge cases discovered during model check/simulation cycles.
- Ensure model checking blocks degenerate repeating schedules that would cause infinite loops at runtime.

### Description
- Implemented explicit `Schedule` destructor that deletes all owned `SchedulableItem*` and the backing `_schedulableItems` container.
- Updated `_loadInstance()` to delete previously stored `SchedulableItem*` before clearing and repopulating the list, preventing reload leaks.
- Rewrote `getExpression()` to handle empty lists safely, compute cycle duration, avoid infinite loops when `_repeatAfterLast` is true and cycle duration is zero, and use `fmod` for cyclical time mapping.
- Strengthened `_check()` to require at least one positive-duration item when `repeatAfterLast` is enabled, and kept existing non-negative-duration and expression checks.
- Improved `show()` to include `items` count and `repeatAfterLast` flag and simplified `_createInternalAndAttachedData()` to a coherent no-op for the current implementation.
- Added unit tests to `source/tests/unit/test_simulator_runtime.cpp` covering lifecycle/destructor, reload replacing items, `getExpression()` for empty/non-repeating/repeating schedules, and `_check()` failure/success cases.

### Testing
- Configured and built tests and plugins with: `cmake -S . -B build -G Ninja -DGENESYS_BUILD_TESTS=ON -DGENESYS_BUILD_KERNEL=ON -DGENESYS_BUILD_PARSER=ON -DGENESYS_BUILD_PLUGINS=ON ...` and the build completed successfully.
- Built the runtime test target with: `cmake --build build --target genesys_test_simulator_runtime` and the build succeeded.
- Ran focused schedule unit tests: `ctest --test-dir build -R "SimulatorRuntimeTest.*Schedule" --output-on-failure` and all schedule-related tests passed (100% for the filtered tests).
- Ran broader smoke-level CTest (`ctest --test-dir build -LE smoke`) in this environment; the runtime/schedule tests executed and passed, while several placeholder tests were reported as `*_NOT_BUILT` (Not Run) by CTest in this configuration.

---

- o que você realizou de fato;
  - Corrigi ownership/destrutor de `Schedule`, proteção contra leak em `_loadInstance()`, robustez de `getExpression()`, reforço de `_check()`, melhorias em `show()` e simplificação de `_createInternalAndAttachedData()` e adicionei testes unitários cobrindo os cenários obrigatórios.
- o que não realizou;
  - Não alterei outros plugins fora do escopo (por exemplo `SignalData`, `Failure`, `Queue`, `Variable`, `Resource`, `Sequence`, `Delay`).
- por que não realizou;
  - Essas alterações eram explicitamente proibidas pelo escopo desta etapa.
- riscos remanescentes;
  - Validação manual com ASan/Valgrind não foi executada aqui, portanto regressões de uso não cobertas pelos novos testes podem permanecer.
  - Alguns alvos de teste no `ctest -LE smoke` aparecem como `*_NOT_BUILT` neste ambiente; uma validação CI completa depende de build configuration que gere esses alvos.
- observações relevantes;
  - `getExpression()` agora evita loop infinito em ciclos com duração total zero e retorna fallback seguro quando a lista está vazia.
  - `_check()` previne modelagem que levaria a comportamento indefinido em tempo de simulação.
- arquivos alterados;
  - `source/plugins/data/Schedule.h`
  - `source/plugins/data/Schedule.cpp`
  - `source/tests/unit/test_simulator_runtime.cpp`
- comandos executados e resultados resumidos;
  - `cmake -S . -B build -G Ninja -DGENESYS_BUILD_TESTS=ON -DGENESYS_BUILD_KERNEL=ON -DGENESYS_BUILD_PARSER=ON -DGENESYS_BUILD_PLUGINS=ON ...` → configure success.
  - `cmake --build build --target genesys_test_simulator_runtime` → build success.
  - `ctest --test-dir build -R "SimulatorRuntimeTest.*Schedule" --output-on-failure` → all filtered schedule tests passed.
  - `ctest --test-dir build -LE smoke --output-on-failure` → runtime/schedule tests passed; CTest shows several `*_NOT_BUILT` tests as Not Run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d91163f220832191cca0e363efb15a)