### PR TITLE
HYPTEST-2: Use normal quantiles for one-population proportion CIs (with finite-population correction)

### DIFF
--- a/source/tools/ARCHITECTURE_tools.md
+++ b/source/tools/ARCHITECTURE_tools.md
@@ -26,6 +26,7 @@ The `tools` package provides domain-support services for statistical analysis an
 ### Hypothesis testing
 - Maintain current contract and refine implementation completeness, especially two-population methods.
 - HYPTEST-1 alignment keeps the current pooled-vs-Welch heuristic, but documents it as a TODO while consolidating one-population p-value coherence and the two-proportion-difference confidence interval formula.
+- HYPTEST-2 final alignment updates one-population proportion confidence intervals to the normal-approximation formulation (including finite-population correction when `N` is provided).
 
 ### Distribution abstractions
 - Introduce `Distribution_if` and specialized continuous/discrete interfaces.

--- a/source/tools/HypothesisTesterDefaultImpl1.cpp
+++ b/source/tools/HypothesisTesterDefaultImpl1.cpp
@@ -118,8 +118,12 @@ HypothesisTester_if::ConfidenceInterval HypothesisTesterDefaultImpl1::proportion
 	if (n < 2 || prop < 0.0 || prop > 1.0) {
 		throw std::invalid_argument("proportionConfidenceInterval requires n >= 2 and 0 <= prop <= 1");
 	}
-	double correctConf = (1.0 - confidenceLevel) / 2.0;
-	double critic = -ProbabilityDistribution::inverseTStudent(correctConf, 0.0, 1.0, n - 1);
+	validateConfidenceLevel(confidenceLevel);
+	// Use the large-sample normal approximation for one-population proportion CI;
+	// keep the previous t-Student quantile expression commented for historical/technical traceability.
+	const double alpha = 1.0 - confidenceLevel;
+	const double critic = ProbabilityDistribution::inverseNormal(1.0 - alpha / 2.0, 0.0, 1.0);
+	// const double critic = -ProbabilityDistribution::inverseTStudent((1.0 - confidenceLevel) / 2.0, 0.0, 1.0, n - 1);
 	double e0 = critic * sqrt(prop * (1 - prop) / n);
 	return HypothesisTester_if::ConfidenceInterval(prop - e0, prop + e0, e0);
 }
@@ -128,9 +132,13 @@ HypothesisTester_if::ConfidenceInterval HypothesisTesterDefaultImpl1::proportion
 	if (N <= 1 || n < 2 || n > static_cast<unsigned int> (N) || prop < 0.0 || prop > 1.0) {
 		throw std::invalid_argument("proportionConfidenceInterval(population) requires N > 1, 2 <= n <= N and 0 <= prop <= 1");
 	}
-	double correctConf = (1.0 - confidenceLevel) / 2.0;
-	double critic = -ProbabilityDistribution::inverseTStudent(correctConf, 0.0, 1.0, n - 1);
-	double e0 = critic * sqrt(prop * (1 - prop) / n) * sqrt((N - n) / (N - 1));
+	validateConfidenceLevel(confidenceLevel);
+	// Use the finite-population proportion CI with normal approximation + finite-population correction;
+	// keep the previous t-Student quantile expression commented for historical/technical traceability.
+	const double alpha = 1.0 - confidenceLevel;
+	const double critic = ProbabilityDistribution::inverseNormal(1.0 - alpha / 2.0, 0.0, 1.0);
+	// const double critic = -ProbabilityDistribution::inverseTStudent((1.0 - confidenceLevel) / 2.0, 0.0, 1.0, n - 1);
+	double e0 = critic * sqrt(prop * (1 - prop) / n) * sqrt((static_cast<double> (N) - n) / (static_cast<double> (N) - 1.0));
 	return HypothesisTester_if::ConfidenceInterval(prop - e0, prop + e0, e0);
 }
 

--- a/source/tools/README_tools.md
+++ b/source/tools/README_tools.md
@@ -37,5 +37,6 @@ The `source/tools` package hosts statistical and numerical support abstractions 
 - **Fitting**: interface defined; `FitterDefaultImpl` is functional for uniform/triangular/normal/exponential/erlang/beta/weibull with binary dataset loading and SSE-CDF comparison and is now the default `TraitsTools<Fitter_if>` binding (FITTER-3). `FitterDummyImpl` remains available as legacy placeholder.
 - **Hypothesis testing**: functional baseline exists in `HypothesisTesterDefaultImpl1`, with known partial areas.
   - HYPTEST-1 alignment update: proportion-difference CI now follows the classical two-proportion formula, and one-population average/variance tests now compute p-values with Student-t/chi-square-coherent CDF paths.
+  - HYPTEST-2 final alignment update: one-population proportion confidence intervals (with and without finite-population correction) now use the large-sample normal quantile formulation.
 - **Probability distributions**: mathematical static base and inverse façade available, with internal numeric dependencies.
 - **Numerical solvers**: legacy `Solver_if` + `SolverDefaultImpl1` remain the compatible baseline.


### PR DESCRIPTION
### Motivation
- Align the one-population proportion confidence intervals with the textbook large-sample normal approximation instead of using a t-Student quantile. 
- Preserve historical traceability of the previous t-Student approach while making the formulae coherent with other proportion routines. 
- Apply the finite-population correction (FPC) when population size `N` is provided and avoid integer-truncation in the FPC factor.

### Description
- Replaced the t-Student quantile by the standard-normal quantile in `proportionConfidenceInterval(double prop, unsigned int n, double confidenceLevel)` and added `validateConfidenceLevel(confidenceLevel)` and an English comment explaining the change; the original `inverseTStudent(...)` call is kept commented nearby for historical/technical traceability. 
- Applied the same normal-quantile change plus the finite-population correction in `proportionConfidenceInterval(double prop, unsigned int n, int N, double confidenceLevel)`, added `validateConfidenceLevel(confidenceLevel)` and a short explanatory comment, and fixed the FPC to use `double` casts for `(N - n) / (N - 1)` to avoid integer division. 
- Added two one-line notes about the HYPTEST-2 final alignment in `source/tools/README_tools.md` and `source/tools/ARCHITECTURE_tools.md` to document the change. 

### Testing
- Built and ran a temporary driver that exercises both updated methods (driver created at `/tmp/hyptest2_driver.cpp`) with the command `g++ -std=c++17 -Isource ... -o /tmp/hyptest2_driver && /tmp/hyptest2_driver`. 
- Case A (no FPC): `prop=0.80, n=200, confidence=0.95` produced `A 0.66565 0.93435 halfWidth=0.13435` with center ≈ `0.80`. 
- Case B (with FPC): `prop=0.80, n=200, N=1000, confidence=0.95` produced `B 0.679773 0.920227 halfWidth=0.120227` with center ≈ `0.80`, and `halfWidth(B) < halfWidth(A)` as required. 
- Rebuilt and executed the same driver under sanitizers with `-fsanitize=address,undefined` and observed the same `OK` result with no sanitizer errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d91177ef548321a7288f5367029085)