### PR TITLE
Fix Wait/Signal SignalData persistence and validations

### DIFF
--- a/source/plugins/components/Signal.cpp
+++ b/source/plugins/components/Signal.cpp
@@ -85,31 +85,43 @@ void Signal::_onDispatchEvent(Entity* entity, unsigned int inputPortNumber) {
 bool Signal::_loadInstance(PersistenceRecord *fields) {
 	bool res = ModelComponent::_loadInstance(fields);
 	if (res) {
-		// @TODO: not implemented yet
 		this->_limitExpression = fields->loadField("limitExpression", DEFAULT.limitExpression);
+		std::string signalDataName = fields->loadField("signalData", "");
+		if (signalDataName != "") {
+			// Persisted coupling is restored by name to keep Wait/Signal sharing the same SignalData.
+			_signalData = dynamic_cast<SignalData*>(_parentModel->getDataManager()->getDataDefinition(Util::TypeOf<SignalData>(), signalDataName));
+		}
 	}
 	return res;
 }
 
 void Signal::_saveInstance(PersistenceRecord *fields, bool saveDefaultValues) {
 	ModelComponent::_saveInstance(fields, saveDefaultValues);
-	// @TODO: not implemented yet
 	fields->saveField("limitExpression", _limitExpression, DEFAULT.limitExpression);
+	if (_signalData != nullptr) {
+		// Save associated SignalData name so load can reconnect shared state with Wait components.
+		fields->saveField("signalData", _signalData->getName(), "", saveDefaultValues);
+	}
 }
 
 // protected should override
 
 bool Signal::_check(std::string& errorMessage) {
 	bool resultAll = true;
-	// @TODO: not implemented yet
-	errorMessage += "";
+	if (!_parentModel->checkExpression(_limitExpression, "LimitExpression", errorMessage)) {
+		resultAll = false;
+	}
+	// Current operational contract requires Signal to reference shared SignalData.
+	if (_signalData == nullptr) {
+		errorMessage += "SignalData is null in Signal \"" + this->getName() + "\"";
+		resultAll = false;
+	}
 	return resultAll;
 }
 
 void Signal::_createInternalAndAttachedData() {
-	// internal
 	PluginManager* pm = _parentModel->getParentSimulator()->getPluginManager();
-	//attached
+	// Preserve loaded/configured association; only create SignalData if none is already associated.
 	if (_signalData == nullptr) {
 		_signalData = pm->newInstance<SignalData>(_parentModel);
 	}

--- a/source/plugins/components/Wait.cpp
+++ b/source/plugins/components/Wait.cpp
@@ -138,7 +138,7 @@ void Wait::_onDispatchEvent(Entity* entity, unsigned int inputPortNumber) {
 		message += " for signal \"" + _signalData->getName() + "\"";
 	} else if (_waitType == Wait::WaitType::ScanForCondition) {
 		message += " until codition \"" + _condition + "\" is true";
-	} else if (_waitType == Wait::WaitType::ScanForCondition) {
+	} else if (_waitType == Wait::WaitType::InfiniteHold) {
 		message += " indefinitely";
 	}
 	_parentModel->getTracer()->traceSimulation(this, _parentModel->getSimulation()->getSimulatedTime(), entity, this, message);
@@ -181,10 +181,24 @@ void Wait::_saveInstance(PersistenceRecord *fields, bool saveDefaultValues) {
 
 bool Wait::_check(std::string& errorMessage) {
 	bool resultAll = true;
-	if (_waitType == Wait::WaitType::ScanForCondition) {
+	if (_queue == nullptr) {
+		errorMessage += "Queue is null in Wait \"" + this->getName() + "\"";
+		return false;
+	}
+	if (_waitType == Wait::WaitType::WaitForSignal) {
+		// Wait/Signal operational contract is based on a shared SignalData instance.
+		if (_signalData == nullptr) {
+			errorMessage += "SignalData is null for WaitForSignal in Wait \"" + this->getName() + "\"";
+			resultAll = false;
+		}
+		if (!_parentModel->checkExpression(limitExpression, "LimitExpression", errorMessage)) {
+			resultAll = false;
+		}
+	} else if (_waitType == Wait::WaitType::ScanForCondition) {
 		resultAll = _parentModel->checkExpression(_condition, "Condition", errorMessage);
-		if (resultAll) { // add handler to event AfterProcessEvent
+		if (resultAll && !_isScanConditionHandlerRegistered) { // local guard to avoid duplicate registration on re-checks
 			_parentModel->getOnEventManager()->addOnAfterProcessEventHandler(this, &Wait::_handlerForAfterProcessEventEvent);
+			_isScanConditionHandlerRegistered = true;
 		}
 	}
 	return resultAll;
@@ -230,7 +244,8 @@ void Wait::_initBetweenReplications() {
 unsigned int Wait::_handlerForSignalDataEvent(SignalData* signalData) {
 	unsigned int freed = 0;
 	unsigned int waitLimit = _parentModel->parseExpression(limitExpression);
-	while (_queue->size() > 0 && signalData->remainsToLimit() > 0 &&  freed <= waitLimit) {
+	// Stop when either global signal limit or local wait limit is reached.
+	while (_queue->size() > 0 && signalData->remainsToLimit() > 0 && freed < waitLimit) {
 		Waiting* w = _queue->getAtRank(0);
 		Entity* ent = w->getEntity();
 		ModelComponent* sourceComponent = w->geComponent();

--- a/source/plugins/components/Wait.h
+++ b/source/plugins/components/Wait.h
@@ -129,9 +129,9 @@ private: // internal
 	Queue *_queue = nullptr; // @TODO: It should be a QueueableItem, (Queue or Set)
 private: // attached
 	SignalData* _signalData = nullptr;
+	bool _isScanConditionHandlerRegistered = false; // local guard to avoid duplicate registration in repeated checks
 private: // attributes 1:n
 };
 
 
 #endif /* WAIT_H */
-


### PR DESCRIPTION
### Motivation
- Corrigir a assimetria de persistência entre `Wait` e `Signal` que quebrava o acoplamento via `SignalData` após save/load. 
- Implementar validações faltantes em `Signal` (expressão de limite e presença de `SignalData`).
- Evitar registros duplicados do handler de `ScanForCondition` e corrigir bugs lógicos no `Wait` (trace para `InfiniteHold` e possível off-by-one na liberação de entidades).

### Description
- Persistência: `Signal::_saveInstance()` agora salva o nome de `SignalData` quando presente e `Signal::_loadInstance()` restaura a referência via `DataManager`, preservando o vínculo com `Wait` por nome de `SignalData` (arquivo: `source/plugins/components/Signal.cpp`).
- Validação: `Signal::_check(std::string& errorMessage)` valida `LimitExpression` com `Model::checkExpression(...)` e falha com mensagem quando `_signalData == nullptr` (arquivo: `source/plugins/components/Signal.cpp`).
- Criação de dados: `Signal::_createInternalAndAttachedData()` cria `SignalData` somente se não existir associação prévia (evita sobrescrever referência restaurada pelo load) (arquivo: `source/plugins/components/Signal.cpp`).
- Wait: corrigi o ramo de trace para `InfiniteHold`, fortalecei `_check()` para validar por `WaitType` (exigir `_signalData` e validar `limitExpression` em `WaitForSignal`; validar `_condition` em `ScanForCondition`), e adicionei uma guarda local booleana (`_isScanConditionHandlerRegistered`) para evitar dupla inscrição do handler de `OnAfterProcessEvent` em rechecagens (arquivos: `source/plugins/components/Wait.cpp`, `source/plugins/components/Wait.h`).
- Off-by-one: corrigi a condição de laço em `_handlerForSignalDataEvent()` para respeitar corretamente o limite local do `Wait` usando `freed < waitLimit` em vez de `freed <= waitLimit`, mantendo a interação com o limite global de `SignalData` (arquivo: `source/plugins/components/Wait.cpp`).
- Comentários curtos adicionados nos pontos alterados para explicitar o contrato operacional baseado em `SignalData` compartilhado e a guarda contra registro duplicado.

### Testing
- Configurei e gerei build com CMake+Ninja: `cmake -S . -B build -G Ninja` e `cmake --build build` (build principal: OK).
- Executei a suíte de testes principal via `ctest --test-dir build --output-on-failure`, resultado: 977/980 testes passaram e 3 falharam (`StatisticsTest.*`), aparentemente pré-existentes e fora do escopo `Wait/Signal`.
- Rodei testes focados/binaries relevantes: `genesys_test_support_oneventmanager`, `genesys_test_parser_expressions`, `genesys_test_simulator_runtime` — todos passaram.
- Fiz build com sanitizers (ASan+UBSan) para o target de componentes mínimos: configurei `build-asan` e compilei `genesys_plugins_components_minimal` com sucesso, sem erros detectados durante a compilação.

Files modified: `source/plugins/components/Signal.cpp`, `source/plugins/components/Wait.cpp`, `source/plugins/components/Wait.h`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d915dbe4208321bc2797720b508d6b)