### PR TITLE
docs(gui): fill remaining MainWindow scene-callback Doxygen gaps

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.h
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.h
@@ -273,16 +273,24 @@ private: // simulator event handlers
     /** @brief Compatibility wrapper for after-process animation event delegation. */
     void _onAfterProcessEvent(SimulationEvent * re);
 private: // model Graphics View handlers
+    /** @brief Receives scene mouse callbacks and delegates interaction flow to scene-tool pipeline. */
     void _onSceneMouseEvent(QGraphicsSceneMouseEvent* mouseEvent);
+    /** @brief Handles scene wheel-in callbacks to keep zoom wrappers synchronized. */
     void _onSceneWheelInEvent();
+    /** @brief Handles scene wheel-out callbacks to keep zoom wrappers synchronized. */
     void _onSceneWheelOutEvent();
+    /** @brief Bridges scene graphical-model events to compatibility refresh/update routines. */
     void _onSceneGraphicalModelEvent(const GraphicalModelEvent& event);
 private: // QGraphicsScene Slots
+    /** @brief Reacts to scene dirty-region changes and updates compatibility state flags. */
 	void sceneChanged(const QList<QRectF> &region);
+    /** @brief Reacts to focus-item transitions and synchronizes property/editor wrappers. */
 	void sceneFocusItemChanged(QGraphicsItem *newFocusItem, QGraphicsItem *oldFocusItem, Qt::FocusReason reason);
 	//void sceneRectChanged(const QRectF &rect);
+    /** @brief Reacts to scene selection changes and delegates to property/inspector synchronization. */
 	void sceneSelectionChanged();
 private: // Similar to QGraphicsScene Slots
+    /** @brief Compatibility hook fired when scene model graph changes outside Qt dirty-region notifications. */
 	void sceneGraphicalModelChanged();
 private: // simulator related
     /** @brief Registers simulator event callbacks while preserving private wrapper surface. */


### PR DESCRIPTION
### Motivation
- Close a residual documentation gap by adding minimal Doxygen `@brief` comments for scene-related callback/slot bridge methods in `source/applications/gui/qt/GenesysQtGUI/mainwindow.h` without changing behavior or signatures.

### Description
- Added concise `@brief` comments for `_onSceneMouseEvent`, `_onSceneWheelInEvent`, `_onSceneWheelOutEvent`, `_onSceneGraphicalModelEvent`, `sceneChanged`, `sceneFocusItemChanged`, `sceneSelectionChanged`, and `sceneGraphicalModelChanged` in `mainwindow.h`; this is documentation-only and does not alter `.cpp` files, function signatures, includes, structure ordering, or runtime behavior.

### Testing
- Ran `git diff -- source/applications/gui/qt/GenesysQtGUI/mainwindow.h` and `rg -n "@brief|@param|@return" source/applications/gui/qt/GenesysQtGUI/controllers source/applications/gui/qt/GenesysQtGUI/services source/applications/gui/qt/GenesysQtGUI/mainwindow.h`, and both checks completed showing the added `@brief` annotations and no unintended changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9186fb430832186ba105c115cb69e)