### PR TITLE
Parser: preserve offending lexeme in ILLEGAL errors

### DIFF
--- a/source/parser/parserBisonFlex/bisonparser.yy
+++ b/source/parser/parserBisonFlex/bisonparser.yy
@@ -624,17 +624,21 @@ listaparm:
 illegal: 
 	ILLEGAL           {
 		driver.setResult(-1);
+		std::string lexema = $1.tipo;
+		bool hasLexema = !lexema.empty();
+		std::string literalMsg = hasLexema ? std::string("Literal nao encontrado: \"") + lexema + "\"" : std::string("Literal nao encontrado");
+		std::string caracterMsg = hasLexema ? std::string("Caracter invalido encontrado: \"") + lexema + "\"" : std::string("Caracter invalido encontrado");
 		if(driver.getThrowsException()){
 			if($1.valor == 0){
-			  throw std::string("Literal nao encontrado");
+			  throw literalMsg;
 			}else if($1.valor == 1){
-			  throw std::string("Caracter invalido encontrado");
+			  throw caracterMsg;
 			}
 		} else {
 			if($1.valor == 0){
-			  driver.setErrorMessage(std::string("Literal nao encontrado"));
+			  driver.setErrorMessage(literalMsg);
 			}else if($1.valor == 1){
-				driver.setErrorMessage(std::string("Caracter invalido encontrado"));
+				driver.setErrorMessage(caracterMsg);
 			}
 		}
 	}

--- a/source/parser/parserBisonFlex/lexerparser.ll
+++ b/source/parser/parserBisonFlex/lexerparser.ll
@@ -318,10 +318,10 @@ L      [A-Za-z0-9_.]+
         //Case not found retturns a illegal token
 		//datadef = driver.getModel()->getDataManager()->getDataDefinition(Util::TypeOf<Set>(), std::string(yytext));
 		//std::cout << "NOT FOUND " << std::string(yytext) << std::endl;
-        return yy::genesyspp_parser::make_ILLEGAL(obj_t(0, std::string("Illegal")), loc);
+        return yy::genesyspp_parser::make_ILLEGAL(obj_t(0, std::string(yytext)), loc);
       }
 
-.       {return yy::genesyspp_parser::make_ILLEGAL(obj_t(1, std::string("Illegal")), loc);}
+.       {return yy::genesyspp_parser::make_ILLEGAL(obj_t(1, std::string(yytext)), loc);}
 
 <<EOF>> {return yy::genesyspp_parser::make_END(loc);}
 


### PR DESCRIPTION
### Motivation
- Improve error messages so they include the actual rejected lexeme or character while preserving existing lexer/parser semantics and error classification.

### Description
- In `source/parser/parserBisonFlex/lexerparser.ll` the two `ILLEGAL` emission points were changed to carry the offending lexeme in `obj_t.tipo` by using `std::string(yytext)` instead of the generic string `"Illegal"` while keeping `valor == 0` for unresolved literal and `valor == 1` for single-character invalids.
- In `source/parser/parserBisonFlex/bisonparser.yy` the `illegal` production now reads `$1.tipo` and constructs Portuguese messages that include the lexeme (`Literal nao encontrado: "<lexema>"` and `Caracter invalido encontrado: "<lexema>"`) with a safe fallback to the original generic messages when the lexeme is empty, while preserving `driver.setResult(-1)` and the throw-vs-`setErrorMessage` flow.
- No grammar rules, token declarations, public `Model`/`genesyspp_driver` contracts, Makefile, plugin regeneration mechanisms, or generated artifacts were edited manually.

### Testing
- Attempted parser regeneration/build with `cmake -S . -B build -G Ninja -DGENESYS_BUILD_PARSER=ON -DGENESYS_PARSER_REGENERATE=ON`, which failed because `FLEX_EXECUTABLE` was not available in the environment (configuration stopped before generation).
- Confirmed via diffs that only semantic actions/messages were changed and there were no edits to token/type/grammar declarations.
- No automated parser unit tests were executed because build/regeneration could not run in this environment; there are no parser regression tests executed here.

## O que realizei
- Implementei o transporte do lexema rejeitado via `obj_t.tipo` no lexer, nos dois caminhos de `ILLEGAL` exigidos (`{L}` não resolvido e regra `.`).  
- Atualizei as mensagens da produção `illegal` para incluir explicitamente o lexema, com fallback para mensagens antigas quando vazio.
- Commit realizado no branch atual com a mensagem descritiva das alterações.

## O que não realizei
- Não consegui regenerar/buildar o alvo `genesys_parser` via CMake no ambiente atual.
- Não atualizei artefatos gerados (`GenesysParser.cpp/.h`, `Genesys++-scanner.cpp`) porque a regeneração não pôde rodar sem Flex.
- Não executei testes automatizados adicionais do parser (não houve execução devido bloqueio na etapa de configuração com regeneração).

## Por que não realizei
- O ambiente não possui `FLEX_EXECUTABLE`, e a configuração CMake interrompe antes do build/regenerate.

## Riscos remanescentes
- A validação completa depende da regeneração e build com Flex no ambiente de CI/local; até lá não há garantia binária de que as mudanças se integram sem alteração nos arquivos gerados.
- Mensagens dependem do conteúdo de `$1.tipo`; embora haja fallback, fluxos raros que não preencham `tipo` manterão mensagens genéricas.

## Observações relevantes
- Restrições solicitadas foram respeitadas: sem alteração de política léxica/semântica, sem mudança de gramática/tokens, sem mudança de contratos públicos (`Model`/`genesyspp_driver`), e sem tocar Makefile/plugin dinâmico/FORM/reentrância.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d91ad8c9808321a317f16e5312b374)