### PR TITLE
Add permanent unit regression tests for HypothesisTesterDefaultImpl1

### DIFF
--- a/source/tests/unit/CMakeLists.txt
+++ b/source/tests/unit/CMakeLists.txt
@@ -110,6 +110,34 @@ genesys_add_unit_test(genesys_test_statistics
     genesys_kernel_util
 )
 
+add_executable(genesys_test_tools_hypothesistester
+    test_tools_hypothesistester.cpp
+    ${CMAKE_SOURCE_DIR}/source/tools/HypothesisTesterDefaultImpl1.cpp
+    ${CMAKE_SOURCE_DIR}/source/tools/ProbabilityDistribution.cpp
+    ${CMAKE_SOURCE_DIR}/source/tools/ProbabilityDistributionBase.cpp
+    ${CMAKE_SOURCE_DIR}/source/tools/SolverDefaultImpl1.cpp
+)
+
+target_include_directories(genesys_test_tools_hypothesistester
+    PRIVATE
+        ${CMAKE_SOURCE_DIR}/source
+)
+
+target_link_libraries(genesys_test_tools_hypothesistester
+    PRIVATE
+        genesys_kernel_simulator_runtime
+        genesys_kernel_statistics
+        genesys_kernel_util
+        GTest::gtest_main
+)
+
+gtest_discover_tests(genesys_test_tools_hypothesistester
+    PROPERTIES
+        LABELS "unit"
+)
+
+set_property(TARGET genesys_test_tools_hypothesistester PROPERTY FOLDER tests/unit)
+
 add_custom_target(genesys_kernel_unit_tests
     DEPENDS
         genesys_test_util
@@ -126,6 +154,7 @@ add_custom_target(genesys_kernel_unit_tests
         genesys_test_support_simulationscenario
         genesys_test_support_experimentmanager
         genesys_test_statistics
+        genesys_test_tools_hypothesistester
 )
 
 if(GENESYS_BUILD_WEB_APPLICATION)
@@ -194,6 +223,7 @@ add_custom_target(genesys_kernel_unit_tests_run
     COMMAND $<TARGET_FILE:genesys_test_support_simulationscenario>
     COMMAND $<TARGET_FILE:genesys_test_support_experimentmanager>
     COMMAND $<TARGET_FILE:genesys_test_statistics>
+    COMMAND $<TARGET_FILE:genesys_test_tools_hypothesistester>
     COMMAND $<TARGET_FILE:genesys_test_kernel_simulator_method_inventory>
     DEPENDS
         genesys_kernel_unit_tests

--- a/source/tests/unit/test_tools_hypothesistester.cpp
+++ b/source/tests/unit/test_tools_hypothesistester.cpp
@@ -1,0 +1,87 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+#include "tools/HypothesisTesterDefaultImpl1.h"
+
+namespace {
+
+constexpr double kCenterTolerance = 1e-9;
+
+TEST(HypothesisTesterDefaultImpl1Test, ProportionDifferenceConfidenceIntervalHasExpectedCenterAndFiniteBounds) {
+    HypothesisTesterDefaultImpl1 tester;
+
+    auto ci = tester.proportionDifferenceConfidenceInterval(0.60, 0.0, 100, 0.45, 0.0, 120, 0.95);
+
+    ASSERT_TRUE(std::isfinite(ci.inferiorLimit()));
+    ASSERT_TRUE(std::isfinite(ci.superiorLimit()));
+    ASSERT_TRUE(std::isfinite(ci.halfWidth()));
+    EXPECT_GT(ci.halfWidth(), 0.0);
+
+    const double center = (ci.inferiorLimit() + ci.superiorLimit()) * 0.5;
+    EXPECT_NEAR(center, 0.15, kCenterTolerance);
+}
+
+TEST(HypothesisTesterDefaultImpl1Test, ProportionConfidenceIntervalWithoutFinitePopulationHasExpectedCenterAndFiniteBounds) {
+    HypothesisTesterDefaultImpl1 tester;
+
+    auto ci = tester.proportionConfidenceInterval(0.80, 200, 0.95);
+
+    ASSERT_TRUE(std::isfinite(ci.inferiorLimit()));
+    ASSERT_TRUE(std::isfinite(ci.superiorLimit()));
+    ASSERT_TRUE(std::isfinite(ci.halfWidth()));
+    EXPECT_GT(ci.halfWidth(), 0.0);
+
+    const double center = (ci.inferiorLimit() + ci.superiorLimit()) * 0.5;
+    EXPECT_NEAR(center, 0.80, kCenterTolerance);
+}
+
+TEST(HypothesisTesterDefaultImpl1Test, ProportionConfidenceIntervalWithFinitePopulationShrinksHalfWidth) {
+    HypothesisTesterDefaultImpl1 tester;
+
+    auto noPopulationCorrection = tester.proportionConfidenceInterval(0.80, 200, 0.95);
+    auto finitePopulation = tester.proportionConfidenceInterval(0.80, 200, 1000, 0.95);
+
+    ASSERT_TRUE(std::isfinite(finitePopulation.inferiorLimit()));
+    ASSERT_TRUE(std::isfinite(finitePopulation.superiorLimit()));
+    ASSERT_TRUE(std::isfinite(finitePopulation.halfWidth()));
+    EXPECT_GT(finitePopulation.halfWidth(), 0.0);
+
+    const double center = (finitePopulation.inferiorLimit() + finitePopulation.superiorLimit()) * 0.5;
+    EXPECT_NEAR(center, 0.80, kCenterTolerance);
+    EXPECT_LT(finitePopulation.halfWidth(), noPopulationCorrection.halfWidth());
+}
+
+TEST(HypothesisTesterDefaultImpl1Test, TestAverageOnePopulationCoversNonRejectionAndRejectionWithValidPValue) {
+    HypothesisTesterDefaultImpl1 tester;
+
+    auto nonRejection = tester.testAverage(10.0, 2.0, 30, 10.2, 0.95, HypothesisTester_if::H1Comparition::DIFFERENT);
+    EXPECT_FALSE(nonRejection.rejectH0());
+    EXPECT_TRUE(std::isfinite(nonRejection.pValue()));
+    EXPECT_GE(nonRejection.pValue(), 0.0);
+    EXPECT_LE(nonRejection.pValue(), 1.0);
+
+    auto rejection = tester.testAverage(10.0, 2.0, 30, 11.5, 0.95, HypothesisTester_if::H1Comparition::DIFFERENT);
+    EXPECT_TRUE(rejection.rejectH0());
+    EXPECT_TRUE(std::isfinite(rejection.pValue()));
+    EXPECT_GE(rejection.pValue(), 0.0);
+    EXPECT_LE(rejection.pValue(), 1.0);
+}
+
+TEST(HypothesisTesterDefaultImpl1Test, TestVarianceOnePopulationCoversNonRejectionAndRejectionWithValidPValue) {
+    HypothesisTesterDefaultImpl1 tester;
+
+    auto nonRejection = tester.testVariance(4.0, 30, 4.2, 0.95, HypothesisTester_if::H1Comparition::DIFFERENT);
+    EXPECT_FALSE(nonRejection.rejectH0());
+    EXPECT_TRUE(std::isfinite(nonRejection.pValue()));
+    EXPECT_GE(nonRejection.pValue(), 0.0);
+    EXPECT_LE(nonRejection.pValue(), 1.0);
+
+    auto rejection = tester.testVariance(4.0, 30, 1.5, 0.95, HypothesisTester_if::H1Comparition::DIFFERENT);
+    EXPECT_TRUE(rejection.rejectH0());
+    EXPECT_TRUE(std::isfinite(rejection.pValue()));
+    EXPECT_GE(rejection.pValue(), 0.0);
+    EXPECT_LE(rejection.pValue(), 1.0);
+}
+
+} // namespace


### PR DESCRIPTION
### Motivation
- Protect recently aligned hypothesis-tester behavior by adding permanent, reproducible unit tests for proportion CI, proportion-difference CI, average test and variance test routines.
- Provide a minimal, self-contained test target that exercises the implementation without reopening statistical logic in `source/tools`.

### Description
- Add `source/tests/unit/test_tools_hypothesistester.cpp` containing tests for `proportionDifferenceConfidenceInterval(...)`, `proportionConfidenceInterval(prop,n,confidenceLevel)`, `proportionConfidenceInterval(prop,n,N,confidenceLevel)`, one-population `testAverage(...)`, and one-population `testVariance(...)` with both rejection and non-rejection scenarios.
- Register a dedicated test executable `genesys_test_tools_hypothesistester` in `source/tests/unit/CMakeLists.txt` and wire it into the `genesys_kernel_unit_tests` aggregator and the `genesys_kernel_unit_tests_run` runner.
- Compile only the minimal required tool sources into the test target (`HypothesisTesterDefaultImpl1.cpp`, `ProbabilityDistribution.cpp`, `ProbabilityDistributionBase.cpp`, `SolverDefaultImpl1.cpp`) and limit include directories to the project `source` tree.
- No functional changes to the hypothesis tester implementation were made; only test code and the unit-test target wiring were added.

### Testing
- Configured and built the test target with `cmake -S . -B build` and `cmake --build build --target genesys_test_tools_hypothesistester -j4`, which succeeded.
- Executed the test binary directly with `./build/source/tests/unit/genesys_test_tools_hypothesistester` and observed all tests pass: "5 tests, 5 passed".
- Performed a sanitized build with `cmake -S . -B build-asan -DCMAKE_CXX_FLAGS='-fsanitize=address,undefined -fno-omit-frame-pointer' -DCMAKE_EXE_LINKER_FLAGS='-fsanitize=address,undefined'` then `cmake --build build-asan --target genesys_test_tools_hypothesistester -j4` and ran `ASAN_OPTIONS=detect_leaks=0 ./build-asan/source/tests/unit/genesys_test_tools_hypothesistester`, which also reported all tests passed.
- Note: `ctest -R genesys_test_tools_hypothesistester` did not discover the test by that name in CTest, so validation used direct binary execution; build and runtime verification succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d91a23fac883218986cef7c8bd22da)