### PR TITLE
Fix Station recheck lifecycle and replication reset

### DIFF
--- a/source/plugins/data/Station.cpp
+++ b/source/plugins/data/Station.cpp
@@ -15,6 +15,7 @@
 #include "../../kernel/simulator/Entity.h"
 #include "../../kernel/simulator/Model.h"
 #include "../../kernel/simulator/Attribute.h"
+#include <vector>
 
 #ifdef PLUGINCONNECT_DYNAMIC
 
@@ -55,9 +56,7 @@ std::string Station::show() {
 }
 
 void Station::initBetweenReplications() {
-	_cstatNumberInStation->getStatistics()->getCollector()->clear();
-	_cstatTimeInStation->getStatistics()->getCollector()->clear();
-
+	_initBetweenReplications();
 }
 
 void Station::enter(Entity* entity) {
@@ -125,12 +124,25 @@ void Station::_saveInstance(PersistenceRecord *fields, bool saveDefaultValues) {
 }
 
 bool Station::_check(std::string& errorMessage) {
-	_attachedAttributesInsert({"Entity.Station", "Entity.ArrivalAt" + this->getName()});
 	errorMessage += "";
 	return true;
 }
 
 void Station::_createInternalAndAttachedData() {
+	const std::string baseArrivalAttributeName = "Entity.ArrivalAt";
+	std::string currentArrivalAttributeName = baseArrivalAttributeName + getName();
+	Util::Trimwithin(currentArrivalAttributeName);
+	std::vector<std::string> staleArrivalAttributes;
+	for (const auto& attached : *getAttachedData()) {
+		if (attached.first.rfind(baseArrivalAttributeName, 0) == 0 && attached.first != currentArrivalAttributeName) {
+			staleArrivalAttributes.push_back(attached.first);
+		}
+	}
+	for (const std::string& staleKey : staleArrivalAttributes) {
+		_attachedDataRemove(staleKey);
+	}
+	_attachedAttributesInsert({"Entity.Station", currentArrivalAttributeName});
+
 	if (_reportStatistics) {
 		if (_cstatNumberInStation == nullptr) {
 			_cstatNumberInStation = new StatisticsCollector(_parentModel, getName() + "." + "NumberInStation", this);
@@ -146,8 +158,20 @@ void Station::_createInternalAndAttachedData() {
 			}
 
 		}
-	} else
-		if (_cstatNumberInStation != nullptr) {
+	} else if (_cstatNumberInStation != nullptr || _cstatTimeInStation != nullptr) {
 		_internalDataClear();
+		_cstatNumberInStation = nullptr;
+		_cstatTimeInStation = nullptr;
+	}
+}
+
+void Station::_initBetweenReplications() {
+	ModelDataDefinition::_initBetweenReplications();
+	_numberInStation = 0;
+	if (_cstatNumberInStation != nullptr) {
+		_cstatNumberInStation->getStatistics()->getCollector()->clear();
+	}
+	if (_cstatTimeInStation != nullptr) {
+		_cstatTimeInStation->getStatistics()->getCollector()->clear();
 	}
 }

--- a/source/plugins/data/Station.h
+++ b/source/plugins/data/Station.h
@@ -82,13 +82,14 @@ protected:
 	virtual void _saveInstance(PersistenceRecord *fields, bool saveDefaultValues) override;
 	virtual bool _check(std::string& errorMessage) override;
 	virtual void _createInternalAndAttachedData() override;
+	virtual void _initBetweenReplications() override;
 private:
 	unsigned int _numberInStation = 0;
 	ModelComponent* _enterIntoStationComponent;
 private: // inner elements
 	StatisticsCollector* _cstatNumberInStation = nullptr;
 	StatisticsCollector* _cstatTimeInStation = nullptr;
+	friend class StationTestProbe;
 };
 
 #endif /* STATION_H */
-

--- a/source/tests/unit/test_simulator_runtime.cpp
+++ b/source/tests/unit/test_simulator_runtime.cpp
@@ -19,6 +19,7 @@
 #include "plugins/data/Schedule.h"
 #include "plugins/data/Sequence.h"
 #include "plugins/data/SignalData.h"
+#include "plugins/data/Station.h"
 #include "plugins/components/Delay.h"
 #include "plugins/components/Wait.h"
 
@@ -65,6 +66,31 @@ public:
 
     static size_t FailureCount(const Resource& resource) {
         return resource._failures->size();
+    }
+};
+
+class StationTestProbe : public Station {
+public:
+    StationTestProbe(Model* model, const std::string& name = "") : Station(model, name) {}
+
+    void CreateInternalAndAttachedDataProbe() {
+        _createInternalAndAttachedData();
+    }
+
+    void InitBetweenReplicationsProbe() {
+        _initBetweenReplications();
+    }
+
+    StatisticsCollector* NumberInStationCollectorProbe() const {
+        return _cstatNumberInStation;
+    }
+
+    StatisticsCollector* TimeInStationCollectorProbe() const {
+        return _cstatTimeInStation;
+    }
+
+    unsigned int NumberInStationProbe() const {
+        return _numberInStation;
     }
 };
 
@@ -1744,6 +1770,137 @@ TEST(SimulatorRuntimeTest, SequenceCheckPassesForValidSteps) {
     std::string errorMessage;
     EXPECT_TRUE(sequence.CheckProbe(errorMessage));
     EXPECT_TRUE(errorMessage.empty());
+}
+
+TEST(SimulatorRuntimeTest, StationCreateInternalInitiallyCreatesCollectorsWhenStatisticsEnabled) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    StationTestProbe station(model, "StationCreateStats");
+    station.setReportStatistics(true);
+    station.CreateInternalAndAttachedDataProbe();
+
+    EXPECT_NE(station.NumberInStationCollectorProbe(), nullptr);
+    EXPECT_NE(station.TimeInStationCollectorProbe(), nullptr);
+}
+
+TEST(SimulatorRuntimeTest, StationRecheckWithStatisticsEnabledIsIdempotentAndKeepsCollectors) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    StationTestProbe station(model, "StationIdempotentStats");
+    station.setReportStatistics(true);
+    station.CreateInternalAndAttachedDataProbe();
+    StatisticsCollector* numberCollector = station.NumberInStationCollectorProbe();
+    StatisticsCollector* timeCollector = station.TimeInStationCollectorProbe();
+    ASSERT_NE(numberCollector, nullptr);
+    ASSERT_NE(timeCollector, nullptr);
+
+    station.CreateInternalAndAttachedDataProbe();
+    EXPECT_EQ(station.NumberInStationCollectorProbe(), numberCollector);
+    EXPECT_EQ(station.TimeInStationCollectorProbe(), timeCollector);
+}
+
+TEST(SimulatorRuntimeTest, StationDisablingStatisticsOnRecheckClearsCollectorsPointers) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    StationTestProbe station(model, "StationDisableStats");
+    station.setReportStatistics(true);
+    station.CreateInternalAndAttachedDataProbe();
+    ASSERT_NE(station.NumberInStationCollectorProbe(), nullptr);
+    ASSERT_NE(station.TimeInStationCollectorProbe(), nullptr);
+
+    station.setReportStatistics(false);
+    station.CreateInternalAndAttachedDataProbe();
+    EXPECT_EQ(station.NumberInStationCollectorProbe(), nullptr);
+    EXPECT_EQ(station.TimeInStationCollectorProbe(), nullptr);
+}
+
+TEST(SimulatorRuntimeTest, StationReenableStatisticsOnRecheckRecreatesCollectors) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    StationTestProbe station(model, "StationReenableStats");
+    station.setReportStatistics(true);
+    station.CreateInternalAndAttachedDataProbe();
+    ASSERT_NE(station.NumberInStationCollectorProbe(), nullptr);
+    ASSERT_NE(station.TimeInStationCollectorProbe(), nullptr);
+
+    station.setReportStatistics(false);
+    station.CreateInternalAndAttachedDataProbe();
+    ASSERT_EQ(station.NumberInStationCollectorProbe(), nullptr);
+    ASSERT_EQ(station.TimeInStationCollectorProbe(), nullptr);
+
+    station.setReportStatistics(true);
+    station.CreateInternalAndAttachedDataProbe();
+    EXPECT_NE(station.NumberInStationCollectorProbe(), nullptr);
+    EXPECT_NE(station.TimeInStationCollectorProbe(), nullptr);
+}
+
+TEST(SimulatorRuntimeTest, StationInitBetweenReplicationsHookResetsLocalCount) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    StationTestProbe station(model, "StationReplicationReset");
+    station.setReportStatistics(false);
+    station.CreateInternalAndAttachedDataProbe();
+    Entity* entityA = model->createEntity("StationReplicationEntityA", true);
+    Entity* entityB = model->createEntity("StationReplicationEntityB", true);
+    station.enter(entityA);
+    station.enter(entityB);
+    ASSERT_EQ(station.NumberInStationProbe(), 2u);
+
+    station.InitBetweenReplicationsProbe();
+    EXPECT_EQ(station.NumberInStationProbe(), 0u);
+}
+
+TEST(SimulatorRuntimeTest, StationRenameRecheckKeepsOnlyCurrentArrivalAttributeAttached) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    StationTestProbe station(model, "StationRenameOld");
+    station.CreateInternalAndAttachedDataProbe();
+    auto* attached = station.getAttachedData();
+    ASSERT_EQ(attached->count("Entity.ArrivalAtStationRenameOld"), 1u);
+
+    station.setName("StationRenameNew");
+    station.CreateInternalAndAttachedDataProbe();
+    EXPECT_EQ(attached->count("Entity.ArrivalAtStationRenameNew"), 1u);
+    EXPECT_EQ(attached->count("Entity.ArrivalAtStationRenameOld"), 0u);
+    EXPECT_EQ(attached->count("Entity.Station"), 1u);
+}
+
+TEST(SimulatorRuntimeTest, StationEnterLeaveFlowRemainsCoherentAfterRechecksAndResets) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    StationTestProbe station(model, "StationFlow");
+    station.setReportStatistics(true);
+    station.CreateInternalAndAttachedDataProbe();
+    station.setReportStatistics(false);
+    station.CreateInternalAndAttachedDataProbe();
+    station.setReportStatistics(true);
+    station.CreateInternalAndAttachedDataProbe();
+    station.setReportStatistics(false);
+    station.CreateInternalAndAttachedDataProbe();
+
+    Entity* entity = model->createEntity("StationFlowEntity", true);
+    station.enter(entity);
+    EXPECT_EQ(station.NumberInStationProbe(), 1u);
+    EXPECT_DOUBLE_EQ(entity->getAttributeValue("Entity.Station"), static_cast<double>(station.getId()));
+    EXPECT_NO_THROW(entity->getAttributeValue("Entity.ArrivalAtStationFlow"));
+
+    station.leave(entity);
+    EXPECT_EQ(station.NumberInStationProbe(), 0u);
+    EXPECT_DOUBLE_EQ(entity->getAttributeValue("Entity.Station"), 0.0);
 }
 
 TEST(SimulatorRuntimeTest, SignalDataDestructorHandlesOwnedHandlersLifecycle) {


### PR DESCRIPTION
PLUGINS

### Motivation
- Fix lifecycle bugs in `Station` that left dangling collector pointers after rechecks and broke reset between replications. 
- Move attached-attribute reconciliation out of validation into the recheck flow to avoid accumulating obsolete `Entity.ArrivalAt<...>` attachments after renames. 
- Ensure `_numberInStation` and collectors are coherent across model rechecks and replication cycles so `enter()`/`leave()` and statistics remain consistent. 

### Description
- Reconciled attached attributes in `Station::_createInternalAndAttachedData()` by keeping `Entity.Station` and installing the current `Entity.ArrivalAt<StationName>` while removing stale `Entity.ArrivalAt...` keys created by prior names. 
- Created statistics collectors only when `_reportStatistics == true`, and when statistics are disabled call `_internalDataClear()` and set `_cstatNumberInStation = nullptr` and `_cstatTimeInStation = nullptr` to avoid dangling pointers. 
- Implemented `Station::_initBetweenReplications()` override to reset `_numberInStation = 0`, clear collectors safely, and delegated public `initBetweenReplications()` to this hook. 
- Added `friend class StationTestProbe` to enable targeted unit probes, and added focused unit tests in `test_simulator_runtime.cpp` to cover creation, idempotency, disabling/re-enabling, replication reset, rename reconciliation, and enter/leave coherence. 

### Testing
- Configured and generated build files using `cmake -S . -B build -G Ninja -DGENESYS_BUILD_TESTS=ON -DGENESYS_BUILD_KERNEL=ON -DGENESYS_BUILD_PARSER=ON -DGENESYS_BUILD_PLUGINS=ON ...` and the configuration step completed successfully. 
- Built the test binary with `cmake --build build --target genesys_test_simulator_runtime` and the build succeeded. 
- Ran Station-focused tests with `ctest --test-dir build -R "SimulatorRuntimeTest.*Station" --output-on-failure` and all Station tests passed. 
- Ran `ctest --test-dir build -LE smoke --output-on-failure` which reported many `*_NOT_BUILT` tests (these are expected/unavailable in this build configuration). 

```markdown
- o que você realizou de fato;
  - Corrigi `Station.h/.cpp` para lifecycle seguro dos collectors, implementei `_initBetweenReplications()` e movi a reconciliação de attached attributes para `_createInternalAndAttachedData()`; atualizei `_check()` para ser validação somente; e adicionei testes unitários para os cenários exigidos.
- o que não realizou;
  - Não implementei features fora do escopo (station set, parent activity area, save attribute).
  - Não modifiquei outros plugins proibidos (`SignalData`, `Schedule`, `Failure`, `Queue`, `Variable`, `Resource`, `Sequence`, `Delay`).
- por que não realizou;
  - Essas mudanças estavam explicitamente fora do escopo desta etapa.
- riscos remanescentes;
  - `leave()` ainda pressupõe `entity->getEntityType()` válido quando `_reportStatistics == true` (comportamento já existente); atenção caso entidades nulas ou tipos não-reportantes apareçam em cenários futuros.
  - Execução ampla de `ctest -LE smoke` continua mostrando testes `*_NOT_BUILT` em função da configuração de build atual.
- observações relevantes;
  - Alteração garante que renomear uma `Station` e rechecar não deixa `Entity.ArrivalAt<nomeAntigo>` anexado.
  - Reset entre replicações agora usa o hook virtual correto chamado pelo kernel, evitando perda de coerência de `_numberInStation`.
- arquivos alterados;
  - `source/plugins/data/Station.h`
  - `source/plugins/data/Station.cpp`
  - `source/tests/unit/test_simulator_runtime.cpp`
- comandos executados e resultados resumidos.
  - `cmake -S . -B build -G Ninja -DGENESYS_BUILD_TESTS=ON -DGENESYS_BUILD_KERNEL=ON -DGENESYS_BUILD_PARSER=ON -DGENESYS_BUILD_PLUGINS=ON ...` → configuração completa com sucesso.
  - `cmake --build build --target genesys_test_simulator_runtime` → build bem-sucedido.
  - `ctest --test-dir build -R "SimulatorRuntimeTest.*Station" --output-on-failure` → todos os testes filtrados passaram.
  - `ctest --test-dir build -LE smoke --output-on-failure` → alguns testes aparecem como `*_NOT_BUILT` (não gerados nesta configuração), comportamento esperado.
```

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d91c6baeec8321b63b9f66a7f998b5)