### PR TITLE
Fix Set lifecycle, type validation, and attached-data idempotency

### DIFF
--- a/source/plugins/data/Set.cpp
+++ b/source/plugins/data/Set.cpp
@@ -13,6 +13,7 @@
 
 #include "Set.h"
 #include "../../kernel/simulator/Model.h"
+#include <vector>
 
 #ifdef PLUGINCONNECT_DYNAMIC
 
@@ -43,6 +44,11 @@ Set::Set(Model* model, std::string name) : ModelDataDefinition(model, Util::Type
     _addProperty(propElementSet);
 }
 
+Set::~Set() {
+    delete _elementSet;
+    _elementSet = nullptr;
+}
+
 std::string Set::show() {
     return ModelDataDefinition::show() +
             "";
@@ -62,7 +68,9 @@ List<ModelDataDefinition*>* Set::getElementSet() const {
 
 void Set::addElementSet(ModelDataDefinition* newElement) {
     _elementSet->insert(newElement);
-    _setOfType = newElement->getClassname();
+    if (_elementSet->size() == 1 && (_setOfType.empty() || _setOfType == DEFAULT.setOfType)) {
+        _setOfType = newElement->getClassname();
+    }
 }
 
 void Set::removeElementSet(ModelDataDefinition* element) {
@@ -88,6 +96,7 @@ bool Set::_loadInstance(PersistenceRecord *fields) {
     bool res = ModelDataDefinition::_loadInstance(fields);
     if (res) {
         try {
+            _elementSet->clear();
             _setOfType = fields->loadField("type", DEFAULT.setOfType);
             unsigned int memberSize = fields->loadField("members", DEFAULT.membersSize);
             for (unsigned int i = 0; i < memberSize; i++) {
@@ -118,20 +127,30 @@ void Set::_saveInstance(PersistenceRecord *fields, bool saveDefaultValues) {
 
 bool Set::_check(std::string& errorMessage) {
     bool resultAll = true;
-    if (_elementSet->size() > 0) {
-        std::string typeOfFirstElement = _elementSet->front()->getClassname();
-        if (_setOfType == "") {
-            _setOfType = typeOfFirstElement;
-        } else if (_setOfType != typeOfFirstElement) {
-            resultAll = false;
-            errorMessage += "Set is of type \"" + _setOfType + "\" and first modeldatum is of type \"" + typeOfFirstElement + "\"";
+    std::vector<std::string> previousMemberKeys;
+    for (const auto& pair : *getAttachedData()) {
+        if (pair.first.rfind("Member", 0) == 0) {
+            previousMemberKeys.push_back(pair.first);
         }
     }
-    int i = 0;
-    for (ModelDataDefinition* data : *_elementSet->list()) {
-        this->_attachedDataInsert("Member" + Util::StrIndex(i), data);
+    for (const std::string& key : previousMemberKeys) {
+        _attachedDataRemove(key);
     }
-    errorMessage += "";
+
+    if (_elementSet->size() > 0) {
+        unsigned int i = 0;
+        for (ModelDataDefinition* data : *_elementSet->list()) {
+            std::string currentType = data->getClassname();
+            if (_setOfType.empty()) {
+                _setOfType = currentType;
+            } else if (_setOfType != currentType) {
+                resultAll = false;
+                errorMessage += "Set is of type \"" + _setOfType + "\" but member[" + Util::StrIndex(i) + "]=\"" + data->getName() + "\" is of type \"" + currentType + "\"";
+            }
+            _attachedDataInsert("Member" + Util::StrIndex(i), data);
+            ++i;
+        }
+    }
     return resultAll;
 }
 
@@ -143,6 +162,17 @@ ParserChangesInformation* Set::_getParserChangesInformation() {
 }
 
 void Set::_createInternalAndAttachedData() {
+    std::vector<std::string> previousSetMemberKeys;
+    const std::string setMemberPrefix = getName() + ".";
+    for (const auto& pair : *getAttachedData()) {
+        if (pair.first.rfind(setMemberPrefix, 0) == 0) {
+            previousSetMemberKeys.push_back(pair.first);
+        }
+    }
+    for (const std::string& key : previousSetMemberKeys) {
+        _attachedDataRemove(key);
+    }
+
     for(ModelDataDefinition* dd: *_elementSet->list()) {
         _attachedDataInsert(getName()+"."+dd->getName(), dd);
     }

--- a/source/plugins/data/Set.h
+++ b/source/plugins/data/Set.h
@@ -56,7 +56,7 @@ Type is Entity Picture.
 class Set : public ModelDataDefinition {
 public:
 	Set(Model* model, std::string name = "");
-	virtual ~Set() = default;
+	virtual ~Set() override;
 public: // static
 	static ModelDataDefinition* LoadInstance(Model* model, PersistenceRecord *fields);
 	static PluginInformation* GetPluginInformation();
@@ -90,4 +90,3 @@ private:
 };
 
 #endif /* SET_H */
-

--- a/source/tests/unit/test_simulator_runtime.cpp
+++ b/source/tests/unit/test_simulator_runtime.cpp
@@ -20,6 +20,7 @@
 #include "plugins/data/Sequence.h"
 #include "plugins/data/SignalData.h"
 #include "plugins/data/Station.h"
+#include "plugins/data/Set.h"
 #include "plugins/components/Delay.h"
 #define private public
 #define protected public
@@ -387,6 +388,27 @@ public:
 
     void InternalEventNoopProbe(void* parameter) {
         (void) parameter;
+    }
+};
+
+class SetProbe : public Set {
+public:
+    SetProbe(Model* model, const std::string& name = "") : Set(model, name) {}
+
+    bool CheckProbe(std::string& errorMessage) {
+        return _check(errorMessage);
+    }
+
+    bool LoadInstanceProbe(PersistenceRecord* fields) {
+        return _loadInstance(fields);
+    }
+
+    void SaveInstanceProbe(PersistenceRecord* fields, bool saveDefaultValues = false) {
+        _saveInstance(fields, saveDefaultValues);
+    }
+
+    void CreateInternalAndAttachedDataProbe() {
+        _createInternalAndAttachedData();
     }
 };
 
@@ -1830,6 +1852,137 @@ TEST(SimulatorRuntimeTest, SequenceCheckPassesForValidSteps) {
     std::string errorMessage;
     EXPECT_TRUE(sequence.CheckProbe(errorMessage));
     EXPECT_TRUE(errorMessage.empty());
+}
+
+TEST(SimulatorRuntimeTest, SetDestructorDeletesOwnedContainerButNotMembers) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    Resource memberA(model, "SetLifecycleMemberA");
+    Resource memberB(model, "SetLifecycleMemberB");
+
+    auto* set = new SetProbe(model, "SetLifecycle");
+    set->addElementSet(&memberA);
+    set->addElementSet(&memberB);
+    ASSERT_EQ(set->getElementSet()->size(), 2u);
+
+    delete set;
+    EXPECT_EQ(memberA.getName(), "SetLifecycleMemberA");
+    EXPECT_EQ(memberB.getName(), "SetLifecycleMemberB");
+}
+
+TEST(SimulatorRuntimeTest, SetLoadInstanceReplacesStateWithoutResidualMembers) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    Resource memberA(model, "SetLoadMemberA");
+    Resource memberB(model, "SetLoadMemberB");
+    Resource memberC(model, "SetLoadMemberC");
+    SetProbe set(model, "SetLoad");
+
+    set.addElementSet(&memberA);
+    set.addElementSet(&memberB);
+    FakeModelPersistenceRuntime persistence;
+    PersistenceRecord firstFields(persistence);
+    set.SaveInstanceProbe(&firstFields, true);
+
+    set.getElementSet()->clear();
+    set.addElementSet(&memberC);
+    PersistenceRecord secondFields(persistence);
+    set.SaveInstanceProbe(&secondFields, true);
+
+    ASSERT_TRUE(set.LoadInstanceProbe(&firstFields));
+    ASSERT_EQ(set.getElementSet()->size(), 2u);
+    ASSERT_TRUE(set.LoadInstanceProbe(&secondFields));
+    ASSERT_EQ(set.getElementSet()->size(), 1u);
+    EXPECT_EQ(set.getElementSet()->front(), &memberC);
+}
+
+TEST(SimulatorRuntimeTest, SetCheckFailsForMixedMemberTypes) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    Resource resource(model, "SetMixedResource");
+    Queue queue(model, "SetMixedQueue");
+    SetProbe set(model, "SetMixed");
+    set.addElementSet(&resource);
+    set.addElementSet(&queue);
+
+    std::string errorMessage;
+    EXPECT_FALSE(set.CheckProbe(errorMessage));
+    EXPECT_NE(errorMessage.find("member["), std::string::npos);
+    EXPECT_NE(errorMessage.find("SetMixedQueue"), std::string::npos);
+    EXPECT_NE(errorMessage.find("Queue"), std::string::npos);
+}
+
+TEST(SimulatorRuntimeTest, SetCheckPassesForHomogeneousMembersAndPreservesOrder) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    Resource memberA(model, "SetHomogeneousA");
+    Resource memberB(model, "SetHomogeneousB");
+    SetProbe set(model, "SetHomogeneous");
+    set.addElementSet(&memberA);
+    set.addElementSet(&memberB);
+
+    std::string errorMessage;
+    EXPECT_TRUE(set.CheckProbe(errorMessage));
+    EXPECT_TRUE(errorMessage.empty());
+    ASSERT_EQ(set.getElementSet()->size(), 2u);
+    auto members = set.getElementSet()->list();
+    EXPECT_EQ(members->front(), &memberA);
+    EXPECT_EQ(members->back(), &memberB);
+}
+
+TEST(SimulatorRuntimeTest, SetCheckCreatesDistinctIndexedAttachedMembers) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    Resource memberA(model, "SetAttachedIndexA");
+    Resource memberB(model, "SetAttachedIndexB");
+    SetProbe set(model, "SetAttachedIndex");
+    set.addElementSet(&memberA);
+    set.addElementSet(&memberB);
+
+    std::string errorMessage;
+    ASSERT_TRUE(set.CheckProbe(errorMessage));
+    auto* attached = set.getAttachedData();
+    const std::string member0Key = "Member" + Util::StrIndex(0);
+    const std::string member1Key = "Member" + Util::StrIndex(1);
+    ASSERT_EQ(attached->count(member0Key), 1u);
+    ASSERT_EQ(attached->count(member1Key), 1u);
+    EXPECT_EQ(attached->at(member0Key), &memberA);
+    EXPECT_EQ(attached->at(member1Key), &memberB);
+}
+
+TEST(SimulatorRuntimeTest, SetRecheckRemovesObsoleteAttachedMembers) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    Resource memberA(model, "SetRecheckA");
+    Resource memberB(model, "SetRecheckB");
+    SetProbe set(model, "SetRecheck");
+    set.addElementSet(&memberA);
+    set.addElementSet(&memberB);
+    set.CreateInternalAndAttachedDataProbe();
+
+    auto* attached = set.getAttachedData();
+    ASSERT_EQ(attached->count("SetRecheck.SetRecheckA"), 1u);
+    ASSERT_EQ(attached->count("SetRecheck.SetRecheckB"), 1u);
+
+    set.getElementSet()->clear();
+    set.addElementSet(&memberB);
+    set.CreateInternalAndAttachedDataProbe();
+
+    EXPECT_EQ(attached->count("SetRecheck.SetRecheckA"), 0u);
+    ASSERT_EQ(attached->count("SetRecheck.SetRecheckB"), 1u);
+    EXPECT_EQ(attached->at("SetRecheck.SetRecheckB"), &memberB);
 }
 
 TEST(SimulatorRuntimeTest, StationCreateInternalInitiallyCreatesCollectorsWhenStatisticsEnabled) {


### PR DESCRIPTION
### Motivation
- Close multiple confirmed bugs in the `Set` data element related to container lifecycle, reload duplication, incorrect type validation, and non-idempotent attached-data recreation. 
- Preserve Genesys semantics: homogeneous typed sets, stable member order, safe reload/recheck, and non-owning attachment semantics. 
- Provide minimal, safe changes limited to `Set.*` and focused unit tests to validate the fixes.

### Description
- Implemented an explicit `Set` destructor to free the owned `_elementSet` container without deleting non-owned `ModelDataDefinition*` members. 
- Fixed `_loadInstance()` to clear the existing `_elementSet` before rebuilding from persistence so reloads replace prior state and preserve persisted order. 
- Rewrote `_check()` to remove stale `Member*` attached entries before reinserting, validate the type of every member (fail with a clear message on mismatch), infer `_setOfType` from the first valid member when empty, and correctly increment the attached-data index for each member. 
- Adjusted `addElementSet()` to avoid overwriting `_setOfType` on every insertion while still inferring type in the initial/default case, preventing type-masking by subsequent inserts. 
- Made `_createInternalAndAttachedData()` idempotent by removing obsolete `SetName.*` attachments before inserting current members (preserving member order). 
- Added `SetProbe` and six focused unit tests in `test_simulator_runtime.cpp` that exercise lifecycle, reload replacement, mixed-type failure, homogeneous pass with preserved order, distinct indexed attached members, and cleanup of obsolete attached members.

### Testing
- Configured the project and built the runtime tests with CMake and Ninja successfully using the recommended test build options. 
- Built the `genesys_test_simulator_runtime` target successfully. 
- Executed `ctest -R "SimulatorRuntimeTest.*Set" --output-on-failure` and all Set-related tests passed (100% for the filtered Set tests). 
- Executed `ctest -LE smoke --output-on-failure` in this environment where multiple `*_NOT_BUILT` test executables are expected; the smoke run reports many not-built tests due to this configuration but the Set-target validation remains green.

```markdown
- o que você realizou de fato;
  - Corrigi integralmente o plugin `Set` (lifecycle do container, reload sem resíduos, validação de tipos para todos os membros, indexação correta de attached data e idempotência na (re)criação de attacheds) e adicionei testes unitários focados.

- o que não realizou;
  - Não alterei outros dataelements ou módulos fora do escopo autorizado.
  - Não forcei a construção de executáveis que não são gerados nesta configuração (vários alvos aparecem como `*_NOT_BUILT`).

- por que não realizou;
  - Respeitei o escopo proibido da tarefa e a configuração de build/CTEST do ambiente, que não produz alguns alvos de teste nesta invocação.

- riscos remanescentes;
  - `_setOfType` mantém um valor default histórico; embora a correção evite mascaramento por inserções subsequentes, modelos legados com persistência inconsistente podem ainda requerer verificação manual.
  - A limpeza de attacheds depende do contrato atual de nomes de chave (`Member*` e `SetName.*`); mudanças futuras nesse contrato exigirão ajuste similar.

- observações relevantes;
  - As mudanças foram propositalmente mínimas e localizadas para evitar impactos fora do escopo.
  - Non-owner semantics for member pointers are preserved; apenas o container é destruído no destrutor.

- arquivos alterados;
  - `source/plugins/data/Set.h`
  - `source/plugins/data/Set.cpp`
  - `source/tests/unit/test_simulator_runtime.cpp`

- comandos executados e resultados resumidos.
  - `cmake -S . -B build -G Ninja -DGENESYS_BUILD_TESTS=ON -DGENESYS_BUILD_KERNEL=ON -DGENESYS_BUILD_PARSER=ON -DGENESYS_BUILD_PLUGINS=ON -DGENESYS_TERMINAL_APPLICATION=OFF -DGENESYS_BUILD_GUI_APPLICATION=OFF -DGENESYS_BUILD_WEB_APPLICATION=OFF` → configuration completed successfully.
  - `cmake --build build --target genesys_test_simulator_runtime` → target built successfully.
  - `ctest --test-dir build -R "SimulatorRuntimeTest.*Set" --output-on-failure` → all Set-related tests passed.
  - `ctest --test-dir build -LE smoke --output-on-failure` → executed but many `*_NOT_BUILT` tests reported as Not Run in this configuration; Set tests remain green.
```

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d92aec34f883219836b17b17c61d9f)