### PR TITLE
Fix Set dataelement lifecycle, recheck idempotency, and type validation

### DIFF
--- a/source/plugins/data/Set.cpp
+++ b/source/plugins/data/Set.cpp
@@ -43,6 +43,11 @@ Set::Set(Model* model, std::string name) : ModelDataDefinition(model, Util::Type
     _addProperty(propElementSet);
 }
 
+Set::~Set() {
+    delete _elementSet;
+    _elementSet = nullptr;
+}
+
 std::string Set::show() {
     return ModelDataDefinition::show() +
             "";
@@ -61,8 +66,13 @@ List<ModelDataDefinition*>* Set::getElementSet() const {
 }
 
 void Set::addElementSet(ModelDataDefinition* newElement) {
+    if (newElement == nullptr) {
+        return;
+    }
     _elementSet->insert(newElement);
-    _setOfType = newElement->getClassname();
+    if (_elementSet->size() == 1) {
+        _setOfType = newElement->getClassname();
+    }
 }
 
 void Set::removeElementSet(ModelDataDefinition* element) {
@@ -88,6 +98,7 @@ bool Set::_loadInstance(PersistenceRecord *fields) {
     bool res = ModelDataDefinition::_loadInstance(fields);
     if (res) {
         try {
+            _elementSet->clear();
             _setOfType = fields->loadField("type", DEFAULT.setOfType);
             unsigned int memberSize = fields->loadField("members", DEFAULT.membersSize);
             for (unsigned int i = 0; i < memberSize; i++) {
@@ -118,20 +129,31 @@ void Set::_saveInstance(PersistenceRecord *fields, bool saveDefaultValues) {
 
 bool Set::_check(std::string& errorMessage) {
     bool resultAll = true;
-    if (_elementSet->size() > 0) {
-        std::string typeOfFirstElement = _elementSet->front()->getClassname();
-        if (_setOfType == "") {
-            _setOfType = typeOfFirstElement;
-        } else if (_setOfType != typeOfFirstElement) {
-            resultAll = false;
-            errorMessage += "Set is of type \"" + _setOfType + "\" and first modeldatum is of type \"" + typeOfFirstElement + "\"";
+    std::string expectedType = _setOfType;
+    if (expectedType == "" && _elementSet->size() > 0) {
+        expectedType = _elementSet->front()->getClassname();
+        _setOfType = expectedType;
+    }
+
+    std::list<std::string> attachedKeysToRemove;
+    for (const std::pair<std::string, ModelDataDefinition*>& pair : *getAttachedData()) {
+        if (pair.first.rfind("Member", 0) == 0) {
+            attachedKeysToRemove.push_back(pair.first);
         }
     }
+    for (const std::string& key : attachedKeysToRemove) {
+        _attachedDataRemove(key);
+    }
+
     int i = 0;
     for (ModelDataDefinition* data : *_elementSet->list()) {
+        if (data != nullptr && expectedType != "" && data->getClassname() != expectedType) {
+            resultAll = false;
+            errorMessage += "Set is of type \"" + expectedType + "\" but member \"" + data->getName() + "\" is of type \"" + data->getClassname() + "\". ";
+        }
         this->_attachedDataInsert("Member" + Util::StrIndex(i), data);
+        i++;
     }
-    errorMessage += "";
     return resultAll;
 }
 
@@ -143,6 +165,17 @@ ParserChangesInformation* Set::_getParserChangesInformation() {
 }
 
 void Set::_createInternalAndAttachedData() {
+    std::list<std::string> attachedKeysToRemove;
+    const std::string keyPrefix = getName() + ".";
+    for (const std::pair<std::string, ModelDataDefinition*>& pair : *getAttachedData()) {
+        if (pair.first.rfind(keyPrefix, 0) == 0) {
+            attachedKeysToRemove.push_back(pair.first);
+        }
+    }
+    for (const std::string& key : attachedKeysToRemove) {
+        _attachedDataRemove(key);
+    }
+
     for(ModelDataDefinition* dd: *_elementSet->list()) {
         _attachedDataInsert(getName()+"."+dd->getName(), dd);
     }

--- a/source/plugins/data/Set.h
+++ b/source/plugins/data/Set.h
@@ -56,7 +56,7 @@ Type is Entity Picture.
 class Set : public ModelDataDefinition {
 public:
 	Set(Model* model, std::string name = "");
-	virtual ~Set() = default;
+	virtual ~Set() override;
 public: // static
 	static ModelDataDefinition* LoadInstance(Model* model, PersistenceRecord *fields);
 	static PluginInformation* GetPluginInformation();
@@ -90,4 +90,3 @@ private:
 };
 
 #endif /* SET_H */
-

--- a/source/tests/unit/test_simulator_runtime.cpp
+++ b/source/tests/unit/test_simulator_runtime.cpp
@@ -20,6 +20,7 @@
 #include "plugins/data/Sequence.h"
 #include "plugins/data/SignalData.h"
 #include "plugins/data/Station.h"
+#include "plugins/data/Set.h"
 #include "plugins/components/Delay.h"
 #define private public
 #define protected public
@@ -387,6 +388,27 @@ public:
 
     void InternalEventNoopProbe(void* parameter) {
         (void) parameter;
+    }
+};
+
+class SetProbe : public Set {
+public:
+    SetProbe(Model* model, const std::string& name = "") : Set(model, name) {}
+
+    bool CheckProbe(std::string& errorMessage) {
+        return _check(errorMessage);
+    }
+
+    void CreateInternalAndAttachedDataProbe() {
+        _createInternalAndAttachedData();
+    }
+
+    void SaveInstanceProbe(PersistenceRecord* fields, bool saveDefaultValues = false) {
+        _saveInstance(fields, saveDefaultValues);
+    }
+
+    bool LoadInstanceProbe(PersistenceRecord* fields) {
+        return _loadInstance(fields);
     }
 };
 
@@ -1830,6 +1852,147 @@ TEST(SimulatorRuntimeTest, SequenceCheckPassesForValidSteps) {
     std::string errorMessage;
     EXPECT_TRUE(sequence.CheckProbe(errorMessage));
     EXPECT_TRUE(errorMessage.empty());
+}
+
+TEST(SimulatorRuntimeTest, SetDestructorReleasesOwnedContainerWithoutDeletingMembers) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    auto* queueA = new Queue(model, "SetLifecycleQueueA");
+    auto* queueB = new Queue(model, "SetLifecycleQueueB");
+    {
+        auto* set = new SetProbe(model, "SetLifecycle");
+        set->addElementSet(queueA);
+        set->addElementSet(queueB);
+        ASSERT_EQ(set->getElementSet()->size(), 2u);
+        delete set;
+    }
+
+    EXPECT_NE(model->getDataManager()->getDataDefinition(Util::TypeOf<Queue>(), "SetLifecycleQueueA"), nullptr);
+    EXPECT_NE(model->getDataManager()->getDataDefinition(Util::TypeOf<Queue>(), "SetLifecycleQueueB"), nullptr);
+
+    delete queueA;
+    delete queueB;
+}
+
+TEST(SimulatorRuntimeTest, SetLoadInstanceReplacesPreviousMembersWithoutResidualState) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    Queue queueA(model, "SetPersistQueueA");
+    Queue queueB(model, "SetPersistQueueB");
+    Queue queueC(model, "SetPersistQueueC");
+
+    SetProbe first(model, "SetPersistFirst");
+    first.setSetOfType(Util::TypeOf<Queue>());
+    first.addElementSet(&queueA);
+    first.addElementSet(&queueB);
+
+    SetProbe second(model, "SetPersistSecond");
+    second.setSetOfType(Util::TypeOf<Queue>());
+    second.addElementSet(&queueC);
+
+    FakeModelPersistenceRuntime persistence;
+    PersistenceRecord fieldsFirst(persistence);
+    PersistenceRecord fieldsSecond(persistence);
+    first.SaveInstanceProbe(&fieldsFirst, true);
+    second.SaveInstanceProbe(&fieldsSecond, true);
+
+    SetProbe loaded(model, "SetPersistLoaded");
+    ASSERT_TRUE(loaded.LoadInstanceProbe(&fieldsFirst));
+    ASSERT_EQ(loaded.getElementSet()->size(), 2u);
+    ASSERT_EQ(loaded.getElementSet()->getAtRank(0), &queueA);
+    ASSERT_EQ(loaded.getElementSet()->getAtRank(1), &queueB);
+
+    ASSERT_TRUE(loaded.LoadInstanceProbe(&fieldsSecond));
+    ASSERT_EQ(loaded.getElementSet()->size(), 1u);
+    EXPECT_EQ(loaded.getElementSet()->getAtRank(0), &queueC);
+}
+
+TEST(SimulatorRuntimeTest, SetCheckFailsForHeterogeneousMemberTypes) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    Queue queue(model, "SetMixedQueue");
+    Variable variable(model, "SetMixedVariable");
+    SetProbe set(model, "SetMixed");
+    set.addElementSet(&queue);
+    set.addElementSet(&variable);
+
+    std::string errorMessage;
+    EXPECT_FALSE(set.CheckProbe(errorMessage));
+    EXPECT_NE(errorMessage.find("member"), std::string::npos);
+    EXPECT_NE(errorMessage.find("SetMixedVariable"), std::string::npos);
+}
+
+TEST(SimulatorRuntimeTest, SetCheckPassesForHomogeneousMembersAndPreservesOrder) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    Queue queueA(model, "SetCheckQueueA");
+    Queue queueB(model, "SetCheckQueueB");
+    SetProbe set(model, "SetCheckHomogeneous");
+    set.addElementSet(&queueA);
+    set.addElementSet(&queueB);
+
+    std::string errorMessage;
+    EXPECT_TRUE(set.CheckProbe(errorMessage));
+    EXPECT_TRUE(errorMessage.empty());
+    ASSERT_EQ(set.getElementSet()->size(), 2u);
+    EXPECT_EQ(set.getElementSet()->getAtRank(0), &queueA);
+    EXPECT_EQ(set.getElementSet()->getAtRank(1), &queueB);
+}
+
+TEST(SimulatorRuntimeTest, SetCheckCreatesIndexedAttachedMembersWithoutKeyCollisions) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    Queue queueA(model, "SetAttachedQueueA");
+    Queue queueB(model, "SetAttachedQueueB");
+    SetProbe set(model, "SetAttached");
+    set.addElementSet(&queueA);
+    set.addElementSet(&queueB);
+
+    std::string errorMessage;
+    ASSERT_TRUE(set.CheckProbe(errorMessage));
+    auto* attached = set.getAttachedData();
+    ASSERT_EQ(attached->count("Member[0]"), 1u);
+    ASSERT_EQ(attached->count("Member[1]"), 1u);
+    EXPECT_EQ(attached->at("Member[0]"), &queueA);
+    EXPECT_EQ(attached->at("Member[1]"), &queueB);
+}
+
+TEST(SimulatorRuntimeTest, SetRecheckRemovesObsoleteAttachedMembers) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    Queue queueA(model, "SetRecheckQueueA");
+    Queue queueB(model, "SetRecheckQueueB");
+    SetProbe set(model, "SetRecheck");
+    set.addElementSet(&queueA);
+    set.addElementSet(&queueB);
+
+    std::string errorMessage;
+    ASSERT_TRUE(set.CheckProbe(errorMessage));
+    set.CreateInternalAndAttachedDataProbe();
+    auto* attached = set.getAttachedData();
+    ASSERT_EQ(attached->count("SetRecheck.SetRecheckQueueA"), 1u);
+    ASSERT_EQ(attached->count("SetRecheck.SetRecheckQueueB"), 1u);
+
+    set.removeElementSet(&queueA);
+    errorMessage.clear();
+    ASSERT_TRUE(set.CheckProbe(errorMessage));
+    set.CreateInternalAndAttachedDataProbe();
+
+    EXPECT_EQ(attached->count("SetRecheck.SetRecheckQueueA"), 0u);
+    ASSERT_EQ(attached->count("SetRecheck.SetRecheckQueueB"), 1u);
+    EXPECT_EQ(attached->at("SetRecheck.SetRecheckQueueB"), &queueB);
 }
 
 TEST(SimulatorRuntimeTest, StationCreateInternalInitiallyCreatesCollectorsWhenStatisticsEnabled) {


### PR DESCRIPTION
### Motivation
- Fix ownership leak and lifecycle of the `_elementSet` container and prevent deletion of non-owned members. 
- Prevent duplication/residual state when loading/reloading persisted `Set` instances. 
- Ensure `_check()` validates every member's type (not only the first) and creates attached keys with unique indices. 
- Make attached-data creation idempotent so rechecks remove obsolete attached entries and preserve member order.

### Description
- Added explicit `Set::~Set()` to delete the owned `_elementSet` container without deleting the non-owning `ModelDataDefinition*` members (file: `source/plugins/data/Set.cpp`, header updated in `Set.h`).
- `_loadInstance()` now clears `_elementSet` before populating it from persistence to avoid duplication/residual state and preserve the persisted order (file: `source/plugins/data/Set.cpp`).
- `addElementSet()` now ignores `nullptr` and sets `_setOfType` only on the first insertion so that subsequent additions do not silently overwrite the set's declared type (file: `source/plugins/data/Set.cpp`).
- `_check()` now:
  - infers `_setOfType` from the first member only when the type is empty,
  - validates every member against the expected type and reports a clear error message on mismatch,
  - increments the index used for attached keys so `Member[i]` keys are distinct,
  - removes stale `Member*` attached keys before reinserting current ones (file: `source/plugins/data/Set.cpp`).
- `_createInternalAndAttachedData()` now removes obsolete `getName()+"."` attachments prior to reattaching current members to preserve idempotency and order (file: `source/plugins/data/Set.cpp`).
- Added `SetProbe` and six unit tests that exercise lifecycle, persistence reload, type validation, index-keying of attached members, and removal of obsolete attached entries (file: `source/tests/unit/test_simulator_runtime.cpp`).

### Testing
- Configured and built tests with `cmake -S . -B build -G Ninja -DGENESYS_BUILD_TESTS=ON -DGENESYS_BUILD_KERNEL=ON -DGENESYS_BUILD_PARSER=ON -DGENESYS_BUILD_PLUGINS=ON -DGENESYS_TERMINAL_APPLICATION=OFF -DGENESYS_BUILD_GUI_APPLICATION=OFF -DGENESYS_BUILD_WEB_APPLICATION=OFF` and the build completed successfully.
- Built runtime test executable with `cmake --build build --target genesys_test_simulator_runtime` and linking completed successfully.
- Ran focused tests with `ctest --test-dir build -R "SimulatorRuntimeTest.*Set" --output-on-failure` and all `Set`-related tests passed.
- Ran broader smoke run `ctest --test-dir build -LE smoke --output-on-failure`; runtime `Set` tests passed but the smoke run reports several `*_NOT_BUILT` entries in this configuration (these are unrelated to the `Set` changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d92a9da27083218e0ce04259256c85)