### PR TITLE
GUI: disable plugin tree and property editor during active simulation

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
@@ -531,6 +531,8 @@ void MainWindow::_actualizeActions() {
             canConnect = scene->connectingStep() == 0;
         }
     }
+    // Lock GUI interactions tied to model editing while simulation is running or paused.
+    const bool simulationInteractionLocked = opened && (running || paused);
 
     //
     ui->graphicsView->setEnabled(opened);
@@ -563,6 +565,8 @@ void MainWindow::_actualizeActions() {
     ui->actionActivateGraphicalSimulation->setEnabled(opened);
     ui->actionSimulatorsPluginManager->setEnabled(!running);
     ui->actionSimulatorPreferences->setEnabled(!running);
+    // Keep plugins tree disabled while simulation interaction is locked.
+    ui->treeWidget_Plugins->setEnabled(opened && !simulationInteractionLocked);
 
     // debug
     ui->tableWidget_Breakpoints->setEnabled(opened && !running);
@@ -570,7 +574,8 @@ void MainWindow::_actualizeActions() {
     ui->tableWidget_Variables->setEnabled(opened && !running);
 
     // Property Editor
-    ui->treeViewPropertyEditor->setEnabled(!running);
+    // Keep property editor disabled while simulation interaction is locked.
+    ui->treeViewPropertyEditor->setEnabled(opened && !simulationInteractionLocked);
 
     // based on SELECTED GRAPHICAL OBJECTS or on COMMANDS DONE (UNDO/REDO)
     ui->toolBarArranje->setEnabled(opened && !running);

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow_scene.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow_scene.cpp
@@ -129,6 +129,18 @@ void MainWindow::sceneSelectionChanged() {
         qInfo() << "[MainWindow] sceneSelectionChanged exit early due to shutdown";
         return;
     }
+    // Skip property editor synchronization while simulation is running or paused.
+    const bool simulationInteractionLocked =
+        simulator != nullptr &&
+        simulator->getModelManager()->current() != nullptr &&
+        simulator->getModelManager()->current()->getSimulation() != nullptr &&
+        (simulator->getModelManager()->current()->getSimulation()->isRunning() ||
+         simulator->getModelManager()->current()->getSimulation()->isPaused());
+
+    if (simulationInteractionLocked) {
+        qInfo() << "[MainWindow] sceneSelectionChanged skipped while simulation keeps property editor disabled";
+        return;
+    }
     if (_propertyEditorController == nullptr) {
         if (ui != nullptr && ui->treeViewPropertyEditor != nullptr) {
             qWarning() << "[MainWindow] sceneSelectionChanged without controller. Clearing property editor directly";


### PR DESCRIPTION
### Motivation
- Prevent editing interactions during a running or paused simulation by disabling the Plugins tree and the Property Editor, and by stopping scene-selection updates from syncing into the Property Editor while simulation is active.

### Description
- Added a local `simulationInteractionLocked` flag in `MainWindow::_actualizeActions()` and used it to disable `treeWidget_Plugins` with `ui->treeWidget_Plugins->setEnabled(opened && !simulationInteractionLocked);`.
- Replaced `ui->treeViewPropertyEditor->setEnabled(!running);` with `ui->treeViewPropertyEditor->setEnabled(opened && !simulationInteractionLocked);` so the Property Editor is disabled during both `running` and `paused` states.
- Added an early-return guard in `MainWindow::sceneSelectionChanged()` that detects a running or paused simulation and logs/returns before calling `_propertyEditorController->sceneSelectionChanged()`.
- Changes are restricted to `source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp` and `source/applications/gui/qt/GenesysQtGUI/mainwindow_scene.cpp` and include short English comments above each modified block.

### Testing
- Ran `git diff -- source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp source/applications/gui/qt/GenesysQtGUI/mainwindow_scene.cpp` to verify that only the two requested files were modified and the diffs reflect the described edits.
- Reopened both modified files and inspected them to confirm `simulationInteractionLocked` is used, `treeWidget_Plugins` and `treeViewPropertyEditor` are controlled by the lock, and `sceneSelectionChanged()` returns early while the simulation is `running` or `paused` so `_propertyEditorController->sceneSelectionChanged()` is not invoked in that state.
- Attempted a GUI-capable CMake configure to build the GUI, but configuration failed in this environment because `qmake` is not available in `PATH`, so a full compile could not be run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d92da876d08321a802ceee9f24d8fb)