### PR TITLE
test: cover Wait validation contract checks

### DIFF
--- a/source/tests/unit/test_simulator_runtime.cpp
+++ b/source/tests/unit/test_simulator_runtime.cpp
@@ -2136,6 +2136,47 @@ TEST(SimulatorRuntimeTest, WaitScanForConditionRecheckDoesNotReRegisterHandlerFl
     EXPECT_TRUE(wait.IsScanConditionHandlerRegisteredProbe());
 }
 
+TEST(SimulatorRuntimeTest, WaitCheckValidatesWaitForSignalContractAndLimitExpression) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    WaitProbe wait(model, "WaitForSignalCheck");
+    Queue queue(model, "WaitForSignalQueue");
+    SignalDataProbe signalData(model, "WaitForSignalData");
+
+    wait.setQueue(&queue);
+    wait.setWaitType(Wait::WaitType::WaitForSignal);
+    wait.setLimitExpression("1");
+
+    std::string missingSignalError;
+    EXPECT_FALSE(wait.CheckProbe(missingSignalError));
+    EXPECT_NE(missingSignalError.find("SignalData is null"), std::string::npos);
+
+    wait.setSignalData(&signalData);
+    wait.setLimitExpression("invalid +");
+
+    std::string invalidLimitError;
+    EXPECT_FALSE(wait.CheckProbe(invalidLimitError));
+    EXPECT_NE(invalidLimitError.find("LimitExpression"), std::string::npos);
+}
+
+TEST(SimulatorRuntimeTest, WaitCheckValidatesScanConditionExpression) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    WaitProbe wait(model, "WaitScanConditionCheck");
+    Queue queue(model, "WaitScanConditionQueue");
+    wait.setQueue(&queue);
+    wait.setWaitType(Wait::WaitType::ScanForCondition);
+    wait.setCondition("invalid +");
+
+    std::string errorMessage;
+    EXPECT_FALSE(wait.CheckProbe(errorMessage));
+    EXPECT_NE(errorMessage.find("Condition"), std::string::npos);
+}
+
 TEST(SimulatorRuntimeTest, DelayCreateInternalInitiallyCreatesStatisticsCollectorWhenEnabled) {
     Simulator simulator;
     Model* model = simulator.getModelManager()->newModel();


### PR DESCRIPTION
### Motivation
- Add focused unit tests to assert `Wait::_check()` behavior by type (WaitForSignal and ScanForCondition) and close previously missing negative validation coverage without changing runtime code.

### Description
- Added two unit tests to `source/tests/unit/test_simulator_runtime.cpp` that verify `WaitForSignal` fails when `SignalData` is missing and when `LimitExpression` is invalid, and that `ScanForCondition` fails on an invalid `Condition` expression; no changes were made to `Wait`/`Signal` implementation files.

### Testing
- Configured and built with `cmake -S . -B build -G Ninja` and `cmake --build build -j4`, then executed the runtime tests with `./build/source/tests/unit/genesys_test_simulator_runtime`, which passed (all tests green). 
- Rebuilt with sanitizers (`build-asan`) and ran `ASAN_OPTIONS=detect_leaks=0 ./build-asan/source/tests/unit/genesys_test_simulator_runtime`, which also passed; `ctest -R` did not discover the target so the test binary was executed directly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d92d05c5548321975b52c059f95490)