### PR TITLE
Fix Batch/Separate grouping semantics and add runtime regression tests

### DIFF
--- a/source/plugins/components/Batch.cpp
+++ b/source/plugins/components/Batch.cpp
@@ -55,6 +55,10 @@ std::string Batch::convertEnumToStr(GroupedAttribs attribs) {
 }
 
 Batch::Batch(Model* model, std::string name) : ModelComponent(model, Util::TypeOf<Batch>(), name) {
+	SimulationControlGenericEnum<Batch::BatchType, Batch>* propBatchType = new SimulationControlGenericEnum<Batch::BatchType, Batch>(
+				std::bind(&Batch::getBatchType, this),
+				std::bind(&Batch::setBatchType, this, std::placeholders::_1),
+				Util::TypeOf<Batch>(), getName(), "BatchType", "");
     SimulationControlGenericEnum<Batch::Rule, Batch>* propRule = new SimulationControlGenericEnum<Batch::Rule, Batch>(
                 std::bind(&Batch::getRule, this),
                 std::bind(&Batch::setRule, this, std::placeholders::_1),
@@ -78,6 +82,7 @@ Batch::Batch(Model* model, std::string name) : ModelComponent(model, Util::TypeO
 				Util::TypeOf<Batch>(), getName(), "BatchSize", "");
 	
 
+	_parentModel->getControls()->insert(propBatchType);
     _parentModel->getControls()->insert(propRule);
     _parentModel->getControls()->insert(propGroupedAttribs);
 	_parentModel->getControls()->insert(propGroupedEntity);
@@ -85,6 +90,7 @@ Batch::Batch(Model* model, std::string name) : ModelComponent(model, Util::TypeO
 	_parentModel->getControls()->insert(propSize);
 
 	// setting properties
+	_addProperty(propBatchType);
     _addProperty(propRule);
     _addProperty(propGroupedAttribs);
 	_addProperty(propGroupedEntity);
@@ -123,6 +129,14 @@ EntityType* Batch::getGroupedEntityType() const {
 	return _groupedEntityType;
 }
 
+void Batch::setBatchType(Batch::BatchType batchType) {
+	_batchType = batchType;
+}
+
+Batch::BatchType Batch::getBatchType() const {
+	return _batchType;
+}
+
 void Batch::setAttributeName(std::string attributeName) {
 	this->_attributeName = attributeName;
 }
@@ -156,46 +170,76 @@ Batch::GroupedAttribs Batch::getGroupedAttributes() const {
 }
 
 void Batch::_onDispatchEvent(Entity* entity, unsigned int inputPortNumber) {
-	double tnow = _parentModel->getSimulation()->getSimulatedTime();
+	ModelDataManager* elements = _parentModel->getDataManager();
+	ModelDataDefinition* queueByName = elements->getDataDefinition(Util::TypeOf<Queue>(), this->getName() + ".Queue");
+	if (queueByName != nullptr) {
+		_queue = dynamic_cast<Queue*>(queueByName);
+	}
+	ModelDataDefinition* groupByName = elements->getDataDefinition(Util::TypeOf<EntityGroup>(), this->getName() + ".EntiyGroup");
+	if (groupByName != nullptr) {
+		_entityGroup = dynamic_cast<EntityGroup*>(groupByName);
+	}
+	if (_queue == nullptr || _entityGroup == nullptr) {
+		_createInternalAndAttachedData();
+		if (_queue == nullptr || _entityGroup == nullptr) {
+			traceError("Batch internal data is not initialized (Queue/EntityGroup).", TraceManager::Level::L1_errorFatal);
+			return;
+		}
+	}
+	// Queue the incoming entity first, then evaluate whether a complete batch can be formed.
+	double tnow = 0.0;
+	if (_parentModel->getSimulation() != nullptr) {
+		tnow = _parentModel->getSimulation()->getSimulatedTime();
+	}
 	_queue->insertElement(new Waiting(entity, tnow, this, 0));
-	unsigned int batchSize = _parentModel->parseExpression(_batchSize);
+	unsigned int batchSize = 0;
+	try {
+		batchSize = static_cast<unsigned int>(std::stoul(_batchSize));
+	} catch (...) {
+		batchSize = static_cast<unsigned int>(_parentModel->parseExpression(_batchSize));
+	}
+	if (batchSize == 0) {
+		traceError("Batch size evaluated to zero. Entity will remain waiting.", TraceManager::Level::L3_errorRecover);
+		return;
+	}
 	std::list<Waiting*>* entitiesToGroup = nullptr;
 	// check if batch size is complete
 	if (_rule == Batch::Rule::Any) {
-		if (_queue->size() == batchSize) {
+		if (_queue->size() >= batchSize) {
 			entitiesToGroup = new std::list<Waiting*>();
-			for (unsigned int i = 0; i < _queue->size(); i++) {
+			for (unsigned int i = 0; i < batchSize; i++) {
 				entitiesToGroup->insert(entitiesToGroup->end(), _queue->getAtRank(i));
 			}
-			traceSimulation(this, "Queue has " + std::to_string(_queue->size()) + " elements and a group with " + std::to_string(batchSize) + " elements will be created",TraceManager::Level::L7_internal);
+			traceSimulation(this, "Queue has " + std::to_string(_queue->size()) + " elements and a group with " + std::to_string(batchSize) + " first arrivals will be created",TraceManager::Level::L7_internal);
 
 		} else {
 			traceSimulation(this, "Queue has " + std::to_string(_queue->size()) + " elements, not enought to form a group with " + std::to_string(batchSize));
 		}
 	} else if (_rule == Batch::Rule::ByAttribute) {// rule IS Batch::Rule::ByAttribute
-		std::map<double, unsigned int>* countByValue = new std::map<double, unsigned int>();
-		double value, testValue;
-		Waiting* we;
-		std::map<double, unsigned int>::iterator it;
+		// Track the first attribute value that reaches the target cardinality in queue order.
+		std::map<double, unsigned int> countByValue;
+		double selectedValue = 0.0;
+		bool foundValue = false;
 		for (unsigned int i = 0; i < _queue->size(); i++) {
-			value = _queue->getAtRank(i)->getEntity()->getAttributeValue(_attributeName);
-			while ((it = countByValue->find(value)) == countByValue->end()) {// first time this value shows up
-				countByValue->insert({value, 0u});
+			Waiting* waiting = _queue->getAtRank(i);
+			double value = waiting->getEntity()->getAttributeValue(_attributeName);
+			unsigned int count = ++countByValue[value];
+			if (count >= batchSize) {
+				selectedValue = value;
+				foundValue = true;
+				break;
 			}
-			(*it).second = (*it).second + 1;
-			if ((*it).second == batchSize) {
-				entitiesToGroup = new std::list<Waiting*>();
-				value = (*it).first;
-				for (unsigned int j = 0; j < _queue->size(); j++) {
-					we = _queue->getAtRank(j);
-					testValue = we->getEntity()->getAttributeValue(_attributeName);
-					if (testValue == value) {
-						entitiesToGroup->insert(entitiesToGroup->end(), we);
-					}
+		}
+		if (foundValue) {
+			entitiesToGroup = new std::list<Waiting*>();
+			for (unsigned int i = 0; i < _queue->size() && entitiesToGroup->size() < batchSize; i++) {
+				Waiting* we = _queue->getAtRank(i);
+				double testValue = we->getEntity()->getAttributeValue(_attributeName);
+				if (testValue == selectedValue) {
+					entitiesToGroup->insert(entitiesToGroup->end(), we);
 				}
-				traceSimulation(this,  "Found " + std::to_string(entitiesToGroup->size()) + " elements in queue with the same value (" + std::to_string(value) + ") for attribute \"" + _attributeName + "\", and a group will be created", TraceManager::Level::L7_internal);
-				break; //@TODO //breake? //next? 
 			}
+			traceSimulation(this,  "Found at least " + std::to_string(batchSize) + " elements in queue with value (" + std::to_string(selectedValue) + ") for attribute \"" + _attributeName + "\", and a group will be created", TraceManager::Level::L7_internal);
 		}
 	} else { // BY EntityType
 
@@ -291,36 +335,49 @@ void Batch::_saveInstance(PersistenceRecord *fields, bool saveDefaultValues) {
 }
 
 void Batch::_createInternalAndAttachedData() {
+	// Keep attached-data keys stable across rechecks and remove stale aliases.
 	_attachedAttributesInsert({"Entity.Group"});
-	_attachedDataInsert("GroupdEntityType", _groupedEntityType);
+	_attachedDataRemove("GroupdEntityType");
+	_attachedDataInsert("GroupedEntityType", _groupedEntityType);
 	if (_queue == nullptr) {
 		PluginManager* plugins = _parentModel->getParentSimulator()->getPluginManager();
 		_queue = plugins->newInstance<Queue>(_parentModel, this->getName() + ".Queue");
+		if (_queue == nullptr) {
+			// Fallback for runtime contexts where plugin lookup is unavailable but Queue is linked in-process.
+			_queue = new Queue(_parentModel, this->getName() + ".Queue");
+		}
+		ModelDataDefinition::CreateInternalData(_queue);
 		_internalDataInsert("EntityQueue", _queue);
 		_entityGroup = plugins->newInstance<EntityGroup>(_parentModel, this->getName() + ".EntiyGroup");
+		if (_entityGroup == nullptr) {
+			// Fallback for runtime contexts where plugin lookup is unavailable but EntityGroup is linked in-process.
+			_entityGroup = new EntityGroup(_parentModel, this->getName() + ".EntiyGroup");
+		}
+		ModelDataDefinition::CreateInternalData(_entityGroup);
 		_internalDataInsert("EntityGroup", _entityGroup);
 	}
 	if (_attributeName != "") {
 		ModelDataManager* elements = _parentModel->getDataManager();
 		ModelDataDefinition* attribute = elements->getDataDefinition(Util::TypeOf<Attribute>(), _attributeName);
 		_attachedDataInsert("AttributeName", attribute);
+	} else {
+		_attachedDataRemove("AttributeName");
 	}
 }
 
 bool Batch::_check(std::string& errorMessage) {
+	// Validate expression and conditional references without mixing arithmetic operators on booleans.
 	bool resultAll = true;
 	ModelDataManager* elements = _parentModel->getDataManager();
-	if (_attributeName != "") {
-		resultAll &= elements->getDataDefinition(Util::TypeOf<Attribute>(), _attributeName) == nullptr;
-	}
 	if (_groupedEntityType != nullptr) {
-		resultAll += elements->check(Util::TypeOf<EntityType>(), _groupedEntityType, "Grouped Entity Type", errorMessage);
+		resultAll &= elements->check(Util::TypeOf<EntityType>(), _groupedEntityType, "GroupedEntityType", errorMessage);
 	}
-	if (_attributeName != "") {
-		ModelDataDefinition* attribute = elements->getDataDefinition(Util::TypeOf<Attribute>(), _attributeName);
-		resultAll &= attribute == nullptr;
+	if (_rule == Batch::Rule::ByAttribute) {
+		resultAll &= elements->check(Util::TypeOf<Attribute>(), _attributeName, "AttributeName", true, errorMessage);
+	} else if (!_attributeName.empty()) {
+		resultAll &= elements->check(Util::TypeOf<Attribute>(), _attributeName, "AttributeName", false, errorMessage);
 	}
-	resultAll += _parentModel->checkExpression(_batchSize, "Batch Size", errorMessage);
+	resultAll &= _parentModel->checkExpression(_batchSize, "BatchSize", errorMessage);
 
 	return resultAll;
 }

--- a/source/plugins/components/Batch.h
+++ b/source/plugins/components/Batch.h
@@ -81,6 +81,8 @@ public:
 	void setGroupedEntityType(EntityType* groupedEntityType);
 	void setGroupedEntityTypeName(std::string groupedEntityTypeName);
 	EntityType* getGroupedEntityType() const;
+	void setBatchType(Batch::BatchType batchType);
+	Batch::BatchType getBatchType() const;
 	void setAttributeName(std::string attributeName);
 	std::string getAttributeName() const;
 	void setBatchSize(std::string batchSize);
@@ -122,4 +124,3 @@ private: // attributes 1:n
 
 
 #endif /* BATCH_H */
-

--- a/source/plugins/components/Separate.cpp
+++ b/source/plugins/components/Separate.cpp
@@ -46,6 +46,7 @@ ModelComponent* Separate::LoadInstance(Model* model, PersistenceRecord *fields) 
 }
 
 void Separate::_onDispatchEvent(Entity* entity, unsigned int inputPortNumber) {
+	// This path handles split-existing-batch semantics using the representative "Entity.Group" marker.
 	unsigned int entityGroupId = entity->getAttributeValue("Entity.Group"); //This attribute refers to the Batch internal modeldatum EntityGroup (which may contain several groups --map--
 	if (entityGroupId == 0) {
 		traceSimulation(this, TraceManager::Level::L7_internal, "Entity is not grouped. Nothing to do");
@@ -54,14 +55,24 @@ void Separate::_onDispatchEvent(Entity* entity, unsigned int inputPortNumber) {
 		EntityGroup* entityGroup = dynamic_cast<EntityGroup*> (_parentModel->getDataManager()->getDataDefinition(Util::TypeOf<EntityGroup>(), entityGroupId));
 		if (entityGroup == nullptr) {
 			traceError("Error: Could not find EntityGroup Id=" + std::to_string(entityGroupId), TraceManager::Level::L3_errorRecover);
+			this->_parentModel->sendEntityToComponent(entity, getConnectionManager()->getFrontConnection());
 		} else {
-			Entity* e;
 			unsigned int idGroupKey = entity->getId();
-			while ((e = entityGroup->getGroup(idGroupKey)->front()) != nullptr) {
+			List<Entity*>* members = entityGroup->getGroup(idGroupKey);
+			if (members->size() == 0) {
+				traceSimulation(this, TraceManager::Level::L7_internal, "Group key has no members. Representative entity will continue unchanged");
+				this->_parentModel->sendEntityToComponent(entity, getConnectionManager()->getFrontConnection());
+				return;
+			}
+			while (members->size() > 0) {
+				Entity* e = members->front();
 				entityGroup->removeElement(idGroupKey, e);
+				// Reset group marker so separated members do not keep stale grouping state.
+				e->setAttributeValue("Entity.Group", 0.0);
 				traceSimulation(this, TraceManager::Level::L7_internal, "Entity " + e ->getName() + " was separated out of the group " + std::to_string(entityGroupId) + " key=" + std::to_string(idGroupKey));
 				_parentModel->sendEntityToComponent(e, _connections->getFrontConnection());
 			}
+			// Remove temporary representative after all members are released.
 			_parentModel->removeEntity(entity);
 		}
 	}
@@ -77,8 +88,11 @@ void Separate::_saveInstance(PersistenceRecord *fields, bool saveDefaultValues) 
 }
 
 bool Separate::_check(std::string& errorMessage) {
+	// Require the special marker attribute used by split-existing-batch flow.
 	bool resultAll = true;
 	_attachedAttributesInsert({"Entity.Group"});
+	ModelDataManager* elements = _parentModel->getDataManager();
+	resultAll &= elements->check(Util::TypeOf<Attribute>(), "Entity.Group", "Entity.Group", true, errorMessage);
 	return resultAll;
 }
 
@@ -88,4 +102,3 @@ PluginInformation* Separate::GetPluginInformation() {
 	// ...
 	return info;
 }
-

--- a/source/plugins/data/Queue.cpp
+++ b/source/plugins/data/Queue.cpp
@@ -81,7 +81,10 @@ std::string Queue::show() {
 void Queue::insertElement(Waiting* modeldatum) {
 	modeldatum->setArrivalOrder(_nextArrivalOrder++);
 	if (_reportStatistics) {
-		double tnow = _parentModel->getSimulation()->getSimulatedTime();
+		double tnow = 0.0;
+		if (_parentModel->getSimulation() != nullptr) {
+			tnow = _parentModel->getSimulation()->getSimulatedTime();
+		}
 		double duration = tnow - _lastTimeNumberInQueueChanged;
 		this->_cstatNumberInQueue->getStatistics()->getCollector()->addValue(_list->size(), duration); // save the OLD quantity and for how long it was there
 		_lastTimeNumberInQueueChanged = tnow;
@@ -94,7 +97,10 @@ void Queue::removeElement(Waiting* modeldatum) {
 		return;
 	}
 	if (_reportStatistics) {
-		double tnow = _parentModel->getSimulation()->getSimulatedTime();
+		double tnow = 0.0;
+		if (_parentModel->getSimulation() != nullptr) {
+			tnow = _parentModel->getSimulation()->getSimulatedTime();
+		}
 		double duration = tnow - _lastTimeNumberInQueueChanged;
 		this->_cstatNumberInQueue->getStatistics()->getCollector()->addValue(_list->size(), duration); // save the OLD quantity and for how long it was there
 		_lastTimeNumberInQueueChanged = tnow;

--- a/source/tests/unit/test_simulator_runtime.cpp
+++ b/source/tests/unit/test_simulator_runtime.cpp
@@ -21,7 +21,10 @@
 #include "plugins/data/SignalData.h"
 #include "plugins/data/Station.h"
 #include "plugins/data/Set.h"
+#include "plugins/data/EntityGroup.h"
 #include "plugins/components/Delay.h"
+#include "plugins/components/Batch.h"
+#include "plugins/components/Separate.h"
 #define private public
 #define protected public
 #include "plugins/components/Wait.h"
@@ -348,6 +351,72 @@ public:
         return _signalData;
     }
 };
+
+class CollectorSinkComponentProbe : public ModelComponent {
+public:
+    CollectorSinkComponentProbe(Model* model, const std::string& name = "")
+        : ModelComponent(model, "CollectorSinkComponentProbe", name) {}
+
+    const std::vector<Entity*>& ReceivedEntities() const {
+        return _received;
+    }
+
+protected:
+    void _onDispatchEvent(Entity* entity, unsigned int inputPortNumber) override {
+        (void)inputPortNumber;
+        _received.push_back(entity);
+    }
+
+    bool _loadInstance(PersistenceRecord* fields) override {
+        return ModelComponent::_loadInstance(fields);
+    }
+
+    void _saveInstance(PersistenceRecord* fields, bool saveDefaultValues) override {
+        ModelComponent::_saveInstance(fields, saveDefaultValues);
+    }
+
+private:
+    std::vector<Entity*> _received;
+};
+
+class BatchProbe : public Batch {
+public:
+    BatchProbe(Model* model, const std::string& name = "") : Batch(model, name) {}
+
+    void CreateInternalAndAttachedDataProbe() {
+        _createInternalAndAttachedData();
+    }
+
+    bool CheckProbe(std::string& errorMessage) {
+        return _check(errorMessage);
+    }
+
+    void DispatchEventProbe(Entity* entity, unsigned int inputPortNumber = 0) {
+        _onDispatchEvent(entity, inputPortNumber);
+    }
+};
+
+class SeparateProbe : public Separate {
+public:
+    SeparateProbe(Model* model, const std::string& name = "") : Separate(model, name) {}
+
+    bool CheckProbe(std::string& errorMessage) {
+        return _check(errorMessage);
+    }
+
+    void DispatchEventProbe(Entity* entity, unsigned int inputPortNumber = 0) {
+        _onDispatchEvent(entity, inputPortNumber);
+    }
+};
+
+static void DrainFutureEvents(Model* model) {
+    while (!model->getFutureEvents()->empty()) {
+        Event* event = model->getFutureEvents()->front();
+        model->getFutureEvents()->pop_front();
+        ModelComponent::DispatchEvent(event);
+        delete event;
+    }
+}
 
 class FailureProbe : public Failure {
 public:
@@ -2493,4 +2562,211 @@ TEST(SimulatorRuntimeTest, SignalDataCheckPassesWithValidHandler) {
     std::string errorMessage;
     EXPECT_TRUE(signal.CheckProbe(errorMessage));
     EXPECT_TRUE(errorMessage.empty());
+}
+
+TEST(SimulatorRuntimeTest, BatchAnyFormsSingleBatchWithAtLeastBatchSizeAndKeepsOverflowQueued) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    BatchProbe batch(model, "BatchAny");
+    CollectorSinkComponentProbe sink(model, "BatchAnySink");
+    batch.connectTo(&sink);
+    batch.setBatchSize("2");
+    batch.setRule(Batch::Rule::Any);
+    batch.CreateInternalAndAttachedDataProbe();
+
+    EntityType* partType = new EntityType(model, "BatchAnyPart");
+    Entity* e1 = model->createEntity("AnyE1", true);
+    Entity* e2 = model->createEntity("AnyE2", true);
+    Entity* e3 = model->createEntity("AnyE3", true);
+    e1->setEntityType(partType);
+    e2->setEntityType(partType);
+    e3->setEntityType(partType);
+
+    batch.DispatchEventProbe(e1);
+    batch.DispatchEventProbe(e2);
+    batch.DispatchEventProbe(e3);
+    DrainFutureEvents(model);
+
+    Queue* queue = dynamic_cast<Queue*>(model->getDataManager()->getDataDefinition(Util::TypeOf<Queue>(), "BatchAny.Queue"));
+    ASSERT_NE(queue, nullptr);
+    EXPECT_EQ(queue->size(), 1u);
+    ASSERT_EQ(sink.ReceivedEntities().size(), 1u);
+}
+
+TEST(SimulatorRuntimeTest, BatchByAttributeFormsExactBatchSizeOfFirstCompatibleEntities) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    BatchProbe batch(model, "BatchByAttribute");
+    CollectorSinkComponentProbe sink(model, "BatchByAttributeSink");
+    batch.connectTo(&sink);
+    batch.setBatchSize("2");
+    batch.setRule(Batch::Rule::ByAttribute);
+    batch.setAttributeName("Color");
+    batch.CreateInternalAndAttachedDataProbe();
+
+    EntityType* partType = new EntityType(model, "BatchByAttrPart");
+    (void)new Attribute(model, "Color");
+    Entity* e1 = model->createEntity("ByAttrE1", true);
+    Entity* e2 = model->createEntity("ByAttrE2", true);
+    Entity* e3 = model->createEntity("ByAttrE3", true);
+    Entity* e4 = model->createEntity("ByAttrE4", true);
+    e1->setEntityType(partType);
+    e2->setEntityType(partType);
+    e3->setEntityType(partType);
+    e4->setEntityType(partType);
+    e1->setAttributeValue("Color", 1.0);
+    e2->setAttributeValue("Color", 2.0);
+    e3->setAttributeValue("Color", 1.0);
+    e4->setAttributeValue("Color", 1.0);
+
+    batch.DispatchEventProbe(e1);
+    batch.DispatchEventProbe(e2);
+    batch.DispatchEventProbe(e3);
+    batch.DispatchEventProbe(e4);
+    DrainFutureEvents(model);
+
+    Queue* queue = dynamic_cast<Queue*>(model->getDataManager()->getDataDefinition(Util::TypeOf<Queue>(), "BatchByAttribute.Queue"));
+    ASSERT_NE(queue, nullptr);
+    EXPECT_EQ(queue->size(), 2u);
+    ASSERT_EQ(sink.ReceivedEntities().size(), 1u);
+}
+
+TEST(SimulatorRuntimeTest, BatchTemporaryThenSeparateReleasesOriginalMembersInOrder) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    BatchProbe batch(model, "BatchTemp");
+    SeparateProbe separate(model, "SeparateAfterTemp");
+    CollectorSinkComponentProbe sink(model, "BatchTempSink");
+    batch.connectTo(&separate);
+    separate.connectTo(&sink);
+    batch.setBatchType(Batch::BatchType::Temporary);
+    batch.setBatchSize("2");
+    batch.setRule(Batch::Rule::Any);
+    batch.CreateInternalAndAttachedDataProbe();
+
+    EntityType* partType = new EntityType(model, "BatchTempPart");
+    Entity* e1 = model->createEntity("TempE1", true);
+    Entity* e2 = model->createEntity("TempE2", true);
+    e1->setEntityType(partType);
+    e2->setEntityType(partType);
+
+    batch.DispatchEventProbe(e1);
+    batch.DispatchEventProbe(e2);
+    DrainFutureEvents(model);
+
+    ASSERT_EQ(sink.ReceivedEntities().size(), 2u);
+    EXPECT_EQ(sink.ReceivedEntities()[0], e1);
+    EXPECT_EQ(sink.ReceivedEntities()[1], e2);
+}
+
+TEST(SimulatorRuntimeTest, BatchPermanentRepresentativePassesThroughSeparateWithoutResurrectingMembers) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    BatchProbe batch(model, "BatchPermanent");
+    SeparateProbe separate(model, "SeparateAfterPermanent");
+    CollectorSinkComponentProbe sink(model, "BatchPermanentSink");
+    batch.connectTo(&separate);
+    separate.connectTo(&sink);
+    batch.setBatchType(Batch::BatchType::Permanent);
+    batch.setBatchSize("2");
+    batch.setRule(Batch::Rule::Any);
+    batch.CreateInternalAndAttachedDataProbe();
+
+    EntityType* partType = new EntityType(model, "BatchPermanentPart");
+    Entity* e1 = model->createEntity("PermE1", true);
+    Entity* e2 = model->createEntity("PermE2", true);
+    const Util::identification e1Id = e1->getId();
+    const Util::identification e2Id = e2->getId();
+    e1->setEntityType(partType);
+    e2->setEntityType(partType);
+
+    batch.DispatchEventProbe(e1);
+    batch.DispatchEventProbe(e2);
+    DrainFutureEvents(model);
+
+    ASSERT_EQ(sink.ReceivedEntities().size(), 1u);
+    EXPECT_NE(sink.ReceivedEntities()[0], e1);
+    EXPECT_NE(sink.ReceivedEntities()[0], e2);
+    EXPECT_EQ(dynamic_cast<Entity*>(model->getDataManager()->getDataDefinition(Util::TypeOf<Entity>(), e1Id)), nullptr);
+    EXPECT_EQ(dynamic_cast<Entity*>(model->getDataManager()->getDataDefinition(Util::TypeOf<Entity>(), e2Id)), nullptr);
+}
+
+TEST(SimulatorRuntimeTest, BatchCheckValidatesByAttributeRequirementAndMinimalValidConfiguration) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    BatchProbe invalidBatch(model, "BatchCheckInvalid");
+    invalidBatch.setRule(Batch::Rule::ByAttribute);
+    invalidBatch.setBatchSize("2");
+    invalidBatch.setAttributeName("");
+    std::string invalidError;
+    EXPECT_FALSE(invalidBatch.CheckProbe(invalidError));
+    EXPECT_FALSE(invalidError.empty());
+
+    BatchProbe validBatch(model, "BatchCheckValid");
+    validBatch.setRule(Batch::Rule::Any);
+    validBatch.setBatchSize("2");
+    std::string validError;
+    EXPECT_TRUE(validBatch.CheckProbe(validError));
+    EXPECT_TRUE(validError.empty());
+}
+
+TEST(SimulatorRuntimeTest, SeparateHandlesUngroupedEntitySafely) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    SeparateProbe separate(model, "SeparateUngrouped");
+    CollectorSinkComponentProbe sink(model, "SeparateUngroupedSink");
+    separate.connectTo(&sink);
+
+    EntityType* partType = new EntityType(model, "SeparateUngroupedPart");
+    Entity* entity = model->createEntity("UngroupedEntity", true);
+    entity->setEntityType(partType);
+    entity->setAttributeValue("Entity.Group", 0.0, "", true);
+
+    separate.DispatchEventProbe(entity);
+    DrainFutureEvents(model);
+
+    ASSERT_EQ(sink.ReceivedEntities().size(), 1u);
+    EXPECT_EQ(sink.ReceivedEntities()[0], entity);
+}
+
+TEST(SimulatorRuntimeTest, SeparateCheckAndValidGroupReferenceRemainCoherent) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    SeparateProbe separate(model, "SeparateValidGroup");
+    CollectorSinkComponentProbe sink(model, "SeparateValidGroupSink");
+    separate.connectTo(&sink);
+
+    std::string checkError;
+    EXPECT_TRUE(separate.CheckProbe(checkError));
+    EXPECT_TRUE(checkError.empty());
+
+    EntityType* partType = new EntityType(model, "SeparateGroupedPart");
+    EntityGroup* entityGroup = new EntityGroup(model, "ManualEntityGroup");
+    Entity* representative = model->createEntity("Representative", true);
+    Entity* member = model->createEntity("Member", true);
+    representative->setEntityType(partType);
+    member->setEntityType(partType);
+    representative->setAttributeValue("Entity.Group", entityGroup->getId(), "", true);
+    entityGroup->insertElement(representative->getId(), member);
+
+    separate.DispatchEventProbe(representative);
+    DrainFutureEvents(model);
+
+    ASSERT_EQ(sink.ReceivedEntities().size(), 1u);
+    EXPECT_EQ(sink.ReceivedEntities()[0], member);
+    EXPECT_EQ(member->getAttributeValue("Entity.Group"), 0.0);
 }


### PR DESCRIPTION
PLUGIN COMPONENT

### Motivation
- Repair incorrect and fragile grouping/separation behavior observed in `Batch` and `Separate` so batches form and split predictably and match intended semantics.
- Harden validation/persistence and attached-data handling to avoid stale attachments and runtime nulls when creating internal `Queue`/`EntityGroup` data.
- Add focused runtime regression tests to lock the expected behavior for `Batch::Rule::Any`, `Batch::Rule::ByAttribute` and the `Separate` split path.

### Description
- Batch: form batches when queue size is `>= batchSize` and select exactly the first `batchSize` arrivals for `Rule::Any`, and for `Rule::ByAttribute` detect the first attribute value that reaches `batchSize` and collect exactly `batchSize` matching entities in arrival order. (changes in `source/plugins/components/Batch.cpp`).
- Batch: fix `_check()` logic and improve validations (batch size expression, required attribute when `ByAttribute`, optional `GroupedEntityType`) and reconcile attached-data keys (`GroupdEntityType` → `GroupedEntityType`) and cleanup of obsolete attached entries. (changes in `source/plugins/components/Batch.cpp` and `Batch.h`).
- Batch: add minimal public API for `BatchType` (`Temporary`/`Permanent`) and expose it as a simulation control so the component can be configured safely. (changes in `source/plugins/components/Batch.h`/`.cpp`).
- Batch: harden internal initialization of `_queue` and `_entityGroup` with safe fallbacks and ensure their internal data is created before use to avoid runtime nulls (changes in `source/plugins/components/Batch.cpp`).
- Separate: strengthen split-existing-batch path to handle missing/empty groups safely, release members in original order, reset member `Entity.Group` marker, and remove the temporary representative; also validate `Entity.Group` attached attribute in `_check()`. (changes in `source/plugins/components/Separate.cpp`).
- Queue: minor defensive changes to tolerate null simulation pointer when computing timestamps in tests/runtime. (changes in `source/plugins/data/Queue.cpp`).
- Tests: added local probes and regression tests to `source/tests/unit/test_simulator_runtime.cpp` covering: Batch Any overflow behavior, Batch ByAttribute exact-selection, Temporary batch → Separate roundtrip, Permanent batch behavior with Separate, `_check()` validations and Separate safe handling.

### Testing
- Configured and built the project with `cmake -S . -B build -G Ninja` and `cmake --build build` with tests enabled and plugins static; build succeeded.
- Ran the full unit test binary `./build/source/tests/unit/genesys_test_simulator_runtime` and observed the simulator runtime tests pass including the new Batch/Separate tests (component-level run: the binary executed and the added tests passed).
- Executed the ctest suite with `ctest --test-dir build -L unit --output-on-failure`; 99% of tests passed and three preexisting `StatisticsTest` cases failed (unrelated to Batch/Separate): `DefaultsAreStableWithExplicitCollector`, `IncrementalUpdatesMatchAnalyticalValuesForThreeSamples`, and `CollectorClearResetsStatisticsViaCallback`.
- The new tests included in `source/tests/unit/test_simulator_runtime.cpp` exercised grouping and separation scenarios and succeeded in the test run recorded above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d92de172b08321a9eb11887ddda00a)