### PR TITLE
Harden Label destination handling and add runtime tests

### DIFF
--- a/source/plugins/data/Label.cpp
+++ b/source/plugins/data/Label.cpp
@@ -70,7 +70,13 @@ PluginInformation* Label::GetPluginInformation() {
 //
 
 std::string Label::show() {
-	return ModelDataDefinition::show();
+	std::string enteringComponentName = _enteringLabelComponentName;
+	if (_enteringLabelComponent != nullptr && enteringComponentName.empty()) {
+		enteringComponentName = _enteringLabelComponent->getName();
+	}
+	return ModelDataDefinition::show() +
+			",label=\"" + _label + "\"" +
+			",enteringComponentName=" + (enteringComponentName.empty() ? "NULL" : enteringComponentName);
 }
 
 void Label::setLabel(std::string _label) {
@@ -81,12 +87,31 @@ std::string Label::getLabel() const {
 	return _label;
 }
 
+void Label::setEnterIntoLabelComponent(ModelComponent* enteringLabelComponent) {
+	_enteringLabelComponent = enteringLabelComponent;
+	_enteringLabelComponentName = enteringLabelComponent != nullptr ? enteringLabelComponent->getName() : "";
+}
+
 ModelComponent* Label::getEnterIntoLabelComponent() const {
 	return _enteringLabelComponent;
 }
 
+std::string Label::getEnteringLabelComponentName() const {
+	return _enteringLabelComponentName;
+}
+
 void Label::sendEntityToLabelComponent(Entity* entity, double timeDelay) {
-	//_parentModel->sendEntityToComponent(entity, _enteringLabelComponent->getConnections()->getFrontConnection(), timeDelay);
+	if (_enteringLabelComponent == nullptr) {
+		traceError("Label \"" + getName() + "\" has no entering component defined. Entity was not sent.");
+		return;
+	}
+	if (!_enteringLabelComponentName.empty()) {
+		ModelComponent* resolved = _parentModel->getComponentManager()->find(_enteringLabelComponentName);
+		if (resolved == nullptr || resolved != _enteringLabelComponent) {
+			traceError("Label \"" + getName() + "\" entering component reference is stale or invalid (\"" + _enteringLabelComponentName + "\"). Entity was not sent.");
+			return;
+		}
+	}
 	_parentModel->sendEntityToComponent(entity, _enteringLabelComponent, timeDelay);
 }
 
@@ -97,9 +122,15 @@ bool Label::_loadInstance(PersistenceRecord *fields) {
 	if (res) {
 		try {
 			this->_label = fields->loadField("label", "");
-			std::string componentName = fields->loadField("enteringComponentName", "");
-			ModelComponent* comp = _parentModel->getComponentManager()->find(componentName);
-			this->_enteringLabelComponent = comp;
+			this->_enteringLabelComponent = nullptr;
+			this->_enteringLabelComponentName = fields->loadField("enteringComponentName", "");
+			if (!_enteringLabelComponentName.empty()) {
+				ModelComponent* comp = _parentModel->getComponentManager()->find(_enteringLabelComponentName);
+				this->_enteringLabelComponent = comp;
+				if (comp == nullptr) {
+					traceError("Label \"" + getName() + "\" could not resolve entering component \"" + _enteringLabelComponentName + "\" while loading.");
+				}
+			}
 		} catch (...) {
 		}
 	}
@@ -109,20 +140,43 @@ bool Label::_loadInstance(PersistenceRecord *fields) {
 void Label::_saveInstance(PersistenceRecord *fields, bool saveDefaultValues) {
 	ModelDataDefinition::_saveInstance(fields, saveDefaultValues);
 	fields->saveField("label", this->_label, "", saveDefaultValues);
+	std::string componentName = _enteringLabelComponentName;
 	if (_enteringLabelComponent != nullptr) {
-		fields->saveField("enteringComponentName", _enteringLabelComponent->getName(), "", saveDefaultValues);
+		componentName = _enteringLabelComponent->getName();
+		_enteringLabelComponentName = componentName;
+	}
+	if (!componentName.empty()) {
+		fields->saveField("enteringComponentName", componentName, "", saveDefaultValues);
 	}
 }
 
 // could be overriden
 
 bool Label::_check(std::string& errorMessage) {
-	bool resultAll = true;
-	resultAll &= (_enteringLabelComponent != nullptr);
-	if (!resultAll) {
-		errorMessage += "Entering Label Component was not defined";
+	_attachedDataRemove("EnteringLabelComponent");
+
+	if (_enteringLabelComponent == nullptr) {
+		errorMessage += "Label \"" + getName() + "\" entering component was not defined";
+		return false;
 	}
-	return resultAll;
+
+	if (_enteringLabelComponentName.empty()) {
+		_enteringLabelComponentName = _enteringLabelComponent->getName();
+	}
+
+	ModelComponent* resolvedComponent = _parentModel->getComponentManager()->find(_enteringLabelComponentName);
+	if (resolvedComponent == nullptr) {
+		errorMessage += "Label \"" + getName() + "\" entering component \"" + _enteringLabelComponentName + "\" does not exist in current model";
+		return false;
+	}
+
+	if (resolvedComponent != _enteringLabelComponent) {
+		errorMessage += "Label \"" + getName() + "\" entering component reference is stale for \"" + _enteringLabelComponentName + "\"";
+		return false;
+	}
+
+	_attachedDataInsert("EnteringLabelComponent", _enteringLabelComponent);
+	return true;
 }
 
 //ParserChangesInformation* Label::_getParserChangesInformation() {}

--- a/source/plugins/data/Label.h
+++ b/source/plugins/data/Label.h
@@ -27,7 +27,9 @@ public:
 	virtual std::string show() override;
 	void setLabel(std::string _label);
 	std::string getLabel() const;
+	void setEnterIntoLabelComponent(ModelComponent* enteringLabelComponent);
 	ModelComponent* getEnterIntoLabelComponent() const;
+	std::string getEnteringLabelComponentName() const;
 	void sendEntityToLabelComponent(Entity* entity, double timeDelay);
 protected: // must be overriden 
 	virtual bool _loadInstance(PersistenceRecord *fields) override;
@@ -39,8 +41,8 @@ protected: // could be overriden
 	//virtual void _createInternalAndAttachedData();
 private:
 	std::string _label;
+	std::string _enteringLabelComponentName;
 	ModelComponent* _enteringLabelComponent = nullptr;
 };
 
 #endif /* LABEL_H */
-

--- a/source/tests/unit/test_simulator_runtime.cpp
+++ b/source/tests/unit/test_simulator_runtime.cpp
@@ -21,6 +21,7 @@
 #include "plugins/data/SignalData.h"
 #include "plugins/data/Station.h"
 #include "plugins/data/Set.h"
+#include "plugins/data/Label.h"
 #include "plugins/components/Delay.h"
 #define private public
 #define protected public
@@ -409,6 +410,23 @@ public:
 
     void CreateInternalAndAttachedDataProbe() {
         _createInternalAndAttachedData();
+    }
+};
+
+class LabelProbe : public Label {
+public:
+    LabelProbe(Model* model, const std::string& name = "") : Label(model, name) {}
+
+    bool CheckProbe(std::string& errorMessage) {
+        return _check(errorMessage);
+    }
+
+    bool LoadInstanceProbe(PersistenceRecord* fields) {
+        return _loadInstance(fields);
+    }
+
+    void SaveInstanceProbe(PersistenceRecord* fields, bool saveDefaultValues = false) {
+        _saveInstance(fields, saveDefaultValues);
     }
 };
 
@@ -1983,6 +2001,125 @@ TEST(SimulatorRuntimeTest, SetRecheckRemovesObsoleteAttachedMembers) {
     EXPECT_EQ(attached->count("SetRecheck.SetRecheckA"), 0u);
     ASSERT_EQ(attached->count("SetRecheck.SetRecheckB"), 1u);
     EXPECT_EQ(attached->at("SetRecheck.SetRecheckB"), &memberB);
+}
+
+TEST(SimulatorRuntimeTest, LabelCheckFailsWithoutEnteringComponent) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    LabelProbe label(model, "LabelMissingEnteringComponent");
+    label.setLabel("Dock-A");
+
+    std::string errorMessage;
+    EXPECT_FALSE(label.CheckProbe(errorMessage));
+    EXPECT_NE(errorMessage.find("entering component was not defined"), std::string::npos);
+}
+
+TEST(SimulatorRuntimeTest, LabelCheckPassesWithValidEnteringComponentAndAttachesReference) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    Delay destination(model, "LabelValidDestination");
+    LabelProbe label(model, "LabelValid");
+    label.setLabel("Dock-B");
+    label.setEnterIntoLabelComponent(&destination);
+
+    std::string errorMessage;
+    EXPECT_TRUE(label.CheckProbe(errorMessage));
+    EXPECT_TRUE(errorMessage.empty());
+    auto* attached = label.getAttachedData();
+    ASSERT_EQ(attached->count("EnteringLabelComponent"), 1u);
+    EXPECT_EQ(attached->at("EnteringLabelComponent"), &destination);
+}
+
+TEST(SimulatorRuntimeTest, LabelLoadWithMissingComponentKeepsStateCoherentAndTraceable) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    LabelProbe source(model, "LabelLoadSource");
+    source.setLabel("Dock-C");
+    Delay validDestination(model, "LabelLoadValidDestination");
+    source.setEnterIntoLabelComponent(&validDestination);
+
+    FakeModelPersistenceRuntime persistence;
+    PersistenceRecord fields(persistence);
+    source.SaveInstanceProbe(&fields, true);
+    fields.saveField("enteringComponentName", std::string("MissingComponent"));
+
+    LabelProbe label(model, "LabelLoadMissing");
+    ASSERT_TRUE(label.LoadInstanceProbe(&fields));
+    EXPECT_EQ(label.getLabel(), "Dock-C");
+    EXPECT_EQ(label.getEnteringLabelComponentName(), "MissingComponent");
+    EXPECT_EQ(label.getEnterIntoLabelComponent(), nullptr);
+
+    const auto* traceErrors = model->getTracer()->errorMessages()->list();
+    const bool foundTrace = std::any_of(traceErrors->begin(), traceErrors->end(), [](const std::string& message) {
+        return message.find("MissingComponent") != std::string::npos;
+    });
+    EXPECT_TRUE(foundTrace);
+
+    std::string errorMessage;
+    EXPECT_FALSE(label.CheckProbe(errorMessage));
+    EXPECT_NE(errorMessage.find("was not defined"), std::string::npos);
+}
+
+TEST(SimulatorRuntimeTest, LabelSendEntityWithoutDestinationDoesNotCrashAndEmitsTrace) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    LabelProbe label(model, "LabelSendWithoutDestination");
+    Entity* entity = model->createEntity("LabelSendEntity", true);
+    ASSERT_NE(entity, nullptr);
+
+    EXPECT_NO_THROW(label.sendEntityToLabelComponent(entity, 0.0));
+
+    const auto* traceErrors = model->getTracer()->errorMessages()->list();
+    const bool foundTrace = std::any_of(traceErrors->begin(), traceErrors->end(), [](const std::string& message) {
+        return message.find("has no entering component defined") != std::string::npos;
+    });
+    EXPECT_TRUE(foundTrace);
+
+    model->removeEntity(entity);
+}
+
+TEST(SimulatorRuntimeTest, LabelShowIncludesLabelAndEnteringComponentName) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    Delay destination(model, "LabelShowDestination");
+    LabelProbe label(model, "LabelShow");
+    label.setLabel("Dock-D");
+    label.setEnterIntoLabelComponent(&destination);
+
+    const std::string shown = label.show();
+    EXPECT_NE(shown.find("label=\"Dock-D\""), std::string::npos);
+    EXPECT_NE(shown.find("enteringComponentName=LabelShowDestination"), std::string::npos);
+}
+
+TEST(SimulatorRuntimeTest, LabelSaveLoadRoundTripPreservesLabelAndEnteringComponentName) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    Delay destination(model, "LabelRoundTripDestination");
+    LabelProbe source(model, "LabelRoundTripSource");
+    source.setLabel("Dock-E");
+    source.setEnterIntoLabelComponent(&destination);
+
+    FakeModelPersistenceRuntime persistence;
+    PersistenceRecord fields(persistence);
+    source.SaveInstanceProbe(&fields, true);
+
+    LabelProbe loaded(model, "LabelRoundTripLoaded");
+    ASSERT_TRUE(loaded.LoadInstanceProbe(&fields));
+    EXPECT_EQ(loaded.getLabel(), "Dock-E");
+    EXPECT_EQ(loaded.getEnteringLabelComponentName(), "LabelRoundTripDestination");
+    EXPECT_EQ(loaded.getEnterIntoLabelComponent(), &destination);
 }
 
 TEST(SimulatorRuntimeTest, StationCreateInternalInitiallyCreatesCollectorsWhenStatisticsEnabled) {


### PR DESCRIPTION
### Motivation
- Prevent unsafe dereference of the Label destination pointer and avoid crashes when destination is null or stale. 
- Ensure persistence/load keep a coherent, diagnosable state for unresolved destinations. 
- Increase model-check validation for Label so a missing or stale entering component is reported clearly. 
- Improve observability of Label instances via `show()` and attached-data mapping when a valid destination exists.

### Description
- Added a persisted name field `_enteringLabelComponentName` and small API methods `setEnterIntoLabelComponent()` and `getEnteringLabelComponentName()` to keep pointer/name state synchronized (changes in `Label.h`).
- `show()` now includes `label` and the entering component name (or `NULL`) for better observability (changes in `Label.cpp`).
- `sendEntityToLabelComponent()` now checks for `nullptr`, validates the component against the model `ComponentManager` (detects stale references), logs clear errors and aborts safely without sending when invalid (changes in `Label.cpp`).
- `_loadInstance()` now preserves the entering-component name, attempts to resolve it at load time, clears previous pointer state, and emits a trace error if resolution fails (changes in `Label.cpp`).
- `_saveInstance()` writes the entering component name coherently whether it was set by pointer or previously loaded name (changes in `Label.cpp`).
- `_check()` now validates that there is an entering component defined, that it exists in the current model, that pointer and name are coherent (detects stale references), and registers the valid destination via attached-data `EnteringLabelComponent` (changes in `Label.cpp`).
- Added `LabelProbe` helper and six focused unit tests covering: check failing when missing, check passing when valid, load with missing component (traceable), safe `sendEntityToLabelComponent()` without destination, `show()` contents, and save/load round-trip preservation (changes in `source/tests/unit/test_simulator_runtime.cpp`).

### Testing
- Configured and built runtime tests: `cmake -S . -B build -G Ninja -DGENESYS_BUILD_TESTS=ON -DGENESYS_BUILD_KERNEL=ON -DGENESYS_BUILD_PARSER=ON -DGENESYS_BUILD_PLUGINS=ON -DGENESYS_TERMINAL_APPLICATION=OFF -DGENESYS_BUILD_GUI_APPLICATION=OFF -DGENESYS_BUILD_WEB_APPLICATION=OFF` (succeeded).
- Built target `genesys_test_simulator_runtime` (succeeded).
- Executed label-focused tests: `ctest --test-dir build -R "SimulatorRuntimeTest.*Label" --output-on-failure` and the Label tests passed (100%: all Label unit tests succeeded).
- Ran broader smoke selection: `ctest --test-dir build -LE smoke --output-on-failure` (the run shows many `*_NOT_BUILT` tests in this configuration; this is an environment/target selection issue and not caused by the Label changes; the runtime tests including Label passed).

---

```markdown
- o que você realizou de fato;
  - Endureci o plugin `Label`: validações robustas de destino (nome + ponteiro), carregamento com diagnóstico, persistência coerente, `show()` melhorado, `sendEntityToLabelComponent()` seguro e attached-data do destino quando válido; e adicionei 6 testes unitários cobrindo os cenários obrigatórios.
- o que não realizou;
  - Não modifiquei outros plugins/data/components fora do escopo permitido.
  - Não executei refatorações arquiteturais amplas nem mudei mecanismos globais de persistência/checagem.
- por que não realizou;
  - Essas alterações estavam explicitamente proibidas ou eram desnecessárias para resolver os problemas identificados em `Label` nesta etapa.
- riscos remanescentes;
  - Caso código externo injete um ponteiro inválido diretamente (sem passar pela API/setter), ainda existe risco inerente a ponteiros crus; as validações por nome mitigam o fluxo normal, mas não eliminam corrupção arbitrária de memória proveniente de fora do escopo.
- observações relevantes;
  - `_check()` registra o destino válido como attached-data (`EnteringLabelComponent`) sem alterar arquitetura global; isso atende ao requisito de refletir estruturalmente o componente de entrada de forma local e segura.
  - `ctest -LE smoke` reportou vários executáveis `NOT_BUILT` na configuração atual; porém os testes de runtime e todos os testes de Label passaram com sucesso.
- arquivos alterados;
  - `source/plugins/data/Label.h`
  - `source/plugins/data/Label.cpp`
  - `source/tests/unit/test_simulator_runtime.cpp`
- comandos executados e resultados resumidos.
  - `cmake ...` (configure) — sucesso.
  - `cmake --build build --target genesys_test_simulator_runtime` — sucesso.
  - `ctest --test-dir build -R "SimulatorRuntimeTest.*Label" --output-on-failure` — todos os testes de Label passaram (100%).
  - `ctest --test-dir build -LE smoke --output-on-failure` — executou, mas muitos testes aparecem como `NOT_BUILT` nesta configuração; não relacionado à correção do Label.
```

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d930cde5a483218a6c6be3e516eef1)