### PR TITLE
GUI: block residual scene structural edits while paused

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
@@ -1836,6 +1836,9 @@ void ModelGraphicsScene::setUndoStack(QUndoStack* undo) {
 
 
 void ModelGraphicsScene::beginConnection() {
+    if (checkIgnoreEvent()) {
+        return;
+    }
     _connectingStep = 1;
     // Set the connection cursor only when a valid parent view is available.
     QGraphicsView* parentView = sceneParentGraphicsView(this);
@@ -2214,7 +2217,7 @@ bool ModelGraphicsScene::checkIgnoreEvent() {
         return false;
     }
 
-    return simulation->isRunning();
+    return simulation->isRunning() || simulation->isPaused();
 }
 void ModelGraphicsScene::mousePressEvent(QGraphicsSceneMouseEvent *mouseEvent) {
     if (checkIgnoreEvent()) {
@@ -2834,6 +2837,10 @@ void ModelGraphicsScene::dragMoveEvent(QGraphicsSceneDragDropEvent *event) {
 }
 
 void ModelGraphicsScene::keyPressEvent(QKeyEvent *keyEvent) {
+    if (checkIgnoreEvent()) {
+        keyEvent->ignore();
+        return;
+    }
     QGraphicsScene::keyPressEvent(keyEvent);
     QList<QGraphicsItem*> selected = this->selectedItems();
     if (keyEvent->key() == Qt::Key_Delete && selected.size() > 0) {


### PR DESCRIPTION
### Motivation
- Prevent structural mutations of the graphical model from scene/view handlers while a simulation is active, including when it is paused.
- Close a small residual gap where scene-level handlers (move, connect, drop, delete) could still change the model even though top-level UI surfaces were disabled.

### Description
- Extended `ModelGraphicsScene::checkIgnoreEvent()` to return true when the simulation is running OR paused, so scene handlers respect the same interaction lock used by the rest of the UI (`source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp`).
- Added a guard in `ModelGraphicsScene::beginConnection()` to prevent starting the connection flow when interaction is locked.
- Added a guard in `ModelGraphicsScene::keyPressEvent()` to ignore key events (notably Delete) when interaction is locked, preventing direct deletion undo commands from the scene.
- Changes are limited to `ModelGraphicsScene.cpp` and keep scope minimal and reversible, without modifying controllers/services or property editor logic.

### Testing
- Reviewed and re-opened source files `mainwindow.cpp`, `mainwindow_scene.cpp`, `ModelGraphicsScene.cpp`, and `ModelGraphicsView.cpp` to audit relevant paths before editing, and verified the updated call-sites.
- Ran `git diff -- source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp` to verify the exact patch content; the diff was produced successfully.
- Committed the change locally with `git commit` which completed successfully.
- No build or unit tests were run in this pass; compilation was not attempted as part of this focused audit-and-fix step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d93a733ed483219e8be90a2b977fa5)