### PR TITLE
GUI: harden queue animation state and add fallback animation image

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/animations/AnimationQueue.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/animations/AnimationQueue.cpp
@@ -98,13 +98,20 @@ void AnimationQueue::verifyRemoveAnimationQueue() {
 
 // Se o componente for um componente de fila, adiciona animação
 void AnimationQueue::addAnimationQueue(bool visivible) {
+    // Guard queue animation insertion when queue graphics infrastructure is not initialized.
     if (_graphicalComponent) {
         if (_graphicalComponent->hasQueue()) {
+            QList<QList<GraphicalImageAnimation *>*> *imagesQueue = _graphicalComponent->getImagesQueue();
+            if (imagesQueue == nullptr || imagesQueue->empty() || imagesQueue->at(0) == nullptr) {
+                qInfo() << "AnimationQueue: queue animation insertion skipped due to uninitialized queue graphics infrastructure";
+                return;
+            }
+
             QString animationImageName = _graphicalComponent->getAnimationImageName();
             unsigned int width = 30;
             unsigned int height = 30;
 
-            unsigned int sizeQueue = (unsigned int) _graphicalComponent->getImagesQueue()->at(0)->size();
+            unsigned int sizeQueue = (unsigned int) imagesQueue->at(0)->size();
 
             QPointF position = calculatePositionImageQueue(0, sizeQueue, width, height);
 
@@ -119,18 +126,25 @@ void AnimationQueue::addAnimationQueue(bool visivible) {
 
             _myScene->update();
         }
+        else {
+            qInfo() << "AnimationQueue: queue animation insertion skipped due to uninitialized queue graphics infrastructure";
+        }
+    } else {
+        qInfo() << "AnimationQueue: queue animation insertion skipped due to uninitialized queue graphics infrastructure";
     }
 }
 
 // Se o componente for um componente de fila, remove a animação
 void AnimationQueue::removeAnimationQueue() {
+    // Guard batch queue removal path to avoid out-of-range access when queue list is empty.
     if (_graphicalComponent) {
         if (_graphicalComponent->hasQueue()) {
 
             unsigned int images = 1;
 
             if (_graphicalComponent->getComponent()->getClassname() == "Batch") {
-                if (!_graphicalComponent->getImagesQueue()->empty())
+                QList<QList<GraphicalImageAnimation *>*> *imagesQueue = _graphicalComponent->getImagesQueue();
+                if (imagesQueue != nullptr && !imagesQueue->empty() && imagesQueue->at(0) != nullptr)
                     images = (unsigned int) _graphicalComponent->getImagesQueue()->at(0)->size();
             }
 

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/GraphicalImageAnimation.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/GraphicalImageAnimation.cpp
@@ -1,4 +1,6 @@
 #include "GraphicalImageAnimation.h"
+#include <algorithm>
+#include <QPainter>
 
 GraphicalImageAnimation::GraphicalImageAnimation(const QPointF startPoint, unsigned int width, unsigned int height, const QString imageName) :
     _startPoint(startPoint), _width(width), _height(height), _imageName(imageName){
@@ -60,9 +62,13 @@ void GraphicalImageAnimation::updateImage() {
     // Forma o caminho completo para a imagem
     _imagePath = _defaultPath + _imageName;
 
-    // Carrega a imagem
+    // Load from filesystem first and fallback to an in-memory marker pixmap if missing.
     QPixmap source(_imagePath);
-    // Redimensiona a imagem
+    if (source.isNull()) {
+        qInfo() << "GraphicalImageAnimation: fallback image used for missing file" << _imagePath;
+        source = buildFallbackPixmap();
+    }
+    // Resize only after ensuring a valid source pixmap.
     QPixmap resizedImage = source.scaled(_width, _height);
 
     // Define a imagem do item atual
@@ -70,4 +76,22 @@ void GraphicalImageAnimation::updateImage() {
 
     // Define a posição inicial da imagem
     setPos(_startPoint);
+}
+
+QPixmap GraphicalImageAnimation::buildFallbackPixmap() const {
+    // Build a clear visual placeholder with safe minimum dimensions.
+    const int safeWidth = std::max(8, static_cast<int>(_width));
+    const int safeHeight = std::max(8, static_cast<int>(_height));
+    QPixmap fallback(safeWidth, safeHeight);
+    fallback.fill(Qt::white);
+
+    QPainter painter(&fallback);
+    painter.setRenderHint(QPainter::Antialiasing, true);
+    painter.setPen(QPen(Qt::black, 1));
+    painter.drawRect(0, 0, safeWidth - 1, safeHeight - 1);
+    painter.setPen(QPen(Qt::red, 2));
+    painter.drawLine(0, 0, safeWidth - 1, safeHeight - 1);
+    painter.drawLine(0, safeHeight - 1, safeWidth - 1, 0);
+
+    return fallback;
 }

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/GraphicalImageAnimation.h
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/GraphicalImageAnimation.h
@@ -28,6 +28,9 @@ public:
     void updateImage();
 
 private:
+    // Builds an in-memory marker image when the file-based image cannot be loaded.
+    QPixmap buildFallbackPixmap() const;
+
     // Caminho padrão das imagens
     QString _defaultPath = "../../images/";
 

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/GraphicalModelComponent.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/GraphicalModelComponent.cpp
@@ -528,6 +528,8 @@ void GraphicalModelComponent::clearQueues() {
     }
     _imagesQueue->clear();
     _mapQueue->clear();
+    // Keep logical queue state synchronized with structural queue cleanup.
+    _hasQueue = false;
 }
 
 /*


### PR DESCRIPTION
### Motivation
- Prevent a crash caused by `AnimationQueue::addAnimationQueue()` accessing `getImagesQueue()->at(0)` when `_imagesQueue` was structurally cleared but `_hasQueue` remained true. 
- Ensure image-based animations remain visible when the image file is missing by providing a local in-memory fallback marker.

### Description
- Reset logical queue state in `GraphicalModelComponent::clearQueues()` by setting `_hasQueue = false` after clearing `_imagesQueue` and `_mapQueue` so `hasQueue()` cannot be true for an empty structure.
- Harden `AnimationQueue::addAnimationQueue(bool)` with defensive guards that validate `_graphicalComponent`, `_graphicalComponent->hasQueue()`, `getImagesQueue() != nullptr`, `!getImagesQueue()->empty()` and `getImagesQueue()->at(0) != nullptr`; if guards fail the method returns early and emits a concise `qInfo()` explaining the skip.
- Add a minimal guard in `AnimationQueue::removeAnimationQueue()` (Batch path) to avoid calling `at(0)->size()` when the images queue list may be null/empty, using the same defensive checks.
- Add a local fallback mechanism to `GraphicalImageAnimation`: a new private helper `QPixmap buildFallbackPixmap() const;` and update `updateImage()` to load the file first, detect `source.isNull()`, log a short `qInfo()` and use the fallback pixmap (white background, black border, red X) before scaling and assigning the pixmap.
- All changes are localized to the requested files and preserve existing animation pipeline logic and behavior where valid.

### Testing
- Reopened and inspected the four target files to confirm changes: `GraphicalModelComponent::clearQueues()` resets `_hasQueue`, `AnimationQueue::addAnimationQueue()` no longer calls `at(0)` without validation, `AnimationQueue::removeAnimationQueue()` guarded in the Batch path, and `GraphicalImageAnimation::updateImage()` uses a generated fallback pixmap when file loading fails.
- Ran the focused diff command for the four target files (`git diff -- <files>`) to verify edits and reviewed the produced patch.
- Committed the changes (`GUI: harden queue animation state and add fallback animation image`).
- Attempted a quick GUI build with `cmake --build build --target GenesysQtGUI -j2`, but the environment lacks a `build/` directory so a build could not be executed in this session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d950cf04dc8321a137303ce9b87ae5)