### PR TITLE
Rename ModelDataDefinition internal _properties to _simulationControls with compatibility wrappers

### DIFF
--- a/source/kernel/simulator/ModelDataDefinition.cpp
+++ b/source/kernel/simulator/ModelDataDefinition.cpp
@@ -50,8 +50,8 @@ ModelDataDefinition::ModelDataDefinition(Model* model, std::string thistypename,
 	_parentModel->getControls()->insert(propName);
 
 	// setting properties
-	_addProperty(propName);
-	_addProperty(propReportStatistics);
+	_addSimulationControl(propName);
+	_addSimulationControl(propReportStatistics);
 }
 
 bool ModelDataDefinition::hasChanged() const {
@@ -77,21 +77,21 @@ ModelDataDefinition::~ModelDataDefinition() {
 	_internalDataClear();
 	// Keep model registry consistent by removing this modeldata from the manager first.
 	_parentModel->getDataManager()->remove(this);
-	// Detach and destroy owned SimulationControl properties tracked by this model element.
-	if (_properties != nullptr) {
-		for (SimulationControl* property : *_properties->list()) {
-			if (property == nullptr) {
+	// Detach and destroy owned SimulationControl entries tracked by this model element.
+	if (_simulationControls != nullptr) {
+		for (SimulationControl* control : *_simulationControls->list()) {
+			if (control == nullptr) {
 				continue;
 			}
-			_parentModel->getControls()->remove(property);
-			SimulationResponse* response = dynamic_cast<SimulationResponse*>(property);
+			_parentModel->getControls()->remove(control);
+			SimulationResponse* response = dynamic_cast<SimulationResponse*>(control);
 			if (response != nullptr) {
 				_parentModel->getResponses()->remove(response);
 			}
-			delete property;
+			delete control;
 		}
-		delete _properties;
-		_properties = nullptr;
+		delete _simulationControls;
+		_simulationControls = nullptr;
 	}
 	// Destroy the internal-data registry container after its owned contents are cleared.
 	delete _internalData;
@@ -414,22 +414,28 @@ void ModelDataDefinition::_createInternalAndAttachedData() {
 
 }
 
+void ModelDataDefinition::_addSimulationControl(SimulationControl* control) {
+	_simulationControls->insert(control);
+}
+
 void ModelDataDefinition::_addProperty(SimulationControl* property) {
-	_properties->insert(property);
+	// Legacy compatibility wrapper.
+	_addSimulationControl(property);
 }
 
 /*
 void ModelDataDefinition::_addSimulationResponse(SimulationControl* response) {
 	_simulationResponses->insert(response); //@TODO: Check if exists before insert?
 }
-
-void ModelDataDefinition::_addSimulationControl(SimulationControl* control) {
-	_simulationControls->insert(control);
-}
 */
 
 List<SimulationControl*> *ModelDataDefinition::getProperties() const {
-	return _properties;
+	// Legacy compatibility wrapper.
+	return getSimulationControls();
+}
+
+List<SimulationControl*>* ModelDataDefinition::getSimulationControls() const {
+	return _simulationControls;
 }
 
 

--- a/source/kernel/simulator/ModelDataDefinition.h
+++ b/source/kernel/simulator/ModelDataDefinition.h
@@ -104,9 +104,14 @@ public:
 	 * \brief getProperties
 	 * \return
 	 *
-	 * Transitional kernel API: this class now exposes explicit SimulationControl
-	 * pointers while the broader migration away from the legacy PropertyBase
-	 * naming remains in progress.
+	 * Preferred API for writable controls owned by this model data definition.
+	 */
+	List<SimulationControl*>* getSimulationControls() const;
+	/*!
+	 * \brief getProperties
+	 * \return
+	 *
+	 * Legacy compatibility wrapper that delegates to getSimulationControls().
 	 */
 	List<SimulationControl*> *getProperties() const;
 
@@ -155,9 +160,10 @@ protected: //! could be overriden by derived classes
 	virtual void _initBetweenReplications();
 	/*! This method is necessary only for those components that instantiate internal elements that must exist before simulation starts and even before model checking. That's the case of components that have internal StatisticsCollectors, since others components may refer to them as expressions (as in "TVAG(ThisCSTAT)") and therefore the modeldatum must exist before checking such expression */
 	virtual void _createInternalAndAttachedData(); /*< A ModelDataDefinition or ModelComponent that includes (internal) ou refers to (attach) other ModelDataDefinition must register them inside this method. */
+	virtual void _addSimulationControl(SimulationControl* control);
+	// Legacy compatibility wrapper that delegates to _addSimulationControl().
 	virtual void _addProperty(SimulationControl* property);
 	//virtual void _addSimulationResponse(SimulationControl* response);
-	//virtual void _addSimulationControl(SimulationControl* control);
 
 private: // name is now private. So changes in name must be throught setName, wich gives oportunity to rename internelElements, SimulationControls and SimulationResponses
 	std::string _name;
@@ -184,14 +190,9 @@ protected: //! just an easy access to trace manager
 
 protected:
 	//List<SimulationControl*>* _simulationResponses = new List<SimulationControl*>();
-	//List<SimulationControl*>* _simulationControls = new List<SimulationControl*>();
-	// Transitional compatibility store for kernel-side writable controls.
-	// The long-term direction is to use explicit SimulationResponse and
-	// SimulationControl collections throughout the kernel.
-	List<SimulationControl*>* _properties = new List<SimulationControl*>();
+	List<SimulationControl*>* _simulationControls = new List<SimulationControl*>();
 	//PropertyListG* _propertiesG = new PropertyListG();
 };
 //namespace\\}
 
 #endif /* MODELELEMENT_H */
-

--- a/source/kernel/simulator/PropertyGenesys.h
+++ b/source/kernel/simulator/PropertyGenesys.h
@@ -15,18 +15,19 @@ public:
     }
 
 public:
-    void changeProperty(SimulationControl* property, const std::string& value, bool remove = false) {
-        if (property != nullptr) {
-            property->setValue(value, remove);
+    // Current GUI editing path writes values through SimulationControl.
+    void changeProperty(SimulationControl* control, const std::string& value, bool remove = false) {
+        if (control != nullptr) {
+            control->setValue(value, remove);
         }
     }
 
     SimulationControl* findProperty(const std::string& id, const std::string& attribute) {
         for (auto element : _elements) {
             if (std::to_string(element->getId()) == id) {
-                for (auto prop : *element->getProperties()->list()) {
-                    if (prop->getName() == attribute) {
-                        return prop;
+                for (auto control : *element->getProperties()->list()) {
+                    if (control->getName() == attribute) {
+                        return control;
                     }
                 }
             }

--- a/source/plugins/components/PickStation.cpp
+++ b/source/plugins/components/PickStation.cpp
@@ -313,6 +313,5 @@ void PickStation::_createInternalAndAttachedData() {
 }
 
 void PickStation::_addProperty(SimulationControl* property) {
-	_properties->insert(property);
+	_addSimulationControl(property);
 }
-

--- a/source/plugins/data/Schedule.cpp
+++ b/source/plugins/data/Schedule.cpp
@@ -225,7 +225,7 @@ void Schedule::_addProperty(SimulationControl* property) {
 	/*!
 	 * \brief Keep local property mirror aligned with controls registered in model.
 	 */
-	_properties->insert(property);
+	_addSimulationControl(property);
 }
 
 //


### PR DESCRIPTION
### Motivation
- Clarify the internal model datum naming by using a semantically correct member for the collection of `SimulationControl*` while preserving existing API semantics for legacy callers.

### Description
- Introduced the preferred API `List<SimulationControl*>* getSimulationControls() const` and the protected inserter `void _addSimulationControl(SimulationControl* control)` and replaced the internal field `_properties` with `_simulationControls` used by the implementation.
- Kept backwards-compatible wrappers `List<SimulationControl*>* getProperties() const` and `virtual void _addProperty(SimulationControl* property)` and made them delegate to the new API, with short English comments marking them as legacy wrappers.
- Updated the constructor, destructor and internal uses in `ModelDataDefinition.cpp` to operate on `_simulationControls` and added minimal, safe edits in `PropertyGenesys.h` plus two plugin overrides so `_addProperty(...)` routes through `_addSimulationControl(...)` to retain compile- and runtime compatibility.

### Testing
- Built the kernel with `cmake --preset debug-kernel` and then `cmake --build --preset debug-kernel`, and the build completed successfully in this environment.
- Files changed: `source/kernel/simulator/ModelDataDefinition.h`, `source/kernel/simulator/ModelDataDefinition.cpp`, `source/kernel/simulator/PropertyGenesys.h`, `source/plugins/components/PickStation.cpp`, and `source/plugins/data/Schedule.cpp`.
- Exact compatibility wrappers kept: `List<SimulationControl*> *getProperties() const;` and `virtual void _addProperty(SimulationControl* property);` which now delegate to `getSimulationControls()` and `_addSimulationControl(...)` respectively.
- Behavior confirmation: this change is a naming/API cleanup only and preserves existing behavior by delegating legacy APIs to the new internals, so runtime behavior is unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d95c179374832193022733f12c4b4f)