### PR TITLE
Add SimulationControl-first API to PropertyEditorGenesys with legacy wrappers

### DIFF
--- a/source/kernel/simulator/PropertyGenesys.h
+++ b/source/kernel/simulator/PropertyGenesys.h
@@ -15,17 +15,16 @@ public:
     }
 
 public:
-    // Current GUI editing path writes values through SimulationControl.
-    void changeProperty(SimulationControl* control, const std::string& value, bool remove = false) {
+    void changeSimulationControl(SimulationControl* control, const std::string& value, bool remove = false) {
         if (control != nullptr) {
             control->setValue(value, remove);
         }
     }
 
-    SimulationControl* findProperty(const std::string& id, const std::string& attribute) {
+    SimulationControl* findSimulationControl(const std::string& id, const std::string& attribute) {
         for (auto element : _elements) {
             if (std::to_string(element->getId()) == id) {
-                for (auto control : *element->getProperties()->list()) {
+                for (auto control : *element->getSimulationControls()->list()) {
                     if (control->getName() == attribute) {
                         return control;
                     }
@@ -33,6 +32,16 @@ public:
             }
         }
         return nullptr;
+    }
+
+    // Legacy compatibility wrapper. Prefer changeSimulationControl.
+    void changeProperty(SimulationControl* control, const std::string& value, bool remove = false) {
+        changeSimulationControl(control, value, remove);
+    }
+
+    // Legacy compatibility wrapper. Prefer findSimulationControl.
+    SimulationControl* findProperty(const std::string& id, const std::string& attribute) {
+        return findSimulationControl(id, attribute);
     }
 
     void addElement(ModelComponent* component) {


### PR DESCRIPTION
### Motivation
- Replace legacy "Property" naming with semantically correct "SimulationControl" in the central helper API while preserving full backward compatibility and switching the lookup to use `getSimulationControls()`.

### Description
- Added `changeSimulationControl(SimulationControl* control, const std::string& value, bool remove = false)` and `findSimulationControl(const std::string& id, const std::string& attribute)` to `PropertyEditorGenesys`, updated `findSimulationControl` to iterate via `element->getSimulationControls()->list()`, and kept legacy wrappers `changeProperty(...)` and `findProperty(...)` which delegate to the new methods in `source/kernel/simulator/PropertyGenesys.h`.

### Testing
- Verified the new symbols and file contents with `rg` and `sed` which showed the new preferred methods and the compatibility wrappers, and attempted `cmake --build` but no `build/` directory was present so a full compile could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d95f92028c83218a7300c55247ea6b)