### PR TITLE
Fix missing Delay->Dispose animation event and conditional queue insertion

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/animations/AnimationTransition.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/animations/AnimationTransition.cpp
@@ -433,10 +433,16 @@ void AnimationTransition::onAnimationFinished() {
     // Mark finished callback as handled for idempotent terminal cleanup.
     _isFinishedHandled = true;
 
-    // Only notify queue insertion when both scene and destination component are valid.
-    if (_myScene != nullptr && _graphicalEndComponent != nullptr) {
-        // Log queue-insert dispatch performed on a valid destination component.
-        qInfo() << "GUI AnimationTransition onAnimationFinished animateQueueInsert=true";
+    // Insert queue animation only when destination queue graphics infrastructure is initialized.
+    bool shouldAnimateQueueInsert = false;
+    if (_graphicalEndComponent != nullptr && _graphicalEndComponent->hasQueue()) {
+        QList<QList<GraphicalImageAnimation *>*>* imagesQueue = _graphicalEndComponent->getImagesQueue();
+        shouldAnimateQueueInsert = (imagesQueue != nullptr && !imagesQueue->empty() && imagesQueue->at(0) != nullptr);
+    }
+    qInfo() << "GUI AnimationTransition onAnimationFinished queueInsertDecision="
+            << (shouldAnimateQueueInsert ? "insert" : "skip")
+            << "destinationId=" << (_graphicalEndComponent ? _graphicalEndComponent->getComponent()->getId() : 0);
+    if (_myScene != nullptr && _graphicalEndComponent != nullptr && shouldAnimateQueueInsert) {
         _myScene->animateQueueInsert(_graphicalEndComponent->getComponent(), _viewSimulation);
     }
 

--- a/source/applications/gui/qt/GenesysQtGUI/controllers/SimulationEventController.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/SimulationEventController.cpp
@@ -266,12 +266,16 @@ void SimulationEventController::onEntityRemoveHandler(SimulationEvent* re) const
 
 // Preserve entity-move animation pipeline behavior.
 void SimulationEventController::onMoveEntityEvent(SimulationEvent* re) const {
+    ModelComponent* sourceComponent = (re && re->getCurrentEvent()) ? re->getCurrentEvent()->getComponent() : nullptr;
+    ModelComponent* destinationComponent = re ? re->getDestinationComponent() : nullptr;
     // Log move-event correlation context before dispatching transition animation.
     qInfo() << "GUI SimulationEvent onMoveEntityEvent begin graphicalSimulationChecked="
             << (_activateGraphicalSimulation ? _activateGraphicalSimulation->isChecked() : false)
             << "eventPtr=" << (re ? re->getCurrentEvent() : nullptr)
-            << "sourceId=" << ((re && re->getCurrentEvent() && re->getCurrentEvent()->getComponent()) ? re->getCurrentEvent()->getComponent()->getId() : 0)
-            << "destinationId=" << ((re && re->getDestinationComponent()) ? re->getDestinationComponent()->getId() : 0);
+            << "sourceId=" << (sourceComponent ? sourceComponent->getId() : 0)
+            << "sourceName=" << (sourceComponent ? QString::fromStdString(sourceComponent->getName()) : QStringLiteral("<null>"))
+            << "destinationId=" << (destinationComponent ? destinationComponent->getId() : 0)
+            << "destinationName=" << (destinationComponent ? QString::fromStdString(destinationComponent->getName()) : QStringLiteral("<null>"));
     _scene->animateCounter();
     _scene->animateVariable();
 
@@ -283,8 +287,10 @@ void SimulationEventController::onMoveEntityEvent(SimulationEvent* re) const {
                 // Log event and endpoint identifiers used to correlate with scene/animation logs.
                 qInfo() << "GUI SimulationEvent onMoveEntityEvent sourceId="
                         << (source ? source->getId() : 0)
+                        << "sourceName=" << (source ? QString::fromStdString(source->getName()) : QStringLiteral("<null>"))
                         << "destinationId="
                         << (destination ? destination->getId() : 0)
+                        << "destinationName=" << (destination ? QString::fromStdString(destination->getName()) : QStringLiteral("<null>"))
                         << "eventPtr=" << re->getCurrentEvent();
 
                 _scene->animateQueueRemove(source);

--- a/source/kernel/simulator/Model.cpp
+++ b/source/kernel/simulator/Model.cpp
@@ -147,6 +147,15 @@ void Model::sendEntityToComponent(Entity* entity, ModelComponent* component, dou
 	auto se = _simulation->_createSimulationEvent();
 	se->setDestinationComponent(component);
 	se->setEntityMoveTimeDelay(timeDelay);
+    // Log emitted move-event endpoints before notifying GUI/observer handlers.
+    ModelComponent* sourceComponent = (se->getCurrentEvent() != nullptr ? se->getCurrentEvent()->getComponent() : nullptr);
+    std::string sourceName = (sourceComponent != nullptr ? sourceComponent->getName() : "<null>");
+    std::string destinationName = (component != nullptr ? component->getName() : "<null>");
+    std::string message = "Entity move event emitted sourceId=" + std::to_string(sourceComponent != nullptr ? sourceComponent->getId() : 0)
+            + " sourceName=" + sourceName
+            + " destinationId=" + std::to_string(component != nullptr ? component->getId() : 0)
+            + " destinationName=" + destinationName;
+    this->getTracer()->traceSimulation(this, TraceManager::Level::L8_detailed, message);
     this->getOnEventManager()->NotifyEntityMoveHandlers(se.get()); // it's my friend
 	Event* newEvent = new Event(this->getSimulation()->getSimulatedTime()+timeDelay, entity, component, componentinputPortNumber);
 	this->getFutureEvents()->insert(newEvent);

--- a/source/plugins/components/Delay.cpp
+++ b/source/plugins/components/Delay.cpp
@@ -99,6 +99,9 @@ Util::TimeUnit Delay::delayTimeUnit() const {
 }
 
 void Delay::_onDispatchEvent(Entity* entity, unsigned int inputPortNumber) {
+    // Keep unused input-port parameter explicit for delay scheduling path.
+    (void) inputPortNumber;
+
 	double waitTime = _parentModel->parseExpression(_delayExpression);
 	Util::TimeUnit stu = _parentModel->getSimulation()->getReplicationBaseTimeUnit(); //getReplicationLengthTimeUnit();
 	waitTime *= Util::TimeUnitConvert(_delayTimeUnit, stu);
@@ -111,9 +114,9 @@ void Delay::_onDispatchEvent(Entity* entity, unsigned int inputPortNumber) {
 		std::string attribIndex="";
 		entity->setAttributeValue("Entity.Total" + allocationCategory + "Time", totalWaitTime + waitTime, attribIndex, true);
 	}
+    // Route delayed forwarding through Model API so entity-move handlers are notified.
+    _parentModel->sendEntityToComponent(entity, this->getConnectionManager()->getFrontConnection(), waitTime);
 	double delayEndTime = _parentModel->getSimulation()->getSimulatedTime() + waitTime;
-	Event* newEvent = new Event(delayEndTime, entity, this->getConnectionManager()->getFrontConnection());
-	_parentModel->getFutureEvents()->insert(newEvent);
 	traceSimulation(this, "End of delay of "/*entity " + std::to_string(entity->entityNumber())*/ + entity->getName() + " scheduled to time " + std::to_string(delayEndTime) + Util::StrTimeUnitShort(stu) + " (wait time " + std::to_string(waitTime) + Util::StrTimeUnitShort(stu) + ") // " + _delayExpression+ " "+Util::StrTimeUnitShort(_delayTimeUnit));
 }
 


### PR DESCRIPTION
### Motivation
- `Delay::_onDispatchEvent` scheduled the future `Event` directly and bypassed `NotifyEntityMoveHandlers`, so moves like Create -> Delay -> Dispose emitted only the first transition to the GUI.
- `AnimationTransition::onAnimationFinished` always attempted queue insertion when a destination existed, producing noisy "queue infrastructure not initialized" logs for destinations without queue graphics (e.g. `Dispose`).

### Description
- Route delayed forwarding in `Delay::_onDispatchEvent` through the model API by calling `Model::sendEntityToComponent(...)` so entity-move handlers are notified (fixes missing Delay->Dispose move event). (modified `source/plugins/components/Delay.cpp`).
- Add a compact trace at emission in `Model::sendEntityToComponent(...)` with `sourceId/sourceName` and `destinationId/destinationName` to help correlate where moves are emitted. (modified `source/kernel/simulator/Model.cpp`).
- Improve move-event consumer logs in `SimulationEventController::onMoveEntityEvent(...)` to include `sourceId/sourceName` and `destinationId/destinationName` for end-to-end correlation. (modified `source/applications/gui/qt/GenesysQtGUI/controllers/SimulationEventController.cpp`).
- Harden `AnimationTransition::onAnimationFinished()` to compute a `queueInsertDecision` and only call `animateQueueInsert` when the destination graphical queue infrastructure is initialized, logging the decision as `insert` or `skip`. (modified `source/applications/gui/qt/GenesysQtGUI/animations/AnimationTransition.cpp`).

### Testing
- Ran `cmake -S . -B build` and `cmake --build build -j4` and the build completed successfully (no compile errors after changes). (success)
- Executed the smoke binary `./build/source/tests/smoke/genesys_smoke_simulator_start` which started successfully, confirming runtime linkage. (success)
- Ran `ctest --test-dir build -R genesys_smoke_simulator_start` which reported no registered tests; no failing automated tests were observed. (informational)
- Visual GUI validation could not be executed in this environment because the build was configured with `GENESYS_BUILD_GUI=OFF`, so the visual confirmation of Create -> Delay -> Dispose must be validated in a GUI-enabled build; logs and code-level fixes are in place to produce the two animate events and to avoid spurious queue-insert attempts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d95ebf45088321899692e3ab3bd762)