### PR TITLE
Migrate central Qt GUI consumers to getSimulationControls

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/controllers/ModelInspectorController.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/ModelInspectorController.cpp
@@ -46,8 +46,8 @@ void ModelInspectorController::actualizeModelComponents(bool force) const {
             treeComp->setText(1, QString::fromStdString(comp->getClassname()));
             treeComp->setText(2, QString::fromStdString(comp->getName()));
             std::string properties = "";
-            for (auto prop : *comp->getProperties()->list()) {
-                properties += prop->getName() + ":" + prop->getValue() + ", ";
+            for (auto control : *comp->getSimulationControls()->list()) {
+                properties += control->getName() + ":" + control->getValue() + ", ";
             }
             properties = properties.substr(0, properties.length() - 2);
             treeComp->setText(3, QString::fromStdString(properties));
@@ -82,8 +82,8 @@ void ModelInspectorController::actualizeModelDataDefinitions(bool force) const {
                 treeComp->setText(1, QString::fromStdString(comp->getClassname()));
                 treeComp->setText(2, QString::fromStdString(comp->getName()));
                 std::string properties = "";
-                for (auto prop : *comp->getProperties()->list()) {
-                    properties += prop->getName() + ":" + prop->getValue() + ", ";
+                for (auto control : *comp->getSimulationControls()->list()) {
+                    properties += control->getName() + ":" + control->getValue() + ", ";
                 }
                 properties = properties.substr(0, properties.length() - 2);
                 treeComp->setText(3, QString::fromStdString(properties));

--- a/source/applications/gui/qt/GenesysQtGUI/propertyeditor/PropertyEditor.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/propertyeditor/PropertyEditor.cpp
@@ -27,13 +27,13 @@ void PropertyEditor::setModelBlock(ModelDataDefinition* modelblock) {
 	//PropertyT<bool>* propBool;
 	//PropertyT<std::string>* propStr;
 	//PropertyT<Util::TimeUnit>* propTUnit;
-	for (auto prop : *modelblock->getProperties()->list()) {
+	for (auto control : *modelblock->getSimulationControls()->list()) {
 		//propDouble = dynamic_cast<PropertyT<double>*>(prop);
 		//propUInt = dynamic_cast<PropertyT<unsigned int>*>(prop);
 		//propBool = dynamic_cast<PropertyT<bool>*>(prop);
 		//propStr = dynamic_cast<PropertyT<std::string>*>(prop);
 		//propTUnit = dynamic_cast<PropertyT<Util::TimeUnit>*>(prop);
-		category = QString::fromStdString(prop->getName()); ///!@TODO Era para ser getClassName());
+		category = QString::fromStdString(control->getName()); ///!@TODO Era para ser getClassName());
 		QList<QTreeWidgetItem*> founds = findItems(category, Qt::MatchContains);
 		if (founds.size() == 0) {
 			treeRootItem = new QTreeWidgetItem(this);
@@ -64,13 +64,13 @@ void PropertyEditor::setModelBlock(ModelDataDefinition* modelblock) {
 		QTreeWidgetItem *treeItemChild = new QTreeWidgetItem();
 		//treeItemChild->setWhatsThis(0, QString::fromStdString(plugin->getPluginInfo()->getPluginTypename()));
 		//treeItemChild->setTextColor(0, treeRootItem->backgroundColor(0));
-		treeItemChild->setText(0, QString::fromStdString(prop->getName()));
+		treeItemChild->setText(0, QString::fromStdString(control->getName()));
 		//treeItemChild->setText(1, QString::fromStdString(std::to_string(prop->getValue())));
 		//treeItemChild->setToolTip(0, QString::fromStdString(plugtextAdds));
 		//treeItemChild->setStatusTip(0, QString::fromStdString(plugin->getPluginInfo()->getLanguageTemplate()));
 		//treeItemChild->setFlags(Qt::ItemIsSelectable | Qt::ItemIsDragEnabled | Qt::ItemNeverHasChildren);
 		treeRootItem->addChild(treeItemChild);
-		QWidget* lineEdit = new QLineEdit(QString::fromStdString(prop->getValue()));
+		QWidget* lineEdit = new QLineEdit(QString::fromStdString(control->getValue()));
 		this->setItemWidget(treeItemChild, 1, lineEdit);
 	}
 	resizeColumnToContents(0);


### PR DESCRIPTION
### Motivation
- Move central GUI consumers off the legacy `getProperties()` wrapper to the canonical `getSimulationControls()` API exposed by `ModelDataDefinition` and components. 
- Keep the change minimal and low-risk by touching only central inspector/editor call sites and preserving runtime behavior and compatibility. 

### Description
- Replaced `modelblock->getProperties()` with `modelblock->getSimulationControls()` in `PropertyEditor::setModelBlock` and renamed the loop variable from `prop` to `control` where trivial and safe. 
- Replaced `comp->getProperties()` with `comp->getSimulationControls()` in `ModelInspectorController::actualizeModelComponents` and `ModelInspectorController::actualizeModelDataDefinitions` and renamed the loop variable from `prop` to `control` at those call sites. 
- Kept all assembly/formatting logic unchanged and did not remove or alter the legacy `getProperties()` compatibility method. 
- Files changed: `source/applications/gui/qt/GenesysQtGUI/propertyeditor/PropertyEditor.cpp` and `source/applications/gui/qt/GenesysQtGUI/controllers/ModelInspectorController.cpp`. 

### Testing
- `cmake --preset debug` configure completed successfully in this environment. (succeeded) 
- `cmake --build --preset debug` completed successfully and produced the kernel/plugins/test artifacts (succeeded). 
- Attempted GUI-enabled configure with `-DGENESYS_BUILD_GUI_APPLICATION=ON` failed due to missing Qt `qmake` in the environment (expected environment limitation; failure unrelated to code change). 

Notes: only the two central GUI consumer files listed above were migrated and behavior was preserved by keeping the same string assembly and UI population logic; the legacy `getProperties()` accessor was not removed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d961e46ddc8321adf2b0743d025cc5)