### PR TITLE
Harden Delay dispatch and fix animation Qt resource paths

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/GenesysQtGUI_resources.qrc
+++ b/source/applications/gui/qt/GenesysQtGUI/GenesysQtGUI_resources.qrc
@@ -704,6 +704,16 @@
         <file>resources/icons/pack4/iconsMxGraph/zoomout.gif</file>
     </qresource>
     <qresource prefix="/animations">
+        <file alias="boat.png">resources/animations/boat.png</file>
+        <file alias="car.png">resources/animations/car.png</file>
+        <file alias="default.png">resources/animations/default.png</file>
+        <file alias="gear.png">resources/animations/gear.png</file>
+        <file alias="laptop.png">resources/animations/laptop.png</file>
+        <file alias="motorcycle-with-person.png">resources/animations/motorcycle-with-person.png</file>
+        <file alias="motorcycle.png">resources/animations/motorcycle.png</file>
+        <file alias="plane.png">resources/animations/plane.png</file>
+        <file alias="tractor.png">resources/animations/tractor.png</file>
+        <file alias="woman.png">resources/animations/woman.png</file>
         <file>resources/animations/.gitkeep</file>
     </qresource>
     <qresource prefix="/">

--- a/source/kernel/simulator/Model.cpp
+++ b/source/kernel/simulator/Model.cpp
@@ -140,6 +140,16 @@ Model::~Model() {
 }
 
 void Model::sendEntityToComponent(Entity* entity, Connection* connection, double timeDelay) {
+	if (connection == nullptr) {
+		this->getTracer()->traceSimulation(this, TraceManager::Level::L3_errorRecover,
+				"Model::sendEntityToComponent skipped: null connection");
+		return;
+	}
+	if (connection->component == nullptr) {
+		this->getTracer()->traceSimulation(this, TraceManager::Level::L3_errorRecover,
+				"Model::sendEntityToComponent skipped: null destination component");
+		return;
+	}
 	this->sendEntityToComponent(entity, connection->component, timeDelay, connection->channel.portNumber);
 }
 

--- a/source/plugins/components/Delay.cpp
+++ b/source/plugins/components/Delay.cpp
@@ -114,8 +114,14 @@ void Delay::_onDispatchEvent(Entity* entity, unsigned int inputPortNumber) {
 		std::string attribIndex="";
 		entity->setAttributeValue("Entity.Total" + allocationCategory + "Time", totalWaitTime + waitTime, attribIndex, true);
 	}
+    Connection* frontConnection = this->getConnectionManager()->getFrontConnection();
+    if (frontConnection == nullptr || frontConnection->component == nullptr) {
+        traceSimulation(this, "Delay dispatch skipped: invalid front connection");
+        return;
+    }
+
     // Route delayed forwarding through Model API so entity-move handlers are notified.
-    _parentModel->sendEntityToComponent(entity, this->getConnectionManager()->getFrontConnection(), waitTime);
+    _parentModel->sendEntityToComponent(entity, frontConnection, waitTime);
 	double delayEndTime = _parentModel->getSimulation()->getSimulatedTime() + waitTime;
 	traceSimulation(this, "End of delay of "/*entity " + std::to_string(entity->entityNumber())*/ + entity->getName() + " scheduled to time " + std::to_string(delayEndTime) + Util::StrTimeUnitShort(stu) + " (wait time " + std::to_string(waitTime) + Util::StrTimeUnitShort(stu) + ") // " + _delayExpression+ " "+Util::StrTimeUnitShort(_delayTimeUnit));
 }


### PR DESCRIPTION
### Motivation
- Close the GUI animation pipeline by ensuring move events are emitted safely in the kernel, making the animation PNGs resolvable by Qt Resource, and avoiding crashes from null connections. 
- Keep the existing GUI animation safeguards and fallback behavior intact while making the smallest safe changes. 

### Description
- Add null checks and concise trace-on-skip in `Model::sendEntityToComponent(Entity*, Connection*, double)` so `connection` and `connection->component` are validated before use. 
- Capture and validate `frontConnection` locally inside `Delay::_onDispatchEvent(...)` and return with a short trace if the connection or its destination component is invalid, before calling `_parentModel->sendEntityToComponent(...)`. 
- Update `GenesysQtGUI_resources.qrc` to map animation PNGs under the `/animations` prefix with explicit `alias` entries so the images are accessible as `:/animations/<name>.png` while preserving other existing qresource prefixes. 
- Preserved existing behaviors including `queueInsertDecision` in `AnimationTransition::onAnimationFinished()`, the guards in `AnimationQueue.cpp`, `_hasQueue` reset in `GraphicalModelComponent::clearQueues()`, and the fallback image policy in `GraphicalImageAnimation`. 

### Testing
- Built the kernel artifacts with `cmake --preset debug-kernel && cmake --build --preset debug-kernel -- -k 0`, which completed successfully. 
- Attempted to configure a GUI build with `cmake -S . -B build/gui-check -G Ninja -DGENESYS_BUILD_GUI_APPLICATION=ON ...`, which failed in this environment because `qmake` is not available in `PATH`, so a GUI binary could not be produced here. 
- Performed source inspection and `rg` checks to confirm `GraphicalImageAnimation` still uses `:/animations/` and that the `.qrc` now exposes the 10 PNGs via aliases, and verified the new null-guards in `Model.cpp` and local `frontConnection` validation in `Delay.cpp` (all automated checks passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d966db952c8321ae08a75e35c8f632)