### PR TITLE
Fix Match: validation, persistence, queue reconciliation and runtime semantics

### DIFF
--- a/source/plugins/components/Match.cpp
+++ b/source/plugins/components/Match.cpp
@@ -13,7 +13,9 @@
 
 #include "Match.h"
 
+#include <algorithm>
 #include "../../kernel/simulator/Model.h"
+#include "../../kernel/simulator/Attribute.h"
 #include "../../kernel/simulator/Simulator.h"
 #include "../../kernel/simulator/SimulationControlAndResponse.h"
 
@@ -77,47 +79,106 @@ ModelComponent* Match::LoadInstance(Model* model, PersistenceRecord *fields) {
 }
 
 void Match::_onDispatchEvent(Entity* entity, unsigned int inputPortNumber) {
-	Waiting* waiting = new Waiting(entity, _parentModel->getSimulation()->getSimulatedTime(), this);
-	if (_rule == Match::Rule::ByAttribute) {
-		double value = entity->getAttributeValue(_attributeName);
-		// std::map<Queue*, std::map<double, unsigned int>*>*
-		std::pair<Queue*, std::map<double, unsigned int>*> pair1;
-		while (_entitiesByAttrib->find(_queues->getAtRank(inputPortNumber)) == _entitiesByAttrib->end()) {
-			_entitiesByAttrib->insert({_queues->getAtRank(inputPortNumber), new std::map<double, unsigned int>()});
-		}
-		pair1 = *(_entitiesByAttrib->find(_queues->getAtRank(inputPortNumber)));
-		std::pair<double, unsigned int> pair2;
-		while (pair1.second->find(value) == pair1.second->end()) {
-			pair1.second->insert({value, 0});
-		}
-		pair2 = *(pair1.second->find(value));
-		pair2.second++;
+	if (_queues == nullptr || _queues->size() != _numberOfQueues) {
+		_createInternalAndAttachedData();
 	}
+	if (_queues == nullptr || _queues->size() != _numberOfQueues) {
+		traceError("Match internal queues are not initialized.", TraceManager::Level::L1_errorFatal);
+		return;
+	}
+	if (inputPortNumber >= _queues->size()) {
+		traceError("Match received entity on invalid input port " + std::to_string(inputPortNumber) + ".", TraceManager::Level::L3_errorRecover);
+		return;
+	}
+
+	unsigned int matchSize = static_cast<unsigned int>(_parentModel->parseExpression(_matchSize));
+	if (matchSize == 0) {
+		traceError("MatchSize evaluated to zero. Entity will remain waiting.", TraceManager::Level::L3_errorRecover);
+		return;
+	}
+
+	double tnow = 0.0;
+	if (_parentModel->getSimulation() != nullptr) {
+		tnow = _parentModel->getSimulation()->getSimulatedTime();
+	}
+	Waiting* waiting = new Waiting(entity, tnow, this);
 	_queues->getAtRank(inputPortNumber)->insertElement(waiting);
-	unsigned int matchSize = _parentModel->parseExpression(_matchSize);
-	unsigned int i = 0;
+
 	if (_rule == Match::Rule::Any) {
 		bool foundAll = true;
-		while (foundAll && i < _queues->size()) {
-			foundAll &= _queues->getAtRank(i++)->size() >= matchSize;
+		for (unsigned int i = 0; foundAll && i < _queues->size(); ++i) {
+			foundAll = foundAll && (_queues->getAtRank(i)->size() >= matchSize);
 		}
 		if (foundAll) {
 			// release entities
-			Entity* waitingEntity;
+			Entity* waitingEntity = nullptr;
 			for (Queue* queue : *_queues->list()) {
-				for (i = 0; i < matchSize; i++) {
+				for (unsigned int i = 0; i < matchSize; i++) {
 					waiting = queue->first();
+					if (waiting == nullptr) {
+						break;
+					}
 					waitingEntity = waiting->getEntity();
 					queue->removeElement(waiting);
-					// @TODO: Actualize STATISTICS about queue/wait time
 					_parentModel->sendEntityToComponent(waitingEntity, this->getConnectionManager()->getFrontConnection(), 0.0);
 				}
 			}
 		}
-	} else {
-		// by attribute
-		bool foundAll = true;
-		while (foundAll && i < _queues->size()) {
+	} else if (_rule == Match::Rule::ByAttribute) {
+		std::list<double> candidateValues;
+		Queue* firstQueue = _queues->size() > 0 ? _queues->getAtRank(0) : nullptr;
+		if (firstQueue != nullptr) {
+			for (unsigned int i = 0; i < firstQueue->size(); ++i) {
+				Waiting* queueWaiting = firstQueue->getAtRank(i);
+				if (queueWaiting != nullptr) {
+					double candidate = queueWaiting->getEntity()->getAttributeValue(_attributeName);
+					if (std::find(candidateValues.begin(), candidateValues.end(), candidate) == candidateValues.end()) {
+						candidateValues.push_back(candidate);
+					}
+				}
+			}
+		}
+		double selectedValue = 0.0;
+		bool foundMatch = false;
+		for (double candidate : candidateValues) {
+			bool candidateInAllQueues = true;
+			for (unsigned int q = 0; candidateInAllQueues && q < _queues->size(); ++q) {
+				Queue* queue = _queues->getAtRank(q);
+				unsigned int countInQueue = 0;
+				for (unsigned int i = 0; i < queue->size(); ++i) {
+					Waiting* queueWaiting = queue->getAtRank(i);
+					if (queueWaiting != nullptr && queueWaiting->getEntity()->getAttributeValue(_attributeName) == candidate) {
+						++countInQueue;
+						if (countInQueue >= matchSize) {
+							break;
+						}
+					}
+				}
+				candidateInAllQueues = countInQueue >= matchSize;
+			}
+			if (candidateInAllQueues) {
+				selectedValue = candidate;
+				foundMatch = true;
+				break;
+			}
+		}
+
+		if (foundMatch) {
+			for (unsigned int q = 0; q < _queues->size(); ++q) {
+				Queue* queue = _queues->getAtRank(q);
+				unsigned int released = 0;
+				for (unsigned int i = 0; i < queue->size() && released < matchSize; /* no increment */) {
+					Waiting* queueWaiting = queue->getAtRank(i);
+					if (queueWaiting != nullptr && queueWaiting->getEntity()->getAttributeValue(_attributeName) == selectedValue) {
+						Entity* waitingEntity = queueWaiting->getEntity();
+						queue->removeElement(queueWaiting);
+						_parentModel->sendEntityToComponent(waitingEntity, this->getConnectionManager()->getFrontConnection(), 0.0);
+						++released;
+						continue;
+					}
+					++i;
+				}
+			}
 		}
 	}
 }
@@ -126,9 +187,9 @@ bool Match::_loadInstance(PersistenceRecord *fields) {
 	bool res = ModelComponent::_loadInstance(fields);
 	if (res) {
 		_rule =  static_cast<Rule>(fields->loadField("rule", static_cast<int>(DEFAULT.rule)));
+		_numberOfQueues = fields->loadField("numberOfQueues", DEFAULT.numberOfQueues);
 		_matchSize = fields->loadField("matchSize", DEFAULT.matchSize);
 		_attributeName = fields->loadField("attributeName", DEFAULT.attributeName);
-		//@TODO _queues
 	}
 	return res;
 }
@@ -136,6 +197,7 @@ bool Match::_loadInstance(PersistenceRecord *fields) {
 void Match::_saveInstance(PersistenceRecord *fields, bool saveDefaultValues) {
 	ModelComponent::_saveInstance(fields, saveDefaultValues);
 	fields->saveField("rule", static_cast<int> (_rule), static_cast<int> (DEFAULT.rule), saveDefaultValues);
+	fields->saveField("numberOfQueues", _numberOfQueues, DEFAULT.numberOfQueues, saveDefaultValues);
 	fields->saveField("matchSize", _matchSize, DEFAULT.matchSize, saveDefaultValues);
 	fields->saveField("attributeName", _attributeName, DEFAULT.attributeName, saveDefaultValues);
 	fields->saveField("queues", _queues->size(), 0u, saveDefaultValues);
@@ -175,19 +237,29 @@ unsigned int Match::getNumberOfQueues() const {
 
 bool Match::_check(std::string& errorMessage) {
 	bool resultAll = true;
-	// @TODO: not implemented yet
-	errorMessage += "";
+	if (_numberOfQueues < 2) {
+		errorMessage += "NumberOfQueues must be at least 2. ";
+		resultAll = false;
+	}
+	resultAll &= _parentModel->checkExpression(_matchSize, "MatchSize", errorMessage);
+	const bool attributeMandatory = _rule == Match::Rule::ByAttribute;
+	resultAll &= _parentModel->getDataManager()->check(Util::TypeOf<Attribute>(), _attributeName, "AttributeName", attributeMandatory, errorMessage);
 	return resultAll;
 }
 
 void Match::_createInternalAndAttachedData() {
 	while (_queues->size() > _numberOfQueues) {
-		this->_internalDataRemove(_queues->last()->getName());
-		_internalDataRemove(_queues->last()->getName());
+		Queue* obsoleteQueue = _queues->last();
+		_internalDataRemove(obsoleteQueue->getName());
 		_queues->remove(_queues->last());
+		_entitiesByAttrib->erase(obsoleteQueue);
 	}
 	while (_queues->size() < _numberOfQueues) {
 		Queue* newQueue = _parentModel->getParentSimulator()->getPluginManager()->newInstance<Queue>(_parentModel, getName() + ".Queue" + std::to_string(_queues->size()));
+		if (newQueue == nullptr) {
+			newQueue = new Queue(_parentModel, getName() + ".Queue" + std::to_string(_queues->size()));
+		}
+		ModelDataDefinition::CreateInternalData(newQueue);
 		_queues->insert(newQueue);
 		_internalDataInsert(newQueue->getName(), newQueue);
 	}
@@ -196,7 +268,6 @@ void Match::_createInternalAndAttachedData() {
 PluginInformation * Match::GetPluginInformation() {
 	PluginInformation* info = new PluginInformation(Util::TypeOf<Match>(), &Match::LoadInstance, &Match::NewInstance);
 	info->setCategory("Decision");
-	info->setMaximumInputs(2);
 	info->setMaximumInputs(99);
 	//info->getDynamicLibFilenameDependencies()->insert("queue.so");
 	// ...

--- a/source/tests/unit/test_simulator_runtime.cpp
+++ b/source/tests/unit/test_simulator_runtime.cpp
@@ -25,6 +25,7 @@
 #include "plugins/components/Delay.h"
 #include "plugins/components/Batch.h"
 #include "plugins/components/Separate.h"
+#include "plugins/components/Match.h"
 #define private public
 #define protected public
 #include "plugins/components/Wait.h"
@@ -406,6 +407,31 @@ public:
 
     void DispatchEventProbe(Entity* entity, unsigned int inputPortNumber = 0) {
         _onDispatchEvent(entity, inputPortNumber);
+    }
+};
+
+class MatchProbe : public Match {
+public:
+    MatchProbe(Model* model, const std::string& name = "") : Match(model, name) {}
+
+    bool CheckProbe(std::string& errorMessage) {
+        return _check(errorMessage);
+    }
+
+    void CreateInternalAndAttachedDataProbe() {
+        _createInternalAndAttachedData();
+    }
+
+    void DispatchEventProbe(Entity* entity, unsigned int inputPortNumber = 0) {
+        _onDispatchEvent(entity, inputPortNumber);
+    }
+
+    void SaveInstanceProbe(PersistenceRecord* fields, bool saveDefaultValues = false) {
+        _saveInstance(fields, saveDefaultValues);
+    }
+
+    bool LoadInstanceProbe(PersistenceRecord* fields) {
+        return _loadInstance(fields);
     }
 };
 
@@ -2603,6 +2629,187 @@ TEST(SimulatorRuntimeTest, SignalDataCheckPassesWithValidHandler) {
     std::string errorMessage;
     EXPECT_TRUE(signal.CheckProbe(errorMessage));
     EXPECT_TRUE(errorMessage.empty());
+}
+
+TEST(SimulatorRuntimeTest, MatchAnyReleasesOnlyWhenAllQueuesHaveEnoughEntities) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    MatchProbe match(model, "MatchAnyBasic");
+    CollectorSinkComponentProbe sink(model, "MatchAnyBasicSink");
+    match.connectTo(&sink);
+    match.setRule(Match::Rule::Any);
+    match.setNumberOfQueues(2);
+    match.setMatchSize("1");
+    match.CreateInternalAndAttachedDataProbe();
+
+    EntityType* partType = new EntityType(model, "MatchAnyBasicPart");
+    Entity* q0e1 = model->createEntity("MatchAnyQ0E1", true);
+    Entity* q1e1 = model->createEntity("MatchAnyQ1E1", true);
+    q0e1->setEntityType(partType);
+    q1e1->setEntityType(partType);
+
+    match.DispatchEventProbe(q0e1, 0);
+    DrainFutureEvents(model);
+    EXPECT_TRUE(sink.ReceivedEntities().empty());
+
+    match.DispatchEventProbe(q1e1, 1);
+    DrainFutureEvents(model);
+
+    ASSERT_EQ(sink.ReceivedEntities().size(), 2u);
+    EXPECT_EQ(sink.ReceivedEntities()[0], q0e1);
+    EXPECT_EQ(sink.ReceivedEntities()[1], q1e1);
+}
+
+TEST(SimulatorRuntimeTest, MatchAnyWithMatchSizeTwoReleasesExactlyTwoPerQueueAndKeepsOverflowWaiting) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    MatchProbe match(model, "MatchAnySizeTwo");
+    CollectorSinkComponentProbe sink(model, "MatchAnySizeTwoSink");
+    match.connectTo(&sink);
+    match.setRule(Match::Rule::Any);
+    match.setNumberOfQueues(2);
+    match.setMatchSize("2");
+    match.CreateInternalAndAttachedDataProbe();
+
+    EntityType* partType = new EntityType(model, "MatchAnySizeTwoPart");
+    Entity* q0e1 = model->createEntity("MatchAny2Q0E1", true);
+    Entity* q0e2 = model->createEntity("MatchAny2Q0E2", true);
+    Entity* q0e3 = model->createEntity("MatchAny2Q0E3", true);
+    Entity* q1e1 = model->createEntity("MatchAny2Q1E1", true);
+    Entity* q1e2 = model->createEntity("MatchAny2Q1E2", true);
+    q0e1->setEntityType(partType);
+    q0e2->setEntityType(partType);
+    q0e3->setEntityType(partType);
+    q1e1->setEntityType(partType);
+    q1e2->setEntityType(partType);
+
+    match.DispatchEventProbe(q0e1, 0);
+    match.DispatchEventProbe(q0e2, 0);
+    match.DispatchEventProbe(q0e3, 0);
+    match.DispatchEventProbe(q1e1, 1);
+    match.DispatchEventProbe(q1e2, 1);
+    DrainFutureEvents(model);
+
+    Queue* q0 = dynamic_cast<Queue*>(model->getDataManager()->getDataDefinition(Util::TypeOf<Queue>(), "MatchAnySizeTwo.Queue0"));
+    Queue* q1 = dynamic_cast<Queue*>(model->getDataManager()->getDataDefinition(Util::TypeOf<Queue>(), "MatchAnySizeTwo.Queue1"));
+    ASSERT_NE(q0, nullptr);
+    ASSERT_NE(q1, nullptr);
+    EXPECT_EQ(q0->size(), 1u);
+    EXPECT_EQ(q1->size(), 0u);
+    ASSERT_EQ(sink.ReceivedEntities().size(), 4u);
+}
+
+TEST(SimulatorRuntimeTest, MatchByAttributeSynchronizesOnlyCompatibleAttributeValues) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    (void)new Attribute(model, "Color");
+    MatchProbe match(model, "MatchByAttribute");
+    CollectorSinkComponentProbe sink(model, "MatchByAttributeSink");
+    match.connectTo(&sink);
+    match.setRule(Match::Rule::ByAttribute);
+    match.setNumberOfQueues(2);
+    match.setMatchSize("1");
+    match.setAttributeName("Color");
+    match.CreateInternalAndAttachedDataProbe();
+
+    EntityType* partType = new EntityType(model, "MatchByAttributePart");
+    Entity* q0Color1 = model->createEntity("MatchByAttrQ0Color1", true);
+    Entity* q1Color2 = model->createEntity("MatchByAttrQ1Color2", true);
+    Entity* q0Color2 = model->createEntity("MatchByAttrQ0Color2", true);
+    q0Color1->setEntityType(partType);
+    q1Color2->setEntityType(partType);
+    q0Color2->setEntityType(partType);
+    q0Color1->setAttributeValue("Color", 1.0);
+    q1Color2->setAttributeValue("Color", 2.0);
+    q0Color2->setAttributeValue("Color", 2.0);
+
+    match.DispatchEventProbe(q0Color1, 0);
+    match.DispatchEventProbe(q1Color2, 1);
+    DrainFutureEvents(model);
+    EXPECT_TRUE(sink.ReceivedEntities().empty());
+
+    match.DispatchEventProbe(q0Color2, 0);
+    DrainFutureEvents(model);
+
+    Queue* q0 = dynamic_cast<Queue*>(model->getDataManager()->getDataDefinition(Util::TypeOf<Queue>(), "MatchByAttribute.Queue0"));
+    Queue* q1 = dynamic_cast<Queue*>(model->getDataManager()->getDataDefinition(Util::TypeOf<Queue>(), "MatchByAttribute.Queue1"));
+    ASSERT_NE(q0, nullptr);
+    ASSERT_NE(q1, nullptr);
+    ASSERT_EQ(sink.ReceivedEntities().size(), 2u);
+    EXPECT_EQ(q0->size(), 1u);
+    EXPECT_EQ(q1->size(), 0u);
+    EXPECT_EQ(sink.ReceivedEntities()[0], q0Color2);
+    EXPECT_EQ(sink.ReceivedEntities()[1], q1Color2);
+}
+
+TEST(SimulatorRuntimeTest, MatchPersistenceRoundTripPreservesRuleQueueCountMatchSizeAndAttribute) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    MatchProbe source(model, "MatchPersistSource");
+    source.setRule(Match::Rule::ByAttribute);
+    source.setNumberOfQueues(4);
+    source.setMatchSize("3");
+    source.setAttributeName("Color");
+
+    FakeModelPersistenceRuntime persistence;
+    PersistenceRecord fields(persistence);
+    source.SaveInstanceProbe(&fields, true);
+
+    MatchProbe loaded(model, "MatchPersistLoaded");
+    ASSERT_TRUE(loaded.LoadInstanceProbe(&fields));
+    EXPECT_EQ(loaded.getRule(), Match::Rule::ByAttribute);
+    EXPECT_EQ(loaded.getNumberOfQueues(), 4u);
+    EXPECT_EQ(loaded.getMatchSize(), "3");
+    EXPECT_EQ(loaded.getAttributeName(), "Color");
+}
+
+TEST(SimulatorRuntimeTest, MatchCheckValidatesQueueCountMatchSizeAndByAttributeContract) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    MatchProbe invalidQueues(model, "MatchCheckInvalidQueues");
+    invalidQueues.setRule(Match::Rule::Any);
+    invalidQueues.setNumberOfQueues(1);
+    invalidQueues.setMatchSize("1");
+    std::string invalidQueuesError;
+    EXPECT_FALSE(invalidQueues.CheckProbe(invalidQueuesError));
+    EXPECT_NE(invalidQueuesError.find("NumberOfQueues"), std::string::npos);
+
+    MatchProbe invalidMatchSize(model, "MatchCheckInvalidExpression");
+    invalidMatchSize.setRule(Match::Rule::Any);
+    invalidMatchSize.setNumberOfQueues(2);
+    invalidMatchSize.setMatchSize("bad_expr(");
+    std::string invalidExpressionError;
+    EXPECT_FALSE(invalidMatchSize.CheckProbe(invalidExpressionError));
+    EXPECT_NE(invalidExpressionError.find("MatchSize"), std::string::npos);
+
+    MatchProbe invalidAttribute(model, "MatchCheckInvalidAttribute");
+    invalidAttribute.setRule(Match::Rule::ByAttribute);
+    invalidAttribute.setNumberOfQueues(2);
+    invalidAttribute.setMatchSize("1");
+    invalidAttribute.setAttributeName("MissingColorAttribute");
+    std::string invalidAttributeError;
+    EXPECT_FALSE(invalidAttribute.CheckProbe(invalidAttributeError));
+    EXPECT_NE(invalidAttributeError.find("AttributeName"), std::string::npos);
+
+    (void)new Attribute(model, "Color");
+    MatchProbe valid(model, "MatchCheckValid");
+    valid.setRule(Match::Rule::ByAttribute);
+    valid.setNumberOfQueues(2);
+    valid.setMatchSize("1");
+    valid.setAttributeName("Color");
+    std::string validError;
+    EXPECT_TRUE(valid.CheckProbe(validError));
+    EXPECT_TRUE(validError.empty());
 }
 
 TEST(SimulatorRuntimeTest, BatchAnyFormsSingleBatchWithAtLeastBatchSizeAndKeepsOverflowQueued) {


### PR DESCRIPTION
### Motivation
- Close multiple defects in the `Match` component so it behaves predictably at runtime: missing validation, incomplete persistence, inconsistent internal queue reconciliation, and broken matching semantics for both `Any` and `ByAttribute` rules.
- Keep changes minimal and deterministic to allow safe review and integration without redesigning kernel subsystems.

### Description
- Persist/load `numberOfQueues` explicitly and continue saving/loading `rule`, `matchSize` and `attributeName` to complete the component round-trip persistence contract.
- Implement `_check()` to validate `NumberOfQueues >= 2`, check `MatchSize` expression validity, and require `AttributeName` only when `Rule::ByAttribute` is configured, producing informative error messages.
- Reconcile internal queues in `_createInternalAndAttachedData()` by removing obsolete queues cleanly, erasing related index state, creating missing queues with plugin fallback (`new Queue(...)`) and calling `CreateInternalData` to initialize internals.
- Implement `Rule::Any` runtime semantics: enqueue by `inputPortNumber`, validate port and internal queues, evaluate `matchSize`, check all queues have at least `matchSize` elements, and release exactly `matchSize` entities per queue in FIFO order.
- Implement `Rule::ByAttribute` runtime semantics via a simple deterministic scan: collect candidate attribute values from the first queue, verify a candidate exists with at least `matchSize` entries in every queue, and release exactly `matchSize` compatible entities per queue preserving FIFO order.
- Harden input-port validation and zero `MatchSize` handling, and remove duplicated `setMaximumInputs()` call in `GetPluginInformation()`.
- Add `MatchProbe` and unit tests covering the required regression scenarios (Any basic blocking, Any with matchSize>1 and overflow, ByAttribute synchronization, persistence round-trip, and `_check()` failure/success cases).

### Testing
- Ran configuration and build: `cmake -S . -B build -G Ninja` and `cmake --build build`, both completed successfully.
- Ran the simulator runtime unit binary: `./build/source/tests/unit/genesys_test_simulator_runtime` and the full binary executed; the suite ran and the modified/added Match tests passed (match-focused tests and runtime binary execution succeeded).
- Ran `ctest --test-dir build -L unit --output-on-failure`; build/tests completed but 3 preexisting `StatisticsTest` cases failed (unrelated to Match) while the Match-related tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da50162abc832187f2c1016e4de50e)