### PR TITLE
Harden Label data element destination handling and add runtime tests

### DIFF
--- a/source/plugins/data/Label.cpp
+++ b/source/plugins/data/Label.cpp
@@ -70,7 +70,11 @@ PluginInformation* Label::GetPluginInformation() {
 //
 
 std::string Label::show() {
-	return ModelDataDefinition::show();
+	std::string msg = ModelDataDefinition::show();
+	msg += ",label=\"" + _label + "\"";
+	msg += ",enteringComponent=";
+	msg += (_enteringLabelComponent != nullptr ? _enteringLabelComponent->getName() : "NULL");
+	return msg;
 }
 
 void Label::setLabel(std::string _label) {
@@ -81,12 +85,20 @@ std::string Label::getLabel() const {
 	return _label;
 }
 
+void Label::setEnterIntoLabelComponent(ModelComponent* enteringLabelComponent) {
+	_enteringLabelComponent = enteringLabelComponent;
+}
+
 ModelComponent* Label::getEnterIntoLabelComponent() const {
 	return _enteringLabelComponent;
 }
 
 void Label::sendEntityToLabelComponent(Entity* entity, double timeDelay) {
 	//_parentModel->sendEntityToComponent(entity, _enteringLabelComponent->getConnections()->getFrontConnection(), timeDelay);
+	if (_enteringLabelComponent == nullptr) {
+		traceError("Label \"" + getName() + "\" has no entering component defined. Entity was not sent.", TraceManager::Level::L2_results);
+		return;
+	}
 	_parentModel->sendEntityToComponent(entity, _enteringLabelComponent, timeDelay);
 }
 
@@ -97,9 +109,16 @@ bool Label::_loadInstance(PersistenceRecord *fields) {
 	if (res) {
 		try {
 			this->_label = fields->loadField("label", "");
+			this->_enteringLabelComponent = nullptr;
 			std::string componentName = fields->loadField("enteringComponentName", "");
-			ModelComponent* comp = _parentModel->getComponentManager()->find(componentName);
-			this->_enteringLabelComponent = comp;
+			if (!componentName.empty()) {
+				ModelComponent* comp = _parentModel->getComponentManager()->find(componentName);
+				if (comp == nullptr) {
+					traceError("Label \"" + getName() + "\" could not resolve entering component \"" + componentName + "\" while loading.", TraceManager::Level::L2_results);
+				} else {
+					this->_enteringLabelComponent = comp;
+				}
+			}
 		} catch (...) {
 		}
 	}
@@ -118,9 +137,18 @@ void Label::_saveInstance(PersistenceRecord *fields, bool saveDefaultValues) {
 
 bool Label::_check(std::string& errorMessage) {
 	bool resultAll = true;
-	resultAll &= (_enteringLabelComponent != nullptr);
-	if (!resultAll) {
-		errorMessage += "Entering Label Component was not defined";
+	_attachedDataRemove("EnteringLabelComponent");
+	if (_enteringLabelComponent == nullptr) {
+		errorMessage += "Label \"" + getName() + "\" entering component was not defined. ";
+		resultAll = false;
+	} else {
+		ModelComponent* modelComponentByName = _parentModel->getComponentManager()->find(_enteringLabelComponent->getName());
+		if (modelComponentByName == nullptr || modelComponentByName != _enteringLabelComponent) {
+			errorMessage += "Label \"" + getName() + "\" entering component \"" + _enteringLabelComponent->getName() + "\" is stale or not owned by this model. ";
+			resultAll = false;
+		} else {
+			_attachedDataInsert("EnteringLabelComponent", _enteringLabelComponent);
+		}
 	}
 	return resultAll;
 }

--- a/source/plugins/data/Label.h
+++ b/source/plugins/data/Label.h
@@ -27,6 +27,7 @@ public:
 	virtual std::string show() override;
 	void setLabel(std::string _label);
 	std::string getLabel() const;
+	void setEnterIntoLabelComponent(ModelComponent* enteringLabelComponent);
 	ModelComponent* getEnterIntoLabelComponent() const;
 	void sendEntityToLabelComponent(Entity* entity, double timeDelay);
 protected: // must be overriden 
@@ -43,4 +44,3 @@ private:
 };
 
 #endif /* LABEL_H */
-

--- a/source/tests/unit/test_simulator_runtime.cpp
+++ b/source/tests/unit/test_simulator_runtime.cpp
@@ -21,6 +21,7 @@
 #include "plugins/data/SignalData.h"
 #include "plugins/data/Station.h"
 #include "plugins/data/Set.h"
+#include "plugins/data/Label.h"
 #include "plugins/data/EntityGroup.h"
 #include "plugins/components/Delay.h"
 #include "plugins/components/Batch.h"
@@ -478,6 +479,23 @@ public:
 
     void CreateInternalAndAttachedDataProbe() {
         _createInternalAndAttachedData();
+    }
+};
+
+class LabelProbe : public Label {
+public:
+    LabelProbe(Model* model, const std::string& name = "") : Label(model, name) {}
+
+    bool CheckProbe(std::string& errorMessage) {
+        return _check(errorMessage);
+    }
+
+    bool LoadInstanceProbe(PersistenceRecord* fields) {
+        return _loadInstance(fields);
+    }
+
+    void SaveInstanceProbe(PersistenceRecord* fields, bool saveDefaultValues = false) {
+        _saveInstance(fields, saveDefaultValues);
     }
 };
 
@@ -1920,6 +1938,106 @@ TEST(SimulatorRuntimeTest, SequenceCheckPassesForValidSteps) {
 
     std::string errorMessage;
     EXPECT_TRUE(sequence.CheckProbe(errorMessage));
+    EXPECT_TRUE(errorMessage.empty());
+}
+
+TEST(SimulatorRuntimeTest, LabelCheckFailsWithoutEnteringComponent) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    LabelProbe label(model, "LabelCheckMissingDestination");
+    std::string errorMessage;
+    EXPECT_FALSE(label.CheckProbe(errorMessage));
+    EXPECT_NE(errorMessage.find("entering component was not defined"), std::string::npos);
+    EXPECT_EQ(label.getAttachedData()->count("EnteringLabelComponent"), 0u);
+}
+
+TEST(SimulatorRuntimeTest, LabelCheckPassesWithValidEnteringComponentAndAttachesIt) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    LabelProbe label(model, "LabelCheckValidDestination");
+    CollectorSinkComponentProbe sink(model, "LabelCheckSink");
+    label.setEnterIntoLabelComponent(&sink);
+
+    std::string errorMessage;
+    EXPECT_TRUE(label.CheckProbe(errorMessage));
+    EXPECT_TRUE(errorMessage.empty());
+    ASSERT_EQ(label.getAttachedData()->count("EnteringLabelComponent"), 1u);
+    EXPECT_EQ(label.getAttachedData()->at("EnteringLabelComponent"), &sink);
+}
+
+TEST(SimulatorRuntimeTest, LabelLoadWithMissingEnteringComponentRemainsTraceableAndCheckFails) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    FakeModelPersistenceRuntime persistence;
+    PersistenceRecord fields(persistence);
+    fields.saveField("typename", Util::TypeOf<Label>());
+    fields.saveField("id", 1u);
+    fields.saveField("name", "LabelLoadMissingDestination");
+    fields.saveField("reportStatistics", true);
+    fields.saveField("label", "Dock-A");
+    fields.saveField("enteringComponentName", "ComponentThatDoesNotExist");
+
+    LabelProbe loaded(model, "LabelLoadMissingDestination");
+    ASSERT_TRUE(loaded.LoadInstanceProbe(&fields));
+    EXPECT_EQ(loaded.getEnterIntoLabelComponent(), nullptr);
+    EXPECT_EQ(loaded.getLabel(), "Dock-A");
+
+    std::string errorMessage;
+    EXPECT_FALSE(loaded.CheckProbe(errorMessage));
+    EXPECT_NE(errorMessage.find("entering component was not defined"), std::string::npos);
+}
+
+TEST(SimulatorRuntimeTest, LabelSendEntityWithoutDestinationDoesNotCrash) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    LabelProbe label(model, "LabelSafeSendWithoutDestination");
+    EXPECT_NO_THROW(label.sendEntityToLabelComponent(nullptr, 0.0));
+}
+
+TEST(SimulatorRuntimeTest, LabelShowIncludesLabelAndEnteringComponent) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    LabelProbe label(model, "LabelShowProbe");
+    CollectorSinkComponentProbe sink(model, "LabelShowSink");
+    label.setLabel("Station-Transfer");
+    label.setEnterIntoLabelComponent(&sink);
+
+    const std::string shown = label.show();
+    EXPECT_NE(shown.find("label=\"Station-Transfer\""), std::string::npos);
+    EXPECT_NE(shown.find("enteringComponent=LabelShowSink"), std::string::npos);
+}
+
+TEST(SimulatorRuntimeTest, LabelSaveAndLoadRoundTripPreservesLabelAndEnteringComponentName) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    CollectorSinkComponentProbe sink(model, "LabelPersistSink");
+    LabelProbe source(model, "LabelPersistSource");
+    source.setLabel("QueueToSink");
+    source.setEnterIntoLabelComponent(&sink);
+
+    FakeModelPersistenceRuntime persistence;
+    PersistenceRecord fields(persistence);
+    source.SaveInstanceProbe(&fields, true);
+
+    LabelProbe loaded(model, "LabelPersistLoaded");
+    ASSERT_TRUE(loaded.LoadInstanceProbe(&fields));
+    EXPECT_EQ(loaded.getLabel(), "QueueToSink");
+    EXPECT_EQ(loaded.getEnterIntoLabelComponent(), &sink);
+
+    std::string errorMessage;
+    EXPECT_TRUE(loaded.CheckProbe(errorMessage));
     EXPECT_TRUE(errorMessage.empty());
 }
 


### PR DESCRIPTION
### Motivation
- Close robustness gaps in the `Label` data element by ensuring destination pointers are safe, load/check operations are observable and coherent, and `show()` exposes useful state.
- Prevent crashes and stale-pointer behavior when a `Label` references a missing or removed receiving component and provide actionable diagnostics for persistence/load workflows.

### Description
- Added `setEnterIntoLabelComponent(ModelComponent*)` to allow explicit assignment of the entering component and retained existing getter `getEnterIntoLabelComponent()`.
- Improved `show()` to include the `Label` value and the entering component name (or `NULL`).
- Made `sendEntityToLabelComponent()` safe by guarding against `nullptr` destination and emitting a trace error instead of dereferencing a null/stale pointer.
- Hardened `_loadInstance()` to reset internal pointer state before resolution and emit a trace error when the persisted `enteringComponentName` cannot be resolved.
- Reworked `_check()` to provide useful error messages, verify the referenced component is still present in the model via `ComponentManager::find(...)`, and keep attached-data entry `EnteringLabelComponent` synchronized with validity.
- Added unit-test probes and six Label-focused tests to `source/tests/unit/test_simulator_runtime.cpp` covering check/load/send/show and persistence round-trip behavior.

### Testing
- Configured and built tests with `cmake -S . -B build -G Ninja -DGENESYS_BUILD_TESTS=ON -DGENESYS_BUILD_KERNEL=ON -DGENESYS_BUILD_PARSER=ON -DGENESYS_BUILD_PLUGINS=ON -DGENESYS_TERMINAL_APPLICATION=OFF -DGENESYS_BUILD_GUI_APPLICATION=OFF -DGENESYS_BUILD_WEB_APPLICATION=OFF`, which completed successfully.
- Built the runtime test target with `cmake --build build --target genesys_test_simulator_runtime`, which completed successfully and produced the test binary.
- Ran targeted Label tests with `ctest --test-dir build -R "SimulatorRuntimeTest.*Label" --output-on-failure` and all Label tests passed (7/7).
- Ran `ctest --test-dir build -LE smoke --output-on-failure`; the runtime tests passed but the full suite reported several `_NOT_BUILT` entries in this configuration (environment/build configuration limitation), not related to the Label changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da50295728832190633cc18cde64e1)