### PR TITLE
Fix EntityGroup runtime lifecycle and replication safety

### DIFF
--- a/source/plugins/data/EntityGroup.cpp
+++ b/source/plugins/data/EntityGroup.cpp
@@ -32,7 +32,10 @@ EntityGroup::EntityGroup(Model* model, std::string name) : ModelDataDefinition(m
 }
 
 EntityGroup::~EntityGroup() {
-	//_parentModel->elements()->remove(Util::TypeOf<StatisticsCollector>(), _cstatNumberInGroup);
+	_clearGroups();
+	delete _groupMap;
+	_groupMap = nullptr;
+	_cstatNumberInGroup = nullptr;
 }
 
 std::string EntityGroup::show() {
@@ -47,24 +50,46 @@ void EntityGroup::insertElement(unsigned int idKey, Entity* modeldatum) {
 		it = _groupMap->find(idKey);
 	}
 	(*it).second->insert(modeldatum);
-	_cstatNumberInGroup->getStatistics()->getCollector()->addValue((*it).second->size());
+	if (_cstatNumberInGroup != nullptr) {
+		_cstatNumberInGroup->getStatistics()->getCollector()->addValue((*it).second->size());
+	}
 }
 
 void EntityGroup::removeElement(unsigned int idKey, Entity * modeldatum) {
 	std::map<unsigned int, List<Entity*>*>::iterator it = _groupMap->find(idKey);
 	if (it != _groupMap->end()) {
 		(*it).second->remove(modeldatum);
-		_cstatNumberInGroup->getStatistics()->getCollector()->addValue((*it).second->size());
+		if (_cstatNumberInGroup != nullptr) {
+			_cstatNumberInGroup->getStatistics()->getCollector()->addValue((*it).second->size());
+		}
+		if ((*it).second->size() == 0) {
+			_detachedEmptyGroups.push_back((*it).second);
+			_groupMap->erase(it);
+		}
 	}
 }
 
 List<Entity*>* EntityGroup::getGroup(unsigned int idKey) {
 	std::map<unsigned int, List<Entity*>*>::iterator it = _groupMap->find(idKey);
 	if (it == _groupMap->end()) {
-		return new List<Entity*>(); // not found
+		return nullptr;
 	} else {
 		return (*it).second;
 	}
+}
+
+void EntityGroup::_clearGroups() {
+	if (_groupMap == nullptr) {
+		return;
+	}
+	for (auto& entry : *_groupMap) {
+		delete entry.second;
+	}
+	_groupMap->clear();
+	for (List<Entity*>* detachedGroup : _detachedEmptyGroups) {
+		delete detachedGroup;
+	}
+	_detachedEmptyGroups.clear();
 }
 
 bool EntityGroup::_loadInstance(PersistenceRecord *fields) {
@@ -107,10 +132,15 @@ void EntityGroup::_createInternalAndAttachedData() {
 			_cstatNumberInGroup = new StatisticsCollector(_parentModel, "NumberInGroup", this);
 			_internalDataInsert("NumberInGroup", _cstatNumberInGroup);
 		}
-	} else
-		if (_cstatNumberInGroup != nullptr) {
+	} else if (_cstatNumberInGroup != nullptr) {
 		_internalDataClear();
+		_cstatNumberInGroup = nullptr;
 	}
+}
+
+void EntityGroup::_initBetweenReplications() {
+	ModelDataDefinition::_initBetweenReplications();
+	_clearGroups();
 }
 
 bool EntityGroup::_check(std::string& errorMessage) {

--- a/source/plugins/data/EntityGroup.h
+++ b/source/plugins/data/EntityGroup.h
@@ -17,6 +17,7 @@
 #include "../../kernel/simulator/ModelDataDefinition.h"
 #include "../../kernel/simulator/Entity.h"
 #include "../../kernel/util/List.h"
+#include <list>
 #include <map>
 
 /*
@@ -39,20 +40,20 @@ public:
 	void insertElement(unsigned int idKey, Entity* modeldatum);
 	void removeElement(unsigned int idKey, Entity* modeldatum);
 	List<Entity*>* getGroup(unsigned int idKey);
-public:
-	void initBetweenReplications();
 protected:
 	virtual bool _loadInstance(PersistenceRecord *fields) override;
 	virtual void _saveInstance(PersistenceRecord *fields, bool saveDefaultValues) override;
 	virtual bool _check(std::string& errorMessage) override;
+	virtual void _initBetweenReplications() override;
 	virtual void _createInternalAndAttachedData() override;
 private:
+	void _clearGroups();
 	void _initCStats();
 private: //1::n
 	std::map<unsigned int, List<Entity*>*>* _groupMap = new std::map<unsigned int, List<Entity*>*>();
+	std::list<List<Entity*>*> _detachedEmptyGroups;
 private: // child inner modeldatum
 	StatisticsCollector* _cstatNumberInGroup = nullptr;
 };
 
 #endif /* ENTITYGROUP_H */
-

--- a/source/tests/unit/test_simulator_runtime.cpp
+++ b/source/tests/unit/test_simulator_runtime.cpp
@@ -22,7 +22,11 @@
 #include "plugins/data/Station.h"
 #include "plugins/data/Set.h"
 #include "plugins/data/Label.h"
+#define private public
+#define protected public
 #include "plugins/data/EntityGroup.h"
+#undef protected
+#undef private
 #include "plugins/components/Delay.h"
 #include "plugins/components/Batch.h"
 #include "plugins/components/Separate.h"
@@ -408,6 +412,23 @@ public:
 
     void DispatchEventProbe(Entity* entity, unsigned int inputPortNumber = 0) {
         _onDispatchEvent(entity, inputPortNumber);
+    }
+};
+
+class EntityGroupProbe : public EntityGroup {
+public:
+    EntityGroupProbe(Model* model, const std::string& name = "") : EntityGroup(model, name) {}
+
+    void InitBetweenReplicationsProbe() {
+        _initBetweenReplications();
+    }
+
+    void CreateInternalAndAttachedDataProbe() {
+        _createInternalAndAttachedData();
+    }
+
+    StatisticsCollector* NumberInGroupCollectorProbe() const {
+        return _cstatNumberInGroup;
     }
 };
 
@@ -3135,4 +3156,111 @@ TEST(SimulatorRuntimeTest, SeparateCheckAndValidGroupReferenceRemainCoherent) {
     ASSERT_EQ(sink.ReceivedEntities().size(), 1u);
     EXPECT_EQ(sink.ReceivedEntities()[0], member);
     EXPECT_EQ(member->getAttributeValue("Entity.Group"), 0.0);
+}
+
+TEST(SimulatorRuntimeTest, EntityGroupInsertAndGetExistingGroupPreservesInsertionOrder) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    EntityGroupProbe entityGroup(model, "EntityGroupExisting");
+    EntityType* partType = new EntityType(model, "EntityGroupExistingPart");
+    Entity* e1 = model->createEntity("GroupE1", true);
+    Entity* e2 = model->createEntity("GroupE2", true);
+    e1->setEntityType(partType);
+    e2->setEntityType(partType);
+
+    const unsigned int groupKey = 101u;
+    entityGroup.insertElement(groupKey, e1);
+    entityGroup.insertElement(groupKey, e2);
+    List<Entity*>* members = entityGroup.getGroup(groupKey);
+
+    ASSERT_NE(members, nullptr);
+    ASSERT_EQ(members->size(), 2u);
+    EXPECT_EQ(members->getAtRank(0), e1);
+    EXPECT_EQ(members->getAtRank(1), e2);
+}
+
+TEST(SimulatorRuntimeTest, EntityGroupGetGroupReturnsNullptrForMissingGroup) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    EntityGroupProbe entityGroup(model, "EntityGroupMissing");
+    EXPECT_EQ(entityGroup.getGroup(999u), nullptr);
+}
+
+TEST(SimulatorRuntimeTest, EntityGroupRemoveElementDeletesEmptyGroupEntry) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    EntityGroupProbe entityGroup(model, "EntityGroupRemove");
+    EntityType* partType = new EntityType(model, "EntityGroupRemovePart");
+    Entity* e1 = model->createEntity("GroupRemoveE1", true);
+    e1->setEntityType(partType);
+
+    const unsigned int groupKey = 202u;
+    entityGroup.insertElement(groupKey, e1);
+    ASSERT_NE(entityGroup.getGroup(groupKey), nullptr);
+
+    entityGroup.removeElement(groupKey, e1);
+    EXPECT_EQ(entityGroup.getGroup(groupKey), nullptr);
+}
+
+TEST(SimulatorRuntimeTest, EntityGroupInitBetweenReplicationsClearsAllRuntimeGroups) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    EntityGroupProbe entityGroup(model, "EntityGroupReplicationReset");
+    EntityType* partType = new EntityType(model, "EntityGroupReplicationResetPart");
+    Entity* e1 = model->createEntity("GroupResetE1", true);
+    Entity* e2 = model->createEntity("GroupResetE2", true);
+    e1->setEntityType(partType);
+    e2->setEntityType(partType);
+
+    entityGroup.insertElement(301u, e1);
+    entityGroup.insertElement(302u, e2);
+    ASSERT_NE(entityGroup.getGroup(301u), nullptr);
+    ASSERT_NE(entityGroup.getGroup(302u), nullptr);
+
+    entityGroup.InitBetweenReplicationsProbe();
+    EXPECT_EQ(entityGroup.getGroup(301u), nullptr);
+    EXPECT_EQ(entityGroup.getGroup(302u), nullptr);
+}
+
+TEST(SimulatorRuntimeTest, EntityGroupStatisticsToggleResetsAndRecreatesCollectorOnRecheck) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    EntityGroupProbe entityGroup(model, "EntityGroupStatsToggle");
+    ASSERT_NE(entityGroup.NumberInGroupCollectorProbe(), nullptr);
+
+    entityGroup.setReportStatistics(false);
+    entityGroup.CreateInternalAndAttachedDataProbe();
+    EXPECT_EQ(entityGroup.NumberInGroupCollectorProbe(), nullptr);
+
+    entityGroup.setReportStatistics(true);
+    entityGroup.CreateInternalAndAttachedDataProbe();
+    EXPECT_NE(entityGroup.NumberInGroupCollectorProbe(), nullptr);
+}
+
+TEST(SimulatorRuntimeTest, EntityGroupDestructorCleansOwnedGroupContainersSafely) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    EXPECT_NO_FATAL_FAILURE({
+        EntityGroupProbe entityGroup(model, "EntityGroupDestructorCleanup");
+        EntityType* partType = new EntityType(model, "EntityGroupDestructorPart");
+        Entity* e1 = model->createEntity("GroupDestructorE1", true);
+        Entity* e2 = model->createEntity("GroupDestructorE2", true);
+        e1->setEntityType(partType);
+        e2->setEntityType(partType);
+        entityGroup.insertElement(401u, e1);
+        entityGroup.insertElement(401u, e2);
+        entityGroup.insertElement(402u, e1);
+    });
 }


### PR DESCRIPTION
### Motivation

- Close real runtime bugs in `EntityGroup`: ownership/leaks of the internal map and lists, unsafe `getGroup()` semantics that returned orphan heap objects, missing reset between replications, dangling statistics collector pointer after a stats toggle, and empty groups lingering in the map.
- Ensure `EntityGroup` behaves like a transient runtime container used by `Batch`/`Separate`: resettable between replicates, safe to query when absent, and deterministic in member ordering and cleanup.

### Description

- Implemented a destructor cleanup path that reclaims all owned `List<Entity*>` objects and deletes the `_groupMap`, and made the collector pointer safe (no dangling pointer). (changes in `EntityGroup.cpp` / `EntityGroup.h`).
- Added a reusable private helper `_clearGroups()` used by both the destructor and the replication-reset hook to centralize group cleanup logic. (new method in `EntityGroup.h` / `EntityGroup.cpp`).
- Changed `getGroup()` to return `nullptr` for missing keys instead of allocating an orphan `List`, and removed empty groups from `_groupMap` inside `removeElement()` while deferring actual delete safely until cleanup. (behavioral changes in `EntityGroup.cpp`).
- Overrode `_initBetweenReplications()` to call `_clearGroups()` (reset runtime state between replications) and fixed `_createInternalAndAttachedData()` to null `_cstatNumberInGroup` after `_internalDataClear()` when statistics are toggled off. (lifecycle fixes in `EntityGroup.cpp` / `EntityGroup.h`).
- Added unit tests and a small test probe `EntityGroupProbe` to `source/tests/unit/test_simulator_runtime.cpp` covering insertion/order, missing-group semantics, empty-group removal, replication reset, stats toggle lifecycle, and destructor safety. (tests added/updated in `test_simulator_runtime.cpp`).

### Testing

- Configured and built tests with `cmake -S . -B build -G Ninja -DGENESYS_BUILD_TESTS=ON -DGENESYS_BUILD_KERNEL=ON -DGENESYS_BUILD_PARSER=ON -DGENESYS_BUILD_PLUGINS=ON -DGENESYS_TERMINAL_APPLICATION=OFF -DGENESYS_BUILD_GUI_APPLICATION=OFF -DGENESYS_BUILD_WEB_APPLICATION=OFF`, and the build completed successfully.
- Built the simulator runtime tests with `cmake --build build --target genesys_test_simulator_runtime` and the target linked successfully.
- Ran focused tests with `ctest --test-dir build -R "SimulatorRuntimeTest.*EntityGroup" --output-on-failure` and all EntityGroup-related tests passed (6/6).
- Ran a broader set that included interacting `Batch`/`Separate` tests with `ctest --test-dir build -R "SimulatorRuntimeTest.(BatchTemporaryThenSeparateReleasesOriginalMembersInOrder|SeparateCheckAndValidGroupReferenceRemainCoherent|EntityGroup.*)" --output-on-failure` and those runs passed (8/8).
- Executed `ctest --test-dir build -LE smoke --output-on-failure` which reported unrelated `*_NOT_BUILT` tests in this configuration (these are not regressions introduced here and are due to the broader test layout), so a partial non-built test list is expected in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da59d349608321b0c0e57184a68181)