### PR TITLE
Harden Process macrocomponent lifecycle, reconcile Seize/Delay/Release and add runtime tests

### DIFF
--- a/source/plugins/components/Process.cpp
+++ b/source/plugins/components/Process.cpp
@@ -175,15 +175,94 @@ void Process::_adjustConnections() {
 	}
 }
 
+void Process::_ensureInternalComponents() {
+	PluginManager* plugins = _parentModel->getParentSimulator()->getPluginManager();
+	if (_seize == nullptr) {
+		_seize = plugins->newInstance<Seize>(_parentModel, getName() + ".Seize");
+		if (_seize == nullptr) {
+			_seize = new Seize(_parentModel, getName() + ".Seize");
+		}
+	}
+	if (_delay == nullptr) {
+		_delay = plugins->newInstance<Delay>(_parentModel, getName() + ".Delay");
+		if (_delay == nullptr) {
+			_delay = new Delay(_parentModel, getName() + ".Delay");
+		}
+	}
+	if (_release == nullptr) {
+		_release = plugins->newInstance<Release>(_parentModel, getName() + ".Release");
+		if (_release == nullptr) {
+			_release = new Release(_parentModel, getName() + ".Release");
+		}
+	}
+	_seize->setModelLevel(_id);
+	_delay->setModelLevel(_id);
+	_release->setModelLevel(_id);
+
+	_seize->getConnectionManager()->connections()->clear();
+	_delay->getConnectionManager()->connections()->clear();
+	_seize->getConnectionManager()->insert(_delay);
+	_delay->getConnectionManager()->insert(_release);
+
+	_internalDataInsert("Seize", _seize);
+	_internalDataInsert("Delay", _delay);
+	_internalDataInsert("Release", _release);
+}
+
+void Process::_reconcileInternalComponents() {
+	_release->getReleaseRequests()->clear();
+	for (SeizableItem* seizeItem : *_seize->getSeizeRequests()->list()) {
+		SeizableItem* releaseItem = new SeizableItem(seizeItem);
+		std::string saveAttr = seizeItem->getSaveAttribute();
+		if (saveAttr == "") {
+			saveAttr = "Entity." + this->getName() + ".";
+			if (seizeItem->getSeizableType() == SeizableItem::SeizableType::RESOURCE) {
+				saveAttr += seizeItem->getResourceName();
+			} else if (seizeItem->getSet() != nullptr) {
+				saveAttr += seizeItem->getSet()->getName();
+			} else {
+				saveAttr += "Set";
+			}
+			saveAttr += "SaveAttribute";
+			seizeItem->setSaveAttribute(saveAttr);
+		}
+		releaseItem->setSelectionRule(SeizableItem::SelectionRule::SPECIFICMEMBER);
+		releaseItem->setSaveAttribute(saveAttr);
+		_release->getReleaseRequests()->insert(releaseItem);
+		this->_attachedAttributesInsert({saveAttr});
+	}
+}
+
+bool Process::_hasConsistentInternalChain(std::string& errorMessage) const {
+	Connection* seizeOut = _seize->getConnectionManager()->getFrontConnection();
+	Connection* delayOut = _delay->getConnectionManager()->getFrontConnection();
+	if (seizeOut == nullptr || seizeOut->component != _delay) {
+		errorMessage += "Process internal chain is invalid: expected Seize -> Delay. ";
+		return false;
+	}
+	if (delayOut == nullptr || delayOut->component != _release) {
+		errorMessage += "Process internal chain is invalid: expected Delay -> Release. ";
+		return false;
+	}
+	if (getConnectionManager()->size() > 0 && getConnectionManager()->getFrontConnection()->component != _seize) {
+		errorMessage += "Process external output must target internal Seize. ";
+		return false;
+	}
+	return true;
+}
+
 bool Process::_loadInstance(PersistenceRecord *fields) {
 	bool res = ModelComponent::_loadInstance(fields);
 	if (res) {
+		_ensureInternalComponents();
 		_seize->setAllocationType(static_cast<Util::AllocationType> (fields->loadField("allocationType", static_cast<int> (_seize->DEFAULT.allocationType))));
 		_seize->setPriority(fields->loadField("priority", _seize->DEFAULT.priority));
+		_seize->setPriorityExpression(fields->loadField("priorityExpression", _seize->DEFAULT.priorityExpression));
 		QueueableItem* queueableItem = new QueueableItem(nullptr);
 		queueableItem->setElementManager(_parentModel->getDataManager());
 		queueableItem->loadInstance(fields);
 		_seize->setQueueableItem(queueableItem);
+		_seize->getSeizeRequests()->clear();
 		unsigned short numRequests = fields->loadField("resquests", _seize->DEFAULT.seizeRequestSize);
 		for (unsigned short i = 0; i < numRequests; i++) {
 			SeizableItem* item = new SeizableItem(nullptr, "", SeizableItem::SelectionRule::LARGESTREMAININGCAPACITY);
@@ -193,9 +272,8 @@ bool Process::_loadInstance(PersistenceRecord *fields) {
 		}
 		_delay->setDelayExpression(fields->loadField("delayExpression", _delay->DEFAULT.delayExpression));
 		_delay->setDelayTimeUnit(fields->loadField("delayExpressionTimeUnit", _delay->DEFAULT.delayTimeUnit));
-		_seize->setModelLevel(_id);
-		_delay->setModelLevel(_id);
-		_release->setModelLevel(_id);
+		_reconcileInternalComponents();
+		_adjustConnections();
 	}
 	return res;
 }
@@ -238,56 +316,38 @@ PluginInformation* Process::GetPluginInformation() {
 }
 
 void Process::_createInternalAndAttachedData() {
-	if (_seize == nullptr) {
-		PluginManager* plugins = _parentModel->getParentSimulator()->getPluginManager();
-		// the following components are created into the "_id" model level (a submodel) and therefore will not be saved
-		_seize = plugins->newInstance<Seize>(_parentModel, getName() + ".Seize");
-		_delay = plugins->newInstance<Delay>(_parentModel, getName() + ".Delay");
-		_release = plugins->newInstance<Release>(_parentModel, getName() + ".Release");
-		_seize->setModelLevel(_id); // set level as subcomponent
-		_delay->setModelLevel(_id); // set level as subcomponent
-		_release->setModelLevel(_id); // set level as subcomponent
-		_seize->getConnectionManager()->insert(_delay);
-		_delay->getConnectionManager()->insert(_release);
-		_internalDataInsert("Seize", _seize);
-		_internalDataInsert("Delay", _delay);
-		_internalDataInsert("Release", _release);
-	}
+	_ensureInternalComponents();
 	_adjustConnections();
-	if (!_flagConstructing) { // this method was called before checking the model, not by the object constructor
-		// garantee that release releases exactlly what seize seizes
-		_release->getReleaseRequests()->clear();
-		for (SeizableItem* item : *_seize->getSeizeRequests()->list()) {
-			_release->getReleaseRequests()->insert(item);
-		}
-		SeizableItem* releaseItem;
-		unsigned int i = 0;
-		for (SeizableItem* seizeItem : *_seize->getSeizeRequests()->list()) {
-			std::string saveAttr = seizeItem->getSaveAttribute();
-			if (saveAttr == "") { // force seize to have a save attribute
-				saveAttr = "Entity." + this->getName() + ".";
-				if (seizeItem->getSeizableType() == SeizableItem::SeizableType::RESOURCE)
-					saveAttr += seizeItem->getResourceName();
-				else
-					saveAttr += seizeItem->getSet()->getName();
-				saveAttr += "SaveAttribute";
-				seizeItem->setSaveAttribute(saveAttr);
-			}
-			releaseItem = _release->getReleaseRequests()->getAtRank(i);
-			releaseItem->setSelectionRule(SeizableItem::SelectionRule::SPECIFICMEMBER);
-			releaseItem->setSaveAttribute(saveAttr);
-			this->_attachedAttributesInsert({saveAttr});
-			i++;
-		}
+	if (!_flagConstructing) {
+		_reconcileInternalComponents();
 	}
 }
 
 bool Process::_check(std::string& errorMessage) {
+	_ensureInternalComponents();
+	_adjustConnections();
 	bool resultAll = true;
+
+	if (_seize == nullptr || _delay == nullptr || _release == nullptr) {
+		errorMessage += "Process must have internal Seize, Delay and Release components. ";
+		return false;
+	}
+	resultAll &= _hasConsistentInternalChain(errorMessage);
+	if (_seize->getQueueableItem() == nullptr) {
+		resultAll = false;
+		errorMessage += "Process requires a QueueableItem in internal Seize. ";
+	}
+	if (_seize->getSeizeRequests()->size() == 0) {
+		resultAll = false;
+		errorMessage += "Process requires at least one SeizeRequest. ";
+	}
+	if (_seize->getSeizeRequests()->size() != _release->getReleaseRequests()->size()) {
+		resultAll = false;
+		errorMessage += "Process requires matching SeizeRequests and ReleaseRequests cardinality. ";
+	}
 
 	resultAll &= ModelComponent::Check(_seize);
 	resultAll &= ModelComponent::Check(_delay);
 	resultAll &= ModelComponent::Check(_release);
-	errorMessage += "";
 	return resultAll;
 }

--- a/source/plugins/components/Process.h
+++ b/source/plugins/components/Process.h
@@ -58,6 +58,9 @@ protected: // virtual
 	virtual void _createInternalAndAttachedData() override;
 private: // methods
 	void _adjustConnections();
+	void _ensureInternalComponents();
+	void _reconcileInternalComponents();
+	bool _hasConsistentInternalChain(std::string& errorMessage) const;
 private: // attributes 1:1
 	Seize* _seize = nullptr;
 	Delay* _delay = nullptr;
@@ -69,4 +72,3 @@ private: // attributes 1:n
 };
 
 #endif /* PROCESS_H */
-

--- a/source/tests/unit/test_simulator_runtime.cpp
+++ b/source/tests/unit/test_simulator_runtime.cpp
@@ -33,6 +33,11 @@
 #include "plugins/components/Match.h"
 #define private public
 #define protected public
+#include "plugins/components/Process.h"
+#undef protected
+#undef private
+#define private public
+#define protected public
 #include "plugins/components/Wait.h"
 #include "plugins/components/Signal.h"
 #undef protected
@@ -356,6 +361,31 @@ public:
     SignalData* SignalDataPtrProbe() const {
         return _signalData;
     }
+};
+
+class ProcessProbe : public Process {
+public:
+    ProcessProbe(Model* model, const std::string& name = "") : Process(model, name) {}
+
+    bool CheckProbe(std::string& errorMessage) {
+        return _check(errorMessage);
+    }
+
+    void CreateInternalAndAttachedDataProbe() {
+        _createInternalAndAttachedData();
+    }
+
+    void SaveInstanceProbe(PersistenceRecord* fields, bool saveDefaultValues = false) {
+        _saveInstance(fields, saveDefaultValues);
+    }
+
+    bool LoadInstanceProbe(PersistenceRecord* fields) {
+        return _loadInstance(fields);
+    }
+
+    Seize* SeizePtrProbe() const { return _seize; }
+    Delay* DelayPtrProbe() const { return _delay; }
+    Release* ReleasePtrProbe() const { return _release; }
 };
 
 class CollectorSinkComponentProbe : public ModelComponent {
@@ -3263,4 +3293,128 @@ TEST(SimulatorRuntimeTest, EntityGroupDestructorCleansOwnedGroupContainersSafely
         entityGroup.insertElement(401u, e2);
         entityGroup.insertElement(402u, e1);
     });
+}
+
+TEST(SimulatorRuntimeTest, ProcessCreateInternalMacroComponentKeepsSeizeDelayReleaseChainCoherent) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    ProcessProbe process(model, "ProcessCreateMacro");
+    Delay sink(model, "ProcessCreateMacroSink");
+    process.getConnectionManager()->insert(&sink);
+    process.CreateInternalAndAttachedDataProbe();
+
+    ASSERT_NE(process.SeizePtrProbe(), nullptr);
+    ASSERT_NE(process.DelayPtrProbe(), nullptr);
+    ASSERT_NE(process.ReleasePtrProbe(), nullptr);
+    EXPECT_EQ(process.SeizePtrProbe()->getLevel(), process.getId());
+    EXPECT_EQ(process.DelayPtrProbe()->getLevel(), process.getId());
+    EXPECT_EQ(process.ReleasePtrProbe()->getLevel(), process.getId());
+    ASSERT_NE(process.SeizePtrProbe()->getConnectionManager()->getFrontConnection(), nullptr);
+    ASSERT_NE(process.DelayPtrProbe()->getConnectionManager()->getFrontConnection(), nullptr);
+    EXPECT_EQ(process.SeizePtrProbe()->getConnectionManager()->getFrontConnection()->component, process.DelayPtrProbe());
+    EXPECT_EQ(process.DelayPtrProbe()->getConnectionManager()->getFrontConnection()->component, process.ReleasePtrProbe());
+    ASSERT_NE(process.getConnectionManager()->getFrontConnection(), nullptr);
+    EXPECT_EQ(process.getConnectionManager()->getFrontConnection()->component, process.SeizePtrProbe());
+    ASSERT_NE(process.ReleasePtrProbe()->getConnectionManager()->getFrontConnection(), nullptr);
+    EXPECT_EQ(process.ReleasePtrProbe()->getConnectionManager()->getFrontConnection()->component, &sink);
+}
+
+TEST(SimulatorRuntimeTest, ProcessRecheckReconcilesReleaseRequestsFromSeizeRequests) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    ProcessProbe process(model, "ProcessReconcile");
+    Queue* queue = new Queue(model, "ProcessReconcileQueue");
+    process.setQueueableItem(new QueueableItem(queue));
+    Resource* r1 = new Resource(model, "ProcessReconcileR1");
+    Resource* r2 = new Resource(model, "ProcessReconcileR2");
+    process.addSeizeRequest(new SeizableItem(r1, "1", SeizableItem::SelectionRule::LARGESTREMAININGCAPACITY, "Entity.CustomSaveR1"));
+    process.addSeizeRequest(new SeizableItem(r2, "2", SeizableItem::SelectionRule::LARGESTREMAININGCAPACITY));
+    process.CreateInternalAndAttachedDataProbe();
+
+    std::string errorMessage;
+    ASSERT_TRUE(process.CheckProbe(errorMessage)) << errorMessage;
+    ASSERT_NE(process.ReleasePtrProbe(), nullptr);
+    ASSERT_EQ(process.SeizePtrProbe()->getSeizeRequests()->size(), process.ReleasePtrProbe()->getReleaseRequests()->size());
+    ASSERT_EQ(process.ReleasePtrProbe()->getReleaseRequests()->size(), 2u);
+    EXPECT_EQ(process.ReleasePtrProbe()->getReleaseRequests()->getAtRank(0)->getSelectionRule(), SeizableItem::SelectionRule::SPECIFICMEMBER);
+    EXPECT_EQ(process.ReleasePtrProbe()->getReleaseRequests()->getAtRank(1)->getSelectionRule(), SeizableItem::SelectionRule::SPECIFICMEMBER);
+    EXPECT_EQ(process.ReleasePtrProbe()->getReleaseRequests()->getAtRank(0)->getSaveAttribute(), "Entity.CustomSaveR1");
+    EXPECT_FALSE(process.ReleasePtrProbe()->getReleaseRequests()->getAtRank(1)->getSaveAttribute().empty());
+}
+
+TEST(SimulatorRuntimeTest, ProcessPersistenceRoundTripPreservesConfigurationAndReconcilesInternals) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    ProcessProbe source(model, "ProcessPersistSource");
+    Queue* queue = new Queue(model, "ProcessPersistQueue");
+    source.setAllocationType(Util::AllocationType::ValueAdded);
+    source.setPriority(7u);
+    source.setPriorityExpression("2+3");
+    source.setQueueableItem(new QueueableItem(queue));
+    source.addSeizeRequest(new SeizableItem(new Resource(model, "ProcessPersistResource"), "3", SeizableItem::SelectionRule::LARGESTREMAININGCAPACITY));
+    source.setDelayExpression("4");
+    source.setDelayTimeUnit(Util::TimeUnit::minute);
+    Delay sink(model, "ProcessPersistSink");
+    source.getConnectionManager()->insert(&sink);
+    source.CreateInternalAndAttachedDataProbe();
+
+    FakeModelPersistenceRuntime persistence;
+    PersistenceRecord fields(persistence);
+    source.SaveInstanceProbe(&fields, true);
+
+    ProcessProbe loaded(model, "ProcessPersistLoaded");
+    ASSERT_TRUE(loaded.LoadInstanceProbe(&fields));
+
+    EXPECT_EQ(loaded.getAllocationType(), Util::AllocationType::ValueAdded);
+    EXPECT_EQ(loaded.getPriority(), 7u);
+    EXPECT_EQ(loaded.getPriorityExpression(), "2+3");
+    ASSERT_NE(loaded.getQueueableItem(), nullptr);
+    EXPECT_EQ(loaded.getQueueableItem()->getQueueableName(), "ProcessPersistQueue");
+    ASSERT_EQ(loaded.getSeizeRequests()->size(), 1u);
+    EXPECT_EQ(loaded.getSeizeRequests()->getAtRank(0)->getResourceName(), "ProcessPersistResource");
+    EXPECT_EQ(loaded.delayExpression(), "4");
+    EXPECT_EQ(loaded.delayTimeUnit(), Util::TimeUnit::minute);
+    ASSERT_NE(loaded.ReleasePtrProbe(), nullptr);
+    EXPECT_EQ(loaded.SeizePtrProbe()->getSeizeRequests()->size(), loaded.ReleasePtrProbe()->getReleaseRequests()->size());
+    EXPECT_EQ(fields.loadField("nextId", -1), sink.getId());
+}
+
+TEST(SimulatorRuntimeTest, ProcessCheckFailsWhenInternalCompositionIsInconsistent) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    ProcessProbe process(model, "ProcessInvalid");
+    process.setQueueableItem(new QueueableItem(new Queue(model, "ProcessInvalidQueue")));
+    process.addSeizeRequest(new SeizableItem(new Resource(model, "ProcessInvalidResource"), "1", SeizableItem::SelectionRule::LARGESTREMAININGCAPACITY));
+    process.CreateInternalAndAttachedDataProbe();
+    process.SeizePtrProbe()->getConnectionManager()->connections()->clear();
+    process.DelayPtrProbe()->getConnectionManager()->connections()->clear();
+    process.ReleasePtrProbe()->getReleaseRequests()->clear();
+
+    std::string errorMessage;
+    EXPECT_FALSE(process.CheckProbe(errorMessage));
+    EXPECT_FALSE(errorMessage.empty());
+}
+
+TEST(SimulatorRuntimeTest, ProcessCheckPassesWithMinimalValidConfiguration) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    ProcessProbe process(model, "ProcessValid");
+    process.setQueueableItem(new QueueableItem(new Queue(model, "ProcessValidQueue")));
+    process.addSeizeRequest(new SeizableItem(new Resource(model, "ProcessValidResource"), "1", SeizableItem::SelectionRule::LARGESTREMAININGCAPACITY));
+    process.setDelayExpression("1");
+    process.setDelayTimeUnit(Util::TimeUnit::second);
+    process.CreateInternalAndAttachedDataProbe();
+
+    std::string errorMessage;
+    EXPECT_TRUE(process.CheckProbe(errorMessage)) << errorMessage;
 }


### PR DESCRIPTION
### Motivation
- Fix fragility in `Process` where internal `Seize/Delay/Release` composition could be incomplete after construction/load and where `ReleaseRequests` were not reliably synchronized from `SeizeRequests`.
- Make `Process` behavior deterministic and safe across create/recheck/save/load without redesigning `Seize`/`Release` internals.

### Description
- Added explicit helpers to `Process`: `_ensureInternalComponents()` creates internal `Seize`, `Delay` and `Release` with `PluginManager->newInstance<...>()` plus safe fallback to `new Seize/Delay/Release(...)`, `_reconcileInternalComponents()` rebuilds `ReleaseRequests` from `SeizeRequests` (forcing `SelectionRule::SPECIFICMEMBER` and deriving `saveAttribute` when missing), and `_hasConsistentInternalChain()` that validates `Seize -> Delay -> Release` wiring.
- Made `_loadInstance()` explicitly ensure internals exist, reload `Seize` configuration (including `priorityExpression` and `QueueableItem`), clear and repopulate seize requests and call the reconciliation helper so a loaded `Process` is immediately usable.
- Refactored `_createInternalAndAttachedData()` to use the new helpers and made `_check()` stricter (verifies non-null internals, consistent internal chain, presence of `QueueableItem`, at least one `SeizeRequest`, and cardinality match between seize/release requests) while preserving delegation to `ModelComponent::Check(...)` for subcomponents.
- Files changed: `source/plugins/components/Process.h`, `source/plugins/components/Process.cpp`, and unit test additions in `source/tests/unit/test_simulator_runtime.cpp` (added `ProcessProbe` and tests A–E that exercise creation, reconciliation, persistence round-trip, failing and passing `_check()` scenarios).

### Testing
- Executed full local validation commands: `cmake -S . -B build -G Ninja`, `cmake --build build`, `./build/source/tests/unit/genesys_test_simulator_runtime`, and `ctest --test-dir build -L unit --output-on-failure`.
- All build steps and unit test runs succeeded in this environment: `genesys_test_simulator_runtime` ran and passed (132/132), and `ctest -L unit` reported 1037/1037 tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da607be8e48321ba545f00d9cfed41)