### PR TITLE
GUI: reconstruct graphical data definitions in main model view

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/GraphicalDiagramConnection.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/GraphicalDiagramConnection.cpp
@@ -49,6 +49,11 @@ GraphicalDiagramConnection::GraphicalDiagramConnection(QGraphicsItem* dataDefini
     }
 
     setLine(QLineF(startPoint, endPoint));
+    // Keep diagram links purely representational in this phase.
+    setFlag(QGraphicsItem::ItemIsSelectable, false);
+    setFlag(QGraphicsItem::ItemIsFocusable, false);
+    setFlag(QGraphicsItem::ItemIsMovable, false);
+    setAcceptedMouseButtons(Qt::NoButton);
 }
 
 

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
@@ -679,6 +679,30 @@ void ModelGraphicsScene::removeGraphicalDiagramConnection(GraphicalDiagramConnec
     delete(connection);
 }
 
+// Clear only graphical data-definition nodes without touching normal components/connections.
+void ModelGraphicsScene::clearGraphicalModelDataDefinitions() {
+    QList<GraphicalModelDataDefinition*>* gmdds = getAllDataDefinitions();
+    while (!gmdds->isEmpty()) {
+        GraphicalModelDataDefinition* gmdd = gmdds->first();
+        removeGraphicalModelDataDefinition(gmdd);
+    }
+}
+
+// Clear only diagram arrows that link data-definition artifacts.
+void ModelGraphicsScene::clearGraphicalDiagramConnections() {
+    QList<GraphicalDiagramConnection*>* connections = getAllGraphicalDiagramsConnections();
+    while (!connections->isEmpty()) {
+        GraphicalDiagramConnection* connection = connections->first();
+        removeGraphicalDiagramConnection(connection);
+    }
+}
+
+// Keep legacy diagram visibility checks coherent when data definitions are rebuilt by the builder.
+void ModelGraphicsScene::setDiagramLayerState(bool diagramCreated, bool visible) {
+    _diagram = diagramCreated;
+    _visibleDiagram = visible;
+}
+
 // trata da remocao das conexoes de um componente
 void ModelGraphicsScene::clearConnectionsComponent(GraphicalModelComponent* gmc) {
     ModelGraphicsScene::clearInputConnectionsComponent(gmc);
@@ -1308,21 +1332,9 @@ bool ModelGraphicsScene::visibleDiagram() {
 }
 
 void ModelGraphicsScene::destroyDiagram() {
-    QList<GraphicalModelDataDefinition*>* gmdds = getAllDataDefinitions();
-    int size_gmdds = gmdds->size();
-    for (int i = 0; i < size_gmdds; i++) {
-        GraphicalModelDataDefinition* gmdd = gmdds->first();
-        removeGraphicalModelDataDefinition(gmdd);
-    }
-
-    QList<GraphicalDiagramConnection*>* connections = getAllGraphicalDiagramsConnections();
-    int size_connections = connections->size();
-    for (int i = 0; i < size_connections; i++) {
-        GraphicalDiagramConnection* itemConnection = connections->first();
-        removeGraphicalDiagramConnection(itemConnection);
-    }
-
-    _diagram = false;
+    clearGraphicalModelDataDefinitions();
+    clearGraphicalDiagramConnections();
+    setDiagramLayerState(false, false);
 }
 
 void ModelGraphicsScene::hideDiagrams() {

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.h
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.h
@@ -128,6 +128,9 @@ public: // editing graphic model
     bool addDrawingAnimation(QGraphicsItem * item);
     void removeGraphicalModelDataDefinition(GraphicalModelDataDefinition* gmdd);
     void removeGraphicalDiagramConnection(GraphicalDiagramConnection* connection);
+    void clearGraphicalModelDataDefinitions();
+    void clearGraphicalDiagramConnections();
+    void setDiagramLayerState(bool diagramCreated, bool visible);
     void removeDrawing(QGraphicsItem * item, bool notify = false);
     bool removeDrawingGeometry(QGraphicsItem * item);
     bool removeDrawingAnimation(QGraphicsItem * item);

--- a/source/applications/gui/qt/GenesysQtGUI/services/GraphicalModelBuilder.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/services/GraphicalModelBuilder.cpp
@@ -11,6 +11,8 @@
 #include "../../../../../kernel/simulator/PluginManager.h"
 #include "../../../../../kernel/simulator/Plugin.h"
 #include "../../../../../kernel/simulator/SourceModelComponent.h"
+#include "../../../../../kernel/simulator/ModelDataManager.h"
+#include "../../../../../kernel/simulator/ModelDataDefinition.h"
 
 #include <QTextEdit>
 
@@ -104,6 +106,112 @@ void GraphicalModelBuilder::recursivalyGenerateGraphicalModelFromModel(ModelComp
     *y = yIni;
 }
 
+// Rebuild graphical data definitions and diagram links as part of the main model regeneration flow.
+void GraphicalModelBuilder::rebuildGraphicalDataDefinitionsLayer(std::map<ModelComponent*, GraphicalModelComponent*>* componentMap) {
+    Model* model = _simulator->getModelManager()->current();
+    if (model == nullptr || model->getDataManager() == nullptr || componentMap == nullptr) {
+        return;
+    }
+
+    _scene->clearGraphicalDiagramConnections();
+    _scene->clearGraphicalModelDataDefinitions();
+
+    PluginManager* pluginManager = _simulator->getPluginManager();
+    ModelDataManager* dataManager = model->getDataManager();
+    QColor purple(128, 0, 128);
+    QColor grey(220, 220, 220);
+    std::map<ModelDataDefinition*, GraphicalModelDataDefinition*> dataDefinitionMap;
+
+    // Create one graphical node for each kernel data definition.
+    for (const std::string& dataTypename : dataManager->getDataDefinitionClassnames()) {
+        std::list<ModelDataDefinition*>* listDataDefinitions = dataManager->getDataDefinitionList(dataTypename)->list();
+        for (ModelDataDefinition* dataDefinition : *listDataDefinitions) {
+            if (dataDefinition == nullptr) {
+                continue;
+            }
+            Plugin* plugin = pluginManager->find(dataDefinition->getName());
+            if (plugin == nullptr) {
+                continue;
+            }
+            GraphicalModelDataDefinition* graphicalDataDefinition = _scene->addGraphicalModelDataDefinition(plugin, dataDefinition, QPointF(0, 0), grey);
+            if (graphicalDataDefinition != nullptr) {
+                dataDefinitionMap[dataDefinition] = graphicalDataDefinition;
+            }
+        }
+    }
+
+    QList<GraphicalModelDataDefinition*> visitedDataDefinitions;
+    // Reuse the existing createDiagrams positioning semantics for component-attached/internal data links.
+    for (const auto& componentEntry : *componentMap) {
+        ModelComponent* component = componentEntry.first;
+        GraphicalModelComponent* graphicalComponent = componentEntry.second;
+        if (component == nullptr || graphicalComponent == nullptr) {
+            continue;
+        }
+
+        QPointF componentPosition = graphicalComponent->getOldPosition();
+        qreal yInternal = componentPosition.y();
+        qreal yAttached = componentPosition.y();
+
+        for (const auto& attachedData : *component->getAttachedData()) {
+            auto attachedIt = dataDefinitionMap.find(attachedData.second);
+            if (attachedIt == dataDefinitionMap.end()) {
+                continue;
+            }
+            GraphicalModelDataDefinition* gdd = attachedIt->second;
+            if (visitedDataDefinitions.contains(gdd)) {
+                qreal x = (gdd->x() + componentPosition.x()) / 2.0;
+                gdd->setPos(x, yAttached - 150);
+                gdd->setOldPosition(x, yAttached - 150);
+            } else {
+                visitedDataDefinitions.append(gdd);
+                yAttached -= 150;
+                gdd->setPos(componentPosition.x(), yAttached);
+                gdd->setOldPosition(componentPosition.x(), yAttached);
+                gdd->setColor(purple);
+            }
+            _scene->addGraphicalDiagramConnection(gdd, graphicalComponent, GraphicalDiagramConnection::ConnectionType::ATTACHED);
+        }
+
+        for (const auto& internalData : *component->getInternalData()) {
+            auto internalIt = dataDefinitionMap.find(internalData.second);
+            if (internalIt == dataDefinitionMap.end()) {
+                continue;
+            }
+            GraphicalModelDataDefinition* gdd = internalIt->second;
+            visitedDataDefinitions.append(gdd);
+            yInternal += 150;
+            gdd->setPos(componentPosition.x(), yInternal);
+            gdd->setOldPosition(componentPosition.x(), yInternal);
+            _scene->addGraphicalDiagramConnection(gdd, graphicalComponent, GraphicalDiagramConnection::ConnectionType::INTERNAL);
+        }
+    }
+
+    // Reuse the same lateral placement rule for internal links between data definitions.
+    for (int i = 0; i < visitedDataDefinitions.size(); i++) {
+        GraphicalModelDataDefinition* parentDataDefinition = visitedDataDefinitions.at(i);
+        if (parentDataDefinition == nullptr || parentDataDefinition->getDataDefinition() == nullptr) {
+            continue;
+        }
+        QPointF parentPosition = parentDataDefinition->getOldPosition();
+        qreal x = parentPosition.x();
+        for (const auto& internalData : *parentDataDefinition->getDataDefinition()->getInternalData()) {
+            auto internalIt = dataDefinitionMap.find(internalData.second);
+            if (internalIt == dataDefinitionMap.end()) {
+                continue;
+            }
+            GraphicalModelDataDefinition* childDataDefinition = internalIt->second;
+            visitedDataDefinitions.append(childDataDefinition);
+            x -= 200;
+            childDataDefinition->setPos(x, parentPosition.y());
+            childDataDefinition->setOldPosition(x, parentPosition.y());
+            _scene->addGraphicalDiagramConnection(childDataDefinition, parentDataDefinition, GraphicalDiagramConnection::ConnectionType::INTERNAL);
+        }
+    }
+
+    _scene->setDiagramLayerState(!dataDefinitionMap.empty(), true);
+}
+
 // Preserve the existing full-model generation flow and visitation semantics.
 void GraphicalModelBuilder::generateGraphicalModelFromModel() {
     Model* m = _simulator->getModelManager()->current();
@@ -137,6 +245,8 @@ void GraphicalModelBuilder::generateGraphicalModelFromModel() {
                 }
             }
         } while (foundNotVisited);
+
+        rebuildGraphicalDataDefinitionsLayer(map);
 
         delete map;
         delete visited;

--- a/source/applications/gui/qt/GenesysQtGUI/services/GraphicalModelBuilder.h
+++ b/source/applications/gui/qt/GenesysQtGUI/services/GraphicalModelBuilder.h
@@ -12,6 +12,8 @@ class ModelGraphicsView;
 class ModelGraphicsScene;
 class ModelComponent;
 class GraphicalModelComponent;
+class ModelDataDefinition;
+class GraphicalModelDataDefinition;
 template<typename T> class List;
 
 // Document the service that rebuilds graphical scene artifacts from kernel models.
@@ -56,6 +58,8 @@ public:
     void generateGraphicalModelFromModel();
 
 private:
+    void rebuildGraphicalDataDefinitionsLayer(std::map<ModelComponent*, GraphicalModelComponent*>* componentMap);
+
     Simulator* _simulator;
     ModelGraphicsView* _graphicsView;
     ModelGraphicsScene* _scene;


### PR DESCRIPTION
### Motivation
- Integrate `ModelDataDefinition` visuals into the primary scene reconstruction so the main `GraphicalModel` view draws data definitions and their logical `INTERNAL`/`ATTACHED` links automatically. 
- Reuse existing diagram layout/semantics from `ModelGraphicsScene::createDiagrams()` while keeping the main reconstruction pipeline in `GraphicalModelBuilder::generateGraphicalModelFromModel()` and avoiding invasive changes to unrelated subsystems.

### Description
- Added a focused helper `GraphicalModelBuilder::rebuildGraphicalDataDefinitionsLayer(...)` and invoked it at the end of `generateGraphicalModelFromModel()` to create `GraphicalModelDataDefinition` nodes and `GraphicalDiagramConnection` arrows using the same placement semantics (attached above, internal below, internal lateral links). (`services/GraphicalModelBuilder.h/.cpp`).
- Introduced scene helpers `ModelGraphicsScene::clearGraphicalModelDataDefinitions()`, `ModelGraphicsScene::clearGraphicalDiagramConnections()` and `setDiagramLayerState(...)` to allow safe clearing/rebuild of only the data-definition layer without touching normal components/connections, and refactored `destroyDiagram()` to use them. (`graphicals/ModelGraphicsScene.h/.cpp`).
- Made `GraphicalDiagramConnection` non-interactive for this phase by disabling selection/focus/movement and ignoring mouse buttons so diagram arrows are purely representational. (`graphicals/GraphicalDiagramConnection.cpp`).
- Kept changes minimal and local to the GUI Qt files listed in the task; did not modify persistence, property-editor integration, grouping/undo-redo subsystems, or DOT diagram paths beyond rerouting the main view reconstruction.

### Testing
- Confirmed branch state and committed changes with message `GUI: reconstruct graphical data definitions in main model view` successfully. (local commit performed).
- Performed static inspections with `rg`/searches confirming that `generateGraphicalModelFromModel()` calls the new `rebuildGraphicalDataDefinitionsLayer`, `GraphicalDiagramConnection` disables interaction flags, and new scene clearers exist (`clearGraphicalModelDataDefinitions`, `clearGraphicalDiagramConnections`, `setDiagramLayerState`). These inspections succeeded.
- Attempted CMake configure to build the GUI, but configuration failed because `qmake` is not available in the environment `PATH`; therefore a full GUI build/run validation could not be performed (environment limitation).
- Verified via `git diff` that modifications are limited to the intended files and that no serializer/group/undo/PropertyEditor files were altered.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da650661e08321b28e4b2284a696da)