### PR TITLE
GUI: finalize graphical data definition interaction and initial internal grouping

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/actions/DeleteUndoCommand.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/actions/DeleteUndoCommand.cpp
@@ -1,10 +1,15 @@
 #include "DeleteUndoCommand.h"
+#include "graphicals/GraphicalModelDataDefinition.h"
 
 DeleteUndoCommand::DeleteUndoCommand(QList<QGraphicsItem *> items, ModelGraphicsScene *scene, QUndoCommand *parent)
     : QUndoCommand(parent), _myComponentItems(new QList<ComponentItem>()), _myConnectionItems(new QList<GraphicalConnection *>()), _myDrawingItems(new QList<DrawingItem>()), _myGroupItems(new QList<GroupItem>()), _myGraphicsScene(scene) {
 
     // filtra cada tipo de item possível em sua respectiva lista
     for (QGraphicsItem *item : items) {
+        // Keep data definitions selectable/editable while preventing direct manual deletion.
+        if (dynamic_cast<GraphicalModelDataDefinition *>(item)) {
+            continue;
+        }
         if (GraphicalModelComponent *component = dynamic_cast<GraphicalModelComponent *>(item)) {
             ComponentItem componentItem;
 
@@ -36,6 +41,9 @@ DeleteUndoCommand::DeleteUndoCommand(QList<QGraphicsItem *> items, ModelGraphics
 
             for (int i = 0; i < group->childItems().size(); i++) {
                 GraphicalModelComponent * component = dynamic_cast<GraphicalModelComponent *>(groupItem.group->childItems().at(i));
+                if (component == nullptr) {
+                    continue;
+                }
 
                 ComponentItem componentItem;
 

--- a/source/applications/gui/qt/GenesysQtGUI/controllers/EditCommandController.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/EditCommandController.cpp
@@ -182,7 +182,7 @@ void EditCommandController::onActionEditPasteTriggered() const {
 
 // Preserve delete behavior and action-state refresh callback.
 void EditCommandController::onActionEditDeleteTriggered() const {
-    QList<QGraphicsItem*> selecteds = _graphicsView->scene()->selectedItems();
+    QList<QGraphicsItem*> selecteds = scene()->userDeletableItems(_graphicsView->scene()->selectedItems());
     if (selecteds.isEmpty()) {
         return;
     }

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
@@ -40,6 +40,7 @@
 #include "graphicals/ModelGraphicsScene.h"
 #include "graphicals/ModelGraphicsView.h"
 #include "graphicals/GraphicalModelComponent.h"
+#include "graphicals/GraphicalModelDataDefinition.h"
 #include "graphicals/GraphicalComponentPort.h"
 #include "graphicals/GraphicalConnection.h"
 #include "graphicals/GraphicalDiagramConnection.h"
@@ -701,6 +702,51 @@ void ModelGraphicsScene::clearGraphicalDiagramConnections() {
 void ModelGraphicsScene::setDiagramLayerState(bool diagramCreated, bool visible) {
     _diagram = diagramCreated;
     _visibleDiagram = visible;
+}
+
+QList<QGraphicsItem*> ModelGraphicsScene::userDeletableItems(const QList<QGraphicsItem*>& items) const {
+    QList<QGraphicsItem*> filtered;
+    // Keep data definitions editable/selectable but block their direct manual deletion.
+    for (QGraphicsItem* item : items) {
+        if (dynamic_cast<GraphicalModelDataDefinition*>(item) != nullptr) {
+            continue;
+        }
+        filtered.append(item);
+    }
+    return filtered;
+}
+
+void ModelGraphicsScene::ensureInitialInternalDataDefinitionGrouping(GraphicalModelDataDefinition* dataDefinition, GraphicalModelComponent* component) {
+    // Only auto-group on first materialization when there is no persisted GUI state restoration in progress.
+    if (_persistedGuiRestoreInProgress || dataDefinition == nullptr || component == nullptr || dataDefinition->group() != nullptr) {
+        return;
+    }
+
+    QGraphicsItemGroup* targetGroup = component->group();
+    if (targetGroup == nullptr) {
+        targetGroup = new QGraphicsItemGroup();
+        targetGroup->setHandlesChildEvents(false);
+        targetGroup->setFlag(QGraphicsItem::ItemIsSelectable, true);
+        targetGroup->setFlag(QGraphicsItem::ItemIsMovable, true);
+        addItem(targetGroup);
+        _graphicalGroups->append(targetGroup);
+        insertOldPositionItem(targetGroup, targetGroup->pos());
+    }
+
+    if (component->group() == nullptr) {
+        targetGroup->addToGroup(component);
+        insertOldPositionItem(component, component->pos());
+    }
+    targetGroup->addToGroup(dataDefinition);
+    insertOldPositionItem(dataDefinition, dataDefinition->pos());
+}
+
+void ModelGraphicsScene::setPersistedGuiRestoreInProgress(bool restoring) {
+    _persistedGuiRestoreInProgress = restoring;
+}
+
+bool ModelGraphicsScene::isPersistedGuiRestoreInProgress() const {
+    return _persistedGuiRestoreInProgress;
 }
 
 // trata da remocao das conexoes de um componente
@@ -2854,7 +2900,7 @@ void ModelGraphicsScene::keyPressEvent(QKeyEvent *keyEvent) {
         return;
     }
     QGraphicsScene::keyPressEvent(keyEvent);
-    QList<QGraphicsItem*> selected = this->selectedItems();
+    QList<QGraphicsItem*> selected = userDeletableItems(this->selectedItems());
     if (keyEvent->key() == Qt::Key_Delete && selected.size() > 0) {
         QMessageBox::StandardButton reply = QMessageBox::question(this->_parentWidget, "Delete Component", "Are you sure you want to delete the selected components?", QMessageBox::Yes | QMessageBox::No);
         if (reply == QMessageBox::No) {

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.h
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.h
@@ -131,6 +131,13 @@ public: // editing graphic model
     void clearGraphicalModelDataDefinitions();
     void clearGraphicalDiagramConnections();
     void setDiagramLayerState(bool diagramCreated, bool visible);
+    // Filter out non-deletable items from user-triggered delete flows.
+    QList<QGraphicsItem*> userDeletableItems(const QList<QGraphicsItem*>& items) const;
+    // Keep internal data-definition initial grouping opt-in during model rebuild only.
+    void ensureInitialInternalDataDefinitionGrouping(GraphicalModelDataDefinition* dataDefinition, GraphicalModelComponent* component);
+    // Allow serializer to disable automatic initial grouping while persisted GUI state is being restored.
+    void setPersistedGuiRestoreInProgress(bool restoring);
+    bool isPersistedGuiRestoreInProgress() const;
     void removeDrawing(QGraphicsItem * item, bool notify = false);
     bool removeDrawingGeometry(QGraphicsItem * item);
     bool removeDrawingAnimation(QGraphicsItem * item);
@@ -292,6 +299,7 @@ private:
     bool _drawing = false;
     bool _diagram = false;
     bool _visibleDiagram = false;
+    bool _persistedGuiRestoreInProgress = false;
     unsigned short _connectingStep = 0; //0:nothing, 1:waiting click on source or destination, 2: click on source, 3: click on destination
     bool _controlIsPressed = false;
     bool _snapToGrid = false;

--- a/source/applications/gui/qt/GenesysQtGUI/services/GraphicalModelBuilder.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/services/GraphicalModelBuilder.cpp
@@ -184,6 +184,8 @@ void GraphicalModelBuilder::rebuildGraphicalDataDefinitionsLayer(std::map<ModelC
             yInternal += 150;
             gdd->setPos(componentPosition.x(), yInternal);
             gdd->setOldPosition(componentPosition.x(), yInternal);
+            // Apply automatic initial grouping only for internal data definitions as a first-materialization fallback.
+            _scene->ensureInitialInternalDataDefinitionGrouping(gdd, graphicalComponent);
             _scene->addGraphicalDiagramConnection(gdd, graphicalComponent, GraphicalDiagramConnection::ConnectionType::INTERNAL);
         }
     }

--- a/source/applications/gui/qt/GenesysQtGUI/services/GraphicalModelSerializer.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/services/GraphicalModelSerializer.cpp
@@ -474,6 +474,8 @@ Model* GraphicalModelSerializer::loadGraphicalModel(const std::string& filename)
     if (model != nullptr) {
         // Rebuild the base graphical topology from a single source of truth before applying persisted GUI overlays.
         _clearModelEditors();
+        // Suspend builder-only fallback grouping while persisted .gui positions/groups are being restored.
+        _graphicsView->getScene()->setPersistedGuiRestoreInProgress(true);
         _rebuildGraphicalModelFromModel();
 
         struct PersistedComponentState {
@@ -925,6 +927,7 @@ Model* GraphicalModelSerializer::loadGraphicalModel(const std::string& filename)
                 vBar->setValue(qBound(vBar->minimum(), restoredViewpointY, vBar->maximum()));
             });
         }
+        _graphicsView->getScene()->setPersistedGuiRestoreInProgress(false);
 
         _console->append("\n");
         *_modelFilename = QString::fromStdString(filename);


### PR DESCRIPTION
### Motivation
- Prevent direct user deletion of `GraphicalModelDataDefinition` items while keeping them selectable and editable. 
- Provide a safe, first-materialization fallback that groups `internal` data definitions with their `GraphicalModelComponent` containers, without overriding persisted `.gui` state. 
- Make the minimal, reversible changes necessary to preserve existing behaviors for components, attached data, grouping and serializer compatibility.

### Description
- Added `ModelGraphicsScene::userDeletableItems(...)` and applied it to keyboard-delete (`keyPressEvent`) and the Edit->Delete flow via `EditCommandController::onActionEditDeleteTriggered` to filter out `GraphicalModelDataDefinition` from user-triggered deletions. 
- Hardened `DeleteUndoCommand` so it ignores `GraphicalModelDataDefinition` items and skips non-component children when processing groups. 
- Introduced `ModelGraphicsScene::ensureInitialInternalDataDefinitionGrouping(...)` and invoked it only from the builder loop that materializes `internal` data definitions in `GraphicalModelBuilder::rebuildGraphicalDataDefinitionsLayer`, so `attached` data are unaffected. 
- Added a restoration flag (`_persistedGuiRestoreInProgress`) to `ModelGraphicsScene` and toggled it from `GraphicalModelSerializer::loadGraphicalModel` around the base rebuild so that automatic grouping is suspended while persisted `.gui` positions/groups are restored, preserving compatibility with existing saved state. 
- Kept all changes small, documented with short in-code comments, and avoided any change to the persisted `.gui` format.

### Testing
- Verified the locations of manual deletion flows and that they now pass through the deletion filter using repository search (`rg`) and code inspection, which succeeded. 
- Inspected diffs (`git diff`) and committed the changes on branch `work` with message `GUI: finalize graphical data definition interaction and initial internal grouping`. 
- Ran project configuration for non-GUI preset with `cmake --preset debug` which completed successfully, and attempted GUI configure/build which failed because the environment lacks `qmake` so a full GUI build could not be executed here. 
- Confirmed via code inspection that: `GraphicalModelDataDefinition` remains selectable/editable but is excluded from direct user delete flows, initial grouping is applied only for `internal` items by the builder, and serializer-driven restore disables the fallback grouping during persisted-state restoration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da73d6a7248321a409638bfedce8b8)