### PR TITLE
GUI: finalize graphical data definition interaction and initial internal grouping

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/actions/DeleteUndoCommand.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/actions/DeleteUndoCommand.cpp
@@ -1,10 +1,15 @@
 #include "DeleteUndoCommand.h"
+#include "graphicals/GraphicalModelDataDefinition.h"
 
 DeleteUndoCommand::DeleteUndoCommand(QList<QGraphicsItem *> items, ModelGraphicsScene *scene, QUndoCommand *parent)
     : QUndoCommand(parent), _myComponentItems(new QList<ComponentItem>()), _myConnectionItems(new QList<GraphicalConnection *>()), _myDrawingItems(new QList<DrawingItem>()), _myGroupItems(new QList<GroupItem>()), _myGraphicsScene(scene) {
 
     // filtra cada tipo de item possível em sua respectiva lista
     for (QGraphicsItem *item : items) {
+        // Keep data definitions managed by model reconstruction instead of direct delete actions.
+        if (dynamic_cast<GraphicalModelDataDefinition *>(item)) {
+            continue;
+        }
         if (GraphicalModelComponent *component = dynamic_cast<GraphicalModelComponent *>(item)) {
             ComponentItem componentItem;
 

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
@@ -57,6 +57,7 @@
 #include <QPointer>
 #include <QTimer>
 #include <QDebug>
+#include <algorithm>
 
 namespace {
 // Safely cast the scene parent to a generic graphics view.
@@ -2856,6 +2857,13 @@ void ModelGraphicsScene::keyPressEvent(QKeyEvent *keyEvent) {
     QGraphicsScene::keyPressEvent(keyEvent);
     QList<QGraphicsItem*> selected = this->selectedItems();
     if (keyEvent->key() == Qt::Key_Delete && selected.size() > 0) {
+        // Keep data definitions selectable, but block direct user-triggered deletion.
+        selected.erase(std::remove_if(selected.begin(), selected.end(), [](QGraphicsItem* item) {
+            return dynamic_cast<GraphicalModelDataDefinition*>(item) != nullptr;
+        }), selected.end());
+        if (selected.isEmpty()) {
+            return;
+        }
         QMessageBox::StandardButton reply = QMessageBox::question(this->_parentWidget, "Delete Component", "Are you sure you want to delete the selected components?", QMessageBox::Yes | QMessageBox::No);
         if (reply == QMessageBox::No) {
             return;
@@ -2892,6 +2900,16 @@ void ModelGraphicsScene::drawingTimer() {
 
 void ModelGraphicsScene::setObjectBeingDragged(QTreeWidgetItem* objectBeingDragged) {
     _objectBeingDragged = objectBeingDragged;
+}
+
+// Toggle whether diagram items are currently being reconstructed from persisted .gui state.
+void ModelGraphicsScene::setRestoringPersistedGuiLayout(bool restoring) {
+    _restoringPersistedGuiLayout = restoring;
+}
+
+// Expose persisted-layout restoration state to avoid applying default-only grouping fallbacks.
+bool ModelGraphicsScene::isRestoringPersistedGuiLayout() const {
+    return _restoringPersistedGuiLayout;
 }
 
 void ModelGraphicsScene::setSimulator(Simulator *simulator) {

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.h
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.h
@@ -177,6 +177,8 @@ public:
     void setPropertyEditorUI(std::map<SimulationControl*, DataComponentEditor*>* propEditorUI);
     void setComboBox(std::map<SimulationControl*, ComboBoxEnum*>* propCombo);
     void setObjectBeingDragged(QTreeWidgetItem* objectBeingDragged);
+    void setRestoringPersistedGuiLayout(bool restoring);
+    bool isRestoringPersistedGuiLayout() const;
     void setParentWidget(QWidget *parentWidget);
     unsigned short connectingStep() const;
     void setConnectingStep(unsigned short connectingStep);
@@ -324,6 +326,7 @@ private:
     QList<QGraphicsItem*>* _graphicalAnimations = new QList<QGraphicsItem*>();
     QList<QGraphicsItem*>* _graphicalEntities = new QList<QGraphicsItem*>();
     QList<QGraphicsItemGroup*>* _graphicalGroups = new QList<QGraphicsItemGroup*>();
+    bool _restoringPersistedGuiLayout = false;
 };
 
 #endif /* MODELGRAPHICSSCENE_H */

--- a/source/applications/gui/qt/GenesysQtGUI/services/GraphicalModelBuilder.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/services/GraphicalModelBuilder.cpp
@@ -184,6 +184,12 @@ void GraphicalModelBuilder::rebuildGraphicalDataDefinitionsLayer(std::map<ModelC
             yInternal += 150;
             gdd->setPos(componentPosition.x(), yInternal);
             gdd->setOldPosition(componentPosition.x(), yInternal);
+            // Apply first-materialization fallback grouping only for internal data without persisted layout restoration.
+            if (!_scene->isRestoringPersistedGuiLayout() && gdd->parentItem() == nullptr && gdd->group() == nullptr) {
+                QPointF scenePosition = gdd->scenePos();
+                gdd->setParentItem(graphicalComponent);
+                gdd->setPos(graphicalComponent->mapFromScene(scenePosition));
+            }
             _scene->addGraphicalDiagramConnection(gdd, graphicalComponent, GraphicalDiagramConnection::ConnectionType::INTERNAL);
         }
     }

--- a/source/applications/gui/qt/GenesysQtGUI/services/GraphicalModelSerializer.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/services/GraphicalModelSerializer.cpp
@@ -472,8 +472,11 @@ Model* GraphicalModelSerializer::loadGraphicalModel(const std::string& filename)
     QFile::remove(tempFile.fileName());
 
     if (model != nullptr) {
+        ModelGraphicsScene* scene = _graphicsView->getScene();
         // Rebuild the base graphical topology from a single source of truth before applying persisted GUI overlays.
         _clearModelEditors();
+        // Mark persisted-layout restore so builder defaults do not override saved grouping/positions.
+        scene->setRestoringPersistedGuiLayout(true);
         _rebuildGraphicalModelFromModel();
 
         struct PersistedComponentState {
@@ -648,7 +651,6 @@ Model* GraphicalModelSerializer::loadGraphicalModel(const std::string& filename)
             }
 
             // Apply persisted data definition positions to existing items created by GraphicalModelBuilder.
-            ModelGraphicsScene* scene = _graphicsView->getScene();
             QList<QGraphicsItem*>* graphicalDataDefinitions = scene->getGraphicalModelDataDefinitions();
             if (graphicalDataDefinitions != nullptr) {
                 for (QGraphicsItem* item : *graphicalDataDefinitions) {
@@ -917,6 +919,7 @@ Model* GraphicalModelSerializer::loadGraphicalModel(const std::string& filename)
         }
 
         _applyDiagramsVisibility();
+        scene->setRestoringPersistedGuiLayout(false);
         if (hasPersistedViewState) {
             QTimer::singleShot(0, _ownerWidget, [this, restoredViewpointX, restoredViewpointY]() {
                 QScrollBar* hBar = _graphicsView->horizontalScrollBar();


### PR DESCRIPTION
### Motivation
- Prevent accidental user deletion of graphical data-definition nodes while keeping them selectable for property editing. 
- Provide a safe, non-invasive initial grouping fallback so `internal` data definitions are visually associated with their owner component when first materialized. 
- Preserve existing `.gui` persisted layouts and avoid overwriting saved grouping/positions during restore. 

### Description
- Block direct user delete flows by filtering out `GraphicalModelDataDefinition` from the deletion path in `ModelGraphicsScene::keyPressEvent` and by ignoring them when constructing `DeleteUndoCommand`. 
- Apply a first-materialization fallback grouping in `GraphicalModelBuilder::rebuildGraphicalDataDefinitionsLayer` for `internal` data definitions only by parenting the graphical data item to its `GraphicalModelComponent` when no persisted grouping/parent exists. 
- Add a `ModelGraphicsScene` flag API (`setRestoringPersistedGuiLayout` / `isRestoringPersistedGuiLayout`) to let the serializer mark restore time so the builder skips fallback grouping while applying persisted `.gui` overlays. 
- Added short English comments above modified blocks to explain intent and avoid changing `.gui` serialization format. 

### Testing
- Confirmed current branch (`work`) and produced a diff restricted to five modified files: `ModelGraphicsScene.{h,cpp}`, `GraphicalModelBuilder.cpp`, `GraphicalModelSerializer.cpp`, and `DeleteUndoCommand.cpp`. 
- Ran `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` which configured successfully. 
- Attempted GUI-enabled configure with `-DGENESYS_BUILD_GUI=ON`, but the project ignored that flag in this environment; GUI targets were not built. 
- Started `cmake --build build -j2`; the non-GUI compilation progressed (many objects and static libraries built) with no compile error reported during the observed window, but a full GUI runtime build/test could not be completed here because GUI targets are disabled in the current CMake configuration and a full GUI run is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da74f0a7f083218b63724fbc94b822)