### PR TITLE
Implement File data element: metadata, validation, persistence, and tests

### DIFF
--- a/source/plugins/data/File.cpp
+++ b/source/plugins/data/File.cpp
@@ -12,6 +12,7 @@
  */
 
 #include "File.h"
+#include "../../kernel/simulator/Model.h"
 
 #ifdef PLUGINCONNECT_DYNAMIC
 
@@ -25,12 +26,24 @@ ModelDataDefinition* File::NewInstance(Model* model, std::string name) {
 }
 
 File::File(Model* model, std::string name) : ModelDataDefinition(model, Util::TypeOf<File>(), name) {
-	//_elems = elems;
+	SimulationControlGeneric<std::string>* propSystemFilename = new SimulationControlGeneric<std::string>(
+			std::bind(&File::getSystemFilename, this), std::bind(&File::setSystemFilename, this, std::placeholders::_1),
+			Util::TypeOf<File>(), getName(), "SystemFilename", "");
+	SimulationControlGeneric<std::string>* propAccessMode = new SimulationControlGeneric<std::string>(
+			std::bind(&File::getAccessModeAsString, this), std::bind(&File::setAccessModeAsString, this, std::placeholders::_1),
+			Util::TypeOf<File>(), getName(), "AccessMode", "");
+	_parentModel->getControls()->insert(propSystemFilename);
+	_parentModel->getControls()->insert(propAccessMode);
+	_addProperty(propSystemFilename);
+	_addProperty(propAccessMode);
 }
 
 std::string File::show() {
 	return ModelDataDefinition::show() +
-			"";
+			",systemFilename=\"" + _systemFilename + "\"" +
+			",filenameOnly=\"" + getFilenameOnly() + "\"" +
+			",pathOnly=\"" + getPathOnly() + "\"" +
+			",accessMode=\"" + getAccessModeAsString() + "\"";
 }
 
 PluginInformation* File::GetPluginInformation() {
@@ -53,16 +66,8 @@ bool File::_loadInstance(PersistenceRecord *fields) {
 	bool res = ModelDataDefinition::_loadInstance(fields);
 	if (res) {
 		try {
-			/*!
-			 * \brief Load file metadata fields.
-			 *
-			 * File currently stores only the base ModelDataDefinition data.
-			 * Keep the template commands below as guidance when file-specific
-			 * attributes are introduced.
-			 */
-			// this->_accessType = fields->loadField("accessType", DEFAULT.accessType);
-			// this->_systemFilename = fields->loadField("systemFilename", DEFAULT.systemFilename);
-			// this->_recordsetName = fields->loadField("recordsetName", DEFAULT.recordsetName);
+			setSystemFilename(fields->loadField("systemFilename", DEFAULT.systemFilename));
+			setAccessModeAsString(fields->loadField("accessMode", _accessModeToString(DEFAULT.accessMode)));
 		} catch (...) {
 		}
 	}
@@ -71,22 +76,26 @@ bool File::_loadInstance(PersistenceRecord *fields) {
 
 void File::_saveInstance(PersistenceRecord *fields, bool saveDefaultValues) {
 	ModelDataDefinition::_saveInstance(fields, saveDefaultValues);
-	/*!
-	 * \brief Save file metadata fields.
-	 */
-	// fields->saveField("accessType", _accessType, DEFAULT.accessType, saveDefaultValues);
-	// fields->saveField("systemFilename", _systemFilename, DEFAULT.systemFilename, saveDefaultValues);
-	// fields->saveField("recordsetName", _recordsetName, DEFAULT.recordsetName, saveDefaultValues);
+	fields->saveField("systemFilename", _systemFilename, DEFAULT.systemFilename, saveDefaultValues);
+	fields->saveField("accessMode", getAccessModeAsString(), _accessModeToString(DEFAULT.accessMode), saveDefaultValues);
 }
 
 bool File::_check(std::string& errorMessage) {
-	/*!
-	 * \brief Validate file metadata consistency.
-	 */
 	bool resultAll = true;
-	// resultAll &= (_systemFilename != "");
-	// resultAll &= Util::FileExists(_systemFilename);
-	(void) errorMessage;
+	if (_systemFilename.empty()) {
+		errorMessage += "File \"" + getName() + "\" must define a non-empty systemFilename. ";
+		resultAll = false;
+	}
+	if (_systemFilename.empty() == false) {
+		if (_accessModeWasInvalid) {
+			errorMessage += "File \"" + getName() + "\" has unsupported accessMode. ";
+			resultAll = false;
+		}
+		if ((_accessMode == AccessMode::Read || _accessMode == AccessMode::ReadWrite) && !Util::FileExists(_systemFilename)) {
+			errorMessage += "File \"" + getName() + "\" requires an existing file for accessMode \"" + getAccessModeAsString() + "\". ";
+			resultAll = false;
+		}
+	}
 	return resultAll;
 }
 
@@ -100,4 +109,90 @@ ParserChangesInformation* File::_getParserChangesInformation() {
 	//changes->getProductionToAdd()->insert(...);
 	//changes->getTokensToAdd()->insert(...);
 	return changes;
+}
+
+void File::setSystemFilename(std::string systemFilename) {
+	_systemFilename = _normalizePathSeparators(systemFilename);
+}
+
+std::string File::getSystemFilename() const {
+	return _systemFilename;
+}
+
+std::string File::getFilenameOnly() const {
+	const std::string normalized = _normalizePathSeparators(_systemFilename);
+	return Util::FilenameFromFullFilename(normalized);
+}
+
+std::string File::getPathOnly() const {
+	const std::string normalized = _normalizePathSeparators(_systemFilename);
+	const size_t sepPos = normalized.find_last_of(Util::DirSeparator());
+	if (sepPos == std::string::npos) {
+		return "";
+	}
+	return Util::PathFromFullFilename(normalized);
+}
+
+void File::setAccessMode(AccessMode accessMode) {
+	_accessMode = accessMode;
+	_accessModeWasInvalid = false;
+}
+
+File::AccessMode File::getAccessMode() const {
+	return _accessMode;
+}
+
+void File::setAccessModeAsString(std::string accessMode) {
+	AccessMode parsed = DEFAULT.accessMode;
+	if (_stringToAccessMode(accessMode, &parsed)) {
+		_accessMode = parsed;
+		_accessModeWasInvalid = false;
+	} else {
+		_accessModeWasInvalid = true;
+	}
+}
+
+std::string File::getAccessModeAsString() const {
+	return _accessModeToString(_accessMode);
+}
+
+std::string File::_accessModeToString(AccessMode accessMode) {
+	switch (accessMode) {
+		case AccessMode::Read: return "Read";
+		case AccessMode::Write: return "Write";
+		case AccessMode::Append: return "Append";
+		case AccessMode::ReadWrite: return "ReadWrite";
+		default: return "Read";
+	}
+}
+
+bool File::_stringToAccessMode(const std::string& accessMode, AccessMode* parsedAccessMode) {
+	if (accessMode == "Read") {
+		*parsedAccessMode = AccessMode::Read;
+		return true;
+	}
+	if (accessMode == "Write") {
+		*parsedAccessMode = AccessMode::Write;
+		return true;
+	}
+	if (accessMode == "Append") {
+		*parsedAccessMode = AccessMode::Append;
+		return true;
+	}
+	if (accessMode == "ReadWrite") {
+		*parsedAccessMode = AccessMode::ReadWrite;
+		return true;
+	}
+	return false;
+}
+
+std::string File::_normalizePathSeparators(const std::string& filename) {
+	std::string normalized = filename;
+	const char separator = Util::DirSeparator();
+	for (char& ch : normalized) {
+		if (ch == '/' || ch == '\\') {
+			ch = separator;
+		}
+	}
+	return normalized;
 }

--- a/source/plugins/data/File.h
+++ b/source/plugins/data/File.h
@@ -63,6 +63,13 @@ recordset refers.
  */
 class File : public ModelDataDefinition {
 public:
+	enum class AccessMode : unsigned int {
+		Read = 0,
+		Write = 1,
+		Append = 2,
+		ReadWrite = 3
+	};
+
 	File(Model* model, std::string name = "");
 	virtual ~File() = default;
 public: // static
@@ -70,6 +77,16 @@ public: // static
 	static PluginInformation* GetPluginInformation();
 	static ModelDataDefinition* NewInstance(Model* model, std::string name = "");
 public:
+	void setSystemFilename(std::string systemFilename);
+	std::string getSystemFilename() const;
+	std::string getFilenameOnly() const;
+	std::string getPathOnly() const;
+
+	void setAccessMode(AccessMode accessMode);
+	AccessMode getAccessMode() const;
+	void setAccessModeAsString(std::string accessMode);
+	std::string getAccessModeAsString() const;
+
 	virtual std::string show() override;
 
 protected: // must be overriden 
@@ -79,7 +96,19 @@ protected: // could be overriden
 	virtual bool _check(std::string& errorMessage) override;
 	virtual ParserChangesInformation* _getParserChangesInformation() override;
 
+private:
+	static std::string _accessModeToString(AccessMode accessMode);
+	static bool _stringToAccessMode(const std::string& accessMode, AccessMode* parsedAccessMode);
+	static std::string _normalizePathSeparators(const std::string& filename);
+
+private:
+	const struct DEFAULT_VALUES {
+		std::string systemFilename = "";
+		AccessMode accessMode = AccessMode::Read;
+	} DEFAULT;
+	std::string _systemFilename = DEFAULT.systemFilename;
+	AccessMode _accessMode = DEFAULT.accessMode;
+	bool _accessModeWasInvalid = false;
 };
 
 #endif /* FILE_H */
-

--- a/source/tests/unit/test_simulator_runtime.cpp
+++ b/source/tests/unit/test_simulator_runtime.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include <algorithm>
+#include <fstream>
 #include <memory>
 #include <vector>
 
@@ -23,6 +24,8 @@
 #include "plugins/data/Set.h"
 #include "plugins/data/Label.h"
 #include "plugins/data/Storage.h"
+#include "plugins/data/File.h"
+#include "kernel/util/Util.h"
 #define private public
 #define protected public
 #include "plugins/data/EntityGroup.h"
@@ -640,6 +643,23 @@ public:
 class StorageProbe : public Storage {
 public:
     StorageProbe(Model* model, const std::string& name = "") : Storage(model, name) {}
+
+    bool CheckProbe(std::string& errorMessage) {
+        return _check(errorMessage);
+    }
+
+    bool LoadInstanceProbe(PersistenceRecord* fields) {
+        return _loadInstance(fields);
+    }
+
+    void SaveInstanceProbe(PersistenceRecord* fields, bool saveDefaultValues = false) {
+        _saveInstance(fields, saveDefaultValues);
+    }
+};
+
+class FileProbe : public File {
+public:
+    FileProbe(Model* model, const std::string& name = "") : File(model, name) {}
 
     bool CheckProbe(std::string& errorMessage) {
         return _check(errorMessage);
@@ -3948,4 +3968,165 @@ TEST(SimulatorRuntimeTest, RemoveCheckValidatesRankExpressionsAndMinimalQueueCon
     valid.setRemoveEndRank("0");
     std::string validMessage;
     EXPECT_TRUE(valid.CheckProbe(validMessage)) << validMessage;
+}
+
+TEST(SimulatorRuntimeTest, FileDefaultsExposeSafeDescriptorMetadata) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    FileProbe file(model, "FileDefaults");
+    EXPECT_EQ(file.getSystemFilename(), "");
+    EXPECT_EQ(file.getFilenameOnly(), "");
+    EXPECT_EQ(file.getPathOnly(), "");
+    EXPECT_EQ(file.getAccessModeAsString(), "Read");
+}
+
+TEST(SimulatorRuntimeTest, FileSettersAndGettersPreserveDescriptorInformation) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    FileProbe file(model, "FileSetterGetter");
+    const std::string configured = std::string("folder") + Util::DirSeparator() + "sub" + Util::DirSeparator() + "dataset.csv";
+    file.setSystemFilename(configured);
+    file.setAccessMode(File::AccessMode::Append);
+
+    EXPECT_EQ(file.getSystemFilename(), configured);
+    EXPECT_EQ(file.getFilenameOnly(), "dataset.csv");
+    EXPECT_EQ(file.getPathOnly(), std::string("folder") + Util::DirSeparator() + "sub");
+    EXPECT_EQ(file.getAccessModeAsString(), "Append");
+}
+
+TEST(SimulatorRuntimeTest, FileNormalizesPathSeparatorsBeforeDerivingFilenameAndPath) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    FileProbe withSlashes(model, "FileSlashPath");
+    withSlashes.setSystemFilename("dirA/dirB/slash.txt");
+    EXPECT_EQ(withSlashes.getFilenameOnly(), "slash.txt");
+    EXPECT_EQ(withSlashes.getPathOnly(), std::string("dirA") + Util::DirSeparator() + "dirB");
+
+    FileProbe withBackslashes(model, "FileBackslashPath");
+    withBackslashes.setSystemFilename("dirX\\dirY\\backslash.txt");
+    EXPECT_EQ(withBackslashes.getFilenameOnly(), "backslash.txt");
+    EXPECT_EQ(withBackslashes.getPathOnly(), std::string("dirX") + Util::DirSeparator() + "dirY");
+}
+
+TEST(SimulatorRuntimeTest, FileCheckRejectsEmptyFilenameAndMissingReadableFile) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    FileProbe emptyFilename(model, "FileCheckEmpty");
+    emptyFilename.setAccessMode(File::AccessMode::Write);
+    std::string emptyError;
+    EXPECT_FALSE(emptyFilename.CheckProbe(emptyError));
+    EXPECT_NE(emptyError.find("non-empty systemFilename"), std::string::npos);
+
+    FileProbe missingReadFile(model, "FileCheckMissingRead");
+    missingReadFile.setSystemFilename(std::string("missing") + Util::DirSeparator() + "missing-file-runtime-check.txt");
+    missingReadFile.setAccessMode(File::AccessMode::Read);
+    std::string missingReadError;
+    EXPECT_FALSE(missingReadFile.CheckProbe(missingReadError));
+    EXPECT_NE(missingReadError.find("requires an existing file"), std::string::npos);
+
+    FileProbe invalidAccessMode(model, "FileCheckInvalidMode");
+    invalidAccessMode.setSystemFilename(std::string("any") + Util::DirSeparator() + "path.txt");
+    invalidAccessMode.setAccessModeAsString("invalid-mode");
+    std::string invalidAccessModeError;
+    EXPECT_FALSE(invalidAccessMode.CheckProbe(invalidAccessModeError));
+    EXPECT_NE(invalidAccessModeError.find("unsupported accessMode"), std::string::npos);
+}
+
+TEST(SimulatorRuntimeTest, FileCheckAcceptsMinimalWritableConfiguration) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    FileProbe file(model, "FileCheckWrite");
+    file.setSystemFilename(std::string("new-output") + Util::DirSeparator() + "result.dat");
+    file.setAccessMode(File::AccessMode::Write);
+    std::string errorMessage;
+    EXPECT_TRUE(file.CheckProbe(errorMessage)) << errorMessage;
+}
+
+TEST(SimulatorRuntimeTest, FileShowIncludesFilenamePathAndAccessModeMetadata) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    FileProbe file(model, "FileShow");
+    file.setSystemFilename("show/path/file.txt");
+    file.setAccessMode(File::AccessMode::ReadWrite);
+
+    const std::string shown = file.show();
+    EXPECT_NE(shown.find("systemFilename=\"show"), std::string::npos);
+    EXPECT_NE(shown.find("filenameOnly=\"file.txt\""), std::string::npos);
+    EXPECT_NE(shown.find("pathOnly=\"show"), std::string::npos);
+    EXPECT_NE(shown.find("accessMode=\"ReadWrite\""), std::string::npos);
+}
+
+TEST(SimulatorRuntimeTest, FilePersistenceRoundTripPreservesMetadata) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    const std::string tempFile = Util::RunningPath() + Util::DirSeparator() + "sim_runtime_file_roundtrip.tmp";
+    {
+        std::ofstream temp(tempFile);
+        ASSERT_TRUE(temp.good());
+        temp << "probe";
+    }
+
+    FileProbe source(model, "FilePersistSource");
+    source.setSystemFilename(tempFile);
+    source.setAccessMode(File::AccessMode::ReadWrite);
+
+    FakeModelPersistenceRuntime persistence;
+    PersistenceRecord fields(persistence);
+    source.SaveInstanceProbe(&fields, true);
+
+    FileProbe loaded(model, "FilePersistLoaded");
+    ASSERT_TRUE(loaded.LoadInstanceProbe(&fields));
+    EXPECT_EQ(loaded.getSystemFilename(), source.getSystemFilename());
+    EXPECT_EQ(loaded.getFilenameOnly(), source.getFilenameOnly());
+    EXPECT_EQ(loaded.getPathOnly(), source.getPathOnly());
+    EXPECT_EQ(loaded.getAccessModeAsString(), "ReadWrite");
+
+    Util::FileDelete(tempFile);
+}
+
+TEST(SimulatorRuntimeTest, FileRegistersControlsAndPropertiesForMainMetadata) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    FileProbe file(model, "FileControls");
+    ASSERT_GE(file.getProperties()->size(), 2u);
+
+    bool hasSystemFilenameProperty = false;
+    bool hasAccessModeProperty = false;
+    for (SimulationControl* property : *file.getProperties()->list()) {
+        if (property->getName() == "SystemFilename") {
+            hasSystemFilenameProperty = true;
+        } else if (property->getName() == "AccessMode") {
+            hasAccessModeProperty = true;
+        }
+    }
+    EXPECT_TRUE(hasSystemFilenameProperty);
+    EXPECT_TRUE(hasAccessModeProperty);
+
+    bool modelHasSystemFilenameControl = false;
+    bool modelHasAccessModeControl = false;
+    for (SimulationControl* control : *model->getControls()->list()) {
+        if (control->getName() == "SystemFilename" && control->getElementName() == file.getName()) {
+            modelHasSystemFilenameControl = true;
+        } else if (control->getName() == "AccessMode" && control->getElementName() == file.getName()) {
+            modelHasAccessModeControl = true;
+        }
+    }
+    EXPECT_TRUE(modelHasSystemFilenameControl);
+    EXPECT_TRUE(modelHasAccessModeControl);
 }


### PR DESCRIPTION
### Motivation
- The `File` data element was a stub and must represent a persistent, portable descriptor for external files so other model elements can reference it. 
- Provide minimal, safe metadata (filename + access mode), cross-platform path handling, observable properties and basic validation without implementing real I/O. 

### Description
- Added `systemFilename` storage and an `AccessMode` enum (`Read`, `Write`, `Append`, `ReadWrite`) with string mapping, getters/setters, and path-normalization that converts `/` and `\` to `Util::DirSeparator()`. (files: `source/plugins/data/File.h`, `source/plugins/data/File.cpp`).
- Registered controls/properties for `SystemFilename` and `AccessMode` in both `model->getControls()` and via `_addProperty(...)`, and enhanced `show()` to include `systemFilename`, `filenameOnly`, `pathOnly` and `accessMode`.
- Implemented symmetric persistence via `_saveInstance`/`_loadInstance` for `systemFilename` and `accessMode`, and added `_check()` validations that enforce non-empty `systemFilename`, coherent access mode, and require file existence when mode includes read access, emitting clear `errorMessage` text.
- Added `FileProbe` and eight unit tests in `source/tests/unit/test_simulator_runtime.cpp` covering defaults, setters/getters, path-normalization, invalid/valid `_check()` scenarios, `show()`, persistence round-trip, and presence of controls/properties.

### Testing
- Built the targeted test binary: `cmake -S . -B build -G Ninja -DGENESYS_BUILD_TESTS=ON -DGENESYS_BUILD_KERNEL=ON -DGENESYS_BUILD_PARSER=ON -DGENESYS_BUILD_PLUGINS=ON -DGENESYS_TERMINAL_APPLICATION=OFF -DGENESYS_BUILD_GUI_APPLICATION=OFF -DGENESYS_BUILD_WEB_APPLICATION=OFF` then `cmake --build build --target genesys_test_simulator_runtime` and linking succeeded.
- Ran focused tests: `ctest --test-dir build -R "SimulatorRuntimeTest.*File" --output-on-failure` and all `File` tests passed (8/8 passed).
- Ran broader smoke suite: `ctest --test-dir build -LE smoke --output-on-failure` (suite executed but several unrelated targets are `*_NOT_BUILT` in this configuration; repository-wide test coverage shown as 91% passing with not-built targets reported). 
- Observed a pre-existing compiler warning about `Util::PathFromFullFilename` inline declaration when building; it did not block the build or tests for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da778d9cb88321bf27bb375aebf502)