### PR TITLE
GUI: harden mixed-group edit commands for internal data definitions

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/controllers/EditCommandController.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/EditCommandController.cpp
@@ -83,6 +83,9 @@ void EditCommandController::onActionEditCutTriggered() const {
             } else if (QGraphicsItemGroup* group = dynamic_cast<QGraphicsItemGroup*>(item)) {
                 for (int i = 0; i < group->childItems().size(); i++) {
                     GraphicalModelComponent* component = dynamic_cast<GraphicalModelComponent*>(group->childItems().at(i));
+                    if (component == nullptr) {
+                        continue;
+                    }
 
                     if (!component->getGraphicalInputPorts().empty() && !component->getGraphicalInputPorts().at(0)->getConnections()->empty()) {
                         for (int j = 0; j < component->getGraphicalInputPorts().at(0)->getConnections()->size(); ++j) {
@@ -101,11 +104,13 @@ void EditCommandController::onActionEditCutTriggered() const {
                     groupComponents.append(component);
                 }
 
-                saveItemForCopy(&groupComponents, connGroup);
-                (*_groupCopy)->append(group);
-                currentScene->insertComponentGroup(group, groupComponents);
-                for (unsigned int k = 0; k < static_cast<unsigned int>(connGroup->size()); k++) {
-                    (*_portsCopies)->append(connGroup->at(k));
+                if (!groupComponents.isEmpty()) {
+                    saveItemForCopy(&groupComponents, connGroup);
+                    (*_groupCopy)->append(group);
+                    currentScene->insertComponentGroup(group, groupComponents);
+                    for (unsigned int k = 0; k < static_cast<unsigned int>(connGroup->size()); k++) {
+                        (*_portsCopies)->append(connGroup->at(k));
+                    }
                 }
             } else if (GraphicalConnection* port = dynamic_cast<GraphicalConnection*>(item)) {
                 (*_portsCopies)->append(port);
@@ -144,11 +149,19 @@ void EditCommandController::onActionEditCopyTriggered() const {
                 (*_portsCopies)->append(conn);
             } else if (QGraphicsItemGroup* group = dynamic_cast<QGraphicsItemGroup*>(item)) {
                 group->setSelected(false);
-                (*_groupCopy)->append(group);
+                QList<GraphicalModelComponent*> groupComponents;
 
                 for (int i = 0; i < group->childItems().size(); i++) {
                     GraphicalModelComponent* component = dynamic_cast<GraphicalModelComponent*>(group->childItems().at(i));
+                    if (component == nullptr) {
+                        continue;
+                    }
                     gmcCopiesCopy.append(component);
+                    groupComponents.append(component);
+                }
+
+                if (!groupComponents.isEmpty()) {
+                    (*_groupCopy)->append(group);
                 }
             } else {
                 item->setSelected(false);
@@ -271,10 +284,13 @@ void EditCommandController::helpCopy() const {
 
     for (QGraphicsItemGroup* group : **_groupCopy) {
         QList<GraphicalConnection*>* connGroup = new QList<GraphicalConnection*>();
-        unsigned int size = group->childItems().size();
+        QList<QGraphicsItem*> groupChildren = group->childItems();
 
-        for (unsigned int i = 0; i < size; i++) {
-            GraphicalModelComponent* gmc = dynamic_cast<GraphicalModelComponent*>(group->childItems().at(0));
+        for (QGraphicsItem* child : groupChildren) {
+            GraphicalModelComponent* gmc = dynamic_cast<GraphicalModelComponent*>(child);
+            if (gmc == nullptr) {
+                continue;
+            }
             group->removeFromGroup(gmc);
 
             ModelComponent* previousComponent = gmc->getComponent();
@@ -308,7 +324,7 @@ void EditCommandController::helpCopy() const {
         }
 
         saveItemForCopy(gmcOldGroupAux, connGroup);
-        for (unsigned int k = 0; k < size; k++) {
+        for (unsigned int k = 0; k < static_cast<unsigned int>(gmcOldGroupAux->size()); k++) {
             group->addToGroup(gmcOldGroupAux->at(k));
         }
 
@@ -317,11 +333,13 @@ void EditCommandController::helpCopy() const {
             (*_portsCopies)->append(connGroup->at(k));
         }
 
-        QGraphicsItemGroup* newGroup = new QGraphicsItemGroup();
-        _graphicsView->getScene()->insertComponentGroup(newGroup, *gmcNewGroupAux);
+        if (!gmcNewGroupAux->isEmpty()) {
+            QGraphicsItemGroup* newGroup = new QGraphicsItemGroup();
+            _graphicsView->getScene()->insertComponentGroup(newGroup, *gmcNewGroupAux);
+            groupAux->append(newGroup);
+        }
         gmcOldGroupAux->clear();
         gmcNewGroupAux->clear();
-        groupAux->append(newGroup);
         delete connGroup;
     }
 

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
@@ -2075,6 +2075,10 @@ void ModelGraphicsScene::ungroupModelComponents(QGraphicsItemGroup *group) {
 }
 
 void ModelGraphicsScene::removeGroup(QGraphicsItemGroup* group, bool notify) {
+    if (group == nullptr) {
+        return;
+    }
+
     //Recupere os itens individuais no grupo
     QList<QGraphicsItem*> itemsInGroup = group->childItems();
 
@@ -2083,10 +2087,18 @@ void ModelGraphicsScene::removeGroup(QGraphicsItemGroup* group, bool notify) {
 
     unsigned int size = itemsInGroup.size();
     for (unsigned int i = 0; i < size; i++) {
-        GraphicalModelComponent * gmc = dynamic_cast<GraphicalModelComponent *> (itemsInGroup.at(i));
+        QGraphicsItem* child = itemsInGroup.at(i);
+        if (GraphicalModelComponent * gmc = dynamic_cast<GraphicalModelComponent *> (child)) {
+            group->removeFromGroup(gmc);
+            removeComponent(gmc);
+            continue;
+        }
 
-        group->removeFromGroup(gmc);
-        removeComponent(gmc);
+        // Keep non-component children safe when removing mixed groups.
+        group->removeFromGroup(child);
+        if (child->scene() != this) {
+            addItem(child);
+        }
     }
     _graphicalGroups->removeOne(group);
     group->update();


### PR DESCRIPTION
### Motivation
- Auto-grouping created mixed `QGraphicsItemGroup` containing both `GraphicalModelComponent` and `GraphicalModelDataDefinition`, while legacy edit paths assumed groups contained only components, risking null-dereference and unsafe casts.

### Description
- Hardened `ModelGraphicsScene::removeGroup()` to early-return on `nullptr`, call `removeComponent(...)` only for `GraphicalModelComponent` children, and safely detach non-component children without treating them as components.
- Hardened `EditCommandController::onActionEditCutTriggered()` to skip non-`GraphicalModelComponent` children when collecting group components and to register a group for structural cut only when at least one component is present.
- Hardened `EditCommandController::onActionEditCopyTriggered()` to filter group children by `GraphicalModelComponent` and only add groups to the structural `groupCopy` when they contain components.
- Hardened `EditCommandController::helpCopy()` to iterate a snapshot of group children, skip non-component children when cloning, and create new cloned groups only when component clones exist.
- Changes are small, localized and limited to `ModelGraphicsScene.cpp` and `EditCommandController.cpp` and do not touch serializer, builder, animations, property editor, DOT, or `.gui` format.

### Testing
- Configured the project with `cmake -S . -B build` and performed a full non-GUI build with `cmake --build build -j2`, which completed successfully and produced the expected targets.
- Verified the source diff is restricted to `source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp` and `source/applications/gui/qt/GenesysQtGUI/controllers/EditCommandController.cpp` and that the new guards/filtering cover mixed groups and preserve behavior for homogeneous component groups.
- Attempted GUI-specific configuration with `-DGENESYS_BUILD_GUI=ON`, but the project ignored that variable in this environment so a separate GUI build was not exercised here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da79ee0a608321aea4c07bc6ca03fb)