### PR TITLE
Harden Create/Assign validation and fix Assign persistence indexing

### DIFF
--- a/source/plugins/components/Assign.cpp
+++ b/source/plugins/components/Assign.cpp
@@ -13,6 +13,8 @@
 
 #include "Assign.h"
 #include <string>
+#include <algorithm>
+#include <cctype>
 #include "../../kernel/simulator/Model.h"
 #include "../../kernel/simulator/Attribute.h"
 #include "../../kernel/simulator/Simulator.h"
@@ -135,31 +137,30 @@ void Assign::_saveInstance(PersistenceRecord *fields, bool saveDefaultValues) {
 	for (std::list<Assignment*>::iterator it = _assignments->list()->begin(); it != _assignments->list()->end(); it++, i++) {
 		let = (*it);
 		let->saveInstance(fields, i, saveDefaultValues);
-		i++;
 	}
 }
 
 bool Assign::_check(std::string& errorMessage) {
 	bool resultAll = true;
+	_attachedDataClear();
 	int i = 0;
 	for (Assignment* let : *_assignments->list()) {
-		ModelDataDefinition* data = nullptr;
-		if (let->isAttributeNotVariable()) {
-			data = _parentModel->getDataManager()->getDataDefinition(Util::TypeOf<Attribute>(), let->getDestination());
-			if (data == nullptr) {
-				data = _parentModel->getParentSimulator()->getPluginManager()->newInstance<Attribute>(_parentModel, let->getDestination());
-				_parentModel->getDataManager()->insert(data);
-			}
+		if (let->getDestination().empty()) {
+			errorMessage += "Assignment destination cannot be empty. ";
+			resultAll = false;
+			continue;
 		}
-		if (!let->isAttributeNotVariable()) {
-			data = _parentModel->getDataManager()->getDataDefinition(Util::TypeOf<Variable>(), let->getDestination());
-			if (data == nullptr) {
-				data = _parentModel->getParentSimulator()->getPluginManager()->newInstance<Variable>(_parentModel, let->getDestination());
-				_parentModel->getDataManager()->insert(data);
-			}
+
+		const std::string baseDestination = _destinationBaseName(let->getDestination());
+		const std::string destinationType = let->isAttributeNotVariable() ? Util::TypeOf<Attribute>() : Util::TypeOf<Variable>();
+		ModelDataDefinition* data = _parentModel->getDataManager()->getDataDefinition(destinationType, baseDestination);
+		if (data == nullptr) {
+			errorMessage += destinationType + " \"" + baseDestination + "\" for assignment destination is not in the model. ";
+			resultAll = false;
+		} else {
+			_attachedDataInsert("Assignment" + Util::StrIndex(i), data);
 		}
-		_attachedDataInsert("Assignment" + Util::StrIndex(i), data);
-		// @TODO: +++ Reimplement it. Since 201910, attributes may have index, just like "atrrib1[2]" or "att[10,1]". Because of that, the string may contain not only the name of the attribute, but also its index and therefore, fails on the test bellow.
+
 		resultAll &= _parentModel->checkExpression(let->getExpression(), "assignment", errorMessage);
 		i++;
 	}
@@ -167,20 +168,32 @@ bool Assign::_check(std::string& errorMessage) {
 }
 
 void Assign::_createInternalAndAttachedData() {
+	_attachedDataClear();
 	ModelDataManager* elems = _parentModel->getDataManager();
 	for (Assignment* ass : *_assignments->list()) {
-		ModelDataDefinition* elem;
+		ModelDataDefinition* elem = nullptr;
 		std::string name;
+		const std::string baseDestination = _destinationBaseName(ass->getDestination());
 		if (ass->isAttributeNotVariable()) {
 			name = "Attribute";
-			elem = elems->getDataDefinition(Util::TypeOf<Attribute>(), ass->getDestination());
+			elem = elems->getDataDefinition(Util::TypeOf<Attribute>(), baseDestination);
 		} else {
 			name = "Variable";
-			elem = elems->getDataDefinition(Util::TypeOf<Variable>(), ass->getDestination());
+			elem = elems->getDataDefinition(Util::TypeOf<Variable>(), baseDestination);
 		}
 		//assert elem != nullptr
 		if (elem != nullptr) {
-			this->_attachedDataInsert(name + "_" + ass->getDestination(), elem);
+			this->_attachedDataInsert(name + "_" + baseDestination, elem);
 		}
 	}
+}
+
+std::string Assign::_destinationBaseName(const std::string& destination) {
+	const std::string::size_type bracket = destination.find('[');
+	if (bracket == std::string::npos) {
+		return destination;
+	}
+	std::string base = destination.substr(0, bracket);
+	base.erase(std::find_if(base.rbegin(), base.rend(), [](unsigned char ch) { return !std::isspace(ch); }).base(), base.end());
+	return base;
 }

--- a/source/plugins/components/Assign.h
+++ b/source/plugins/components/Assign.h
@@ -85,6 +85,7 @@ protected: // could be overriden by derived classes
 	virtual void _createInternalAndAttachedData() override; /*< A ModelDataDefinition or ModelComponent that includes (internal) ou refers to (attach) other ModelDataDefinition must register them inside this method. */
 	//virtual void _addProperty(PropertyBase* property);
 private:
+	static std::string _destinationBaseName(const std::string& destination);
 private:
 
 	const struct DEFAULT_VALUES {

--- a/source/plugins/components/Create.cpp
+++ b/source/plugins/components/Create.cpp
@@ -150,14 +150,48 @@ void Create::_saveInstance(PersistenceRecord *fields, bool saveDefaultValues) {
 
 bool Create::_check(std::string& errorMessage) {
 	bool resultAll = SourceModelComponent::_check(errorMessage);
-	// @TODO Check expression with Schedule and Formula all together
+
+	const bool hasExpression = !_timeBetweenCreationsExpression.empty();
+	const bool hasSchedule = _timeBetweenCreationsSchedule != nullptr;
+	const bool hasFormula = _timeBetweenCreationsFormula != nullptr;
+	const unsigned int activeGenerators = static_cast<unsigned int>(hasExpression) + static_cast<unsigned int>(hasSchedule) + static_cast<unsigned int>(hasFormula);
+
+	if (activeGenerators != 1) {
+		errorMessage += "Create must define exactly one time-between-creations source: expression, schedule, or formula. ";
+		resultAll = false;
+	}
+	if (hasSchedule) {
+		resultAll &= _parentModel->getDataManager()->check(Util::TypeOf<Schedule>(), _timeBetweenCreationsSchedule, "TimeBetweenCreationsSchedule", errorMessage);
+		if (_timeBetweenCreationsSchedule != nullptr) {
+			resultAll &= _parentModel->checkExpression(_timeBetweenCreationsSchedule->getExpression(), "TimeBetweenCreationsSchedule", errorMessage);
+		}
+	}
+	if (hasFormula) {
+		resultAll &= _parentModel->getDataManager()->check(Util::TypeOf<Formula>(), _timeBetweenCreationsFormula, "TimeBetweenCreationsFormula", errorMessage);
+		if (_timeBetweenCreationsFormula != nullptr) {
+			resultAll &= _parentModel->checkExpression(_timeBetweenCreationsFormula->getExpression(), "TimeBetweenCreationsFormula", errorMessage);
+		}
+	}
 	return resultAll;
 }
 
 void Create::_createInternalAndAttachedData() {
 	SourceModelComponent::_createInternalAndAttachedData();
+	if (_timeBetweenCreationsSchedule != nullptr) {
+		_attachedDataInsert("TimeBetweenCreationsSchedule", _timeBetweenCreationsSchedule);
+	} else {
+		_attachedDataRemove("TimeBetweenCreationsSchedule");
+	}
+	if (_timeBetweenCreationsFormula != nullptr) {
+		_attachedDataInsert("TimeBetweenCreationsFormula", _timeBetweenCreationsFormula);
+	} else {
+		_attachedDataRemove("TimeBetweenCreationsFormula");
+	}
+
 	if (_reportStatistics && _numberOut == nullptr) {
 		_numberOut = new Counter(_parentModel, getName() + "." + "CountNumberOut", this);
+		_internalDataInsert("CountNumberOut", _numberOut);
+	} else if (_reportStatistics && _numberOut != nullptr) {
 		_internalDataInsert("CountNumberOut", _numberOut);
 	} else if (!_reportStatistics && _numberOut != nullptr) {
 		this->_internalDataClear();

--- a/source/tests/unit/test_simulator_runtime.cpp
+++ b/source/tests/unit/test_simulator_runtime.cpp
@@ -16,6 +16,7 @@
 #include "plugins/data/Variable.h"
 #include "plugins/data/Resource.h"
 #include "plugins/data/Failure.h"
+#include "plugins/data/Formula.h"
 #include "plugins/data/Schedule.h"
 #include "plugins/data/Sequence.h"
 #include "plugins/data/SignalData.h"
@@ -34,6 +35,12 @@
 #include "plugins/components/Match.h"
 #include "plugins/components/Search.h"
 #include "plugins/components/Remove.h"
+#include "plugins/components/Assign.h"
+#define private public
+#define protected public
+#include "plugins/components/Create.h"
+#undef protected
+#undef private
 #define private public
 #define protected public
 #include "plugins/components/Process.h"
@@ -545,6 +552,52 @@ public:
 
     void CreateInternalAndAttachedDataProbe() {
         _createInternalAndAttachedData();
+    }
+};
+
+class AssignProbe : public Assign {
+public:
+    AssignProbe(Model* model, const std::string& name = "") : Assign(model, name) {}
+
+    bool CheckProbe(std::string& errorMessage) {
+        return _check(errorMessage);
+    }
+
+    void SaveInstanceProbe(PersistenceRecord* fields, bool saveDefaultValues = false) {
+        _saveInstance(fields, saveDefaultValues);
+    }
+
+    bool LoadInstanceProbe(PersistenceRecord* fields) {
+        return _loadInstance(fields);
+    }
+
+    void CreateInternalAndAttachedDataProbe() {
+        _createInternalAndAttachedData();
+    }
+};
+
+class CreateProbe : public Create {
+public:
+    CreateProbe(Model* model, const std::string& name = "") : Create(model, name) {}
+
+    bool CheckProbe(std::string& errorMessage) {
+        return _check(errorMessage);
+    }
+
+    void SaveInstanceProbe(PersistenceRecord* fields, bool saveDefaultValues = false) {
+        _saveInstance(fields, saveDefaultValues);
+    }
+
+    bool LoadInstanceProbe(PersistenceRecord* fields) {
+        return _loadInstance(fields);
+    }
+
+    void CreateInternalAndAttachedDataProbe() {
+        _createInternalAndAttachedData();
+    }
+
+    Counter* NumberOutProbe() const {
+        return _numberOut;
     }
 };
 
@@ -3948,4 +4001,171 @@ TEST(SimulatorRuntimeTest, RemoveCheckValidatesRankExpressionsAndMinimalQueueCon
     valid.setRemoveEndRank("0");
     std::string validMessage;
     EXPECT_TRUE(valid.CheckProbe(validMessage)) << validMessage;
+}
+
+TEST(SimulatorRuntimeTest, AssignSaveLoadPreservesMultipleAssignmentsWithoutIndexGaps) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    AssignProbe source(model, "AssignPersistSource");
+    source.addAssignment(new Assignment("Entity.attrA", "1", true));
+    source.addAssignment(new Assignment("Entity.attrB", "2+3", true));
+    source.addAssignment(new Assignment("vCounter", "7", false));
+
+    FakeModelPersistenceRuntime persistence;
+    PersistenceRecord fields(persistence);
+    source.SaveInstanceProbe(&fields, true);
+
+    AssignProbe loaded(model, "AssignPersistLoaded");
+    ASSERT_TRUE(loaded.LoadInstanceProbe(&fields));
+    ASSERT_EQ(loaded.getAssignments()->size(), 3u);
+    auto it = loaded.getAssignments()->list()->begin();
+    EXPECT_EQ((*it)->getDestination(), "Entity.attrA");
+    EXPECT_EQ((*it)->getExpression(), "1");
+    ++it;
+    EXPECT_EQ((*it)->getDestination(), "Entity.attrB");
+    EXPECT_EQ((*it)->getExpression(), "2+3");
+    ++it;
+    EXPECT_EQ((*it)->getDestination(), "vCounter");
+    EXPECT_EQ((*it)->getExpression(), "7");
+    EXPECT_FALSE((*it)->isAttributeNotVariable());
+}
+
+TEST(SimulatorRuntimeTest, AssignCheckFailsForInvalidExpression) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    new Attribute(model, "Entity.attrBadExpr");
+    AssignProbe assign(model, "AssignCheckInvalidExpression");
+    assign.addAssignment(new Assignment("Entity.attrBadExpr", "1+", true));
+
+    std::string errorMessage;
+    EXPECT_FALSE(assign.CheckProbe(errorMessage));
+    EXPECT_FALSE(errorMessage.empty());
+}
+
+TEST(SimulatorRuntimeTest, AssignCreateInternalAndAttachedDataReconcilesChangesWithoutResidualKeys) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    new Attribute(model, "Entity.attrFirst");
+    new Variable(model, "varSecond");
+    new Attribute(model, "Entity.attrThird");
+
+    AssignProbe assign(model, "AssignAttachedReconcile");
+    Assignment* first = new Assignment("Entity.attrFirst", "1", true);
+    Assignment* second = new Assignment("varSecond", "2", false);
+    assign.addAssignment(first);
+    assign.addAssignment(second);
+    assign.CreateInternalAndAttachedDataProbe();
+
+    auto* attachedFirst = assign.getAttachedData();
+    EXPECT_NE(attachedFirst->find("Attribute_Entity.attrFirst"), attachedFirst->end());
+    EXPECT_NE(attachedFirst->find("Variable_varSecond"), attachedFirst->end());
+
+    assign.removeAssignment(first);
+    assign.removeAssignment(second);
+    assign.addAssignment(new Assignment("Entity.attrThird", "3", true));
+    assign.CreateInternalAndAttachedDataProbe();
+
+    auto* attachedSecond = assign.getAttachedData();
+    EXPECT_EQ(attachedSecond->find("Attribute_Entity.attrFirst"), attachedSecond->end());
+    EXPECT_EQ(attachedSecond->find("Variable_varSecond"), attachedSecond->end());
+    EXPECT_NE(attachedSecond->find("Attribute_Entity.attrThird"), attachedSecond->end());
+}
+
+TEST(SimulatorRuntimeTest, AssignCheckAcceptsIndexedAttributeDestinationWhenBaseAttributeExists) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    new Attribute(model, "Entity.attrIndexed");
+    AssignProbe assign(model, "AssignIndexedDestination");
+    assign.addAssignment(new Assignment("Entity.attrIndexed[2]", "5", true));
+
+    std::string errorMessage;
+    EXPECT_TRUE(assign.CheckProbe(errorMessage)) << errorMessage;
+}
+
+TEST(SimulatorRuntimeTest, CreateCheckFailsForAmbiguousTimeBetweenConfiguration) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    Schedule schedule(model, "CreateCheckAmbiguousSchedule");
+    schedule.getSchedulableItems()->insert(new SchedulableItem("1", 1.0, SchedulableItem::Rule::IGNORE));
+
+    CreateProbe create(model, "CreateCheckAmbiguous");
+    create.setTimeBetweenCreationsExpression("1", Util::TimeUnit::second);
+    create.setTimeBetweenCreationsSchedule(&schedule);
+
+    std::string errorMessage;
+    EXPECT_FALSE(create.CheckProbe(errorMessage));
+    EXPECT_NE(errorMessage.find("exactly one time-between-creations source"), std::string::npos);
+}
+
+TEST(SimulatorRuntimeTest, CreateCheckPassesForMinimalValidExpressionConfiguration) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    CreateProbe create(model, "CreateCheckValidExpression");
+    create.setTimeBetweenCreationsFormula(nullptr);
+    create.setTimeBetweenCreationsSchedule(nullptr);
+    create.setTimeBetweenCreationsExpression("1", Util::TimeUnit::second);
+    create.CreateInternalAndAttachedDataProbe(); // ensure default entity type attachment exists before check
+
+    std::string errorMessage;
+    EXPECT_TRUE(create.CheckProbe(errorMessage)) << errorMessage;
+}
+
+TEST(SimulatorRuntimeTest, CreateInternalCounterFollowsReportStatisticsToggleIdempotently) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    CreateProbe create(model, "CreateStatisticsToggle");
+    create.setReportStatistics(true);
+    create.CreateInternalAndAttachedDataProbe();
+    ASSERT_NE(create.NumberOutProbe(), nullptr);
+    Counter* firstCounter = create.NumberOutProbe();
+
+    create.CreateInternalAndAttachedDataProbe();
+    EXPECT_EQ(create.NumberOutProbe(), firstCounter);
+
+    create.setReportStatistics(false);
+    create.CreateInternalAndAttachedDataProbe();
+    EXPECT_EQ(create.NumberOutProbe(), nullptr);
+
+    create.setReportStatistics(true);
+    create.CreateInternalAndAttachedDataProbe();
+    EXPECT_NE(create.NumberOutProbe(), nullptr);
+    EXPECT_EQ(create.getInternalData()->find("CountNumberOut") != create.getInternalData()->end(), true);
+}
+
+TEST(SimulatorRuntimeTest, CreateSaveLoadRoundTripPreservesBasicConfiguration) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    CreateProbe source(model, "CreatePersistSource");
+    source.setEntitiesPerCreation(3);
+    source.setFirstCreation(4.5);
+    source.setMaxCreations("12");
+    source.setTimeBetweenCreationsExpression("2", Util::TimeUnit::minute);
+
+    FakeModelPersistenceRuntime persistence;
+    PersistenceRecord fields(persistence);
+    source.SaveInstanceProbe(&fields, true);
+
+    CreateProbe loaded(model, "CreatePersistLoaded");
+    ASSERT_TRUE(loaded.LoadInstanceProbe(&fields));
+    EXPECT_EQ(loaded.getEntitiesPerCreation(), 3u);
+    EXPECT_DOUBLE_EQ(loaded.getFirstCreation(), 4.5);
+    EXPECT_EQ(loaded.getMaxCreations(), "12");
+    EXPECT_EQ(loaded.getTimeBetweenCreationsExpression(), "2");
+    EXPECT_EQ(loaded.getTimeUnit(), Util::TimeUnit::minute);
 }


### PR DESCRIPTION
### Motivation
- Fix a concrete persistence bug that caused assignment indices to be skipped when saving `Assign` instances. 
- Avoid side effects during validation: `_check()` must not create `Attribute`/`Variable` silently. 
- Make `Create` and `Assign` more robust in reconciling internal/attached data across rechecks and when toggling statistics. 
- Provide runtime regression tests to prevent regressions for assignment persistence, validation, indexed destinations and `Create` configuration/statistics behavior.

### Description
- Fixed `Assign::_saveInstance()` by removing the redundant index increment so saved assignment indices are contiguous and correct (`Assign.cpp`).
- Hardened `Assign::_check()` to validate destination presence and existence (no longer creating `Attribute`/`Variable` during check), validate expressions and attach referenced data; added `_attachedDataClear()` before rebuilding attachments (`Assign.cpp`).
- Implemented safe handling for indexed destinations by extracting a base name (helper `Assign::_destinationBaseName`) so `attr[2]` / `attr[1,3]` validate/attach against `attr` without redesigning index semantics (`Assign.h` / `Assign.cpp`).
- Reconciled `Assign::_createInternalAndAttachedData()` to clear stale attached keys and rebuild attachments only for current assignments, using base destination names for keys (`Assign.cpp`).
- Hardened `Create::_check()` to require exactly one active time-between-creations source among expression/schedule/formula and to validate referenced `Schedule`/`Formula` objects and their expressions when present (`Create.cpp`).
- Made `Create::_createInternalAndAttachedData()` idempotent for attached schedule/formula references and robustly manage the internal `_numberOut` counter when `reportStatistics` is toggled, preserving safe lifecycle across rechecks (`Create.cpp`).
- Added local probes `AssignProbe` and `CreateProbe` in `test_simulator_runtime.cpp` to expose `_check`, `_saveInstance`/`_loadInstance`, `_createInternalAndAttachedData` and minimal internals; added focused tests covering persistence, validation, attached-data reconciliation, indexed destinations, `Create` configuration and statistics toggle (tests A–H). (`test_simulator_runtime.cpp`).

### Testing
- Ran `cmake -S . -B build -G Ninja` and `cmake --build build` successfully.
- Executed the unit test binary `./build/source/tests/unit/genesys_test_simulator_runtime` and `ctest --test-dir build -L unit --output-on-failure`.
- All unit tests passed: `genesys_test_simulator_runtime` passed and overall CTest run reported 100% passed for unit label (with 4 pre-existing disabled tests reported as disabled).
- New/changed tests (assign persistence, invalid-expression check, attached-data reconciliation, indexed destination baseline, create checks and statistics toggle, persistence round-trip) were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da7972a3c0832198f41b79e591f797)