### PR TITLE
Fix CppCompiler dynamic export, validation, logging, and runtime tests

### DIFF
--- a/source/plugins/data/CppCompiler.cpp
+++ b/source/plugins/data/CppCompiler.cpp
@@ -42,8 +42,8 @@
 
 #ifdef PLUGINCONNECT_DYNAMIC
 
-extern "C" StaticGetPluginInformation getPluginInformation() {
-	return &CppCompiler::getPluginInformation;
+extern "C" StaticGetPluginInformation GetPluginInformation() {
+	return &CppCompiler::GetPluginInformation;
 }
 #endif
 
@@ -138,7 +138,13 @@ PluginInformation* CppCompiler::GetPluginInformation() {
 //
 
 std::string CppCompiler::show() {
-	return ModelDataDefinition::show();
+	return ModelDataDefinition::show() +
+			",sourceFilename=\"" + _sourceFilename + "\"" +
+			",outputFilename=\"" + _outputFilename + "\"" +
+			",compilerCommand=\"" + _compilerCommand + "\"" +
+			",outputDir=\"" + _outputDir + "\"" +
+			",tempDir=\"" + _tempDir + "\"" +
+			",libraryLoaded=" + (_libraryLoaded ? "true" : "false");
 }
 
 void CppCompiler::setSourceFilename(std::string _code) {
@@ -210,6 +216,14 @@ bool CppCompiler::_check(std::string& errorMessage) {
 		errorMessage += "CompilerCommand must not be empty. ";
 		resultAll = false;
 	}
+	if (_sourceFilename == "") {
+		errorMessage += "SourceFilename must not be empty. ";
+		resultAll = false;
+	}
+	if (_outputFilename == "") {
+		errorMessage += "OutputFilename must not be empty. ";
+		resultAll = false;
+	}
 	// Optional strict checks that can be enabled later:
 	// resultAll &= Util::FileExists(_compilerCommand);
 	// resultAll &= (_sourceFilename != "");
@@ -226,26 +240,50 @@ void CppCompiler::_initBetweenReplications() {
 
 CppCompiler::CompilationResult CppCompiler::compileToExecutable() {
 	CppCompiler::CompilationResult result;
-	Util::FileDelete(this->_outputFilename);
-	std::string command(_compilerCommand + " " + _flagsGeneral + " " + _flagsExecutable + " " + _objectFiles + " " + _sourceFilename + " -o " + _outputFilename);
+	std::string outputDir = _outputDir;
+	if (!outputDir.empty() && outputDir.back() != Util::DirSeparator()) {
+		outputDir += Util::DirSeparator();
+	}
+	const std::string outputPath = outputDir + _outputFilename;
+	Util::FileDelete(outputPath);
+	std::string command(_compilerCommand + " " + _flagsGeneral + " " + _flagsExecutable + " " + _objectFiles + " " + _sourceFilename + " -o " + outputPath);
 	result = _invokeCompiler(command);
+	if (result.success) {
+		_outputFilename = outputPath;
+	}
 	_compiledToDynamicLibrary = false;
 	return result;
 }
 
 CppCompiler::CompilationResult CppCompiler::compileToDynamicLibrary() {
 	CppCompiler::CompilationResult result;
-	std::string command(_compilerCommand + " " + _flagsGeneral + " " + _flagsDynamicLibrary + " " + _objectFiles + " " + _sourceFilename + " -o " + _outputFilename);
+	std::string outputDir = _outputDir;
+	if (!outputDir.empty() && outputDir.back() != Util::DirSeparator()) {
+		outputDir += Util::DirSeparator();
+	}
+	const std::string outputPath = outputDir + _outputFilename;
+	std::string command(_compilerCommand + " " + _flagsGeneral + " " + _flagsDynamicLibrary + " " + _objectFiles + " " + _sourceFilename + " -o " + outputPath);
 	result = _invokeCompiler(command);
 	_compiledToDynamicLibrary = result.success;
+	if (result.success) {
+		_outputFilename = outputPath;
+	}
 	return result;
 }
 
 CppCompiler::CompilationResult CppCompiler::compileToStaticLibrary() {
 	CppCompiler::CompilationResult result;
-	Util::FileDelete(_outputFilename);
-	std::string command(_compilerCommand + " " + _flagsGeneral + " " + _flagsStaticLibrary + " " + _objectFiles + " " + _sourceFilename + " -o " + _outputFilename);
+	std::string outputDir = _outputDir;
+	if (!outputDir.empty() && outputDir.back() != Util::DirSeparator()) {
+		outputDir += Util::DirSeparator();
+	}
+	const std::string outputPath = outputDir + _outputFilename;
+	Util::FileDelete(outputPath);
+	std::string command(_compilerCommand + " " + _flagsGeneral + " " + _flagsStaticLibrary + " " + _objectFiles + " " + _sourceFilename + " -o " + outputPath);
 	result = _invokeCompiler(command);
+	if (result.success) {
+		_outputFilename = outputPath;
+	}
 	_compiledToDynamicLibrary = false;
 	return result;
 }
@@ -273,11 +311,12 @@ bool CppCompiler::unloadLibrary() {
 			_dynamicLibraryHandle = nullptr;
 			_libraryLoaded = false;
 			return true;
-			_libraryLoaded = false;
 		} catch (const std::exception& e) {
 			return false;
 		}
 	}
+	_dynamicLibraryHandle = nullptr;
+	_libraryLoaded = false;
 	return true;
 }
 
@@ -379,22 +418,27 @@ std::string CppCompiler::_read(std::string filename) {
 }
 
 CppCompiler::CompilationResult CppCompiler::_invokeCompiler(std::string command) {
-	const std::string destPath = "";
-	const std::string redirect = " >" + destPath + "stdout.log 2>" + destPath + "stdout.log";
+	std::string destPath = _tempDir.empty() ? _outputDir : _tempDir;
+	if (!destPath.empty() && destPath.back() != Util::DirSeparator()) {
+		destPath += Util::DirSeparator();
+	}
+	const std::string stdoutFile = destPath + "stdout.log";
+	const std::string stderrFile = destPath + "stderr.log";
+	const std::string redirect = " >" + stdoutFile + " 2>" + stderrFile;
 
 	Util::IncIndent();
 
 	Util::FileDelete(_outputFilename);
-	Util::FileDelete(destPath + "stdout.log");
-	Util::FileDelete(destPath + "stdout.log");
+	Util::FileDelete(stdoutFile);
+	Util::FileDelete(stderrFile);
 
 	const std::string execCommand = command + redirect;
 	//trace(execCommand);
 	system(execCommand.c_str());
 	for (short i = 0; i < 32; i++)
         std::this_thread::yield(); // give the system some time // TODO: Does it work? Is this enough?
-	const std::string resultStdout = _read(destPath+"stdout.log");
-	const std::string resultStderr = _read(destPath+"stderr.log");
+	const std::string resultStdout = _read(stdoutFile);
+	const std::string resultStderr = _read(stderrFile);
 	//trace(resultStdout);
 	//trace(resultStderr);
 
@@ -405,8 +449,8 @@ CppCompiler::CompilationResult CppCompiler::_invokeCompiler(std::string command)
 	result.compilationErrOutput = resultStderr;
 	result.destinationPath = destPath;
 
-	Util::FileDelete(destPath + "stdout.log");
-	Util::FileDelete(destPath + "stderr.log");
+	Util::FileDelete(stdoutFile);
+	Util::FileDelete(stderrFile);
 
 	Util::DecIndent();
 

--- a/source/tests/unit/test_simulator_runtime.cpp
+++ b/source/tests/unit/test_simulator_runtime.cpp
@@ -2,6 +2,8 @@
 #include <algorithm>
 #include <fstream>
 #include <memory>
+#include <sys/stat.h>
+#include <unistd.h>
 #include <vector>
 
 #include "kernel/simulator/Simulator.h"
@@ -25,6 +27,7 @@
 #include "plugins/data/Label.h"
 #include "plugins/data/Storage.h"
 #include "plugins/data/File.h"
+#include "plugins/data/CppCompiler.h"
 #include "kernel/util/Util.h"
 #define private public
 #define protected public
@@ -671,6 +674,27 @@ public:
 
     void SaveInstanceProbe(PersistenceRecord* fields, bool saveDefaultValues = false) {
         _saveInstance(fields, saveDefaultValues);
+    }
+};
+
+class CppCompilerProbe : public CppCompiler {
+public:
+    CppCompilerProbe(Model* model, const std::string& name = "") : CppCompiler(model, name) {}
+
+    bool CheckProbe(std::string& errorMessage) {
+        return _check(errorMessage);
+    }
+
+    bool LoadInstanceProbe(PersistenceRecord* fields) {
+        return _loadInstance(fields);
+    }
+
+    void SaveInstanceProbe(PersistenceRecord* fields, bool saveDefaultValues = false) {
+        _saveInstance(fields, saveDefaultValues);
+    }
+
+    CompilationResult InvokeCompilerProbe(const std::string& command) {
+        return _invokeCompiler(command);
     }
 };
 
@@ -4129,4 +4153,159 @@ TEST(SimulatorRuntimeTest, FileRegistersControlsAndPropertiesForMainMetadata) {
     }
     EXPECT_TRUE(modelHasSystemFilenameControl);
     EXPECT_TRUE(modelHasAccessModeControl);
+}
+
+TEST(SimulatorRuntimeTest, CppCompilerDefaultsExposeMainConfiguration) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    CppCompilerProbe compiler(model, "CppCompilerDefaults");
+    EXPECT_EQ(compiler.getSourceFilename(), "");
+    EXPECT_EQ(compiler.getOutputFilename(), "");
+    EXPECT_EQ(compiler.getCompilerCommand(), "g++");
+    EXPECT_EQ(compiler.getOutputDir(), ".temp/");
+    EXPECT_EQ(compiler.getTempDir(), ".temp/");
+    EXPECT_FALSE(compiler.IsLibraryLoaded());
+}
+
+TEST(SimulatorRuntimeTest, CppCompilerSettersAndGettersPreserveValues) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    CppCompilerProbe compiler(model, "CppCompilerSetGet");
+    compiler.setSourceFilename("my_model.cpp");
+    compiler.setOutputFilename("my_model.so");
+    compiler.setCompilerCommand("clang++");
+    compiler.setOutputDir("out");
+    compiler.setTempDir("tmp");
+
+    EXPECT_EQ(compiler.getSourceFilename(), "my_model.cpp");
+    EXPECT_EQ(compiler.getOutputFilename(), "my_model.so");
+    EXPECT_EQ(compiler.getCompilerCommand(), "clang++");
+    EXPECT_EQ(compiler.getOutputDir(), "out");
+    EXPECT_EQ(compiler.getTempDir(), "tmp");
+}
+
+TEST(SimulatorRuntimeTest, CppCompilerCheckRejectsEmptyRequiredFields) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    CppCompilerProbe compiler(model, "CppCompilerCheckInvalid");
+    compiler.setCompilerCommand("");
+    compiler.setSourceFilename("");
+    compiler.setOutputFilename("");
+
+    std::string errorMessage;
+    EXPECT_FALSE(compiler.CheckProbe(errorMessage));
+    EXPECT_NE(errorMessage.find("CompilerCommand must not be empty"), std::string::npos);
+    EXPECT_NE(errorMessage.find("SourceFilename must not be empty"), std::string::npos);
+    EXPECT_NE(errorMessage.find("OutputFilename must not be empty"), std::string::npos);
+}
+
+TEST(SimulatorRuntimeTest, CppCompilerCheckAcceptsMinimalValidConfiguration) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    CppCompilerProbe compiler(model, "CppCompilerCheckValid");
+    compiler.setCompilerCommand("g++");
+    compiler.setSourceFilename("main.cpp");
+    compiler.setOutputFilename("main.out");
+
+    std::string errorMessage;
+    EXPECT_TRUE(compiler.CheckProbe(errorMessage)) << errorMessage;
+}
+
+TEST(SimulatorRuntimeTest, CppCompilerShowIncludesMainObservabilityFields) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    CppCompilerProbe compiler(model, "CppCompilerShow");
+    compiler.setSourceFilename("input.cpp");
+    compiler.setOutputFilename("output.so");
+    compiler.setCompilerCommand("clang++");
+    compiler.setOutputDir("out");
+    compiler.setTempDir("tmp");
+    compiler.setLibraryLoaded(true);
+
+    const std::string shown = compiler.show();
+    EXPECT_NE(shown.find("sourceFilename=\"input.cpp\""), std::string::npos);
+    EXPECT_NE(shown.find("outputFilename=\"output.so\""), std::string::npos);
+    EXPECT_NE(shown.find("compilerCommand=\"clang++\""), std::string::npos);
+    EXPECT_NE(shown.find("outputDir=\"out\""), std::string::npos);
+    EXPECT_NE(shown.find("tempDir=\"tmp\""), std::string::npos);
+    EXPECT_NE(shown.find("libraryLoaded=true"), std::string::npos);
+}
+
+TEST(SimulatorRuntimeTest, CppCompilerPersistenceRoundTripPreservesMainFields) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    CppCompilerProbe source(model, "CppCompilerPersistSource");
+    source.setSourceFilename("persist.cpp");
+    source.setOutputFilename("persist.so");
+    source.setCompilerCommand("clang++");
+    source.setOutputDir("persist-out");
+    source.setTempDir("persist-tmp");
+    source.setLibraryLoaded(true);
+
+    FakeModelPersistenceRuntime persistence;
+    PersistenceRecord fields(persistence);
+    source.SaveInstanceProbe(&fields, true);
+
+    CppCompilerProbe loaded(model, "CppCompilerPersistLoaded");
+    ASSERT_TRUE(loaded.LoadInstanceProbe(&fields));
+    EXPECT_EQ(loaded.getSourceFilename(), "persist.cpp");
+    EXPECT_EQ(loaded.getOutputFilename(), "persist.so");
+    EXPECT_EQ(loaded.getCompilerCommand(), "clang++");
+    EXPECT_EQ(loaded.getOutputDir(), "persist-out");
+    EXPECT_EQ(loaded.getTempDir(), "persist-tmp");
+    EXPECT_TRUE(loaded.IsLibraryLoaded());
+}
+
+TEST(SimulatorRuntimeTest, CppCompilerInvokeCompilerSeparatesStdoutAndStderrLogs) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    const std::string base = Util::RunningPath() + Util::DirSeparator() + "cppcompiler_runtime";
+    const std::string outputDir = base + "_out";
+    const std::string tempDir = base + "_tmp";
+    ::mkdir(outputDir.c_str(), 0755);
+    ::mkdir(tempDir.c_str(), 0755);
+
+    CppCompilerProbe compiler(model, "CppCompilerInvoke");
+    compiler.setOutputDir(outputDir);
+    compiler.setTempDir(tempDir);
+    const std::string outputPath = outputDir + Util::DirSeparator() + "invoke_result.bin";
+    compiler.setOutputFilename(outputPath);
+    const std::string command = "sh -c \"echo STDOUT_LINE; echo STDERR_LINE 1>&2; touch " + outputPath + "\"";
+    CppCompiler::CompilationResult result = compiler.InvokeCompilerProbe(command);
+
+    EXPECT_TRUE(result.success);
+    EXPECT_NE(result.compilationStdOutput.find("STDOUT_LINE"), std::string::npos);
+    EXPECT_EQ(result.compilationStdOutput.find("STDERR_LINE"), std::string::npos);
+    EXPECT_NE(result.compilationErrOutput.find("STDERR_LINE"), std::string::npos);
+    EXPECT_EQ(result.compilationErrOutput.find("STDOUT_LINE"), std::string::npos);
+    EXPECT_EQ(result.destinationPath, tempDir + Util::DirSeparator());
+
+    Util::FileDelete(outputPath);
+    ::rmdir(outputDir.c_str());
+    ::rmdir(tempDir.c_str());
+}
+
+TEST(SimulatorRuntimeTest, CppCompilerUnloadLibraryIsSafeWhenNoLibraryIsLoaded) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    CppCompilerProbe compiler(model, "CppCompilerUnload");
+    EXPECT_FALSE(compiler.IsLibraryLoaded());
+    EXPECT_TRUE(compiler.unloadLibrary());
+    EXPECT_FALSE(compiler.IsLibraryLoaded());
 }


### PR DESCRIPTION
### Motivation
- Fix multiple runtime bugs and weak validations in `CppCompiler` so compilation, logging and dynamic loading behave predictably and are observable. 
- Add unit coverage to prevent regressions around export symbol, log redirection, path usage and basic validation.

### Description
- Corrected dynamic plugin export under `PLUGINCONNECT_DYNAMIC` to export `GetPluginInformation` and point to `CppCompiler::GetPluginInformation`.
- Enhanced `show()` to include `sourceFilename`, `outputFilename`, `compilerCommand`, `outputDir`, `tempDir` and `libraryLoaded` for better observability.
- Strengthened `_check()` to validate non-empty `compilerCommand`, `sourceFilename` and `outputFilename`, populating `errorMessage` with clear diagnostics.
- Updated compilation flows (`compileToExecutable`, `compileToDynamicLibrary`, `compileToStaticLibrary`) to use persisted `_outputDir` (normalizing directory separators) for output paths and update `_outputFilename` when compilation succeeds.
- Fixed `_invokeCompiler()` redirection so `stdout` and `stderr` go to distinct files in `_tempDir` (falling back to `_outputDir`) and read those files into `compilationStdOutput` and `compilationErrOutput` respectively.
- Cleaned `unloadLibrary()` to remove unreachable code and ensure consistent unloaded state when no library is loaded.
- Added focused unit tests in `test_simulator_runtime.cpp` exercising defaults, setters/getters, invalid/valid `_check()`, `show()`, save/load round-trip, separation of `stdout`/`stderr` in `_invokeCompiler()` (tested via a safe shell command), and safe `unloadLibrary()` behavior.
- Files changed: `source/plugins/data/CppCompiler.cpp`, `source/tests/unit/test_simulator_runtime.cpp`.

### Testing
- Configured build with `cmake -S . -B build -G Ninja -DGENESYS_BUILD_TESTS=ON -DGENESYS_BUILD_KERNEL=ON -DGENESYS_BUILD_PARSER=ON -DGENESYS_BUILD_PLUGINS=ON -DGENESYS_TERMINAL_APPLICATION=OFF -DGENESYS_BUILD_GUI_APPLICATION=OFF -DGENESYS_BUILD_WEB_APPLICATION=OFF` successfully.
- Built the test target with `cmake --build build --target genesys_test_simulator_runtime` successfully.
- Ran the focused tests with `ctest --test-dir build -R "SimulatorRuntimeTest.*CppCompiler" --output-on-failure` and all `CppCompiler` tests passed (8/8).
- Ran broader smoke suite `ctest --test-dir build -LE smoke --output-on-failure` which showed unrelated `_NOT_BUILT` / not-run entries in other test targets for this build profile; the `CppCompiler` test group remained green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da7d0175888321a0c3f28d06b22685)