### PR TITLE
GUI: synchronize canonical data-definition layer and harden mixed-group clipboard flows

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/controllers/EditCommandController.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/EditCommandController.cpp
@@ -6,6 +6,7 @@
 #include "../animations/AnimationVariable.h"
 #include "../graphicals/GraphicalComponentPort.h"
 #include "../graphicals/GraphicalConnection.h"
+#include "../graphicals/GraphicalModelDataDefinition.h"
 #include "../graphicals/GraphicalModelComponent.h"
 #include "../graphicals/ModelGraphicsScene.h"
 #include "../graphicals/ModelGraphicsView.h"
@@ -114,6 +115,8 @@ void EditCommandController::onActionEditCutTriggered() const {
                 }
             } else if (GraphicalConnection* port = dynamic_cast<GraphicalConnection*>(item)) {
                 (*_portsCopies)->append(port);
+            } else if (dynamic_cast<GraphicalModelDataDefinition*>(item) != nullptr) {
+                continue;
             } else {
                 (*_drawCopy)->append(item);
             }
@@ -163,6 +166,9 @@ void EditCommandController::onActionEditCopyTriggered() const {
                 if (!groupComponents.isEmpty()) {
                     (*_groupCopy)->append(group);
                 }
+            } else if (dynamic_cast<GraphicalModelDataDefinition*>(item) != nullptr) {
+                item->setSelected(false);
+                continue;
             } else {
                 item->setSelected(false);
                 (*_drawCopy)->append(item);
@@ -303,6 +309,9 @@ void EditCommandController::helpCopy() const {
 
             GraphicalModelComponent* newgmc = new GraphicalModelComponent(plugin, component, position, color);
             GraphicalModelComponent* oldgmc = currentScene->findGraphicalModelComponent(previousComponent->getId());
+            if (oldgmc == nullptr) {
+                continue;
+            }
 
             if (!oldgmc->getGraphicalInputPorts().empty() && !oldgmc->getGraphicalInputPorts().at(0)->getConnections()->empty()) {
                 connGroup->removeOne(oldgmc->getGraphicalInputPorts().at(0)->getConnections()->at(0));
@@ -377,6 +386,9 @@ void EditCommandController::helpCopy() const {
             }
         }
 
+        if (gmcNewSource == nullptr || gmcNewDestination == nullptr) {
+            continue;
+        }
         sourcePort = gmcNewSource->getGraphicalOutputPorts().at(portSourceConnection);
         destinationPort = gmcNewDestination->getGraphicalInputPorts().at(portDestinationConnection);
 

--- a/source/applications/gui/qt/GenesysQtGUI/controllers/PropertyEditorController.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/PropertyEditorController.cpp
@@ -6,6 +6,7 @@
 #include "graphicals/GraphicalModelComponent.h"
 #include "graphicals/GraphicalModelDataDefinition.h"
 #include "propertyeditor/ObjectPropertyBrowser.h"
+#include "services/GraphicalModelBuilder.h"
 
 #include <QGraphicsItem>
 #include <QDebug>
@@ -179,8 +180,7 @@ void PropertyEditorController::_runGlobalRefresh() const {
         if (scene == nullptr) {
             qWarning() << "[PropertyEditorController] Skipping scene refresh because scene is null";
         } else {
-            // Refresh diagram arrows in-place without forcing legacy destroy/create diagram regeneration.
-            scene->actualizeDiagramArrows();
+            GraphicalModelBuilder::synchronizeGraphicalDataDefinitionsLayer(scene->getSimulator(), scene);
             scene->update();
         }
         qInfo() << "[PropertyEditorController] _runGlobalRefresh exit";

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/GraphicalModelDataDefinition.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/GraphicalModelDataDefinition.cpp
@@ -258,7 +258,6 @@ qreal GraphicalModelDataDefinition::getHeight() const {
 }
 
 bool GraphicalModelDataDefinition::sceneEvent(QEvent *event) {
-	QGraphicsObject::sceneEvent(event); // Unnecessary
+	return QGraphicsObject::sceneEvent(event);
 }
-
 

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
@@ -53,6 +53,7 @@
 #include "dialogs/DialogSelectVariable.h"
 #include "dialogs/DialogTimerConfigure.h"
 #include "animations/AnimationQueue.h"
+#include "services/GraphicalModelBuilder.h"
 #include <QCoreApplication>
 #include <QThread>
 #include <QPointer>
@@ -2865,14 +2866,13 @@ void ModelGraphicsScene::dropEvent(QGraphicsSceneDragDropEvent *event) {
             Plugin* plugin = _simulator->getPluginManager()->find(pluginname.toStdString());
             if (plugin != nullptr) {
                 if (plugin->getPluginInfo()->isComponent()) {
-                    destroyDiagram();
-
                     event->setDropAction(Qt::IgnoreAction);
                     event->accept();
                     // create component in the model
                     ModelComponent* component = (ModelComponent*) plugin->newInstance(_simulator->getModelManager()->current());
                     // create graphically
                     addGraphicalModelComponent(plugin, component, event->scenePos(), color, true);
+                    GraphicalModelBuilder::synchronizeGraphicalDataDefinitionsLayer(_simulator, this);
                     return;
                 }
             }
@@ -2927,9 +2927,9 @@ void ModelGraphicsScene::keyPressEvent(QKeyEvent *keyEvent) {
             return;
         }
 
-        destroyDiagram();
         QUndoCommand *deleteUndoCommand = new DeleteUndoCommand(selected, this);
         _undoStack->push(deleteUndoCommand);
+        GraphicalModelBuilder::synchronizeGraphicalDataDefinitionsLayer(_simulator, this);
     }
     _controlIsPressed = (keyEvent->key() == Qt::Key_Control);
 }

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
@@ -835,12 +835,7 @@ bool MainWindow::_check(bool success)
         ModelGraphicsScene* scene = (ModelGraphicsScene*) (ui->graphicsView->scene());
         // Mensagem de sucesso
         if (success) {
-            if (!scene->existDiagram()){
-                scene->createDiagrams();
-            } else {
-                scene->destroyDiagram();
-                scene->createDiagrams();
-            }
+            GraphicalModelBuilder::synchronizeGraphicalDataDefinitionsLayer(simulator, scene);
             QMessageBox::information(this, "Model Check", "Model successfully checked.");
         }
         // Salva os data definitions dos componentes atuais

--- a/source/applications/gui/qt/GenesysQtGUI/services/GraphicalModelBuilder.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/services/GraphicalModelBuilder.cpp
@@ -15,6 +15,7 @@
 #include "../../../../../kernel/simulator/ModelDataDefinition.h"
 
 #include <QTextEdit>
+#include <QSet>
 
 // Build the graphical reconstruction service with explicit dependencies.
 GraphicalModelBuilder::GraphicalModelBuilder(Simulator* simulator,
@@ -108,115 +109,8 @@ void GraphicalModelBuilder::recursivalyGenerateGraphicalModelFromModel(ModelComp
 
 // Rebuild graphical data definitions and diagram links as part of the main model regeneration flow.
 void GraphicalModelBuilder::rebuildGraphicalDataDefinitionsLayer(std::map<ModelComponent*, GraphicalModelComponent*>* componentMap) {
-    Model* model = _simulator->getModelManager()->current();
-    if (model == nullptr || model->getDataManager() == nullptr || componentMap == nullptr) {
-        return;
-    }
-
-    _scene->clearGraphicalDiagramConnections();
-    _scene->clearGraphicalModelDataDefinitions();
-
-    PluginManager* pluginManager = _simulator->getPluginManager();
-    ModelDataManager* dataManager = model->getDataManager();
-    QColor purple(128, 0, 128);
-    QColor grey(220, 220, 220);
-    std::map<ModelDataDefinition*, GraphicalModelDataDefinition*> dataDefinitionMap;
-
-    // Create one graphical node for each kernel data definition.
-    for (const std::string& dataTypename : dataManager->getDataDefinitionClassnames()) {
-        std::list<ModelDataDefinition*>* listDataDefinitions = dataManager->getDataDefinitionList(dataTypename)->list();
-        for (ModelDataDefinition* dataDefinition : *listDataDefinitions) {
-            if (dataDefinition == nullptr) {
-                continue;
-            }
-            // Resolve data definition plugins by classname to match kernel semantic identifiers.
-            Plugin* plugin = pluginManager->find(dataDefinition->getClassname());
-            if (plugin == nullptr) {
-                continue;
-            }
-            GraphicalModelDataDefinition* graphicalDataDefinition = _scene->addGraphicalModelDataDefinition(plugin, dataDefinition, QPointF(0, 0), grey);
-            if (graphicalDataDefinition != nullptr) {
-                dataDefinitionMap[dataDefinition] = graphicalDataDefinition;
-            }
-        }
-    }
-
-    QList<GraphicalModelDataDefinition*> visitedDataDefinitions;
-    // Reuse the existing createDiagrams positioning semantics for component-attached/internal data links.
-    for (const auto& componentEntry : *componentMap) {
-        ModelComponent* component = componentEntry.first;
-        GraphicalModelComponent* graphicalComponent = componentEntry.second;
-        if (component == nullptr || graphicalComponent == nullptr) {
-            continue;
-        }
-
-        QPointF componentPosition = graphicalComponent->getOldPosition();
-        qreal yInternal = componentPosition.y();
-        qreal yAttached = componentPosition.y();
-
-        for (const auto& attachedData : *component->getAttachedData()) {
-            auto attachedIt = dataDefinitionMap.find(attachedData.second);
-            if (attachedIt == dataDefinitionMap.end()) {
-                continue;
-            }
-            GraphicalModelDataDefinition* gdd = attachedIt->second;
-            if (visitedDataDefinitions.contains(gdd)) {
-                qreal x = (gdd->x() + componentPosition.x()) / 2.0;
-                gdd->setPos(x, yAttached - 150);
-                gdd->setOldPosition(x, yAttached - 150);
-            } else {
-                visitedDataDefinitions.append(gdd);
-                yAttached -= 150;
-                gdd->setPos(componentPosition.x(), yAttached);
-                gdd->setOldPosition(componentPosition.x(), yAttached);
-                gdd->setColor(purple);
-            }
-            _scene->addGraphicalDiagramConnection(gdd, graphicalComponent, GraphicalDiagramConnection::ConnectionType::ATTACHED);
-        }
-
-        for (const auto& internalData : *component->getInternalData()) {
-            auto internalIt = dataDefinitionMap.find(internalData.second);
-            if (internalIt == dataDefinitionMap.end()) {
-                continue;
-            }
-            GraphicalModelDataDefinition* gdd = internalIt->second;
-            visitedDataDefinitions.append(gdd);
-            yInternal += 150;
-            gdd->setPos(componentPosition.x(), yInternal);
-            gdd->setOldPosition(componentPosition.x(), yInternal);
-            // Apply first-materialization fallback grouping only for internal data without persisted layout restoration.
-            if (!_scene->isRestoringPersistedGuiLayout() && gdd->parentItem() == nullptr && gdd->group() == nullptr) {
-                QPointF scenePosition = gdd->scenePos();
-                gdd->setParentItem(graphicalComponent);
-                gdd->setPos(graphicalComponent->mapFromScene(scenePosition));
-            }
-            _scene->addGraphicalDiagramConnection(gdd, graphicalComponent, GraphicalDiagramConnection::ConnectionType::INTERNAL);
-        }
-    }
-
-    // Reuse the same lateral placement rule for internal links between data definitions.
-    for (int i = 0; i < visitedDataDefinitions.size(); i++) {
-        GraphicalModelDataDefinition* parentDataDefinition = visitedDataDefinitions.at(i);
-        if (parentDataDefinition == nullptr || parentDataDefinition->getDataDefinition() == nullptr) {
-            continue;
-        }
-        QPointF parentPosition = parentDataDefinition->getOldPosition();
-        qreal x = parentPosition.x();
-        for (const auto& internalData : *parentDataDefinition->getDataDefinition()->getInternalData()) {
-            auto internalIt = dataDefinitionMap.find(internalData.second);
-            if (internalIt == dataDefinitionMap.end()) {
-                continue;
-            }
-            GraphicalModelDataDefinition* childDataDefinition = internalIt->second;
-            visitedDataDefinitions.append(childDataDefinition);
-            x -= 200;
-            childDataDefinition->setPos(x, parentPosition.y());
-            childDataDefinition->setOldPosition(x, parentPosition.y());
-            _scene->addGraphicalDiagramConnection(childDataDefinition, parentDataDefinition, GraphicalDiagramConnection::ConnectionType::INTERNAL);
-        }
-    }
-
-    _scene->setDiagramLayerState(!dataDefinitionMap.empty(), true);
+    Q_UNUSED(componentMap);
+    synchronizeGraphicalDataDefinitionsLayer(_simulator, _scene);
 }
 
 // Preserve the existing full-model generation flow and visitation semantics.
@@ -258,5 +152,167 @@ void GraphicalModelBuilder::generateGraphicalModelFromModel() {
         delete map;
         delete visited;
         _graphicsView->setCanNotifyGraphicalModelEventHandlers(true);
+    }
+}
+
+void GraphicalModelBuilder::synchronizeGraphicalDataDefinitionsLayer(Simulator* simulator, ModelGraphicsScene* scene) {
+    if (simulator == nullptr || scene == nullptr) {
+        return;
+    }
+
+    Model* model = simulator->getModelManager()->current();
+    if (model == nullptr || model->getDataManager() == nullptr) {
+        scene->clearGraphicalDiagramConnections();
+        scene->clearGraphicalModelDataDefinitions();
+        scene->setDiagramLayerState(false, false);
+        return;
+    }
+
+    std::map<ModelComponent*, GraphicalModelComponent*> componentMap;
+    for (GraphicalModelComponent* gmc : *scene->getAllComponents()) {
+        if (gmc == nullptr || gmc->getComponent() == nullptr) {
+            continue;
+        }
+        componentMap[gmc->getComponent()] = gmc;
+    }
+
+    std::map<ModelDataDefinition*, GraphicalModelDataDefinition*> existingDataDefinitions;
+    for (GraphicalModelDataDefinition* gmdd : *scene->getAllDataDefinitions()) {
+        if (gmdd == nullptr || gmdd->getDataDefinition() == nullptr) {
+            continue;
+        }
+        existingDataDefinitions[gmdd->getDataDefinition()] = gmdd;
+    }
+
+    PluginManager* pluginManager = simulator->getPluginManager();
+    ModelDataManager* dataManager = model->getDataManager();
+    QColor purple(128, 0, 128);
+    QColor grey(220, 220, 220);
+
+    std::map<ModelDataDefinition*, GraphicalModelDataDefinition*> dataDefinitionMap;
+    QSet<ModelDataDefinition*> seenInModel;
+    QSet<ModelDataDefinition*> newDataDefinitions;
+
+    for (const std::string& dataTypename : dataManager->getDataDefinitionClassnames()) {
+        std::list<ModelDataDefinition*>* listDataDefinitions = dataManager->getDataDefinitionList(dataTypename)->list();
+        for (ModelDataDefinition* dataDefinition : *listDataDefinitions) {
+            if (dataDefinition == nullptr) {
+                continue;
+            }
+            seenInModel.insert(dataDefinition);
+
+            auto existingIt = existingDataDefinitions.find(dataDefinition);
+            if (existingIt != existingDataDefinitions.end()) {
+                dataDefinitionMap[dataDefinition] = existingIt->second;
+                continue;
+            }
+
+            Plugin* plugin = pluginManager->find(dataDefinition->getClassname());
+            if (plugin == nullptr) {
+                continue;
+            }
+            GraphicalModelDataDefinition* graphicalDataDefinition = scene->addGraphicalModelDataDefinition(plugin, dataDefinition, QPointF(0, 0), grey);
+            if (graphicalDataDefinition != nullptr) {
+                dataDefinitionMap[dataDefinition] = graphicalDataDefinition;
+                newDataDefinitions.insert(dataDefinition);
+            }
+        }
+    }
+
+    QList<GraphicalModelDataDefinition*> staleGraphicalDataDefinitions;
+    for (auto it = existingDataDefinitions.begin(); it != existingDataDefinitions.end(); ++it) {
+        if (!seenInModel.contains(it->first) && it->second != nullptr) {
+            staleGraphicalDataDefinitions.append(it->second);
+        }
+    }
+    for (GraphicalModelDataDefinition* stale : staleGraphicalDataDefinitions) {
+        scene->removeGraphicalModelDataDefinition(stale);
+    }
+
+    scene->clearGraphicalDiagramConnections();
+
+    for (const auto& componentEntry : componentMap) {
+        ModelComponent* component = componentEntry.first;
+        GraphicalModelComponent* graphicalComponent = componentEntry.second;
+        if (component == nullptr || graphicalComponent == nullptr) {
+            continue;
+        }
+
+        QPointF componentPosition = graphicalComponent->scenePos();
+        qreal yInternal = componentPosition.y();
+        qreal yAttached = componentPosition.y();
+
+        for (const auto& attachedData : *component->getAttachedData()) {
+            auto attachedIt = dataDefinitionMap.find(attachedData.second);
+            if (attachedIt == dataDefinitionMap.end()) {
+                continue;
+            }
+            GraphicalModelDataDefinition* gdd = attachedIt->second;
+            if (gdd == nullptr) {
+                continue;
+            }
+            if (newDataDefinitions.contains(attachedData.second)) {
+                yAttached -= 150;
+                gdd->setParentItem(nullptr);
+                gdd->setPos(componentPosition.x(), yAttached);
+                gdd->setOldPosition(componentPosition.x(), yAttached);
+                gdd->setColor(purple);
+            }
+            scene->addGraphicalDiagramConnection(gdd, graphicalComponent, GraphicalDiagramConnection::ConnectionType::ATTACHED);
+        }
+
+        for (const auto& internalData : *component->getInternalData()) {
+            auto internalIt = dataDefinitionMap.find(internalData.second);
+            if (internalIt == dataDefinitionMap.end()) {
+                continue;
+            }
+            GraphicalModelDataDefinition* gdd = internalIt->second;
+            if (gdd == nullptr) {
+                continue;
+            }
+            if (newDataDefinitions.contains(internalData.second)) {
+                yInternal += 150;
+                gdd->setPos(componentPosition.x(), yInternal);
+                gdd->setOldPosition(componentPosition.x(), yInternal);
+                scene->ensureInitialInternalDataDefinitionGrouping(gdd, graphicalComponent);
+            }
+            scene->addGraphicalDiagramConnection(gdd, graphicalComponent, GraphicalDiagramConnection::ConnectionType::INTERNAL);
+        }
+    }
+
+    for (const auto& dataDefinitionEntry : dataDefinitionMap) {
+        ModelDataDefinition* parentDefinition = dataDefinitionEntry.first;
+        GraphicalModelDataDefinition* parentGraphicalDefinition = dataDefinitionEntry.second;
+        if (parentDefinition == nullptr || parentGraphicalDefinition == nullptr) {
+            continue;
+        }
+
+        QPointF parentPosition = parentGraphicalDefinition->scenePos();
+        qreal x = parentPosition.x();
+        for (const auto& internalData : *parentDefinition->getInternalData()) {
+            auto childIt = dataDefinitionMap.find(internalData.second);
+            if (childIt == dataDefinitionMap.end() || childIt->second == nullptr) {
+                continue;
+            }
+            GraphicalModelDataDefinition* childGraphicalDefinition = childIt->second;
+            if (newDataDefinitions.contains(internalData.second)) {
+                x -= 200;
+                childGraphicalDefinition->setParentItem(nullptr);
+                childGraphicalDefinition->setPos(x, parentPosition.y());
+                childGraphicalDefinition->setOldPosition(x, parentPosition.y());
+            }
+            scene->addGraphicalDiagramConnection(childGraphicalDefinition, parentGraphicalDefinition, GraphicalDiagramConnection::ConnectionType::INTERNAL);
+        }
+    }
+
+    const bool hasDataDefinitions = !dataDefinitionMap.empty();
+    const bool visible = hasDataDefinitions ? scene->visibleDiagram() : false;
+    scene->setDiagramLayerState(hasDataDefinitions, visible);
+    if (hasDataDefinitions) {
+        if (visible) {
+            scene->showDiagrams();
+        } else {
+            scene->hideDiagrams();
+        }
     }
 }

--- a/source/applications/gui/qt/GenesysQtGUI/services/GraphicalModelBuilder.h
+++ b/source/applications/gui/qt/GenesysQtGUI/services/GraphicalModelBuilder.h
@@ -56,6 +56,8 @@ public:
 
     /** @brief Rebuilds the full scene model representation from kernel source components. */
     void generateGraphicalModelFromModel();
+    /** @brief Synchronizes only data-definition graphical layer with current model preserving existing layout. */
+    static void synchronizeGraphicalDataDefinitionsLayer(Simulator* simulator, ModelGraphicsScene* scene);
 
 private:
     void rebuildGraphicalDataDefinitionsLayer(std::map<ModelComponent*, GraphicalModelComponent*>* componentMap);


### PR DESCRIPTION
### Motivation
- Consolidate the graphical representation of kernel `ModelDataDefinition` as a canonical scene layer and stop relying on the legacy destroy/create diagram cycle in normal flows.
- Fix a real bug where `GraphicalModelDataDefinition::sceneEvent(QEvent*)` did not return the base result and could produce undefined behavior.
- Harden clipboard / group handling so mixed groups containing `GraphicalModelDataDefinition` do not produce null dereferences or crash during cut/copy/paste.

### Description
- Added a small public helper `GraphicalModelBuilder::synchronizeGraphicalDataDefinitionsLayer(Simulator*, ModelGraphicsScene*)` that syncs only the data-definition layer from the current model while preserving layout for existing items and only auto-positioning new items (internal new items get initial grouping; attached new items are positioned without auto-grouping). (modified: `services/GraphicalModelBuilder.h`, `services/GraphicalModelBuilder.cpp`)
- Made `rebuildGraphicalDataDefinitionsLayer(...)` delegate to the new synchronization helper to avoid duplicated logic. (modified: `services/GraphicalModelBuilder.cpp`)
- Replaced legacy operational calls in normal flows so the canonical data-definition layer is not destroyed/recreated: `ModelGraphicsScene::dropEvent()` and `ModelGraphicsScene::keyPressEvent()` now call the new sync helper instead of calling `destroyDiagram()`/`createDiagrams()`. (modified: `graphicals/ModelGraphicsScene.cpp`)
- `PropertyEditorController::_runGlobalRefresh()` now calls the sync helper (preserving layout) instead of the legacy `actualizeDiagramArrows()`. (modified: `controllers/PropertyEditorController.cpp`)
- `MainWindow::_check()` uses the sync helper instead of calling `destroyDiagram()/createDiagrams()` as the operational mechanism for the main view. (modified: `mainwindow.cpp`)
- Fixed `GraphicalModelDataDefinition::sceneEvent(QEvent*)` to return the result of `QGraphicsObject::sceneEvent(event)`. (modified: `graphicals/GraphicalModelDataDefinition.cpp`)
- Hardened `EditCommandController` cut/copy/paste/helpCopy flows to safely ignore `GraphicalModelDataDefinition` in the structural clipboard paths and to guard against null `GraphicalModelComponent` lookups to avoid dereference crashes. (modified: `controllers/EditCommandController.cpp`)
- Confirmed `ModelGraphicsScene::removeGroup()` already handled mixed groups safely and preserved that behavior (no regression). (inspected: `graphicals/ModelGraphicsScene.cpp`)
- Kept `GraphicalDiagramConnection` non-interactive (not selectable/focusable/movable). (unchanged behavior)

### Testing
- Confirmed working branch: local branch `work` (the branch `WiP20261` was not present so all changes were applied on `work`).
- Ran repository checks and prepared the changes; commit created with message `GUI: consolidate canonical graphical data-definition layer and mixed-group safety`.
- Ran `cmake --preset debug` (kernel/tests presets) and CMake configuration succeeded for non-GUI builds (configured build files written to `build/debug`).
- Attempted GUI-enabled configure to validate Qt build (`cmake -S . -B build/gui-debug -DGENESYS_BUILD_GUI_APPLICATION=ON ...`) and it failed due to missing `qmake` in PATH (environment limitation), so a full GUI build could not be executed in this environment.
- No GUI binary was built here because Qt/qmake are not available in the environment; thus dynamic runtime validation of the Qt GUI was not performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da80a3114c8321b94070e2d0836e12)