### PR TITLE
Expose simulation aggregates and add Results table in Qt GUI; fix tab-pane bug

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
@@ -15,6 +15,8 @@
 // Kernel
 #include "../../../../kernel/simulator/SinkModelComponent.h"
 #include "../../../../kernel/simulator/Attribute.h"
+#include "../../../../kernel/simulator/Counter.h"
+#include "../../../../kernel/simulator/StatisticsCollector.h"
 #include "../../../TraitsApp.h"
 // GUI
 #include "graphicals/ModelGraphicsScene.h"
@@ -155,6 +157,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
     headers << tr("Number") << tr("Name") << tr("Type"); // << and each attribute as a column
     ui->tableWidget_Entities->setHorizontalHeaderLabels(headers);
     ui->tableWidget_Entities->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
+    _prepareReportsResultsTable();
     ui->tableWidget_Simulation_Event->setContentsMargins(1, 0, 1, 0);
     //
     // Trees
@@ -628,7 +631,7 @@ void MainWindow::_actualizeTabPanes() {
             } else if (index == CONST.TabModelDataDefinitionsIndex) {
                 _actualizeModelDataDefinitions(true);
             }
-        } else if (index == CONST.TabCentralModelIndex) {
+        } else if (index == CONST.TabCentralSimulationIndex) {
             index = ui->tabWidgetSimulation->currentIndex();
             if (index == CONST.TabSimulationBreakpointsIndex) {
                 _actualizeDebugBreakpoints(true);
@@ -638,12 +641,99 @@ void MainWindow::_actualizeTabPanes() {
                 _actualizeDebugVariables(true);
             }
         } else if (index == CONST.TabCentralReportsIndex) {
-            index = ui->tabWidgetReports->currentIndex(); //@TODO: Add results
+            index = ui->tabWidgetReports->currentIndex();
+            if (index == CONST.TabReportResultIndex) {
+                _actualizeReportsResultsTable();
+            }
         }
     } else {
         ui->actionAnimateCounter->setChecked(false);
         ui->actionAnimateVariable->setChecked(false);
         ui->actionAnimateSimulatedTime->setChecked(false);
+    }
+}
+
+void MainWindow::_prepareReportsResultsTable() {
+    QStringList headers;
+    headers << tr("Type")
+            << tr("ParentType")
+            << tr("ParentName")
+            << tr("Name")
+            << tr("NumElements")
+            << tr("Min")
+            << tr("Max")
+            << tr("Average")
+            << tr("Variance")
+            << tr("StdDev")
+            << tr("VarCoef")
+            << tr("HalfWidthCI")
+            << tr("ConfidenceLevel");
+    ui->tableWidget_ReportsResults->setHorizontalHeaderLabels(headers);
+    ui->tableWidget_ReportsResults->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
+    ui->tableWidget_ReportsResults->verticalHeader()->setVisible(false);
+    ui->tableWidget_ReportsResults->setSortingEnabled(false);
+    _clearReportsResultsTable();
+}
+
+void MainWindow::_clearReportsResultsTable() {
+    ui->tableWidget_ReportsResults->setRowCount(0);
+}
+
+void MainWindow::_actualizeReportsResultsTable() {
+    _clearReportsResultsTable();
+    if (simulator == nullptr || simulator->getModelManager() == nullptr || simulator->getModelManager()->current() == nullptr) {
+        return;
+    }
+    ModelSimulation* simulation = simulator->getModelManager()->current()->getSimulation();
+    if (simulation == nullptr) {
+        return;
+    }
+    const List<ModelDataDefinition*>* aggregates = simulation->getSimulationStatisticsAggregates();
+    if (aggregates == nullptr) {
+        return;
+    }
+
+    auto setCell = [this](int row, int col, const QString& value) {
+        ui->tableWidget_ReportsResults->setItem(row, col, new QTableWidgetItem(value));
+    };
+    auto numberToQString = [](double value) {
+        return QString::fromStdString(std::to_string(value));
+    };
+
+    int row = 0;
+    for (ModelDataDefinition* data : *aggregates->list()) {
+        if (data == nullptr) {
+            continue;
+        }
+        ui->tableWidget_ReportsResults->insertRow(row);
+        setCell(row, 0, QString::fromStdString(data->getClassname()));
+        setCell(row, 3, QString::fromStdString(data->getName()));
+
+        ModelDataDefinition* parent = nullptr;
+        if (StatisticsCollector* collector = dynamic_cast<StatisticsCollector*>(data)) {
+            parent = collector->getParent();
+            Statistics_if* stats = collector->getStatistics();
+            if (stats != nullptr) {
+                setCell(row, 4, QString::number(stats->numElements()));
+                setCell(row, 5, numberToQString(stats->min()));
+                setCell(row, 6, numberToQString(stats->max()));
+                setCell(row, 7, numberToQString(stats->average()));
+                setCell(row, 8, numberToQString(stats->variance()));
+                setCell(row, 9, numberToQString(stats->stddeviation()));
+                setCell(row, 10, numberToQString(stats->variationCoef()));
+                setCell(row, 11, numberToQString(stats->halfWidthConfidenceInterval()));
+                setCell(row, 12, numberToQString(stats->confidenceLevel()));
+            }
+        } else if (Counter* counter = dynamic_cast<Counter*>(data)) {
+            parent = counter->getParent();
+            setCell(row, 4, numberToQString(counter->getCountValue()));
+        }
+
+        if (parent != nullptr) {
+            setCell(row, 1, QString::fromStdString(parent->getClassname()));
+            setCell(row, 2, QString::fromStdString(parent->getName()));
+        }
+        row++;
     }
 }
 

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.h
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.h
@@ -344,6 +344,12 @@ private: // view
 	void _actualizeDebugEntities(bool force);
     /** @brief Refreshes debug breakpoints pane while preserving force-update semantics. */
 	void _actualizeDebugBreakpoints(bool force);
+    /** @brief Configures and clears the simulation results table widget headers and behavior. */
+    void _prepareReportsResultsTable();
+    /** @brief Clears all rows from the simulation results table widget. */
+    void _clearReportsResultsTable();
+    /** @brief Fills the simulation results table with final aggregated simulation statistics. */
+    void _actualizeReportsResultsTable();
     /** @brief Compatibility wrapper delegating model-components tree synchronization. */
 	void _actualizeModelComponents(bool force);
     /** @brief Compatibility wrapper delegating data-definitions tree synchronization. */

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.ui
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.ui
@@ -565,6 +565,27 @@
             <attribute name="title">
              <string>Results</string>
             </attribute>
+            <layout class="QVBoxLayout" name="verticalLayout_20">
+             <item>
+              <widget class="QTableWidget" name="tableWidget_ReportsResults">
+               <property name="editTriggers">
+                <set>QAbstractItemView::NoEditTriggers</set>
+               </property>
+               <property name="alternatingRowColors">
+                <bool>true</bool>
+               </property>
+               <property name="selectionBehavior">
+                <enum>QAbstractItemView::SelectRows</enum>
+               </property>
+               <property name="rowCount">
+                <number>0</number>
+               </property>
+               <property name="columnCount">
+                <number>13</number>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </widget>
            <widget class="QWidget" name="tabReportsPlots">
             <attribute name="title">

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow_simulator.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow_simulator.cpp
@@ -93,6 +93,7 @@ void MainWindow::_onSimulationEndHandler(SimulationEvent * re) {
     if (_simulationEventController != nullptr) {
         _simulationEventController->onSimulationEndHandler(re);
     }
+    _actualizeReportsResultsTable();
 }
 
 void MainWindow::_onProcessEventHandler(SimulationEvent * re) {

--- a/source/kernel/simulator/ModelSimulation.cpp
+++ b/source/kernel/simulator/ModelSimulation.cpp
@@ -687,6 +687,10 @@ List<ModelComponent*>* ModelSimulation::getBreakpointsOnComponent() const {
 	return _breakpointsOnComponent;
 }
 
+const List<ModelDataDefinition*>* ModelSimulation::getSimulationStatisticsAggregates() const {
+	return _cstatsAndCountersSimulation;
+}
+
 bool ModelSimulation::isPaused() const {
 	return _isPaused;
 }

--- a/source/kernel/simulator/ModelSimulation.h
+++ b/source/kernel/simulator/ModelSimulation.h
@@ -103,6 +103,7 @@ public: // only gets
 	List<double>* getBreakpointsOnTime() const;
 	List<Entity*>* getBreakpointsOnEntity() const;
 	List<ModelComponent*>* getBreakpointsOnComponent() const;
+	const List<ModelDataDefinition*>* getSimulationStatisticsAggregates() const;
 public:
 	void loadInstance(PersistenceRecord *fields);
 	void saveInstance(PersistenceRecord *fields, bool saveDefaults);


### PR DESCRIPTION
### Motivation
- Provide a read-only path from GUI to the final simulation aggregated model data so the Results tab can present a tabular view of final aggregates without changing textual reporters.
- Add a concrete results widget in the Qt GUI to present final aggregates in columns (Type/ParentType/ParentName/Name/NumElements/Min/Max/Average/Variance/StdDev/VarCoef/HalfWidthCI/ConfidenceLevel).
- Work was performed on the available local branch (`work`) because the requested remote branch `WiP20261` was not present/accessible in this environment. Existing textual Reports behavior was preserved.

### Description
- Exposed a const read-only getter in the kernel: `ModelSimulation::getSimulationStatisticsAggregates()` returning `const List<ModelDataDefinition*>*` (header + implementation). (files: `ModelSimulation.h`, `ModelSimulation.cpp`)
- Added a real `QTableWidget` named `tableWidget_ReportsResults` inside `TabReportsResults` in the UI and kept `textEdit_Reports` unchanged. (file: `mainwindow.ui`)
- Added private MainWindow helpers `_prepareReportsResultsTable()`, `_clearReportsResultsTable()` and `_actualizeReportsResultsTable()` to configure and populate the table from `simulator->getModelManager()->current()->getSimulation()->getSimulationStatisticsAggregates()`, filling statistics for `StatisticsCollector` and basic count for `Counter`. (files: `mainwindow.h`, `mainwindow.cpp`)
- Triggered a final-table refresh at simulation end by calling `_actualizeReportsResultsTable()` from the existing `_onSimulationEndHandler()` wrapper, so the table is updated only after simulation completion and without parsing the textual report. (file: `mainwindow_simulator.cpp`)
- Fixed the confirmed bug in `_actualizeTabPanes()` by changing the duplicated branch to correctly check `CONST.TabCentralSimulationIndex` so simulation sub-tabs are actualized as intended. (file: `mainwindow.cpp`)

### Testing
- Searched and inspected diffs and code occurrences for the new getter, new UI widget name, table fill method, simulation-end refresh call, and the `_actualizeTabPanes()` fix using `rg` and `git diff`, and verified the expected symbols/insertions are present (succeeded).
- Attempted to configure/build the Qt GUI target with CMake, but full GUI build could not proceed in this environment because `qmake` is not available in PATH; CMake configuration failed with an explanatory error (failed).  The non-GUI CMake configure/run path was exercised and showed GUI target not built by default (observed).
- Committed the localized changes to the repository (commit created on local branch `work`) after verification of the focused diffs (succeeded).

Notes: runtime verification of the GUI (opening app, running a simulation, confirming textual Reports unchanged and Results table populated after simulation) was not possible here due to missing Qt build tools; those validations should be performed in a Qt-enabled environment before merging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da835e6e5c8321b9624fd121c20fbc)