### PR TITLE
Fix Write persistence/check robustness and add runtime tests

### DIFF
--- a/source/plugins/components/Write.cpp
+++ b/source/plugins/components/Write.cpp
@@ -75,8 +75,13 @@ void Write::insertText(std::list<std::string> texts) {
 		_writeElements->list()->push_back(text);
 	}
 
-	if (texts.size() > 0 && texts.back().substr(texts.back().length() - 1, 1) != "\n") {
-		_writeElements->list()->push_back("\n");
+	// Keep append semantics, but guard edge cases such as empty list/empty tail string.
+	if (!texts.empty()) {
+		const std::string& last = texts.back();
+		const bool endsWithNewLine = !last.empty() && last.back() == '\n';
+		if (!endsWithNewLine) {
+			_writeElements->list()->push_back("\n");
+		}
 	}
 }
 
@@ -101,7 +106,7 @@ Write::WriteToType Write::writeToType() const {
 }
 
 void Write::_onDispatchEvent(Entity* entity, unsigned int inputPortNumber) {
-	if (this->_writeToType == Write::WriteToType::FILE) { // file is kept open during replication
+	if (this->_writeToType == Write::WriteToType::FILE && !_filename.empty()) { // file is kept open during replication
 		_savefile.open(_filename, std::ofstream::app);
 	}
 	std::string message = "";
@@ -112,7 +117,7 @@ void Write::_onDispatchEvent(Entity* entity, unsigned int inputPortNumber) {
 		} else {
 			message += msgElem;
 		}
-		lastWasShown = msgElem.substr(msgElem.length() - 1, 1) == "\n";
+		lastWasShown = !msgElem.empty() && msgElem.back() == '\n';
 		if (lastWasShown) {
 			message = message.substr(0, message.length() - 1);
 			if (message != "") {
@@ -132,14 +137,14 @@ void Write::_onDispatchEvent(Entity* entity, unsigned int inputPortNumber) {
 			_savefile << message << std::endl;
 		}
 	}
-	if (this->_writeToType == Write::WriteToType::FILE) { // file is kept open during replication (//@TODO: whould need to intercept end of simulation event
+	if (this->_writeToType == Write::WriteToType::FILE && _savefile.is_open()) { // file is kept open during replication (//@TODO: whould need to intercept end of simulation event
 		_savefile.close();
 	}
 	this->_parentModel->sendEntityToComponent(entity, this->getConnectionManager()->getFrontConnection());
 }
 
 void Write::_initBetweenReplications() {
-	if (this->_writeToType == Write::WriteToType::FILE) {
+	if (this->_writeToType == Write::WriteToType::FILE && !_filename.empty()) {
 		try {
 			if (!_savefile.is_open()) {
 				_savefile.open(_filename, std::ofstream::app);
@@ -163,7 +168,6 @@ bool Write::_loadInstance(PersistenceRecord *fields) {
 		for (unsigned short i = 0; i < writesSize; i++) {
 			std::string text = fields->loadField("write" + Util::StrIndex(i), "");
 			_writeElements->insert(text);
-			i++;
 		}
 	}
 	return res;
@@ -184,21 +188,18 @@ void Write::_saveInstance(PersistenceRecord *fields, bool saveDefaultValues) {
 
 bool Write::_check(std::string& errorMessage) {
 	bool resultAll = true;
-	/*
-	WriteText* msgElem;
+	if (_writeToType == Write::WriteToType::FILE && _filename.empty()) {
+		errorMessage.append("Filename must be informed when WriteToType=FILE. ");
+		resultAll = false;
+	}
 	unsigned short i = 0;
-	std::list<WriteText*>* msgs = this->_writeElements->list();
-	for (std::list<WriteText*>::iterator it = msgs->begin(); it != msgs->end(); it++) {
-		msgElem = (*it);
+	for (const std::string& msgElem : *_writeElements->list()) {
 		i++;
-		if (msgElem->isExpression) {
-			resultAll &= _parentModel->checkExpression(msgElem->text, "writeExpression" + Util::strIndex(i), errorMessage);
+		if (!msgElem.empty() && msgElem.front() == '@') {
+			const std::string expression = msgElem.substr(1);
+			resultAll &= _parentModel->checkExpression(expression, "writeExpression" + Util::StrIndex(i), errorMessage);
 		}
 	}
-	 */
-	// when cheking the model (before simulating it), remove the file if exists
-	std::remove(_filename.c_str());
-
 	return resultAll;
 }
 

--- a/source/tests/unit/test_simulator_runtime.cpp
+++ b/source/tests/unit/test_simulator_runtime.cpp
@@ -42,6 +42,7 @@
 #include "plugins/components/Search.h"
 #include "plugins/components/Remove.h"
 #include "plugins/components/Assign.h"
+#include "plugins/components/Write.h"
 #define private public
 #define protected public
 #include "plugins/components/Create.h"
@@ -410,6 +411,23 @@ public:
     Seize* SeizePtrProbe() const { return _seize; }
     Delay* DelayPtrProbe() const { return _delay; }
     Release* ReleasePtrProbe() const { return _release; }
+};
+
+class WriteProbe : public Write {
+public:
+    WriteProbe(Model* model, const std::string& name = "") : Write(model, name) {}
+
+    bool CheckProbe(std::string& errorMessage) {
+        return _check(errorMessage);
+    }
+
+    void SaveInstanceProbe(PersistenceRecord* fields, bool saveDefaultValues = false) {
+        _saveInstance(fields, saveDefaultValues);
+    }
+
+    bool LoadInstanceProbe(PersistenceRecord* fields) {
+        return _loadInstance(fields);
+    }
 };
 
 class CollectorSinkComponentProbe : public ModelComponent {
@@ -4212,6 +4230,114 @@ TEST(SimulatorRuntimeTest, CreateSaveLoadRoundTripPreservesBasicConfiguration) {
     EXPECT_EQ(loaded.getMaxCreations(), "12");
     EXPECT_EQ(loaded.getTimeBetweenCreationsExpression(), "2");
     EXPECT_EQ(loaded.getTimeUnit(), Util::TimeUnit::minute);
+}
+
+TEST(SimulatorRuntimeTest, WritePersistenceRoundTripPreservesAllTextElementsInOrder) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    WriteProbe source(model, "WritePersistSource");
+    source.setWriteToType(Write::WriteToType::FILE);
+    source.setFilename("write_persist_roundtrip.txt");
+    source.insertText({"alpha", "@1+2", "omega"});
+
+    FakeModelPersistenceRuntime persistence;
+    PersistenceRecord saved(persistence);
+    source.SaveInstanceProbe(&saved, true);
+
+    WriteProbe loaded(model, "WritePersistLoaded");
+    ASSERT_TRUE(loaded.LoadInstanceProbe(&saved));
+
+    FakeModelPersistenceRuntime persistenceAfterLoad;
+    PersistenceRecord loadedSaved(persistenceAfterLoad);
+    loaded.SaveInstanceProbe(&loadedSaved, true);
+
+    const unsigned int writesCount = loadedSaved.loadField("writes", 0u);
+    ASSERT_EQ(writesCount, 4u);
+    EXPECT_EQ(loadedSaved.loadField("write[0]", std::string("")), "alpha");
+    EXPECT_EQ(loadedSaved.loadField("write[1]", std::string("")), "@1+2");
+    EXPECT_EQ(loadedSaved.loadField("write[2]", std::string("")), "omega");
+    EXPECT_EQ(loadedSaved.loadField("write[3]", std::string("")), "\n");
+}
+
+TEST(SimulatorRuntimeTest, WriteCheckFailsForInvalidEmbeddedExpression) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    WriteProbe write(model, "WriteCheckInvalidExpression");
+    write.setWriteToType(Write::WriteToType::SCREEN);
+    write.insertText({"@1+"});
+
+    std::string errorMessage;
+    EXPECT_FALSE(write.CheckProbe(errorMessage));
+    EXPECT_NE(errorMessage.find("writeExpression"), std::string::npos);
+}
+
+TEST(SimulatorRuntimeTest, WriteCheckPassesForValidEmbeddedExpressionAndConfiguration) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    WriteProbe write(model, "WriteCheckValidExpression");
+    write.setWriteToType(Write::WriteToType::FILE);
+    write.setFilename("write_check_valid.txt");
+    write.insertText({"result=", "@1+2"});
+
+    std::string errorMessage;
+    EXPECT_TRUE(write.CheckProbe(errorMessage)) << errorMessage;
+}
+
+TEST(SimulatorRuntimeTest, WriteInsertTextHandlesEdgeCasesWithoutBreakingAppendSemantics) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    WriteProbe emptyList(model, "WriteInsertEmptyList");
+    emptyList.insertText({});
+    FakeModelPersistenceRuntime persistenceEmpty;
+    PersistenceRecord savedEmpty(persistenceEmpty);
+    emptyList.SaveInstanceProbe(&savedEmpty, true);
+    EXPECT_EQ(savedEmpty.loadField("writes", 0u), 0u);
+
+    WriteProbe plainText(model, "WriteInsertPlainText");
+    plainText.insertText({"plain"});
+    FakeModelPersistenceRuntime persistencePlain;
+    PersistenceRecord savedPlain(persistencePlain);
+    plainText.SaveInstanceProbe(&savedPlain, true);
+    ASSERT_EQ(savedPlain.loadField("writes", 0u), 2u);
+    EXPECT_EQ(savedPlain.loadField("write[0]", std::string("")), "plain");
+    EXPECT_EQ(savedPlain.loadField("write[1]", std::string("")), "\n");
+
+    WriteProbe emptyString(model, "WriteInsertEmptyString");
+    emptyString.insertText({""});
+    FakeModelPersistenceRuntime persistenceEmptyString;
+    PersistenceRecord savedEmptyString(persistenceEmptyString);
+    emptyString.SaveInstanceProbe(&savedEmptyString, true);
+    ASSERT_EQ(savedEmptyString.loadField("writes", 0u), 2u);
+    EXPECT_EQ(savedEmptyString.loadField("write[0]", std::string("default")), "");
+    EXPECT_EQ(savedEmptyString.loadField("write[1]", std::string("default")), "\n");
+}
+
+TEST(SimulatorRuntimeTest, WritePersistenceRoundTripPreservesWriteToTypeAndFilename) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    WriteProbe source(model, "WritePersistFieldsSource");
+    source.setWriteToType(Write::WriteToType::FILE);
+    source.setFilename("write_fields_roundtrip.txt");
+    source.insertText({"payload"});
+
+    FakeModelPersistenceRuntime persistence;
+    PersistenceRecord saved(persistence);
+    source.SaveInstanceProbe(&saved, true);
+
+    WriteProbe loaded(model, "WritePersistFieldsLoaded");
+    ASSERT_TRUE(loaded.LoadInstanceProbe(&saved));
+    EXPECT_EQ(loaded.writeToType(), Write::WriteToType::FILE);
+    EXPECT_EQ(loaded.filename(), "write_fields_roundtrip.txt");
 }
 
 TEST(SimulatorRuntimeTest, CppCompilerDefaultsExposeMainConfiguration) {


### PR DESCRIPTION
### Motivation
- Correct a persistence bug where `Write::_loadInstance()` skipped persisted text entries due to a double index increment, causing loss/ordering issues.
- Prevent destructive side effects during model validation by making `Write::_check()` non-destructive and actually validating embedded `@...` expressions.
- Harden `Write::insertText()` and minimal file handling so runtime and round-trip persistence are robust for edge cases. 

### Description
- Fixed `_loadInstance()` loop: removed the extra index increment so all `write[i]` entries are loaded and order is preserved (`Write::_loadInstance`).
- Hardened `_check()` to require a non-empty `filename` when `WriteToType == FILE`, validate each `@...` item using `_parentModel->checkExpression(...)`, and removed the destructive `std::remove(_filename.c_str())` behavior so checking does not delete files (`Write::_check`).
- Made `insertText()` robust to empty input and empty trailing strings by guarding `texts.back()` access and preserving original append/newline semantics (`Write::insertText`).
- Added defensive guards in `_onDispatchEvent()` and `_initBetweenReplications()` to skip file open/write/close when the filename is empty and verify `_savefile.is_open()` before closing it (minimal, non-architectural I/O changes).
- Added `WriteProbe` and unit tests in `source/tests/unit/test_simulator_runtime.cpp` covering: persistence round-trip of multiple texts (order preserved), invalid/valid embedded-expression checks, `insertText()` edge cases, and persistence of `writeToType` and `filename` (tests A–E).

### Testing
- Ran configuration and build with `cmake -S . -B build -G Ninja` and `cmake --build build`, both completed successfully.
- Executed the runtime test binary `./build/source/tests/unit/genesys_test_simulator_runtime` and its 166 tests passed.
- Ran the full unit test set with `ctest --test-dir build -L unit --output-on-failure` and the unit suite completed successfully (all unit tests passed); 4 disabled tests were preexisting and not part of this change.

All automated tests mentioned above passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da816a7e908321b6e57241c5d49d48)