### PR TITLE
GUI: finalize canonical data-definition layer integration and remove legacy diagram operational flow

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
@@ -741,6 +741,14 @@ void ModelGraphicsScene::ensureInitialInternalDataDefinitionGrouping(GraphicalMo
     }
     targetGroup->addToGroup(dataDefinition);
     insertOldPositionItem(dataDefinition, dataDefinition->pos());
+
+    if (!_listComponentsGroup.contains(targetGroup)) {
+        _listComponentsGroup.insert(targetGroup, QList<GraphicalModelComponent*>());
+    }
+    QList<GraphicalModelComponent*>& groupedComponents = _listComponentsGroup[targetGroup];
+    if (!groupedComponents.contains(component)) {
+        groupedComponents.append(component);
+    }
 }
 
 void ModelGraphicsScene::setPersistedGuiRestoreInProgress(bool restoring) {
@@ -1235,8 +1243,11 @@ void ModelGraphicsScene::createDiagrams()
 
         for (auto it = listDataDefinitions->begin(); it != listDataDefinitions->end(); ++it) {
             ModelDataDefinition* datadef = *it;
-            std::string pluginName = datadef->getName();
+            std::string pluginName = datadef->getClassname();
             Plugin* plugin = _simulator->getPluginManager()->find(pluginName);
+            if (plugin == nullptr) {
+                continue;
+            }
             addGraphicalModelDataDefinition(plugin, datadef, QPointF(0, 0), grey);
         }
     }
@@ -1367,7 +1378,6 @@ void ModelGraphicsScene::actualizeDiagramArrows() {
 
             removeGraphicalDiagramConnection(itemConnection);
         }
-        if (!visibleDiagram()) hideDiagrams();
     }
 }
 
@@ -1386,13 +1396,6 @@ void ModelGraphicsScene::destroyDiagram() {
 }
 
 void ModelGraphicsScene::hideDiagrams() {
-    QList<GraphicalModelDataDefinition*>* dataDefinitions = getAllDataDefinitions();
-    for (int i = 0; i < dataDefinitions->size(); i++) {
-        dataDefinitions->at(i)->hide();
-        dataDefinitions->at(i)->setFlag(QGraphicsItem::ItemIsSelectable, false);
-        dataDefinitions->at(i)->setFlag(QGraphicsItem::ItemIsMovable, false);
-    }
-
     QList<GraphicalDiagramConnection*>* connections = getAllGraphicalDiagramsConnections();
     for (int i = 0; i < connections->size(); i++) {
         connections->at(i)->hide();
@@ -1404,7 +1407,6 @@ void ModelGraphicsScene::showDiagrams() {
     QList<GraphicalModelDataDefinition*>* dataDefinitions = getAllDataDefinitions();
     if (dataDefinitions->size() > 0) {
         for (int i = 0; i < dataDefinitions->size(); i++) {
-
             dataDefinitions->at(i)->show();
             dataDefinitions->at(i)->setFlag(QGraphicsItem::ItemIsSelectable, true);
             dataDefinitions->at(i)->setFlag(QGraphicsItem::ItemIsMovable, true);

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
@@ -923,9 +923,9 @@ bool MainWindow::_check(bool success)
 
     if (res) {
         ModelGraphicsScene* scene = (ModelGraphicsScene*) (ui->graphicsView->scene());
+        GraphicalModelBuilder::synchronizeGraphicalDataDefinitionsLayer(simulator, scene);
         // Mensagem de sucesso
         if (success) {
-            GraphicalModelBuilder::synchronizeGraphicalDataDefinitionsLayer(simulator, scene);
             QMessageBox::information(this, "Model Check", "Model successfully checked.");
         }
         // Salva os data definitions dos componentes atuais

--- a/source/applications/gui/qt/GenesysQtGUI/services/GraphicalModelBuilder.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/services/GraphicalModelBuilder.cpp
@@ -306,13 +306,8 @@ void GraphicalModelBuilder::synchronizeGraphicalDataDefinitionsLayer(Simulator* 
     }
 
     const bool hasDataDefinitions = !dataDefinitionMap.empty();
-    const bool visible = hasDataDefinitions ? scene->visibleDiagram() : false;
-    scene->setDiagramLayerState(hasDataDefinitions, visible);
+    scene->setDiagramLayerState(hasDataDefinitions, hasDataDefinitions);
     if (hasDataDefinitions) {
-        if (visible) {
-            scene->showDiagrams();
-        } else {
-            scene->hideDiagrams();
-        }
+        scene->showDiagrams();
     }
 }


### PR DESCRIPTION
### Motivation
- Consolidate the canonical graphical data-definition layer so normal flows no longer rely on the legacy create/destroy diagram cycle and overlay visibility semantics.
- Preserve existing data-definition layouts while keeping them part of the main model view (selectable and movable) rather than an optional overlay.
- Fix residual issues: incorrect plugin lookup in legacy `createDiagrams()` and incomplete bookkeeping for automatic grouping of internal data definitions.

### Description
- Run-time orchestration: `MainWindow::_check()` now always calls `GraphicalModelBuilder::synchronizeGraphicalDataDefinitionsLayer(...)` when the model check succeeds (sync moved to the main success path). 
- Scene behavior: `ModelGraphicsScene::hideDiagrams()` no longer hides or disables `GraphicalModelDataDefinition` items (it hides only legacy diagram connections), and `actualizeDiagramArrows()` no longer reapplies legacy hide semantics.
- Legacy method fixes: `ModelGraphicsScene::createDiagrams()` uses `ModelDataDefinition::getClassname()` for plugin lookup and skips entries when the plugin is missing to avoid invalid items.
- Bookkeeping and sync finalization: `ensureInitialInternalDataDefinitionGrouping(...)` now updates `_listComponentsGroup` when it creates an automatic group, and `GraphicalModelBuilder::synchronizeGraphicalDataDefinitionsLayer(...)` finalizes by marking the diagram layer present and showing the canonical data-definition nodes (avoiding branching on legacy visibility state).
- Verified `PropertyEditorController::_runGlobalRefresh()` already uses the canonical `GraphicalModelBuilder::synchronizeGraphicalDataDefinitionsLayer(...)` and was left as-is (it was inspected and confirmed correct).

### Testing
- Confirmed changes by static inspection and project-local executions including `rg` and targeted `sed`/`nl` checks to validate diffs and affected lines; these checks succeeded.
- Source control actions (`git add`/`git commit`) completed successfully and produced commit `ac216f2f` with the requested message; this succeeded.
- Attempted to configure a GUI build with CMake (`cmake -S . -B build/gui-check -G Ninja -DGENESYS_BUILD_GUI_APPLICATION=ON ...`) which failed because `qmake` is not available in PATH and is required by the GUI Qt CMake configuration, so a full GUI build/test could not be executed in this environment.
- No unit or GUI integration tests were run in this environment due to the missing Qt toolchain dependency; all runtime validation is limited to static/diff inspection and local commits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da88511a448321a4d670465f6a501d)