### PR TITLE
Harden Buffer and PickStation runtime checks with regression tests

### DIFF
--- a/source/plugins/components/Buffer.cpp
+++ b/source/plugins/components/Buffer.cpp
@@ -102,10 +102,20 @@ PluginInformation* Buffer::GetPluginInformation() {
 // protected virtual -- must be overriden
 
 void Buffer::_onDispatchEvent(Entity* entity, unsigned int inputPortNumber) {
+	(void)inputPortNumber;
+	if (_capacity == 0) {
+		traceError("Buffer \"" + getName() + "\" received entity with invalid Capacity=0");
+		return;
+	}
+	if (_buffer->size() != _capacity) {
+		_buffer->resize(_capacity, nullptr);
+	}
 	if (_advanceOn == AdvanceOn::NewArrivals) {
 		// just move on
 		Entity* first = _advance(entity);
-		_parentModel->sendEntityToComponent(first, _connections->getFrontConnection());
+		if (first != nullptr) {
+			_parentModel->sendEntityToComponent(first, _connections->getFrontConnection());
+		}
 	} else { // advance on signal. Do not move. Only check if buffer is full
 		if (_buffer->at(_capacity-1) != nullptr) { // full buffer
 			traceSimulation(this, "Entity arrived on a full buffer");
@@ -121,8 +131,9 @@ void Buffer::_onDispatchEvent(Entity* entity, unsigned int inputPortNumber) {
 				{
 					Entity* replaced = _buffer->at(_capacity-1);
 					traceSimulation(this, "Entity "+entity->getName()+" will replace entity "+replaced->getName()+" on the buffer");
-					traceSimulation(this, "Disposing replaced entity "+entity->getName());
+					traceSimulation(this, "Disposing replaced entity "+replaced->getName());
 					_parentModel->removeEntity(replaced);
+					_buffer->at(_capacity-1) = entity;
 					break;
 				}
 				case ArrivalOnFullBufferRule::num_elements:
@@ -130,7 +141,13 @@ void Buffer::_onDispatchEvent(Entity* entity, unsigned int inputPortNumber) {
 					break;
 			}
 		} else { // insert
-			_buffer->at(_capacity-1) = entity;
+			// Keep insertion coherent by placing the arriving entity in the first free slot.
+			for (unsigned int i = 0; i < _capacity; i++) {
+				if (_buffer->at(i) == nullptr) {
+					_buffer->at(i) = entity;
+					break;
+				}
+			}
 		}
 	}
 }
@@ -166,7 +183,19 @@ void Buffer::_saveInstance(PersistenceRecord *fields, bool saveDefaultValues) {
 
 bool Buffer::_check(std::string& errorMessage) {
 	bool resultAll = true;
-	//...
+	if (_capacity == 0) {
+		errorMessage = "Buffer \"" + getName() + "\" must have Capacity greater than zero";
+		traceError(errorMessage);
+		resultAll = false;
+	}
+	if (_advanceOn == AdvanceOn::Signal && _attachedSignal == nullptr) {
+		errorMessage = "Buffer \"" + getName() + "\" configured with AdvanceOn=Signal requires a valid SignalData";
+		traceError(errorMessage);
+		resultAll = false;
+	}
+	if (_buffer != nullptr && _capacity > 0 && _buffer->size() != _capacity) {
+		_buffer->resize(_capacity, nullptr); // keep check idempotent for rechecks
+	}
 	return resultAll;
 }
 
@@ -202,13 +231,29 @@ void Buffer::_createInternalAndAttachedData() {
 	PluginManager* pm = _parentModel->getParentSimulator()->getPluginManager();
 	//attached
 	if (_advanceOn == AdvanceOn::Signal) {
+		if (_signalWithRegisteredHandler != nullptr && _signalWithRegisteredHandler != _attachedSignal) {
+			_signalWithRegisteredHandler->removeSignalDataEventHandler(this);
+			_signalWithRegisteredHandler = nullptr;
+		}
 		if (_attachedSignal  == nullptr) {
 			_attachedSignal = pm->newInstance<SignalData>(_parentModel, getName() + "." + "SignalData");
+			if (_attachedSignal == nullptr) {
+				traceError("Buffer \"" + getName() + "\" failed to create SignalData while configured with AdvanceOn=Signal");
+				_attachedDataRemove("SignalData");
+				return;
+			}
 		}
 		SignalData::SignalDataEventHandler handler = SignalData::SetSignalDataEventHandler<Buffer>(&Buffer::_handlerForSignalDataEvent, this);
-		_attachedSignal->addSignalDataEventHandler(handler, this);
+		if (!_attachedSignal->hasSignalDataEventHandler(this)) {
+			_attachedSignal->addSignalDataEventHandler(handler, this);
+		}
+		_signalWithRegisteredHandler = _attachedSignal;
 		_attachedDataInsert("SignalData", _attachedSignal);
 	} else {
+		if (_signalWithRegisteredHandler != nullptr) {
+			_signalWithRegisteredHandler->removeSignalDataEventHandler(this);
+			_signalWithRegisteredHandler = nullptr;
+		}
 		_attachedDataRemove("SignalData");
 	}
 }

--- a/source/plugins/components/Buffer.h
+++ b/source/plugins/components/Buffer.h
@@ -78,6 +78,7 @@ private:
 	std::vector<Entity*>* _buffer = new std::vector<Entity*>;
 private: // attached
 	SignalData* _attachedSignal = nullptr;
+	SignalData* _signalWithRegisteredHandler = nullptr;
 };
 
 #endif /* BUFFER_H */

--- a/source/plugins/components/PickStation.cpp
+++ b/source/plugins/components/PickStation.cpp
@@ -173,6 +173,7 @@ PluginInformation* PickStation::GetPluginInformation() {
 // protected virtual -- must be overriden
 
 void PickStation::_onDispatchEvent(Entity* entity, unsigned int inputPortNumber) {
+	(void)inputPortNumber;
 	double value, valueResource=0, valueQueue=0, valueExpression=0, bestValue;
 	Station* bestStation = nullptr;
 	if (_testCondition == TestCondition::MAXIMUM) {
@@ -203,6 +204,10 @@ void PickStation::_onDispatchEvent(Entity* entity, unsigned int inputPortNumber)
 			bestValue = value;
 			bestStation = item->getStation();
 		}
+	}
+	if (bestStation == nullptr) {
+		traceError("PickStation \"" + getName() + "\" could not select a valid Station during dispatch");
+		return;
 	}
 	entity->setAttributeValue(_saveAttribute, bestStation->getId());
 	this->_parentModel->sendEntityToComponent(entity, this->getConnectionManager()->getFrontConnection());
@@ -274,8 +279,33 @@ void PickStation::_saveInstance(PersistenceRecord *fields, bool saveDefaultValue
 
 bool PickStation::_check(std::string& errorMessage) {
 	bool resultAll = true;
-	//resultAll &= _someString != "";
-	//resultAll &= _someUint > 0;
+	if (_pickableStationItens->size() == 0) {
+		errorMessage = "PickStation \"" + getName() + "\" requires at least one PickableStationItem";
+		traceError(errorMessage);
+		resultAll = false;
+	}
+	if (_saveAttribute == "") {
+		errorMessage = "PickStation \"" + getName() + "\" requires SaveAttribute to store selected station";
+		traceError(errorMessage);
+		resultAll = false;
+	}
+	if (!_pickConditionExpression && !_pickConditionNumberInQueue && !_pickConditionNumberBusyResource) {
+		errorMessage = "PickStation \"" + getName() + "\" requires at least one active pick condition";
+		traceError(errorMessage);
+		resultAll = false;
+	}
+	unsigned int idx = 0;
+	for (PickableStationItem* item : *_pickableStationItens->list()) {
+		if (item == nullptr || item->getStation() == nullptr) {
+			errorMessage = "PickStation \"" + getName() + "\" has item " + std::to_string(idx) + " without a valid Station";
+			traceError(errorMessage);
+			resultAll = false;
+		}
+		if (_pickConditionExpression && item != nullptr) {
+			resultAll &= _parentModel->checkExpression(item->getExpression(), getName() + ".PickableStationItem[" + std::to_string(idx) + "].Expression", errorMessage);
+		}
+		idx++;
+	}
 	return resultAll;
 }
 
@@ -296,7 +326,9 @@ void PickStation::_createInternalAndAttachedData() {
 	unsigned int i = 0;
 	_attachedDataClear();
 	for (PickableStationItem* item : *_pickableStationItens->list()) {
-		_attachedDataInsert("Station" + std::to_string(i), item->getStation());
+		if (item->getStation() != nullptr) {
+			_attachedDataInsert("Station" + std::to_string(i), item->getStation());
+		}
 		if (item->getResource() != nullptr) {
 			_attachedDataInsert("Resource" + std::to_string(i), item->getResource());
 		}

--- a/source/tests/unit/test_simulator_runtime.cpp
+++ b/source/tests/unit/test_simulator_runtime.cpp
@@ -45,6 +45,12 @@
 #include "plugins/components/Write.h"
 #define private public
 #define protected public
+#include "plugins/components/Buffer.h"
+#include "plugins/components/PickStation.h"
+#undef protected
+#undef private
+#define private public
+#define protected public
 #include "plugins/components/Create.h"
 #undef protected
 #undef private
@@ -427,6 +433,48 @@ public:
 
     bool LoadInstanceProbe(PersistenceRecord* fields) {
         return _loadInstance(fields);
+    }
+};
+
+class BufferProbe : public Buffer {
+public:
+    BufferProbe(Model* model, const std::string& name = "") : Buffer(model, name) {}
+
+    bool CheckProbe(std::string& errorMessage) {
+        return _check(errorMessage);
+    }
+
+    void CreateInternalAndAttachedDataProbe() {
+        _createInternalAndAttachedData();
+    }
+
+    void InitBetweenReplicationsProbe() {
+        _initBetweenReplications();
+    }
+
+    void DispatchEventProbe(Entity* entity, unsigned int inputPortNumber = 0) {
+        _onDispatchEvent(entity, inputPortNumber);
+    }
+
+    std::vector<Entity*>* RawBufferProbe() const {
+        return _buffer;
+    }
+};
+
+class PickStationProbe : public PickStation {
+public:
+    PickStationProbe(Model* model, const std::string& name = "") : PickStation(model, name) {}
+
+    bool CheckProbe(std::string& errorMessage) {
+        return _check(errorMessage);
+    }
+
+    void CreateInternalAndAttachedDataProbe() {
+        _createInternalAndAttachedData();
+    }
+
+    void DispatchEventProbe(Entity* entity, unsigned int inputPortNumber = 0) {
+        _onDispatchEvent(entity, inputPortNumber);
     }
 };
 
@@ -2976,6 +3024,177 @@ TEST(SimulatorRuntimeTest, SignalAndWaitSharedSignalDataRemainCoherentAfterReche
     EXPECT_EQ(signal.SignalDataPtrProbe(), &signalData);
     EXPECT_EQ(wait._signalData, signal.SignalDataPtrProbe());
     EXPECT_TRUE(signalData.hasSignalDataEventHandler(&wait));
+}
+
+TEST(SimulatorRuntimeTest, BufferCheckFailsWhenCapacityIsZero) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    BufferProbe buffer(model, "BufferCheckCapZero");
+    buffer.setCapacity(0);
+
+    std::string errorMessage;
+    EXPECT_FALSE(buffer.CheckProbe(errorMessage));
+    EXPECT_NE(errorMessage.find("Capacity greater than zero"), std::string::npos);
+}
+
+TEST(SimulatorRuntimeTest, BufferCheckRequiresSignalDataWhenAdvanceOnSignal) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    BufferProbe buffer(model, "BufferCheckSignalRequired");
+    buffer.setCapacity(2);
+    buffer.setAdvanceOn(Buffer::AdvanceOn::Signal);
+    buffer.setSignal(nullptr);
+
+    std::string errorMessage;
+    EXPECT_FALSE(buffer.CheckProbe(errorMessage));
+    EXPECT_NE(errorMessage.find("requires a valid SignalData"), std::string::npos);
+}
+
+TEST(SimulatorRuntimeTest, BufferRecheckKeepsInternalVectorSizedToCapacityIdempotently) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    BufferProbe buffer(model, "BufferRecheckResize");
+    buffer.setCapacity(4);
+    buffer.InitBetweenReplicationsProbe();
+    ASSERT_EQ(buffer.RawBufferProbe()->size(), 4u);
+
+    buffer.setCapacity(2);
+    std::string checkError;
+    EXPECT_TRUE(buffer.CheckProbe(checkError));
+    EXPECT_EQ(buffer.RawBufferProbe()->size(), 2u);
+
+    std::string secondCheckError;
+    EXPECT_TRUE(buffer.CheckProbe(secondCheckError));
+    EXPECT_EQ(buffer.RawBufferProbe()->size(), 2u);
+}
+
+TEST(SimulatorRuntimeTest, BufferSignalArrivalOccupiesFirstFreePositionInsteadOfLastByDefault) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    SignalData signal(model, "BufferSignalModeSignal");
+    BufferProbe buffer(model, "BufferSignalMode");
+    buffer.setAdvanceOn(Buffer::AdvanceOn::Signal);
+    buffer.setSignal(&signal);
+    buffer.setCapacity(3);
+    buffer.InitBetweenReplicationsProbe();
+
+    Entity* existing = model->createEntity("BufferExisting", true);
+    Entity* arriving = model->createEntity("BufferArriving", true);
+    buffer.RawBufferProbe()->at(0) = existing;
+    buffer.RawBufferProbe()->at(1) = nullptr;
+    buffer.RawBufferProbe()->at(2) = nullptr;
+
+    buffer.DispatchEventProbe(arriving);
+    EXPECT_EQ(buffer.RawBufferProbe()->at(0), existing);
+    EXPECT_EQ(buffer.RawBufferProbe()->at(1), arriving);
+    EXPECT_EQ(buffer.RawBufferProbe()->at(2), nullptr);
+}
+
+TEST(SimulatorRuntimeTest, BufferNewArrivalsDoesNotForwardNullEntityWhenFirstSlotIsEmpty) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    BufferProbe buffer(model, "BufferNewArrivalsNullGuard");
+    CollectorSinkComponentProbe sink(model, "BufferNewArrivalsNullGuardSink");
+    buffer.connectTo(&sink);
+    buffer.setAdvanceOn(Buffer::AdvanceOn::NewArrivals);
+    buffer.setCapacity(2);
+    buffer.InitBetweenReplicationsProbe();
+
+    Entity* retained = model->createEntity("BufferRetained", true);
+    Entity* arriving = model->createEntity("BufferIncoming", true);
+    buffer.RawBufferProbe()->at(0) = nullptr;
+    buffer.RawBufferProbe()->at(1) = retained;
+
+    buffer.DispatchEventProbe(arriving);
+    DrainFutureEvents(model);
+    EXPECT_TRUE(sink.ReceivedEntities().empty());
+    EXPECT_EQ(buffer.RawBufferProbe()->at(0), retained);
+    EXPECT_EQ(buffer.RawBufferProbe()->at(1), arriving);
+}
+
+TEST(SimulatorRuntimeTest, PickStationCheckFailsWithoutPickableItems) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    PickStationProbe pick(model, "PickNoItems");
+    pick.setSaveAttribute("Entity.PickStation");
+
+    std::string errorMessage;
+    EXPECT_FALSE(pick.CheckProbe(errorMessage));
+    EXPECT_NE(errorMessage.find("requires at least one PickableStationItem"), std::string::npos);
+}
+
+TEST(SimulatorRuntimeTest, PickStationCheckFailsWhenAnyItemHasNoStation) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    PickStationProbe pick(model, "PickNullStation");
+    pick.setSaveAttribute("Entity.PickStation");
+    pick.addPickableStationItem(new PickableStationItem(static_cast<Station*>(nullptr), "1"));
+
+    std::string errorMessage;
+    EXPECT_FALSE(pick.CheckProbe(errorMessage));
+    EXPECT_NE(errorMessage.find("without a valid Station"), std::string::npos);
+}
+
+TEST(SimulatorRuntimeTest, PickStationCheckFailsWithInvalidExpressionWhenExpressionConditionIsActive) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    Station station(model, "PickExprStation");
+    PickStationProbe pick(model, "PickInvalidExpression");
+    pick.setSaveAttribute("Entity.PickStation");
+    pick.setPickConditionExpression(true);
+    pick.setPickConditionNumberInQueue(false);
+    pick.setPickConditionNumberBusyResource(false);
+    pick.addPickableStationItem(new PickableStationItem(&station, "1+"));
+
+    std::string errorMessage;
+    EXPECT_FALSE(pick.CheckProbe(errorMessage));
+    EXPECT_NE(errorMessage.find("Expression"), std::string::npos);
+}
+
+TEST(SimulatorRuntimeTest, PickStationDispatchChoosesStationAndStoresSelectedId) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    Station stationA(model, "PickStationA");
+    Station stationB(model, "PickStationB");
+    Attribute savedStationAttribute(model, "Entity.PickStation");
+    PickStationProbe pick(model, "PickValidDispatch");
+    CollectorSinkComponentProbe sink(model, "PickValidDispatchSink");
+    pick.connectTo(&sink);
+    pick.setSaveAttribute("Entity.PickStation");
+    pick.setTestCondition(PickStation::TestCondition::MINIMUM);
+    pick.setPickConditionExpression(true);
+    pick.setPickConditionNumberInQueue(false);
+    pick.setPickConditionNumberBusyResource(false);
+    pick.addPickableStationItem(new PickableStationItem(&stationA, "5"));
+    pick.addPickableStationItem(new PickableStationItem(&stationB, "1"));
+
+    std::string checkError;
+    ASSERT_TRUE(pick.CheckProbe(checkError)) << checkError;
+
+    Entity* entity = model->createEntity("PickDispatchEntity", true);
+    pick.DispatchEventProbe(entity);
+    DrainFutureEvents(model);
+    ASSERT_EQ(sink.ReceivedEntities().size(), 1u);
+    EXPECT_EQ(sink.ReceivedEntities()[0], entity);
+    EXPECT_EQ(entity->getAttributeValue(savedStationAttribute.getId()), stationB.getId());
 }
 
 TEST(SimulatorRuntimeTest, DelayCreateInternalInitiallyCreatesStatisticsCollectorWhenEnabled) {


### PR DESCRIPTION
### Motivation
- Fix runtime crashes and undefined behavior in `Buffer` and `PickStation` caused by missing validation and unsafe indexed access.
- Provide minimal coherent semantics for buffer insertion/advancement and safe station selection without redesigning core algorithms.
- Prevent handler duplication and attached-data residue when rechecking or changing attached `SignalData`.
- Add focused regression tests to guard the addressed runtime failure modes. 

### Description
- Added validation to `Buffer::_check()` to require `capacity > 0` and to require a non-null `SignalData` when `AdvanceOn == Signal`, with clear `traceError` messages. (files: `Buffer.h`, `Buffer.cpp`).
- Ensured `_buffer` is idempotently resized to `_capacity` before any indexed access and protected dispatch when `_capacity == 0` to avoid out-of-bounds access. (file: `Buffer.cpp`).
- In `AdvanceOn::Signal` mode, changed insertion to place a new arrival into the first free slot (instead of blindly writing to the last slot), and fixed `ReplaceLastPosition` to replace and then set the incoming entity into the last slot. (file: `Buffer.cpp`).
- Prevented forwarding a null entity in `AdvanceOn::NewArrivals` by sending the advanced `first` only when non-null. (file: `Buffer.cpp`).
- Hardened `Buffer::_createInternalAndAttachedData()` to handle `SignalData` allocation failure, avoid duplicate handler registration, and remove previous handlers when attached signal changes by tracking the signal with a registered handler. (files: `Buffer.h`, `Buffer.cpp`).
- Implemented minimum contract checks in `PickStation::_check()` to require at least one `PickableStationItem`, a non-empty `SaveAttribute`, at least one active pick condition, validate item `Station` presence, and check item expressions when expression-based selection is active. (file: `PickStation.cpp`).
- Protected `PickStation::_onDispatchEvent()` from null dereference by returning safely with `traceError` when no valid station can be selected. (file: `PickStation.cpp`).
- Reconciled attached-data insertion in `PickStation::_createInternalAndAttachedData()` to skip null stations and avoid residual invalid attached keys. (file: `PickStation.cpp`).
- Added local probe classes `BufferProbe` and `PickStationProbe` and unit tests covering the required regression cases (Buffer tests A–E and PickStation tests F–I) in `source/tests/unit/test_simulator_runtime.cpp`.

### Testing
- Configured and built the project with `cmake -S . -B build -G Ninja` and `cmake --build build` and executed the unit test binary `./build/source/tests/unit/genesys_test_simulator_runtime`.
- Ran the full unit test suite with `ctest --test-dir build -L unit --output-on-failure`.
- Results: `genesys_test_simulator_runtime` passed all tests in that binary (175/175) and the full `ctest -L unit` run passed 1081/1081 tests in this environment, with the repository’s pre-existing 4 disabled tests unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da888eb8788321a6582bb854072999)