### PR TITLE
Harden Buffer and PickStation runtime null-safety paths

### DIFF
--- a/source/plugins/components/Buffer.cpp
+++ b/source/plugins/components/Buffer.cpp
@@ -295,6 +295,10 @@ void Buffer::setArrivalOnFullBufferRule(Buffer::ArrivalOnFullBufferRule newArriv
 }
 
 Entity* Buffer::_advance(Entity* enteringEntity) {
+	if (_buffer == nullptr || _buffer->empty()) {
+		// Safety guard for inconsistent runtime states (for example, Capacity misconfiguration).
+		return nullptr;
+	}
 	Entity *result = _buffer->front();
 	_buffer->erase(_buffer->begin());
 	_buffer->push_back(enteringEntity);

--- a/source/plugins/components/PickStation.cpp
+++ b/source/plugins/components/PickStation.cpp
@@ -182,6 +182,10 @@ void PickStation::_onDispatchEvent(Entity* entity, unsigned int inputPortNumber)
 		bestValue = std::numeric_limits<double>::max();
 	}
 	for (PickableStationItem* item : *_pickableStationItens->list()) {
+		if (item == nullptr || item->getStation() == nullptr) {
+			// Ignore invalid entries during runtime dispatch; model check reports configuration errors.
+			continue;
+		}
 		if (_pickConditionExpression) {
 			valueExpression = _parentModel->parseExpression(item->getExpression());
 		}
@@ -326,6 +330,10 @@ void PickStation::_createInternalAndAttachedData() {
 	unsigned int i = 0;
 	_attachedDataClear();
 	for (PickableStationItem* item : *_pickableStationItens->list()) {
+		if (item == nullptr) {
+			i++;
+			continue;
+		}
 		if (item->getStation() != nullptr) {
 			_attachedDataInsert("Station" + std::to_string(i), item->getStation());
 		}


### PR DESCRIPTION
### Motivation
- Prevent unsafe dereferences and inconsistent runtime states in `Buffer` and `PickStation` without redesigning existing algorithms. 
- Make runtime behavior robust when model inputs are inconsistent (e.g., empty internal buffer, null pickable items) while preserving existing persistence and selection semantics.

### Description
- Added a defensive guard in `Buffer::_advance()` to return `nullptr` when `_buffer` is `nullptr` or empty to avoid undefined access. (modified `source/plugins/components/Buffer.cpp`).
- Kept `Buffer`'s prior idempotent `_check()`/resize behavior and null-safe advance sending logic unchanged; the new guard is a minimal safety layer. (no API/semantics change).
- Hardened `PickStation::_onDispatchEvent()` to skip `nullptr` or station-less `PickableStationItem` entries during runtime dispatch to avoid null dereference while leaving `_check()` validation to report configuration errors. (modified `source/plugins/components/PickStation.cpp`).
- Hardened `PickStation::_createInternalAndAttachedData()` to skip null list entries when reconciling attached Station/Queue/Resource data, avoiding insertion of nulls into attached-data.

### Testing
- Ran configuration and build with `cmake -S . -B build -G Ninja` and `cmake --build build`, both completed successfully.
- Executed the simulator runtime unit test binary `./build/source/tests/unit/genesys_test_simulator_runtime`, which ran `175` tests and reported `175` passed and `0` failures.
- Ran `ctest --test-dir build -L unit --output-on-failure`, which executed `1081` unit tests and reported `100%` passed with `0` failures and `4` preexisting disabled tests.
- No new tests were added in this patch because required buffer/pickstation scenarios are covered by existing tests in `source/tests/unit/test_simulator_runtime.cpp` and all relevant tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da930f112c8321bd27285c654c1082)