### PR TITLE
GUI: harden shutdown order and disable late trace callbacks during teardown

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
@@ -410,6 +410,10 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
 }
 
 MainWindow::~MainWindow() {
+    // Proactively disable trace callbacks before QWidget and simulator teardown starts.
+    if (simulator != nullptr && simulator->getTraceManager() != nullptr) {
+        simulator->getTraceManager()->beginShutdown();
+    }
     _shuttingDown = true;
     _disconnectSceneSignals("~MainWindow");
     disconnect();

--- a/source/kernel/simulator/Simulator.cpp
+++ b/source/kernel/simulator/Simulator.cpp
@@ -56,12 +56,20 @@ Simulator::Simulator() {
 
 
 Simulator::~Simulator() {
+	// Keep teardown deterministic and avoid dangling manager pointers after deletion.
 	delete _experimentManager;
+	_experimentManager = nullptr;
 	delete _parserManager;
-	delete _traceManager;
+	_parserManager = nullptr;
+	// Destroy models before tracing infrastructure to avoid late traces using a dead tracer.
 	delete _modelManager;
+	_modelManager = nullptr;
+	delete _traceManager;
+	_traceManager = nullptr;
 	delete _pluginManager;
+	_pluginManager = nullptr;
 	delete _licenceManager;
+	_licenceManager = nullptr;
 }
 
 PluginManager* Simulator::getPluginManager() const {

--- a/source/kernel/simulator/TraceManager.cpp
+++ b/source/kernel/simulator/TraceManager.cpp
@@ -22,6 +22,8 @@ TraceManager::TraceManager(Simulator* simulator) {//(Model* model) {
 }
 
 TraceManager::~TraceManager() {
+	// Reuse shutdown path so callback vectors are neutralized before storage is released.
+	beginShutdown();
 	delete _traceHandlers;
 	delete _traceErrorHandlers;
 	delete _traceReportHandlers;
@@ -32,6 +34,19 @@ TraceManager::~TraceManager() {
 	delete _traceSimulationHandlersMethod;
 	delete _traceSimulationExceptionRule;
 	delete _errorMessages;
+}
+
+void TraceManager::beginShutdown() {
+	// Mark tracer as shutting down and clear all callback targets to block late GUI invocations.
+	_shuttingDown = true;
+	_traceHandlers->clear();
+	_traceErrorHandlers->clear();
+	_traceReportHandlers->clear();
+	_traceSimulationHandlers->clear();
+	_traceHandlersMethod->clear();
+	_traceErrorHandlersMethod->clear();
+	_traceReportHandlersMethod->clear();
+	_traceSimulationHandlersMethod->clear();
 }
 
 void TraceManager::setTraceLevel(TraceManager::Level _traceLevel) {
@@ -81,6 +96,10 @@ void TraceManager::trace(TraceManager::Level level, std::string text) {
 }
 
 void TraceManager::trace(std::string text, TraceManager::Level level) {
+	// Ignore traces during teardown to prevent late callbacks on already-destroyed objects.
+	if (_shuttingDown) {
+		return;
+	}
 	if (_traceConditionPassed(level)) {
 		text = Util::Indent() + text;
 		//text = "L" + std::to_string(static_cast<int> (level)) + "    " + Util::Indent() + text;
@@ -104,6 +123,10 @@ void TraceManager::trace(std::string text, TraceManager::Level level) {
 //}
 
 void TraceManager::traceError(std::string text, TraceManager::Level level) {
+	// Ignore traces during teardown to prevent late callbacks on already-destroyed objects.
+	if (_shuttingDown) {
+		return;
+	}
 	text = Util::Indent() + text;
 	_errorMessages->insert(text);
 	TraceErrorEvent exceptEvent = TraceErrorEvent(text, level);
@@ -116,6 +139,10 @@ void TraceManager::traceError(std::string text, TraceManager::Level level) {
 }
 
 void TraceManager::traceError(std::string text, std::exception e) {
+	// Ignore traces during teardown to prevent late callbacks on already-destroyed objects.
+	if (_shuttingDown) {
+		return;
+	}
 	text = Util::Indent() + text;
 	_errorMessages->insert(text);
 	TraceErrorEvent exceptEvent = TraceErrorEvent(text, e);
@@ -133,6 +160,10 @@ void TraceManager::traceSimulation(void* thisobject, TraceManager::Level level, 
 }
 
 void TraceManager::traceSimulation(void* thisobject, std::string text, TraceManager::Level level) {
+	// Ignore traces during teardown to prevent late callbacks on already-destroyed objects.
+	if (_shuttingDown) {
+		return;
+	}
 	if (_traceSimulationConditionPassed(level, thisobject)) {
 		text = Util::Indent() + text;
 		//text = "L" + std::to_string(static_cast<int> (level)) + "    " + Util::Indent() + text;
@@ -152,6 +183,10 @@ void TraceManager::traceSimulation(void* thisobject, TraceManager::Level level, 
 }
 
 void TraceManager::traceSimulation(void* thisobject, double time, Entity* entity, ModelComponent* component, std::string text, TraceManager::Level level) {
+	// Ignore traces during teardown to prevent late callbacks on already-destroyed objects.
+	if (_shuttingDown) {
+		return;
+	}
 	if (_traceSimulationConditionPassed(level, thisobject)) {
 		text = Util::Indent() + text;
 		TraceSimulationEvent e = TraceSimulationEvent(level, time, entity, component, text);
@@ -169,6 +204,10 @@ void TraceManager::traceSimulation(void* thisobject, double time, Entity* entity
 //}
 
 void TraceManager::traceReport(std::string text, TraceManager::Level level) {
+	// Ignore traces during teardown to prevent late callbacks on already-destroyed objects.
+	if (_shuttingDown) {
+		return;
+	}
 	if (_traceConditionPassed(level)) {
 		text = Util::Indent() + text;
 		TraceEvent e = TraceEvent(text, level);

--- a/source/kernel/simulator/TraceManager.h
+++ b/source/kernel/simulator/TraceManager.h
@@ -114,6 +114,8 @@ public: // traces (invoke trace handlers)
 	void traceSimulation(void* thisobject, TraceManager::Level level, double time, Entity* entity, ModelComponent* component, std::string text); //<! Deprected
 	void traceSimulation(void* thisobject, TraceManager::Level level, std::string text); //<! Deprected
 public: // traces
+	// Disable callbacks and clear handler lists before simulator teardown destroys GUI objects.
+	void beginShutdown();
 	void trace(std::string text, TraceManager::Level level = TraceManager::Level::L8_detailed); //!< Trace to a general output, used when not simulating (eg: adding plugins, checking the model, etc
 	void traceError(std::string text, std::exception e); //!< Trace to the error output, used in every situation an error happens (simulating, report, general)
 	void traceError(std::string text, TraceManager::Level level = TraceManager::Level::L1_errorFatal); //!< Trace to the error output, used in every situation an error happens (simulating, report, general)
@@ -174,6 +176,7 @@ private:
 	Simulator* _simulator;
 private:
 	TraceManager::Level _traceLevel; // = TraceManager::Level::L9_mostDetailed;
+	bool _shuttingDown = false;
     double _lastTimeTraceSimulation = -1.0; // an invalid time
 	Util::identification _lastEntityTraceSimulation = 0;
 	Util::identification _lastModuleTraceSimulation = 0;


### PR DESCRIPTION
GUI

### Motivation
- Prevent a shutdown crash caused by Model destruction triggering Trace callbacks after the TraceManager was already deleted by ensuring deterministic teardown ordering and disabling late callbacks.
- Avoid touching animation, Property Editor, DataDefinitions or broad refactors by applying a minimal, reversible hardening limited to shutdown sequencing and trace callback safety. 

### Description
- Reordered `Simulator::~Simulator()` to delete `_modelManager` before `_traceManager` and set deleted pointers to `nullptr` to avoid dangling references. (file: `source/kernel/simulator/Simulator.cpp`).
- Added `bool _shuttingDown` and `void beginShutdown()` to `TraceManager` to mark shutdown and clear all handler lists without destroying the containers (files: `source/kernel/simulator/TraceManager.h`, `source/kernel/simulator/TraceManager.cpp`).
- Early-return guarded all trace entrypoints (`trace`, `traceError`, `traceReport`, `traceSimulation`) when `_shuttingDown` is true to prevent firing callbacks during teardown (file: `source/kernel/simulator/TraceManager.cpp`).
- Invoked `simulator->getTraceManager()->beginShutdown()` defensively at the start of `MainWindow::~MainWindow()` before destroying `ui` and `simulator` to proactively neutralize GUI handlers (file: `source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp`).

### Testing
- Configured the project with `cmake -S . -B build` which completed successfully. 
- Built the code with `cmake --build build -j4` and the build finished successfully (kernel, plugins and tests targets compiled). 
- Verified the following changes are present in source: `Simulator::~Simulator()` now deletes `_modelManager` before `_traceManager`, `TraceManager` exposes `beginShutdown()`, trace methods return early when `_shuttingDown` is true, and `MainWindow::~MainWindow()` calls `beginShutdown()` before `ui`/`simulator` destruction.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daa363cc90832187d257b682aebec7)