### PR TITLE
Fix Delete/Cut filtering to allow GraphicalModelComponent and block pure data definitions

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/actions/DeleteUndoCommand.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/actions/DeleteUndoCommand.cpp
@@ -7,10 +7,12 @@ DeleteUndoCommand::DeleteUndoCommand(QList<QGraphicsItem *> items, ModelGraphics
     // filtra cada tipo de item possível em sua respectiva lista
     for (QGraphicsItem *item : items) {
         // Keep data definitions managed by model reconstruction instead of direct delete actions.
-        if (dynamic_cast<GraphicalModelDataDefinition *>(item)) {
+        const bool isDataDefinition = dynamic_cast<GraphicalModelDataDefinition *>(item) != nullptr;
+        const bool isComponent = dynamic_cast<GraphicalModelComponent *>(item) != nullptr;
+        if (isDataDefinition && !isComponent) {
             continue;
         }
-        if (GraphicalModelComponent *component = dynamic_cast<GraphicalModelComponent *>(item)) {
+        if (GraphicalModelComponent *component = isComponent ? dynamic_cast<GraphicalModelComponent *>(item) : nullptr) {
             ComponentItem componentItem;
 
             componentItem.graphicalComponent = component;

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
@@ -710,7 +710,9 @@ QList<QGraphicsItem*> ModelGraphicsScene::userDeletableItems(const QList<QGraphi
     QList<QGraphicsItem*> filtered;
     // Keep data definitions editable/selectable but block their direct manual deletion.
     for (QGraphicsItem* item : items) {
-        if (dynamic_cast<GraphicalModelDataDefinition*>(item) != nullptr) {
+        const bool isDataDefinition = dynamic_cast<GraphicalModelDataDefinition*>(item) != nullptr;
+        const bool isComponent = dynamic_cast<GraphicalModelComponent*>(item) != nullptr;
+        if (isDataDefinition && !isComponent) {
             continue;
         }
         filtered.append(item);
@@ -2917,13 +2919,6 @@ void ModelGraphicsScene::keyPressEvent(QKeyEvent *keyEvent) {
     QGraphicsScene::keyPressEvent(keyEvent);
     QList<QGraphicsItem*> selected = userDeletableItems(this->selectedItems());
     if (keyEvent->key() == Qt::Key_Delete && selected.size() > 0) {
-        // Keep data definitions selectable, but block direct user-triggered deletion.
-        selected.erase(std::remove_if(selected.begin(), selected.end(), [](QGraphicsItem* item) {
-            return dynamic_cast<GraphicalModelDataDefinition*>(item) != nullptr;
-        }), selected.end());
-        if (selected.isEmpty()) {
-            return;
-        }
         QMessageBox::StandardButton reply = QMessageBox::question(this->_parentWidget, "Delete Component", "Are you sure you want to delete the selected components?", QMessageBox::Yes | QMessageBox::No);
         if (reply == QMessageBox::No) {
             return;

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
@@ -520,7 +520,8 @@ void MainWindow::_actualizeActions() {
         ModelGraphicsScene* scene = ui->graphicsView->getScene();
         if (scene != nullptr) {
             const QList<QGraphicsItem*> selectedItems = scene->selectedItems();
-            canCutCopyDelete = !selectedItems.isEmpty();
+            const QList<QGraphicsItem*> userDeletableSelection = scene->userDeletableItems(selectedItems);
+            canCutCopyDelete = !userDeletableSelection.isEmpty();
             canPaste = !_draw_copy->empty() || !_gmc_copies->empty() || !_group_copy->empty() || !_ports_copies->empty();
 
             int selectedComponents = 0;


### PR DESCRIPTION
### Motivation
- Restore correct Delete/Cut behavior so user can remove `GraphicalModelComponent` (which inherits `GraphicalModelDataDefinition`) while preventing manual deletion of pure `GraphicalModelDataDefinition` nodes. 
- Centralize deletion policy in the scene/undo command (not controllers) to avoid redundant/incorrect class-base filtering. 
- Ensure UI enablement for `Cut/Copy/Delete` reflects items the user is actually allowed to mutate.

### Description
- Change `ModelGraphicsScene::userDeletableItems(...)` to treat an item as non-deletable only when `dynamic_cast<GraphicalModelDataDefinition*>(item) != nullptr` AND `dynamic_cast<GraphicalModelComponent*>(item) == nullptr`, preserving all other logic. (file: `source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp`)
- Remove the redundant/incorrect `GraphicalModelDataDefinition`-only filtering from `ModelGraphicsScene::keyPressEvent(...)` and rely on `userDeletableItems(...)` as the single policy source; keep the confirmation dialog, push of `DeleteUndoCommand`, and call to `GraphicalModelBuilder::synchronizeGraphicalDataDefinitionsLayer(...)`. (file: `source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp`)
- Update `DeleteUndoCommand::DeleteUndoCommand(...)` to ignore only pure `GraphicalModelDataDefinition` items (do not ignore `GraphicalModelComponent`); otherwise preserve component/connection/group/drawing collection logic. (file: `source/applications/gui/qt/GenesysQtGUI/actions/DeleteUndoCommand.cpp`)
- Align `MainWindow::_actualizeActions()` so `canCutCopyDelete` is computed from `scene->userDeletableItems(selectedItems)` instead of `selectedItems.isEmpty()`, preventing `Cut/Copy/Delete` from being enabled when only pure data definitions are selected. (file: `source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp`)
- Branch/commit context: `WiP20261` was not available locally or remotely, so changes were applied on the current working branch (`work`) and committed (local commit created). Files changed: `ModelGraphicsScene.cpp`, `DeleteUndoCommand.cpp`, `mainwindow.cpp`.

### Testing
- Ran repository and local checks including `git` inspection and `git diff` to verify the expected edits; these checks succeeded. 
- Attempted to configure/build the GUI target with `cmake -S . -B build -DGENESYS_BUILD_GUI_APPLICATION=ON`, which failed due to missing `qmake` in the environment (automated configure failed), so runtime GUI build/test was not possible here. 
- No automated unit/UI tests were available or executed in this environment; changes were validated by static inspection of the updated code paths and by confirming a local commit was created successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daaf4eb4ac8321a460eb0b59daa118)