### PR TITLE
Center two-line text block in GraphicalModelDataDefinition::paint

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/GraphicalModelDataDefinition.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/GraphicalModelDataDefinition.cpp
@@ -199,21 +199,39 @@ void GraphicalModelDataDefinition::paint(QPainter *painter, const QStyleOptionGr
 	pathFill.lineTo(pp5);
 	pathFill.lineTo(pp6);
 	painter->drawPath(pathFill);
-	// text
-	QString text = QString::fromStdString(_element->getName());
-	QRect rect2 = QRect(_margin + _raise + 1, _margin + _raise + 1, _margin + wi - 2 * _raise - _margin, _margin + hi - 2 * _raise - _margin);
+	// text (two centered lines as a single vertically centered block)
+	const QString text1 = QString::fromStdString(_element->getClassname());
+	const QString text2 = QString::fromStdString(_element->getName());
+	const QRect contentRect(
+		_margin + _raise + 1,
+		_margin + _raise + 1,
+		wi - 2 * _raise - 2,
+		hi - 2 * _raise - 2
+	);
+	const QFontMetrics fm = painter->fontMetrics();
+	const int lineHeight = fm.height();
+	const int lineSpacing = 3;
+	const int totalHeight = lineHeight * 2 + lineSpacing;
+	const int blockTop = contentRect.top() + (contentRect.height() - totalHeight) / 2;
+	const QRect line1Rect(contentRect.left(), blockTop, contentRect.width(), lineHeight);
+	const QRect line2Rect(contentRect.left(), blockTop + lineHeight + lineSpacing, contentRect.width(), lineHeight);
+	const QPoint shadowOffset(0, 2);
 	brush = QBrush(Qt::NoBrush);
 	painter->setBrush(brush);
 	pen = QPen(myrgba(TraitsGUI<GModelDataDefinition>::textColor));
 	pen.setWidth(2);
 	pen.setCosmetic(true);
-	painter->setPen(pen);
-	painter->drawText(rect2, Qt::AlignCenter, text);
-	pen.setColor(myrgba(TraitsGUI<GModelDataDefinition>::textShadowColor));
-	painter->setPen(pen);
-	painter->drawText(rect2.adjusted(0,2,2,0), Qt::AlignCenter, text);
-	// text shadow
-	//
+	auto drawCenteredTextWithShadow = [&](const QRect& rect, const QString& textLine) {
+		pen.setColor(myrgba(TraitsGUI<GModelDataDefinition>::textShadowColor));
+		painter->setPen(pen);
+		painter->drawText(rect.translated(shadowOffset), Qt::AlignCenter, textLine);
+		pen.setColor(myrgba(TraitsGUI<GModelDataDefinition>::textColor));
+		painter->setPen(pen);
+		painter->drawText(rect, Qt::AlignCenter, textLine);
+	};
+	drawCenteredTextWithShadow(line1Rect, text1);
+	drawCenteredTextWithShadow(line2Rect, text2);
+
 	if (isSelected()) { //draw squares on corners
 		brush = QBrush(Qt::SolidPattern);
 		brush.setColor(myrgba(TraitsGUI<GModelDataDefinition>::selectionSquaresColor));
@@ -260,4 +278,3 @@ qreal GraphicalModelDataDefinition::getHeight() const {
 bool GraphicalModelDataDefinition::sceneEvent(QEvent *event) {
 	return QGraphicsObject::sceneEvent(event);
 }
-


### PR DESCRIPTION
### Motivation
- The existing text-drawing block computed an incorrect inner rect (margins were mishandled) and only drew a single line, so text was not centered as a two-line block.
- The second line positioning and vertical centering as a block were incorrect, and text shadow was drawn after the main text instead of before.

### Description
- Replaced the single-line drawing code with logic that constructs a proper `contentRect` using `_margin` and `_raise` and reduces width/height correctly.
- Obtained `text1 = _element->getClassname()` and `text2 = _element->getName()` and computed `lineHeight` via `QFontMetrics` with a small `lineSpacing` (3 px) to form a two-line block.
- Calculated `totalHeight` and positioned the block vertically centered inside `contentRect`, creating `line1Rect` and `line2Rect` with full `contentRect` width and one-line height, stacked with the chosen spacing.
- Drew each line by rendering the shadow first (offset (0,2)) using `TraitsGUI<GModelDataDefinition>::textShadowColor`, then the main text with `TraitsGUI<GModelDataDefinition>::textColor`, both using `Qt::AlignCenter`, and kept the pen cosmetic/width behavior.

### Testing
- Executed repository change inspections to validate the patch scope and file diff; the checks indicate only the target file's text-drawing block was modified and the change is localized (passed).
- No other automated unit or build tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dabbbd14d48321a9aafcb9fa412c5c)