### PR TITLE
Restrict scene edit flows to operable user items

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/controllers/EditCommandController.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/EditCommandController.cpp
@@ -70,12 +70,12 @@ void EditCommandController::onActionEditCutTriggered() const {
     (*_groupCopy)->clear();
     (*_drawCopy)->clear();
 
-    QList<QGraphicsItem*> selecteds = _graphicsView->scene()->selectedItems();
+    ModelGraphicsScene* currentScene = scene();
+    QList<QGraphicsItem*> selecteds = currentScene->userOperableItems(_graphicsView->scene()->selectedItems());
     if (selecteds.size() > 0) {
-        ModelGraphicsScene* currentScene = scene();
         *_cut = true;
 
-        for (QGraphicsItem* item : _graphicsView->scene()->selectedItems()) {
+        for (QGraphicsItem* item : selecteds) {
             QList<GraphicalModelComponent*> groupComponents;
             QList<GraphicalConnection*>* connGroup = new QList<GraphicalConnection*>();
 
@@ -137,12 +137,13 @@ void EditCommandController::onActionEditCopyTriggered() const {
     (*_groupCopy)->clear();
     (*_drawCopy)->clear();
 
-    QList<QGraphicsItem*> selected = _graphicsView->scene()->selectedItems();
+    ModelGraphicsScene* currentScene = scene();
+    QList<QGraphicsItem*> selected = currentScene->userOperableItems(_graphicsView->scene()->selectedItems());
     QList<GraphicalModelComponent*> gmcCopiesCopy;
 
     if (selected.size() > 0) {
         *_cut = false;
-        for (QGraphicsItem* item : _graphicsView->scene()->selectedItems()) {
+        for (QGraphicsItem* item : selected) {
             if (GraphicalModelComponent* gmc = dynamic_cast<GraphicalModelComponent*>(item)) {
                 gmc->setSelected(false);
                 (*_gmcCopies)->append(gmc);

--- a/source/applications/gui/qt/GenesysQtGUI/controllers/SceneToolController.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/SceneToolController.cpp
@@ -346,14 +346,14 @@ void SceneToolController::onActionDiagramsTriggered() {
     }
 }
 
-// Preserve select-all semantics by selecting every scene item.
+// Preserve select-all semantics while ignoring non-operable internal infrastructure items.
 void SceneToolController::onActionSelectAllTriggered() {
     ModelGraphicsScene* scene = _currentScene();
     if (scene == nullptr) {
         return;
     }
 
-    const QList<QGraphicsItem*> itemsToScene = scene->items();
+    const QList<QGraphicsItem*> itemsToScene = scene->userOperableItems(scene->items());
     for (QGraphicsItem* item : itemsToScene) {
         item->setSelected(true);
     }

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/GraphicalComponentPort.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/GraphicalComponentPort.cpp
@@ -17,7 +17,8 @@ GraphicalComponentPort::GraphicalComponentPort(GraphicalModelComponent* componen
 		_height *= 1.15;
 	}
 	//setPos(0,0);
-    setFlags(QGraphicsItem::ItemIsSelectable | QGraphicsItem::ItemIsFocusable);
+    setFlag(QGraphicsItem::ItemIsSelectable, false);
+    setFlag(QGraphicsItem::ItemIsFocusable, false);
 	setAcceptHoverEvents(true);
 	setAcceptTouchEvents(true);
 	setActive(true);

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
@@ -707,9 +707,22 @@ void ModelGraphicsScene::setDiagramLayerState(bool diagramCreated, bool visible)
 }
 
 QList<QGraphicsItem*> ModelGraphicsScene::userDeletableItems(const QList<QGraphicsItem*>& items) const {
+    return userOperableItems(items);
+}
+
+QList<QGraphicsItem*> ModelGraphicsScene::userOperableItems(const QList<QGraphicsItem*>& items) const {
     QList<QGraphicsItem*> filtered;
-    // Keep data definitions editable/selectable but block their direct manual deletion.
+    // Keep internal infrastructure selectable when needed by logic, but not operable by edit actions.
     for (QGraphicsItem* item : items) {
+        if (item == nullptr) {
+            continue;
+        }
+        if (dynamic_cast<GraphicalComponentPort*>(item) != nullptr) {
+            continue;
+        }
+        if (dynamic_cast<GraphicalDiagramConnection*>(item) != nullptr) {
+            continue;
+        }
         const bool isDataDefinition = dynamic_cast<GraphicalModelDataDefinition*>(item) != nullptr;
         const bool isComponent = dynamic_cast<GraphicalModelComponent*>(item) != nullptr;
         if (isDataDefinition && !isComponent) {

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.h
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.h
@@ -131,6 +131,8 @@ public: // editing graphic model
     void clearGraphicalModelDataDefinitions();
     void clearGraphicalDiagramConnections();
     void setDiagramLayerState(bool diagramCreated, bool visible);
+    // Return only items that can be directly manipulated by user edit commands.
+    QList<QGraphicsItem*> userOperableItems(const QList<QGraphicsItem*>& items) const;
     // Filter out non-deletable items from user-triggered delete flows.
     QList<QGraphicsItem*> userDeletableItems(const QList<QGraphicsItem*>& items) const;
     // Keep internal data-definition initial grouping opt-in during model rebuild only.

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
@@ -520,8 +520,8 @@ void MainWindow::_actualizeActions() {
         ModelGraphicsScene* scene = ui->graphicsView->getScene();
         if (scene != nullptr) {
             const QList<QGraphicsItem*> selectedItems = scene->selectedItems();
-            const QList<QGraphicsItem*> userDeletableSelection = scene->userDeletableItems(selectedItems);
-            canCutCopyDelete = !userDeletableSelection.isEmpty();
+            const QList<QGraphicsItem*> userOperableSelection = scene->userOperableItems(selectedItems);
+            canCutCopyDelete = !userOperableSelection.isEmpty();
             canPaste = !_draw_copy->empty() || !_gmc_copies->empty() || !_group_copy->empty() || !_ports_copies->empty();
 
             int selectedComponents = 0;


### PR DESCRIPTION
### Motivation
- Harden scene operability rules so only items that are truly user-manipulable participate in Select All / Copy / Cut / Delete and action enablement.
- Prevent internal infrastructure (ports, diagram arrows, pure data-definition nodes) from being treated as editable drawable items while preserving selection for property inspection where required.

### Description
- Disable selection and focus on component ports by clearing `ItemIsSelectable` and `ItemIsFocusable` in `GraphicalComponentPort` so ports remain hover/connectable but not part of edit flows.
- Add `ModelGraphicsScene::userOperableItems(...)` and make `userDeletableItems(...)` delegate to it, centralizing the operability policy that excludes `GraphicalComponentPort`, `GraphicalDiagramConnection`, and pure `GraphicalModelDataDefinition` while keeping `GraphicalModelComponent`, `QGraphicsItemGroup`, `GraphicalConnection` and user drawings/animations operable.
- Update `EditCommandController::onActionEditCutTriggered()` and `onActionEditCopyTriggered()` to use the scene's `userOperableItems(...)` filter instead of raw `selectedItems()` so internal items are not copied/cut into `_drawCopy`.
- Update `SceneToolController::onActionSelectAllTriggered()` to select only `userOperableItems(scene->items())` instead of iterating raw `scene->items()`.
- Update `MainWindow::_actualizeActions()` so `canCutCopyDelete` is computed from `userOperableItems(selectedItems)` ensuring action enablement reflects the centralized policy.

### Testing
- Ran `git diff --` on modified files to verify the exact edits and ensure only local, minimal changes were made and committed successfully.
- Performed targeted source searches using `rg` to confirm: ports no longer set selectable/focusable flags, `onActionSelectAllTriggered()` no longer iterates raw `scene->items()`, cut/copy now use `userOperableItems(...)`, `keyPressEvent()` still uses scene policy via `userDeletableItems(...)`, and `_actualizeActions()` uses `userOperableItems(...)`; these checks succeeded.
- Configured the project with `cmake --preset debug` which completed successfully for non-GUI targets, and attempted a GUI-configure with `cmake -S . -B build/gui-debug -DGENESYS_BUILD_GUI_APPLICATION=ON` which failed in this environment because `qmake` is not available in `PATH`, preventing a full GUI build validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dac12b0ba08321acf7ca2b9fd7fb7c)