### PR TITLE
GUI: harden graphical data-definition sync against stale scene bookkeeping

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/controllers/ModelLifecycleController.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/ModelLifecycleController.cpp
@@ -160,8 +160,13 @@ void ModelLifecycleController::onActionModelCloseTriggered() const {
     _ui->graphicsView->getScene()->clearAnimationsQueue();
     _ui->graphicsView->getScene()->getGraphicalModelComponents()->clear();
     _ui->graphicsView->getScene()->getGraphicalConnections()->clear();
+    // Reset data-definition diagram bookkeeping alongside component/connection cleanup.
+    _ui->graphicsView->getScene()->getGraphicalModelDataDefinitions()->clear();
+    _ui->graphicsView->getScene()->getGraphicalDiagramsConnections()->clear();
     _ui->graphicsView->getScene()->getAllComponents()->clear();
     _ui->graphicsView->getScene()->getAllConnections()->clear();
+    _ui->graphicsView->getScene()->getAllDataDefinitions()->clear();
+    _ui->graphicsView->getScene()->getAllGraphicalDiagramsConnections()->clear();
     _ui->graphicsView->getScene()->clearAnimations();
     _ui->graphicsView->getScene()->clear();
     _ui->graphicsView->clear();

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
@@ -59,6 +59,7 @@
 #include <QPointer>
 #include <QTimer>
 #include <QDebug>
+#include <QSet>
 #include <algorithm>
 
 namespace {
@@ -666,6 +667,18 @@ void ModelGraphicsScene::insertComponent(GraphicalModelComponent* gmc, QList<Gra
 }
 
 void ModelGraphicsScene::removeGraphicalModelDataDefinition(GraphicalModelDataDefinition* gmdd) {
+    if (gmdd == nullptr) {
+        return;
+    }
+
+    // Remove only data-definition items that are still alive in the scene snapshot.
+    const QList<QGraphicsItem*> liveItems = items();
+    if (!liveItems.contains(gmdd)) {
+        getGraphicalModelDataDefinitions()->removeOne(gmdd);
+        getAllDataDefinitions()->removeOne(gmdd);
+        return;
+    }
+
     //graphically
     removeItem(gmdd);
     // Keep data-definition ownership lists consistent during removal.
@@ -697,6 +710,59 @@ void ModelGraphicsScene::clearGraphicalDiagramConnections() {
     while (!connections->isEmpty()) {
         GraphicalDiagramConnection* connection = connections->first();
         removeGraphicalDiagramConnection(connection);
+    }
+}
+
+void ModelGraphicsScene::sanitizeGraphicalDataDefinitionsBookkeeping() {
+    // Rebuild live data-definition/diagram sets from scene-owned items before differential synchronization.
+    const QList<QGraphicsItem*> liveItems = items();
+    QSet<GraphicalModelDataDefinition*> liveDataDefinitions;
+    QSet<GraphicalDiagramConnection*> liveDiagramConnections;
+
+    for (QGraphicsItem* item : liveItems) {
+        if (auto* gmdd = dynamic_cast<GraphicalModelDataDefinition*>(item)) {
+            liveDataDefinitions.insert(gmdd);
+            continue;
+        }
+        if (auto* connection = dynamic_cast<GraphicalDiagramConnection*>(item)) {
+            liveDiagramConnections.insert(connection);
+        }
+    }
+
+    // Drop stale pointers from helper lists to prevent dangling addresses from being used as source of truth.
+    for (auto it = _allGraphicalModelDataDefinitions.begin(); it != _allGraphicalModelDataDefinitions.end();) {
+        if (!liveDataDefinitions.contains(*it)) {
+            it = _allGraphicalModelDataDefinitions.erase(it);
+        } else {
+            ++it;
+        }
+    }
+    for (auto it = _allGraphicalDiagramConnections.begin(); it != _allGraphicalDiagramConnections.end();) {
+        if (!liveDiagramConnections.contains(*it)) {
+            it = _allGraphicalDiagramConnections.erase(it);
+        } else {
+            ++it;
+        }
+    }
+
+    QList<QGraphicsItem*>* graphicalDataDefinitions = getGraphicalModelDataDefinitions();
+    for (auto it = graphicalDataDefinitions->begin(); it != graphicalDataDefinitions->end();) {
+        auto* gmdd = dynamic_cast<GraphicalModelDataDefinition*>(*it);
+        if (gmdd == nullptr || !liveDataDefinitions.contains(gmdd)) {
+            it = graphicalDataDefinitions->erase(it);
+        } else {
+            ++it;
+        }
+    }
+
+    QList<QGraphicsItem*>* graphicalDiagramConnections = getGraphicalDiagramsConnections();
+    for (auto it = graphicalDiagramConnections->begin(); it != graphicalDiagramConnections->end();) {
+        auto* connection = dynamic_cast<GraphicalDiagramConnection*>(*it);
+        if (connection == nullptr || !liveDiagramConnections.contains(connection)) {
+            it = graphicalDiagramConnections->erase(it);
+        } else {
+            ++it;
+        }
     }
 }
 

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.h
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.h
@@ -130,6 +130,7 @@ public: // editing graphic model
     void removeGraphicalDiagramConnection(GraphicalDiagramConnection* connection);
     void clearGraphicalModelDataDefinitions();
     void clearGraphicalDiagramConnections();
+    void sanitizeGraphicalDataDefinitionsBookkeeping();
     void setDiagramLayerState(bool diagramCreated, bool visible);
     // Return only items that can be directly manipulated by user edit commands.
     QList<QGraphicsItem*> userOperableItems(const QList<QGraphicsItem*>& items) const;

--- a/source/applications/gui/qt/GenesysQtGUI/services/GraphicalModelBuilder.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/services/GraphicalModelBuilder.cpp
@@ -160,6 +160,9 @@ void GraphicalModelBuilder::synchronizeGraphicalDataDefinitionsLayer(Simulator* 
         return;
     }
 
+    // Sanitize scene helper containers before any diff logic to avoid stale bookkeeping pointers.
+    scene->sanitizeGraphicalDataDefinitionsBookkeeping();
+
     Model* model = simulator->getModelManager()->current();
     if (model == nullptr || model->getDataManager() == nullptr) {
         scene->clearGraphicalDiagramConnections();
@@ -176,8 +179,11 @@ void GraphicalModelBuilder::synchronizeGraphicalDataDefinitionsLayer(Simulator* 
         componentMap[gmc->getComponent()] = gmc;
     }
 
+    // Build the live graphical data-definition snapshot strictly from scene-owned items.
     std::map<ModelDataDefinition*, GraphicalModelDataDefinition*> existingDataDefinitions;
-    for (GraphicalModelDataDefinition* gmdd : *scene->getAllDataDefinitions()) {
+    const QList<QGraphicsItem*> liveItems = scene->items();
+    for (QGraphicsItem* item : liveItems) {
+        GraphicalModelDataDefinition* gmdd = dynamic_cast<GraphicalModelDataDefinition*>(item);
         if (gmdd == nullptr || gmdd->getDataDefinition() == nullptr) {
             continue;
         }


### PR DESCRIPTION
### Motivation
- Fix a segfault happening when `ModelGraphicsScene::removeGraphicalModelDataDefinition(...)` is called from `GraphicalModelBuilder::synchronizeGraphicalDataDefinitionsLayer(...)` after a failed open + new sequence, which pointed to stale/dangling `GraphicalModelDataDefinition*` pointers. 
- Keep the fix minimal and localized to scene bookkeeping and synchronization without touching animations, property editor, serializer (unless strictly necessary), or plugin/parser/tool code.

### Description
- Added `ModelGraphicsScene::sanitizeGraphicalDataDefinitionsBookkeeping()` to prune stale pointers from the scene helper lists (`_allGraphicalModelDataDefinitions`, `_allGraphicalDiagramConnections`, `getGraphicalModelDataDefinitions()` and `getGraphicalDiagramsConnections()`) based on a live `scene->items()` snapshot. 
- Changed `GraphicalModelBuilder::synchronizeGraphicalDataDefinitionsLayer(...)` to call `scene->sanitizeGraphicalDataDefinitionsBookkeeping()` before diff logic and to build `existingDataDefinitions` exclusively from a `scene->items()` snapshot filtered with `dynamic_cast<GraphicalModelDataDefinition*>`. 
- Hardened `ModelGraphicsScene::removeGraphicalModelDataDefinition(...)` with a `nullptr` guard and a liveness check against `items()` so `removeItem`/`delete` are only performed for currently live scene items. 
- Tightened model close cleanup in `ModelLifecycleController::onActionModelCloseTriggered()` to explicitly clear the data-definition and diagram bookkeeping lists alongside components/connections to avoid residual stale pointers after close/new flows.

### Testing
- Executed `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` to configure the project (non-GUI targets) and configuration completed successfully. 
- Attempted GUI-enabled configure/build with `cmake -S . -B build-gui -DGENESYS_BUILD_GUI_APPLICATION=ON -DCMAKE_BUILD_TYPE=Release && cmake --build build-gui --target genesys_gui -j4`, which failed early due to missing Qt `qmake` in the environment, preventing runtime GUI reproduction. 
- No automated unit tests were run in this environment; non-GUI configuration succeeded and the change was committed as `GUI: harden graphical data-definition sync against stale scene bookkeeping`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dac68b9c4083219198d6f8d2a70f27)