### PR TITLE
GUI: defer graphical data-definition sync until after scene drop settles

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
@@ -2955,13 +2955,39 @@ void ModelGraphicsScene::dropEvent(QGraphicsSceneDragDropEvent *event) {
                     ModelComponent* component = (ModelComponent*) plugin->newInstance(_simulator->getModelManager()->current());
                     // create graphically
                     addGraphicalModelComponent(plugin, component, event->scenePos(), color, true);
-                    GraphicalModelBuilder::synchronizeGraphicalDataDefinitionsLayer(_simulator, this);
+                    // Defer synchronization until after the drop event completes and scene transforms settle.
+                    scheduleGraphicalDataDefinitionsSync();
                     return;
                 }
             }
         }
     }
     event->setAccepted(false);
+}
+
+void ModelGraphicsScene::scheduleGraphicalDataDefinitionsSync() {
+    // Coalesce chained requests to avoid running redundant synchronizations in the same event-loop turn.
+    if (_graphicalDataDefinitionsSyncPending) {
+        return;
+    }
+    _graphicalDataDefinitionsSyncPending = true;
+
+    QPointer<ModelGraphicsScene> guardedScene(this);
+    QTimer::singleShot(0, this, [guardedScene]() {
+        if (guardedScene.isNull()) {
+            return;
+        }
+
+        // Clear pending state first so follow-up model mutations can enqueue another sync.
+        guardedScene->_graphicalDataDefinitionsSyncPending = false;
+        Simulator* simulator = guardedScene->_simulator;
+        if (simulator == nullptr || simulator->getModelManager() == nullptr || simulator->getModelManager()->current() == nullptr) {
+            return;
+        }
+
+        // Run canonical layer synchronization only when both the scene and active model are still valid.
+        GraphicalModelBuilder::synchronizeGraphicalDataDefinitionsLayer(simulator, guardedScene.data());
+    });
 }
 
 void ModelGraphicsScene::contextMenuEvent(QGraphicsSceneContextMenuEvent *contextMenuEvent) {

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.h
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.h
@@ -232,6 +232,7 @@ public:
     void insertRestoredDataDefinitions(bool loaded);
     void saveDataDefinitions();
     // --------------------------------- //
+    void scheduleGraphicalDataDefinitionsSync();
 
 public:
     QList<QGraphicsItem*>*getGraphicalModelDataDefinitions() const;
@@ -338,6 +339,7 @@ private:
     QList<QGraphicsItem*>* _graphicalEntities = new QList<QGraphicsItem*>();
     QList<QGraphicsItemGroup*>* _graphicalGroups = new QList<QGraphicsItemGroup*>();
     bool _restoringPersistedGuiLayout = false;
+    bool _graphicalDataDefinitionsSyncPending = false;
 };
 
 #endif /* MODELGRAPHICSSCENE_H */

--- a/source/applications/gui/qt/GenesysQtGUI/services/GraphicalModelBuilder.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/services/GraphicalModelBuilder.cpp
@@ -170,6 +170,23 @@ void GraphicalModelBuilder::synchronizeGraphicalDataDefinitionsLayer(Simulator* 
         scene->setDiagramLayerState(false, false);
         return;
     }
+    ModelDataManager* dataManager = model->getDataManager();
+
+    // Exit early when no model data definitions exist, avoiding unnecessary scene scans and geometry reads.
+    bool hasAnyModelDataDefinition = false;
+    for (const std::string& dataTypename : dataManager->getDataDefinitionClassnames()) {
+        List<ModelDataDefinition*>* modelDataDefinitionList = dataManager->getDataDefinitionList(dataTypename);
+        if (modelDataDefinitionList != nullptr && !modelDataDefinitionList->list()->empty()) {
+            hasAnyModelDataDefinition = true;
+            break;
+        }
+    }
+    if (!hasAnyModelDataDefinition) {
+        scene->clearGraphicalDiagramConnections();
+        scene->clearGraphicalModelDataDefinitions();
+        scene->setDiagramLayerState(false, false);
+        return;
+    }
 
     std::map<ModelComponent*, GraphicalModelComponent*> componentMap;
     for (GraphicalModelComponent* gmc : *scene->getAllComponents()) {
@@ -191,7 +208,6 @@ void GraphicalModelBuilder::synchronizeGraphicalDataDefinitionsLayer(Simulator* 
     }
 
     PluginManager* pluginManager = simulator->getPluginManager();
-    ModelDataManager* dataManager = model->getDataManager();
     QColor purple(128, 0, 128);
     QColor grey(220, 220, 220);
 
@@ -243,10 +259,10 @@ void GraphicalModelBuilder::synchronizeGraphicalDataDefinitionsLayer(Simulator* 
         if (component == nullptr || graphicalComponent == nullptr) {
             continue;
         }
-
-        QPointF componentPosition = graphicalComponent->scenePos();
-        qreal yInternal = componentPosition.y();
-        qreal yAttached = componentPosition.y();
+        qreal yInternal = 0.0;
+        qreal yAttached = 0.0;
+        QPointF componentPosition;
+        bool hasComponentPosition = false;
 
         for (const auto& attachedData : *component->getAttachedData()) {
             auto attachedIt = dataDefinitionMap.find(attachedData.second);
@@ -258,6 +274,13 @@ void GraphicalModelBuilder::synchronizeGraphicalDataDefinitionsLayer(Simulator* 
                 continue;
             }
             if (newDataDefinitions.contains(attachedData.second)) {
+                // Read component geometry only when a newly created attached data definition needs placement.
+                if (!hasComponentPosition) {
+                    componentPosition = graphicalComponent->scenePos();
+                    yInternal = componentPosition.y();
+                    yAttached = componentPosition.y();
+                    hasComponentPosition = true;
+                }
                 yAttached -= 150;
                 gdd->setParentItem(nullptr);
                 gdd->setPos(componentPosition.x(), yAttached);
@@ -277,6 +300,13 @@ void GraphicalModelBuilder::synchronizeGraphicalDataDefinitionsLayer(Simulator* 
                 continue;
             }
             if (newDataDefinitions.contains(internalData.second)) {
+                // Read component geometry only when a newly created internal data definition needs placement.
+                if (!hasComponentPosition) {
+                    componentPosition = graphicalComponent->scenePos();
+                    yInternal = componentPosition.y();
+                    yAttached = componentPosition.y();
+                    hasComponentPosition = true;
+                }
                 yInternal += 150;
                 gdd->setPos(componentPosition.x(), yInternal);
                 gdd->setOldPosition(componentPosition.x(), yInternal);
@@ -292,9 +322,9 @@ void GraphicalModelBuilder::synchronizeGraphicalDataDefinitionsLayer(Simulator* 
         if (parentDefinition == nullptr || parentGraphicalDefinition == nullptr) {
             continue;
         }
-
-        QPointF parentPosition = parentGraphicalDefinition->scenePos();
-        qreal x = parentPosition.x();
+        QPointF parentPosition;
+        qreal x = 0.0;
+        bool hasParentPosition = false;
         for (const auto& internalData : *parentDefinition->getInternalData()) {
             auto childIt = dataDefinitionMap.find(internalData.second);
             if (childIt == dataDefinitionMap.end() || childIt->second == nullptr) {
@@ -302,6 +332,12 @@ void GraphicalModelBuilder::synchronizeGraphicalDataDefinitionsLayer(Simulator* 
             }
             GraphicalModelDataDefinition* childGraphicalDefinition = childIt->second;
             if (newDataDefinitions.contains(internalData.second)) {
+                // Read parent geometry only when placing newly created child data definitions.
+                if (!hasParentPosition) {
+                    parentPosition = parentGraphicalDefinition->scenePos();
+                    x = parentPosition.x();
+                    hasParentPosition = true;
+                }
                 x -= 200;
                 childGraphicalDefinition->setParentItem(nullptr);
                 childGraphicalDefinition->setPos(x, parentPosition.y());


### PR DESCRIPTION
### Motivation
- Dragging a component triggered a synchronous canonical-layer sync from `dropEvent`, and the sync code performed `scenePos()`/geometry reads while the scene transforms were still unstable, causing segfaults inside Qt geometry calls.
- Provide a minimal, local fix that defers the sync until after `dropEvent` completes and avoids unnecessary geometry reads, without touching animations, property editor, serializer, shutdown, or large refactors.

### Description
- Replaced the direct call from `ModelGraphicsScene::dropEvent(...)` to `GraphicalModelBuilder::synchronizeGraphicalDataDefinitionsLayer(...)` with a new helper `ModelGraphicsScene::scheduleGraphicalDataDefinitionsSync()` that uses `QTimer::singleShot(0, ...)` to enqueue the sync on the next event-loop turn.  The helper uses `QPointer` to guard the scene and a boolean `_graphicalDataDefinitionsSyncPending` to coalesce redundant requests. (files: `ModelGraphicsScene.cpp`, `ModelGraphicsScene.h`)
- Added defensive validations in the queued callback to ensure the `Simulator` and active `Model` are still valid before invoking the builder. (file: `ModelGraphicsScene.cpp`)
- In `GraphicalModelBuilder::synchronizeGraphicalDataDefinitionsLayer(...)` added a strong early short-circuit when the active model has no `ModelDataDefinition` entries to avoid unnecessary scene scans. (file: `GraphicalModelBuilder.cpp`)
- Reduced unconditional calls to `scenePos()` by making geometry reads lazy: component/parent positions are only read when newly created data definitions actually need placement. (file: `GraphicalModelBuilder.cpp`)
- Small English comments added immediately above modified blocks to document the change intent; kept changes minimal and localized.

### Testing
- `cmake --preset debug` — configure succeeded. (passed)
- `cmake --build build/debug -j4` — full project build (non-GUI targets and unit tests) completed successfully. (passed)
- Attempted GUI configuration with `-DGENESYS_BUILD_GUI_APPLICATION=ON` failed during configure because `qmake` is not available in PATH in this environment, so GUI runtime reproduction (opening GUI and performing drag scenarios) could not be executed here. (configure failed due to missing Qt tooling)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daca5e368883219b49fda416b56957)