### PR TITLE
Harden GUI data-definition sync against scene teardown crashes

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/controllers/PropertyEditorController.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/PropertyEditorController.cpp
@@ -6,7 +6,6 @@
 #include "graphicals/GraphicalModelComponent.h"
 #include "graphicals/GraphicalModelDataDefinition.h"
 #include "propertyeditor/ObjectPropertyBrowser.h"
-#include "services/GraphicalModelBuilder.h"
 
 #include <QGraphicsItem>
 #include <QDebug>
@@ -180,7 +179,8 @@ void PropertyEditorController::_runGlobalRefresh() const {
         if (scene == nullptr) {
             qWarning() << "[PropertyEditorController] Skipping scene refresh because scene is null";
         } else {
-            GraphicalModelBuilder::synchronizeGraphicalDataDefinitionsLayer(scene->getSimulator(), scene);
+            // Route through scene-owned scheduling to avoid sync during unstable mutation stacks.
+            scene->requestGraphicalDataDefinitionsSync();
             scene->update();
         }
         qInfo() << "[PropertyEditorController] _runGlobalRefresh exit";

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/GraphicalComponentPort.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/GraphicalComponentPort.cpp
@@ -1,6 +1,7 @@
 #include "GraphicalComponentPort.h"
 #include "GraphicalConnection.h"
 #include "GraphicalModelComponent.h"
+#include "ModelGraphicsScene.h"
 #include <QPainter>
 #include "TraitsGUI.h"
 #include "UtilGUI.h"
@@ -52,8 +53,25 @@ void GraphicalComponentPort::mouseMoveEvent(QGraphicsSceneMouseEvent *mouseEvent
 
 QVariant GraphicalComponentPort::itemChange(QGraphicsItem::GraphicsItemChange change, const QVariant &value) {
 	QVariant res = QGraphicsObject::itemChange(change, value);
-	if (change == QGraphicsItem::ItemPositionChange || QGraphicsItem::ItemScenePositionHasChanged) {
+	// Avoid connection geometry updates while scene membership or parentage is changing.
+	if (change == QGraphicsItem::ItemSceneChange
+	        || change == QGraphicsItem::ItemSceneHasChanged
+	        || change == QGraphicsItem::ItemParentChange
+	        || change == QGraphicsItem::ItemParentHasChanged) {
+		return res;
+	}
+
+	// Update connected edges only when scene and component are stable.
+	if (change == QGraphicsItem::ItemPositionChange || change == QGraphicsItem::ItemScenePositionHasChanged) {
+		QGraphicsScene* ownerScene = scene();
+		ModelGraphicsScene* modelScene = dynamic_cast<ModelGraphicsScene*>(ownerScene);
+		if (ownerScene == nullptr || _componentGraph == nullptr || (modelScene != nullptr && modelScene->isGraphicalDataDefinitionsSyncInProgress())) {
+			return res;
+		}
 		for (GraphicalConnection* graphconnection : *_connections) {
+			if (graphconnection == nullptr) {
+				continue;
+			}
 			graphconnection->updateDimensionsAndPosition();
 			//graphconnection->update();//updateDimensions();
 		}

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/GraphicalConnection.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/GraphicalConnection.cpp
@@ -1,5 +1,6 @@
 #include "GraphicalConnection.h"
 #include "GraphicalModelComponent.h"
+#include "ModelGraphicsScene.h"
 #include <QPainter>
 
 GraphicalConnection::GraphicalConnection(GraphicalComponentPort* sourceGraphicalPort, GraphicalComponentPort* destinationGraphicalPort, unsigned int portSourceConnection, unsigned int portDestinationConnection, QColor color, QGraphicsItem *parent) : QGraphicsObject(parent) {
@@ -74,6 +75,22 @@ void GraphicalConnection::setConnectionType(GraphicalConnection::ConnectionType 
 }
 
 void GraphicalConnection::updateDimensionsAndPosition() {
+	// Skip geometric work while endpoints/scenes are unstable or during data-definition sync teardown.
+	if (_sourceGraphicalPort == nullptr || _destinationGraphicalPort == nullptr) {
+		return;
+	}
+	QGraphicsScene* sourceScene = _sourceGraphicalPort->scene();
+	QGraphicsScene* destinationScene = _destinationGraphicalPort->scene();
+	if (sourceScene == nullptr || destinationScene == nullptr || sourceScene != destinationScene) {
+		return;
+	}
+	ModelGraphicsScene* modelScene = dynamic_cast<ModelGraphicsScene*>(sourceScene);
+	if (modelScene != nullptr && modelScene->isGraphicalDataDefinitionsSyncInProgress()) {
+		return;
+	}
+	if (_sourceGraphicalPort->graphicalComponent() == nullptr || _destinationGraphicalPort->graphicalComponent() == nullptr) {
+		return;
+	}
 	/**
 	 * Bloco 1: coleta de geometria absoluta de portas.
 	 */

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
@@ -60,9 +60,27 @@
 #include <QTimer>
 #include <QDebug>
 #include <QSet>
+#include <QMetaObject>
 #include <algorithm>
 
 namespace {
+// Keep sync-in-progress state exception-safe inside queued synchronization execution.
+class ScopedSyncInProgress {
+public:
+    explicit ScopedSyncInProgress(bool* flag) : _flag(flag) {
+        if (_flag != nullptr) {
+            *_flag = true;
+        }
+    }
+    ~ScopedSyncInProgress() {
+        if (_flag != nullptr) {
+            *_flag = false;
+        }
+    }
+private:
+    bool* _flag = nullptr;
+};
+
 // Safely cast the scene parent to a generic graphics view.
 QGraphicsView* sceneParentGraphicsView(ModelGraphicsScene* scene) {
     if (scene == nullptr) {
@@ -389,7 +407,17 @@ GraphicalModelDataDefinition* ModelGraphicsScene::addGraphicalModelDataDefinitio
     getAllDataDefinitions()->append(graphDataDef);
     getGraphicalModelDataDefinitions()->append(graphDataDef);
 
-    addItem(graphDataDef);
+    // Avoid duplicate addItem and avoid cross-scene item ownership conflicts.
+    if (graphDataDef != nullptr) {
+        if (graphDataDef->scene() == this) {
+            // Item is already owned by this scene.
+        } else if (graphDataDef->scene() != nullptr) {
+            graphDataDef->scene()->removeItem(graphDataDef);
+            addItem(graphDataDef);
+        } else {
+            addItem(graphDataDef);
+        }
+    }
 
     return graphDataDef;
 }
@@ -401,7 +429,17 @@ GraphicalDiagramConnection* ModelGraphicsScene::addGraphicalDiagramConnection(QG
     getAllGraphicalDiagramsConnections()->append(connection);
     getGraphicalDiagramsConnections()->append(connection);
 
-    addItem(connection);
+    // Avoid duplicate addItem and avoid cross-scene item ownership conflicts.
+    if (connection != nullptr) {
+        if (connection->scene() == this) {
+            // Item is already owned by this scene.
+        } else if (connection->scene() != nullptr) {
+            connection->scene()->removeItem(connection);
+            addItem(connection);
+        } else {
+            addItem(connection);
+        }
+    }
 
     return connection;
 }
@@ -677,6 +715,20 @@ void ModelGraphicsScene::removeGraphicalModelDataDefinition(GraphicalModelDataDe
         getGraphicalModelDataDefinitions()->removeOne(gmdd);
         getAllDataDefinitions()->removeOne(gmdd);
         return;
+    }
+
+    // Remove all diagram links that still reference this data definition before removing the item itself.
+    QList<GraphicalDiagramConnection*> relatedConnections;
+    for (GraphicalDiagramConnection* connection : *getAllGraphicalDiagramsConnections()) {
+        if (connection == nullptr) {
+            continue;
+        }
+        if (connection->getDataDefinition() == gmdd || connection->getLinkedDataDefinition() == gmdd) {
+            relatedConnections.append(connection);
+        }
+    }
+    for (GraphicalDiagramConnection* connection : relatedConnections) {
+        removeGraphicalDiagramConnection(connection);
     }
 
     //graphically
@@ -2956,7 +3008,7 @@ void ModelGraphicsScene::dropEvent(QGraphicsSceneDragDropEvent *event) {
                     // create graphically
                     addGraphicalModelComponent(plugin, component, event->scenePos(), color, true);
                     // Defer synchronization until after the drop event completes and scene transforms settle.
-                    scheduleGraphicalDataDefinitionsSync();
+                    requestGraphicalDataDefinitionsSync();
                     return;
                 }
             }
@@ -2965,21 +3017,22 @@ void ModelGraphicsScene::dropEvent(QGraphicsSceneDragDropEvent *event) {
     event->setAccepted(false);
 }
 
-void ModelGraphicsScene::scheduleGraphicalDataDefinitionsSync() {
+void ModelGraphicsScene::requestGraphicalDataDefinitionsSync() {
     // Coalesce chained requests to avoid running redundant synchronizations in the same event-loop turn.
-    if (_graphicalDataDefinitionsSyncPending) {
+    if (_graphicalDataDefinitionsSyncPending || _graphicalDataDefinitionsSyncInProgress) {
         return;
     }
     _graphicalDataDefinitionsSyncPending = true;
 
     QPointer<ModelGraphicsScene> guardedScene(this);
-    QTimer::singleShot(0, this, [guardedScene]() {
+    QMetaObject::invokeMethod(this, [guardedScene]() {
         if (guardedScene.isNull()) {
             return;
         }
 
         // Clear pending state first so follow-up model mutations can enqueue another sync.
         guardedScene->_graphicalDataDefinitionsSyncPending = false;
+        ScopedSyncInProgress scopedSyncFlag(&guardedScene->_graphicalDataDefinitionsSyncInProgress);
         Simulator* simulator = guardedScene->_simulator;
         if (simulator == nullptr || simulator->getModelManager() == nullptr || simulator->getModelManager()->current() == nullptr) {
             return;
@@ -2987,7 +3040,16 @@ void ModelGraphicsScene::scheduleGraphicalDataDefinitionsSync() {
 
         // Run canonical layer synchronization only when both the scene and active model are still valid.
         GraphicalModelBuilder::synchronizeGraphicalDataDefinitionsLayer(simulator, guardedScene.data());
-    });
+    }, Qt::QueuedConnection);
+}
+
+// Keep compatibility with existing call sites while enforcing canonical queued scheduling.
+void ModelGraphicsScene::scheduleGraphicalDataDefinitionsSync() {
+    requestGraphicalDataDefinitionsSync();
+}
+
+bool ModelGraphicsScene::isGraphicalDataDefinitionsSyncInProgress() const {
+    return _graphicalDataDefinitionsSyncInProgress;
 }
 
 void ModelGraphicsScene::contextMenuEvent(QGraphicsSceneContextMenuEvent *contextMenuEvent) {
@@ -3031,7 +3093,7 @@ void ModelGraphicsScene::keyPressEvent(QKeyEvent *keyEvent) {
 
         QUndoCommand *deleteUndoCommand = new DeleteUndoCommand(selected, this);
         _undoStack->push(deleteUndoCommand);
-        GraphicalModelBuilder::synchronizeGraphicalDataDefinitionsLayer(_simulator, this);
+        requestGraphicalDataDefinitionsSync();
     }
     _controlIsPressed = (keyEvent->key() == Qt::Key_Control);
 }

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.h
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.h
@@ -232,7 +232,9 @@ public:
     void insertRestoredDataDefinitions(bool loaded);
     void saveDataDefinitions();
     // --------------------------------- //
+    void requestGraphicalDataDefinitionsSync();
     void scheduleGraphicalDataDefinitionsSync();
+    bool isGraphicalDataDefinitionsSyncInProgress() const;
 
 public:
     QList<QGraphicsItem*>*getGraphicalModelDataDefinitions() const;
@@ -340,6 +342,7 @@ private:
     QList<QGraphicsItemGroup*>* _graphicalGroups = new QList<QGraphicsItemGroup*>();
     bool _restoringPersistedGuiLayout = false;
     bool _graphicalDataDefinitionsSyncPending = false;
+    bool _graphicalDataDefinitionsSyncInProgress = false;
 };
 
 #endif /* MODELGRAPHICSSCENE_H */

--- a/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/mainwindow.cpp
@@ -928,7 +928,10 @@ bool MainWindow::_check(bool success)
 
     if (res) {
         ModelGraphicsScene* scene = (ModelGraphicsScene*) (ui->graphicsView->scene());
-        GraphicalModelBuilder::synchronizeGraphicalDataDefinitionsLayer(simulator, scene);
+        // Schedule data-definition synchronization outside this check stack to avoid scene teardown reentrancy.
+        if (scene != nullptr) {
+            scene->requestGraphicalDataDefinitionsSync();
+        }
         // Mensagem de sucesso
         if (success) {
             QMessageBox::information(this, "Model Check", "Model successfully checked.");

--- a/source/applications/gui/qt/GenesysQtGUI/services/GraphicalModelBuilder.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/services/GraphicalModelBuilder.cpp
@@ -276,6 +276,10 @@ void GraphicalModelBuilder::synchronizeGraphicalDataDefinitionsLayer(Simulator* 
             if (newDataDefinitions.contains(attachedData.second)) {
                 // Read component geometry only when a newly created attached data definition needs placement.
                 if (!hasComponentPosition) {
+                    // Only read scene geometry when the component is attached to a valid scene.
+                    if (graphicalComponent->scene() == nullptr) {
+                        continue;
+                    }
                     componentPosition = graphicalComponent->scenePos();
                     yInternal = componentPosition.y();
                     yAttached = componentPosition.y();
@@ -302,6 +306,10 @@ void GraphicalModelBuilder::synchronizeGraphicalDataDefinitionsLayer(Simulator* 
             if (newDataDefinitions.contains(internalData.second)) {
                 // Read component geometry only when a newly created internal data definition needs placement.
                 if (!hasComponentPosition) {
+                    // Only read scene geometry when the component is attached to a valid scene.
+                    if (graphicalComponent->scene() == nullptr) {
+                        continue;
+                    }
                     componentPosition = graphicalComponent->scenePos();
                     yInternal = componentPosition.y();
                     yAttached = componentPosition.y();
@@ -334,6 +342,10 @@ void GraphicalModelBuilder::synchronizeGraphicalDataDefinitionsLayer(Simulator* 
             if (newDataDefinitions.contains(internalData.second)) {
                 // Read parent geometry only when placing newly created child data definitions.
                 if (!hasParentPosition) {
+                    // Only read scene geometry when the parent definition is attached to a valid scene.
+                    if (parentGraphicalDefinition->scene() == nullptr) {
+                        continue;
+                    }
                     parentPosition = parentGraphicalDefinition->scenePos();
                     x = parentPosition.x();
                     hasParentPosition = true;


### PR DESCRIPTION
### Motivation
- Fix intermittent segfaults and add-item warnings caused by synchronous rebuilding of the data-definition/diagram layer while QGraphicsScene items were in unstable teardown or parent/scene transitions.
- Prevent reentrant geometry reads (`scenePos()`/`mapToScene()`) and duplicate `addItem` that produced crashes when drag-and-drop or model-check flows mutated the scene.

### Description
- Introduced a canonical, queued sync entrypoint `ModelGraphicsScene::requestGraphicalDataDefinitionsSync()` with coalescing via `_graphicalDataDefinitionsSyncPending` and an in-progress guard `_graphicalDataDefinitionsSyncInProgress`, keeping `scheduleGraphicalDataDefinitionsSync()` as compatibility that delegates to the new API.
- Replaced direct calls to `GraphicalModelBuilder::synchronizeGraphicalDataDefinitionsLayer(...)` from unstable mutation flows so `dropEvent`, `MainWindow::_check`, delete key flow and `PropertyEditorController` route exclusively through the scene scheduler.
- Added RAII `ScopedSyncInProgress` to set/reset the in-progress flag safely while the queued sync runs, and hardened `GraphicalModelBuilder` to avoid `scenePos()` reads when items are not attached to a scene.
- Prevented geometry reentrancy by adding early-return guards in `GraphicalConnection::updateDimensionsAndPosition()` and by blocking updates in `GraphicalComponentPort::itemChange()` during scene/parent transitions or while sync is in progress.
- Made `ModelGraphicsScene::removeGraphicalModelDataDefinition()` remove all related `GraphicalDiagramConnection` items before removing the data-definition item, and added checks to avoid duplicate `addItem` (handle `item->scene() == this` and cross-scene transfer) when inserting data definitions / diagram connections.
- Files changed: `ModelGraphicsScene.h/.cpp`, `GraphicalConnection.cpp`, `GraphicalComponentPort.cpp`, `GraphicalModelBuilder.cpp`, `mainwindow.cpp`, `controllers/PropertyEditorController.cpp` (small routing change); short English comments were added above modified blocks.

### Testing
- Verified call-site changes and presence of new APIs/flags with repository searches (`rg`) confirming no direct sync calls remain in `dropEvent` or `_check`, and that `requestGraphicalDataDefinitionsSync`, `_graphicalDataDefinitionsSyncPending`, and `_graphicalDataDefinitionsSyncInProgress` exist.
- Confirmed guards were added via `rg`/`nl` checks for `GraphicalConnection::updateDimensionsAndPosition` and `GraphicalComponentPort::itemChange` and that `removeGraphicalModelDataDefinition` removes related diagram connections before deleting the main item.
- Performed a CMake configure and full build of the project (`cmake -S . -B build` and `cmake --build build -j4`) which completed successfully in this environment, noting the build configured with `GENESYS_BUILD_GUI=OFF` so GUI binary/run-time manual tests were not executed.
- Because the environment did not produce a runnable GUI (GUI build disabled in this session), manual runtime scenarios (`Create_1`, `Create_2`, `Create -> Delay -> Dispose`, `Model Check`) were not executed; verification relied on diffs, grep/rg checks and a non-GUI build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dad99041908321bd53bc928701d601)