### PR TITLE
GUI: harden scene sync against connection geometry reentry

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/GraphicalComponentPort.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/GraphicalComponentPort.cpp
@@ -65,7 +65,9 @@ QVariant GraphicalComponentPort::itemChange(QGraphicsItem::GraphicsItemChange ch
 	if (change == QGraphicsItem::ItemPositionChange || change == QGraphicsItem::ItemScenePositionHasChanged) {
 		QGraphicsScene* ownerScene = scene();
 		ModelGraphicsScene* modelScene = dynamic_cast<ModelGraphicsScene*>(ownerScene);
-		if (ownerScene == nullptr || _componentGraph == nullptr || (modelScene != nullptr && modelScene->isGraphicalDataDefinitionsSyncInProgress())) {
+		if (ownerScene == nullptr || _componentGraph == nullptr
+		        || (modelScene != nullptr && (modelScene->isGraphicalDataDefinitionsSyncInProgress()
+		                                       || modelScene->areConnectionGeometryUpdatesBlocked()))) {
 			return res;
 		}
 		for (GraphicalConnection* graphconnection : *_connections) {

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/GraphicalConnection.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/GraphicalConnection.cpp
@@ -85,7 +85,7 @@ void GraphicalConnection::updateDimensionsAndPosition() {
 		return;
 	}
 	ModelGraphicsScene* modelScene = dynamic_cast<ModelGraphicsScene*>(sourceScene);
-	if (modelScene != nullptr && modelScene->isGraphicalDataDefinitionsSyncInProgress()) {
+	if (modelScene != nullptr && modelScene->areConnectionGeometryUpdatesBlocked()) {
 		return;
 	}
 	if (_sourceGraphicalPort->graphicalComponent() == nullptr || _destinationGraphicalPort->graphicalComponent() == nullptr) {
@@ -103,6 +103,7 @@ void GraphicalConnection::updateDimensionsAndPosition() {
 	h1 = _sourceGraphicalPort->height();
 	w2 = _destinationGraphicalPort->width();
 	h2 = _destinationGraphicalPort->height();
+	prepareGeometryChange();
 	/**
 	 * Bloco 2: projeta esta conexão para um sistema de coordenadas local mínimo.
 	 */
@@ -111,11 +112,8 @@ void GraphicalConnection::updateDimensionsAndPosition() {
 	_width = abs(x2 - x1)-(x1 < x2 ? w2 : w1);
 	_height = abs(y2 - y1)+(y1 < y2 ? h2 : h1);
 	/**
-	 * Bloco 3: solicita repaint.
-	 *
-	 * @todo Evitar update() em caminho quente de paint para reduzir jitter.
+	 * Bloco 3: mantém apenas atualização geométrica local.
 	 */
-	update(); //@TODO SHould not call it here
 }
 
 QRectF GraphicalConnection::boundingRect() const {
@@ -131,10 +129,16 @@ QRectF GraphicalConnection::boundingRect() const {
 }
 
 void GraphicalConnection::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) {
-	/**
-	 * Bloco 1: recalcula dimensões para refletir movimentação dos componentes.
-	 */
-	updateDimensionsAndPosition();
+	Q_UNUSED(option);
+	Q_UNUSED(widget);
+	if (_sourceGraphicalPort == nullptr || _destinationGraphicalPort == nullptr) {
+		return;
+	}
+	QGraphicsScene* sourceScene = _sourceGraphicalPort->scene();
+	QGraphicsScene* destinationScene = _destinationGraphicalPort->scene();
+	if (sourceScene == nullptr || destinationScene == nullptr || sourceScene != destinationScene || scene() != sourceScene) {
+		return;
+	}
 	QPen pen = QPen(_color);
 	pen.setWidth(2);
 	painter->setPen(pen);

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/GraphicalConnection.h
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/GraphicalConnection.h
@@ -72,8 +72,8 @@ protected: // virtual
 	//virtual void mousePressEvent(QGraphicsSceneMouseEvent * event);
 	//virtual void	mouseReleaseEvent(QGraphicsSceneMouseEvent * event)
 private:
-	qreal _width;
-	qreal _height;
+	qreal _width = 0.0;
+	qreal _height = 0.0;
 	unsigned int _margin = TraitsGUI<GConnection>::margin;//2;
 	unsigned int _selWidth = TraitsGUI<GConnection>::selectionWidth;//8;
 	ConnectionType _connectionType = ConnectionType::HORIZONTAL;

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
@@ -731,6 +731,10 @@ void ModelGraphicsScene::removeGraphicalModelDataDefinition(GraphicalModelDataDe
         removeGraphicalDiagramConnection(connection);
     }
 
+    if (QGraphicsItemGroup* group = gmdd->group()) {
+        group->removeFromGroup(gmdd);
+    }
+
     //graphically
     removeItem(gmdd);
     // Keep data-definition ownership lists consistent during removal.
@@ -3050,6 +3054,14 @@ void ModelGraphicsScene::scheduleGraphicalDataDefinitionsSync() {
 
 bool ModelGraphicsScene::isGraphicalDataDefinitionsSyncInProgress() const {
     return _graphicalDataDefinitionsSyncInProgress;
+}
+
+void ModelGraphicsScene::setConnectionGeometryUpdatesBlocked(bool blocked) {
+    _connectionGeometryUpdatesBlocked = blocked;
+}
+
+bool ModelGraphicsScene::areConnectionGeometryUpdatesBlocked() const {
+    return _connectionGeometryUpdatesBlocked;
 }
 
 void ModelGraphicsScene::contextMenuEvent(QGraphicsSceneContextMenuEvent *contextMenuEvent) {

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.h
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.h
@@ -235,6 +235,8 @@ public:
     void requestGraphicalDataDefinitionsSync();
     void scheduleGraphicalDataDefinitionsSync();
     bool isGraphicalDataDefinitionsSyncInProgress() const;
+    void setConnectionGeometryUpdatesBlocked(bool blocked);
+    bool areConnectionGeometryUpdatesBlocked() const;
 
 public:
     QList<QGraphicsItem*>*getGraphicalModelDataDefinitions() const;
@@ -343,6 +345,7 @@ private:
     bool _restoringPersistedGuiLayout = false;
     bool _graphicalDataDefinitionsSyncPending = false;
     bool _graphicalDataDefinitionsSyncInProgress = false;
+    bool _connectionGeometryUpdatesBlocked = false;
 };
 
 #endif /* MODELGRAPHICSSCENE_H */

--- a/source/applications/gui/qt/GenesysQtGUI/services/GraphicalModelBuilder.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/services/GraphicalModelBuilder.cpp
@@ -160,6 +160,24 @@ void GraphicalModelBuilder::synchronizeGraphicalDataDefinitionsLayer(Simulator* 
         return;
     }
 
+    class ScopedConnectionGeometryBlocker {
+    public:
+        explicit ScopedConnectionGeometryBlocker(ModelGraphicsScene* guardedScene) : _guardedScene(guardedScene) {
+            if (_guardedScene != nullptr) {
+                _guardedScene->setConnectionGeometryUpdatesBlocked(true);
+            }
+        }
+        ~ScopedConnectionGeometryBlocker() {
+            if (_guardedScene != nullptr) {
+                _guardedScene->setConnectionGeometryUpdatesBlocked(false);
+            }
+        }
+    private:
+        ModelGraphicsScene* _guardedScene = nullptr;
+    };
+
+    ScopedConnectionGeometryBlocker scopedConnectionGeometryBlocker(scene);
+
     // Sanitize scene helper containers before any diff logic to avoid stale bookkeeping pointers.
     scene->sanitizeGraphicalDataDefinitionsBookkeeping();
 


### PR DESCRIPTION
### Motivation
- A segfault was reproduced during data-definition synchronization and Model Check where scene structural mutations (remove/reparent/group operations) raced with connection/port callbacks calling `scenePos()`, leaving the Qt scene graph in an unstable state. 
- `GraphicalModelDataDefinition` items could be removed while still belonging to a `QGraphicsItemGroup`, and connections were allowed to recompute geometry during scene sync, both increasing crash risk.

### Description
- Add an explicit scene-level blocker in `ModelGraphicsScene`: `setConnectionGeometryUpdatesBlocked(bool)` / `areConnectionGeometryUpdatesBlocked()` and a private flag `_connectionGeometryUpdatesBlocked` to gate geometry updates. 
- Wrap `GraphicalModelBuilder::synchronizeGraphicalDataDefinitionsLayer(...)` with a small RAII `ScopedConnectionGeometryBlocker` so the blocker is set for the whole synchronization scope and always released on exit (including early returns). 
- In `ModelGraphicsScene::removeGraphicalModelDataDefinition(...)` detach the data-definition from any `QGraphicsItemGroup` via `group->removeFromGroup(gmdd)` before calling `removeItem` and `delete`, preserving the existing auxiliary lists. 
- Harden `GraphicalConnection::updateDimensionsAndPosition()` with null/scene checks, ensure both endpoints share the same scene, return early if the scene has geometry updates blocked, call `prepareGeometryChange()` before changing geometry, and remove the in-method `update()` call. 
- Make `GraphicalConnection::paint(...)` rendering-only with minimal guards that skip painting when ports or scenes are invalid; stop doing geometry mutation from `paint`. 
- Make `GraphicalComponentPort::itemChange(...)` respect the new scene blocker (in addition to the existing sync-in-progress guard) so it will not call connection geometry updates while blocked. 
- Small defensive initialization: `_width`/`_height` defaulted to `0.0` in `GraphicalConnection` to avoid indeterminate reads. 

### Testing
- Confirmed repository state with `git branch --show-current` and `git branch --list WiP20261` (the branch `WiP20261` is not present; changes were applied on the available branch). 
- Inspected focused diffs with `git diff` and validated only the requested files were changed. 
- Static checks: used `rg` to verify insertion points for `ScopedConnectionGeometryBlocker`, `setConnectionGeometryUpdatesBlocked` / `areConnectionGeometryUpdatesBlocked`, `removeFromGroup(gmdd)`, and `prepareGeometryChange()` are present. 
- Built non-GUI targets via CMake presets: `cmake --preset debug` + `cmake --build build/debug -j2`; kernel/plugins/tests built successfully (non-GUI build completed). 
- Attempted GUI-enabled configure (`-DGENESYS_BUILD_GUI_APPLICATION=ON`) but configuration failed due to missing `qmake` in the environment, so runtime GUI validation could not be executed here. 
- Changes committed with message `GUI: harden scene sync against connection geometry reentry`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db94a7ff0c83218d3534346d640024)