### PR TITLE
GUI: harden canonical data-definition sync and connection geometry updates

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/GraphicalComponentPort.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/GraphicalComponentPort.cpp
@@ -61,8 +61,8 @@ QVariant GraphicalComponentPort::itemChange(QGraphicsItem::GraphicsItemChange ch
 		return res;
 	}
 
-	// Update connected edges only when scene and component are stable.
-	if (change == QGraphicsItem::ItemPositionChange || change == QGraphicsItem::ItemScenePositionHasChanged) {
+	// Update connected edges only when scene/component are stable and final position is committed.
+	if (change == QGraphicsItem::ItemPositionHasChanged || change == QGraphicsItem::ItemScenePositionHasChanged) {
 		QGraphicsScene* ownerScene = scene();
 		ModelGraphicsScene* modelScene = dynamic_cast<ModelGraphicsScene*>(ownerScene);
 		if (ownerScene == nullptr || _componentGraph == nullptr
@@ -72,6 +72,9 @@ QVariant GraphicalComponentPort::itemChange(QGraphicsItem::GraphicsItemChange ch
 		}
 		for (GraphicalConnection* graphconnection : *_connections) {
 			if (graphconnection == nullptr) {
+				continue;
+			}
+			if (graphconnection->scene() != nullptr && graphconnection->scene() != ownerScene) {
 				continue;
 			}
 			graphconnection->updateDimensionsAndPosition();

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/GraphicalConnection.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/GraphicalConnection.cpp
@@ -2,6 +2,7 @@
 #include "GraphicalModelComponent.h"
 #include "ModelGraphicsScene.h"
 #include <QPainter>
+#include <QtMath>
 
 GraphicalConnection::GraphicalConnection(GraphicalComponentPort* sourceGraphicalPort, GraphicalComponentPort* destinationGraphicalPort, unsigned int portSourceConnection, unsigned int portDestinationConnection, QColor color, QGraphicsItem *parent) : QGraphicsObject(parent) {
 	/**
@@ -85,35 +86,36 @@ void GraphicalConnection::updateDimensionsAndPosition() {
 		return;
 	}
 	ModelGraphicsScene* modelScene = dynamic_cast<ModelGraphicsScene*>(sourceScene);
-	if (modelScene != nullptr && modelScene->areConnectionGeometryUpdatesBlocked()) {
+	if (modelScene != nullptr && (modelScene->areConnectionGeometryUpdatesBlocked()
+	                              || modelScene->isGraphicalDataDefinitionsSyncInProgress())) {
 		return;
 	}
 	if (_sourceGraphicalPort->graphicalComponent() == nullptr || _destinationGraphicalPort->graphicalComponent() == nullptr) {
 		return;
 	}
-	/**
-	 * Bloco 1: coleta de geometria absoluta de portas.
-	 */
-	qreal x1, x2, y1, y2, w1, w2, h1, h2;
-	x1 = _sourceGraphicalPort->scenePos().x();
-	x2 = _destinationGraphicalPort->scenePos().x();
-	y1 = _sourceGraphicalPort->scenePos().y();
-	y2 = _destinationGraphicalPort->scenePos().y();
-	w1 = _sourceGraphicalPort->width();
-	h1 = _sourceGraphicalPort->height();
-	w2 = _destinationGraphicalPort->width();
-	h2 = _destinationGraphicalPort->height();
-	prepareGeometryChange();
-	/**
-	 * Bloco 2: projeta esta conexão para um sistema de coordenadas local mínimo.
-	 */
-	setPos((x1 < x2 ? x1 + w1 : x2 + w2) - 2/*penwidth*/, y1 < y2 ? y1 : y2);
-	//setPos((x1 < x2 ? x1 + w1 : x2 + w2) - 2/*penwidth*/, y1 < y2 ? y1 : y2);
-	_width = abs(x2 - x1)-(x1 < x2 ? w2 : w1);
-	_height = abs(y2 - y1)+(y1 < y2 ? h2 : h1);
-	/**
-	 * Bloco 3: mantém apenas atualização geométrica local.
-	 */
+	const QPointF sourceScenePos = _sourceGraphicalPort->scenePos();
+	const QPointF destinationScenePos = _destinationGraphicalPort->scenePos();
+	const qreal w1 = _sourceGraphicalPort->width();
+	const qreal h1 = _sourceGraphicalPort->height();
+	const qreal w2 = _destinationGraphicalPort->width();
+	const qreal h2 = _destinationGraphicalPort->height();
+
+	const qreal newX = (sourceScenePos.x() < destinationScenePos.x() ? sourceScenePos.x() + w1 : destinationScenePos.x() + w2) - 2;
+	const qreal newY = sourceScenePos.y() < destinationScenePos.y() ? sourceScenePos.y() : destinationScenePos.y();
+	const qreal newWidth = qAbs(destinationScenePos.x() - sourceScenePos.x()) - (sourceScenePos.x() < destinationScenePos.x() ? w2 : w1);
+	const qreal newHeight = qAbs(destinationScenePos.y() - sourceScenePos.y()) + (sourceScenePos.y() < destinationScenePos.y() ? h2 : h1);
+
+	const bool positionChanged = !qFuzzyCompare(pos().x() + 1.0, newX + 1.0) || !qFuzzyCompare(pos().y() + 1.0, newY + 1.0);
+	const bool geometryChanged = !qFuzzyCompare(_width + 1.0, newWidth + 1.0) || !qFuzzyCompare(_height + 1.0, newHeight + 1.0);
+	if (!positionChanged && !geometryChanged) {
+		return;
+	}
+	if (geometryChanged) {
+		prepareGeometryChange();
+	}
+	_width = newWidth;
+	_height = newHeight;
+	setPos(newX, newY);
 }
 
 QRectF GraphicalConnection::boundingRect() const {
@@ -137,6 +139,9 @@ void GraphicalConnection::paint(QPainter *painter, const QStyleOptionGraphicsIte
 	QGraphicsScene* sourceScene = _sourceGraphicalPort->scene();
 	QGraphicsScene* destinationScene = _destinationGraphicalPort->scene();
 	if (sourceScene == nullptr || destinationScene == nullptr || sourceScene != destinationScene || scene() != sourceScene) {
+		return;
+	}
+	if (_sourceGraphicalPort->graphicalComponent() == nullptr || _destinationGraphicalPort->graphicalComponent() == nullptr) {
 		return;
 	}
 	QPen pen = QPen(_color);

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/GraphicalDiagramConnection.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/GraphicalDiagramConnection.cpp
@@ -9,51 +9,53 @@ GraphicalDiagramConnection::GraphicalDiagramConnection(QGraphicsItem* dataDefini
     _item2 = linkedTo;
     _type = type;
 
-    QRectF startRect = dataDefinition->sceneBoundingRect();
-    QRectF endRect = linkedTo->sceneBoundingRect();
-
-    QPointF startPoint;
-    QPointF endPoint;
-
-    if (startRect.bottom() < endRect.top()) { //seta para baixo
-
-        startPoint.setX(startRect.center().x());
-        startPoint.setY(startRect.bottom() - 10);
-
-        endPoint.setX(endRect.center().x());
-        endPoint.setY(endRect.top() + 10);
-
-    } else if (startRect.top() > endRect.bottom()){ //seta para cima
-
-        startPoint.setX(startRect.center().x());
-        startPoint.setY(startRect.top() + 10);
-
-        endPoint.setX(endRect.center().x());
-        endPoint.setY(endRect.bottom() - 10);
-
-    } else if (startRect.right() < endRect.left()){ //seta para direita
-
-        startPoint.setX(startRect.right() - 10);
-        startPoint.setY(startRect.center().y());
-
-        endPoint.setX(endRect.left() + 10);
-        endPoint.setY(endRect.center().y());
-
-    } else { //seta para esquerda
-
-        startPoint.setX(startRect.left() + 10);
-        startPoint.setY(startRect.center().y());
-
-        endPoint.setX(endRect.right() - 10);
-        endPoint.setY(endRect.center().y());
-    }
-
-    setLine(QLineF(startPoint, endPoint));
+    refreshGeometry();
     // Keep diagram links purely representational in this phase.
     setFlag(QGraphicsItem::ItemIsSelectable, false);
     setFlag(QGraphicsItem::ItemIsFocusable, false);
     setFlag(QGraphicsItem::ItemIsMovable, false);
     setAcceptedMouseButtons(Qt::NoButton);
+}
+
+void GraphicalDiagramConnection::refreshGeometry() {
+    if (_item1 == nullptr || _item2 == nullptr) {
+        return;
+    }
+    QGraphicsScene* scene1 = _item1->scene();
+    QGraphicsScene* scene2 = _item2->scene();
+    if (scene1 == nullptr || scene2 == nullptr || scene1 != scene2) {
+        return;
+    }
+
+    QRectF startRect = _item1->sceneBoundingRect();
+    QRectF endRect = _item2->sceneBoundingRect();
+
+    QPointF startPoint;
+    QPointF endPoint;
+
+    if (startRect.bottom() < endRect.top()) { //seta para baixo
+        startPoint.setX(startRect.center().x());
+        startPoint.setY(startRect.bottom() - 10);
+        endPoint.setX(endRect.center().x());
+        endPoint.setY(endRect.top() + 10);
+    } else if (startRect.top() > endRect.bottom()){ //seta para cima
+        startPoint.setX(startRect.center().x());
+        startPoint.setY(startRect.top() + 10);
+        endPoint.setX(endRect.center().x());
+        endPoint.setY(endRect.bottom() - 10);
+    } else if (startRect.right() < endRect.left()){ //seta para direita
+        startPoint.setX(startRect.right() - 10);
+        startPoint.setY(startRect.center().y());
+        endPoint.setX(endRect.left() + 10);
+        endPoint.setY(endRect.center().y());
+    } else { //seta para esquerda
+        startPoint.setX(startRect.left() + 10);
+        startPoint.setY(startRect.center().y());
+        endPoint.setX(endRect.right() - 10);
+        endPoint.setY(endRect.center().y());
+    }
+
+    setLine(QLineF(startPoint, endPoint));
 }
 
 

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/GraphicalDiagramConnection.h
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/GraphicalDiagramConnection.h
@@ -24,6 +24,7 @@ public:
 
 public:
     GraphicalDiagramConnection(QGraphicsItem* dataDefinition, QGraphicsItem* linkedTo, ConnectionType type);
+    void refreshGeometry();
 
     void paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget = nullptr) override;
 

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
@@ -731,8 +731,9 @@ void ModelGraphicsScene::removeGraphicalModelDataDefinition(GraphicalModelDataDe
         removeGraphicalDiagramConnection(connection);
     }
 
-    if (QGraphicsItemGroup* group = gmdd->group()) {
-        group->removeFromGroup(gmdd);
+    QGraphicsItemGroup* parentGroup = gmdd->group();
+    if (parentGroup != nullptr) {
+        parentGroup->removeFromGroup(gmdd);
     }
 
     //graphically
@@ -740,6 +741,15 @@ void ModelGraphicsScene::removeGraphicalModelDataDefinition(GraphicalModelDataDe
     // Keep data-definition ownership lists consistent during removal.
     getGraphicalModelDataDefinitions()->removeOne(gmdd);
     getAllDataDefinitions()->removeOne(gmdd);
+    _oldPositionsItems.remove(gmdd);
+
+    // Cleanup trivial automatic grouping leftovers after detaching/removing this data definition.
+    if (parentGroup != nullptr && parentGroup->childItems().isEmpty()) {
+        removeItem(parentGroup);
+        getGraphicalGroups()->removeOne(parentGroup);
+        _listComponentsGroup.remove(parentGroup);
+        delete parentGroup;
+    }
     delete(gmdd);
 }
 
@@ -1504,16 +1514,11 @@ void ModelGraphicsScene::actualizeDiagramArrows() {
 
     if (existDiagram()) {
         QList<GraphicalDiagramConnection*>* connections = getAllGraphicalDiagramsConnections();
-        int size_connections = connections->size();
-        for (int i = 0; i < size_connections; i++) {
-
-            GraphicalDiagramConnection* itemConnection = connections->first();
-
-            QGraphicsItem * item_1 = itemConnection->getDataDefinition();
-            QGraphicsItem * item_2 = itemConnection->getLinkedDataDefinition();
-            addGraphicalDiagramConnection(item_1, item_2, itemConnection->getConnectionType());
-
-            removeGraphicalDiagramConnection(itemConnection);
+        for (GraphicalDiagramConnection* itemConnection : *connections) {
+            if (itemConnection == nullptr) {
+                continue;
+            }
+            itemConnection->refreshGeometry();
         }
     }
 }
@@ -2481,8 +2486,6 @@ void ModelGraphicsScene::mousePressEvent(QGraphicsSceneMouseEvent *mouseEvent) {
                         QUndoCommand *addUndoCommand = new AddUndoCommand(graphicconnection, this);
                         _undoStack->push(addUndoCommand);
 
-                        addItem(graphicconnection);
-
                         // Reset cursor only when the parent model view exists.
                         ModelGraphicsView* parentView = sceneParentModelGraphicsView(this);
                         if (parentView != nullptr) {
@@ -2503,8 +2506,6 @@ void ModelGraphicsScene::mousePressEvent(QGraphicsSceneMouseEvent *mouseEvent) {
                         // porem o connectComponents ja faz isso pra quando há necessidade de fazer reconexao
                         QUndoCommand *addUndoCommand = new AddUndoCommand(graphicconnection, this);
                         _undoStack->push(addUndoCommand);
-
-                        addItem(graphicconnection);
 
                         // Reset cursor only when the parent model view exists.
                         ModelGraphicsView* parentView = sceneParentModelGraphicsView(this);

--- a/source/applications/gui/qt/GenesysQtGUI/services/GraphicalModelBuilder.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/services/GraphicalModelBuilder.cpp
@@ -16,6 +16,31 @@
 
 #include <QTextEdit>
 #include <QSet>
+#include <QtMath>
+
+namespace {
+QPointF stableComponentAnchor(GraphicalModelComponent* component) {
+    if (component == nullptr) {
+        return QPointF();
+    }
+    QPointF anchor = component->getOldPosition();
+    if (!qIsFinite(anchor.x()) || !qIsFinite(anchor.y())) {
+        anchor = component->pos();
+    }
+    return anchor;
+}
+
+QPointF stableDataDefinitionAnchor(GraphicalModelDataDefinition* dataDefinition) {
+    if (dataDefinition == nullptr) {
+        return QPointF();
+    }
+    QPointF anchor = dataDefinition->getOldPosition();
+    if (!qIsFinite(anchor.x()) || !qIsFinite(anchor.y())) {
+        anchor = dataDefinition->pos();
+    }
+    return anchor;
+}
+}
 
 // Build the graphical reconstruction service with explicit dependencies.
 GraphicalModelBuilder::GraphicalModelBuilder(Simulator* simulator,
@@ -294,11 +319,7 @@ void GraphicalModelBuilder::synchronizeGraphicalDataDefinitionsLayer(Simulator* 
             if (newDataDefinitions.contains(attachedData.second)) {
                 // Read component geometry only when a newly created attached data definition needs placement.
                 if (!hasComponentPosition) {
-                    // Only read scene geometry when the component is attached to a valid scene.
-                    if (graphicalComponent->scene() == nullptr) {
-                        continue;
-                    }
-                    componentPosition = graphicalComponent->scenePos();
+                    componentPosition = stableComponentAnchor(graphicalComponent);
                     yInternal = componentPosition.y();
                     yAttached = componentPosition.y();
                     hasComponentPosition = true;
@@ -324,11 +345,7 @@ void GraphicalModelBuilder::synchronizeGraphicalDataDefinitionsLayer(Simulator* 
             if (newDataDefinitions.contains(internalData.second)) {
                 // Read component geometry only when a newly created internal data definition needs placement.
                 if (!hasComponentPosition) {
-                    // Only read scene geometry when the component is attached to a valid scene.
-                    if (graphicalComponent->scene() == nullptr) {
-                        continue;
-                    }
-                    componentPosition = graphicalComponent->scenePos();
+                    componentPosition = stableComponentAnchor(graphicalComponent);
                     yInternal = componentPosition.y();
                     yAttached = componentPosition.y();
                     hasComponentPosition = true;
@@ -360,11 +377,7 @@ void GraphicalModelBuilder::synchronizeGraphicalDataDefinitionsLayer(Simulator* 
             if (newDataDefinitions.contains(internalData.second)) {
                 // Read parent geometry only when placing newly created child data definitions.
                 if (!hasParentPosition) {
-                    // Only read scene geometry when the parent definition is attached to a valid scene.
-                    if (parentGraphicalDefinition->scene() == nullptr) {
-                        continue;
-                    }
-                    parentPosition = parentGraphicalDefinition->scenePos();
+                    parentPosition = stableDataDefinitionAnchor(parentGraphicalDefinition);
                     x = parentPosition.x();
                     hasParentPosition = true;
                 }


### PR DESCRIPTION
### Motivation
- Eliminate crashes and warnings caused by fragile scene/geometry synchronization between data definitions, diagram arrows and connections.  
- Remove duplicate scene insertion of connections that triggers `QGraphicsScene::addItem` warnings and undo/redo conflicts.  
- Ensure geometry updates are done outside the `paint()` path and that canonical data-definition sync does not rely on unstable `scenePos()` transforms.

### Description
- Remove redundant `addItem(graphicconnection)` calls in `ModelGraphicsScene::mousePressEvent()` so `AddUndoCommand::redo()` is the single insertion path. (file: `ModelGraphicsScene.cpp`).
- Make `GraphicalConnection::paint()` rendering-only and move all mutable geometry logic into `updateDimensionsAndPosition()` with strong guards, conditional `prepareGeometryChange()` and no internal `update()` calls. (file: `GraphicalConnection.cpp`, header unchanged semantics).
- Harden `GraphicalComponentPort::itemChange()` to update edges only on stable position-change events (`ItemPositionHasChanged` / `ItemScenePositionHasChanged`) and skip updates when scenes differ or sync/block flags are active. (file: `GraphicalComponentPort.cpp`).
- Replace fragile `scenePos()` anchoring in `GraphicalModelBuilder::synchronizeGraphicalDataDefinitionsLayer()` with helper functions that prefer `getOldPosition()` and fall back to `pos()` only when necessary, avoiding recursive scene transform reads during canonical sync. (file: `GraphicalModelBuilder.cpp`).
- Make removal of `GraphicalModelDataDefinition` safe when items are grouped by detaching from group, removing related `GraphicalDiagramConnection`s first, cleaning `_oldPositionsItems` bookkeeping, and conservatively removing empty automatic groups. (file: `ModelGraphicsScene.cpp`).
- Add `GraphicalDiagramConnection::refreshGeometry()` and change `ModelGraphicsScene::actualizeDiagramArrows()` to refresh connections in-place rather than destroy-and-recreate, reducing scene churn. (files: `GraphicalDiagramConnection.h`, `GraphicalDiagramConnection.cpp`, `ModelGraphicsScene.cpp`).

### Testing
- Ran configuration with CMake: `cmake -S . -B build/codex-gui-fix -G Ninja` which completed successfully.  
- Built project targets: `cmake --build build/codex-gui-fix -j2` which completed successfully and produced non-GUI binaries.  
- Executed smoke binary `./build/codex-gui-fix/source/tests/smoke/genesys_smoke_simulator_start` which launched successfully (simulator startup message observed).  
- Attempted GUI build with provided qmake-driven script `cd source/applications/gui/qt/GenesysQtGUI && ./build_qtgui.sh --config Debug --build-dir build/codex-gui-fix --jobs 2` but it failed because the environment lacks `qmake` (`qmake not found`), so interactive GUI validation (dragging components, Model Check flow and verification of `QGraphicsScene::addItem` warning disappearance) could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dba80eba588321969c58914c3aa860)