### PR TITLE
GUI: fix data-definition sync misclassification and live connection redraw

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/GraphicalComponentPort.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/GraphicalComponentPort.cpp
@@ -20,6 +20,7 @@ GraphicalComponentPort::GraphicalComponentPort(GraphicalModelComponent* componen
 	//setPos(0,0);
     setFlag(QGraphicsItem::ItemIsSelectable, false);
     setFlag(QGraphicsItem::ItemIsFocusable, false);
+    setFlag(QGraphicsItem::ItemSendsScenePositionChanges, true);
 	setAcceptHoverEvents(true);
 	setAcceptTouchEvents(true);
 	setActive(true);

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/GraphicalModelComponent.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/GraphicalModelComponent.cpp
@@ -31,10 +31,14 @@
 
 #include "GraphicalModelComponent.h"
 #include "GraphicalComponentPort.h"
+#include "GraphicalConnection.h"
+#include "ModelGraphicsScene.h"
 #include "TraitsGUI.h"
 #include "UtilGUI.h"
 #include <QPainter>
 #include <QRgba64>
+#include <QSet>
+#include <QDebug>
 
 GraphicalModelComponent::GraphicalModelComponent(Plugin* plugin, ModelComponent* component, QPointF position, QColor color, QGraphicsItem *parent) :  GraphicalModelDataDefinition(plugin, component, position, color) { //  QGraphicsObject(parent) {
 	_component = component;
@@ -70,6 +74,8 @@ GraphicalModelComponent::GraphicalModelComponent(Plugin* plugin, ModelComponent*
 	// position and flags
 	setPos(position.x()/*-_width/2*/, position.y() - _height / 2);
 	setFlags(QGraphicsItem::ItemIsMovable | QGraphicsItem::ItemIsSelectable | QGraphicsItem::ItemIsFocusable);
+    setFlag(QGraphicsItem::ItemSendsGeometryChanges, true);
+    setFlag(QGraphicsItem::ItemSendsScenePositionChanges, true);
 	setAcceptHoverEvents(true);
 	setAcceptTouchEvents(true);
 	setActive(true);
@@ -304,6 +310,50 @@ qreal GraphicalModelComponent::getHeight() const {
 
 bool GraphicalModelComponent::sceneEvent(QEvent *event) {
     return QGraphicsObject::sceneEvent(event); // Unnecessary
+}
+
+QVariant GraphicalModelComponent::itemChange(QGraphicsItem::GraphicsItemChange change, const QVariant& value) {
+    QVariant result = GraphicalModelDataDefinition::itemChange(change, value);
+    if (change != QGraphicsItem::ItemPositionHasChanged
+            && change != QGraphicsItem::ItemScenePositionHasChanged) {
+        return result;
+    }
+
+    ModelGraphicsScene* modelScene = dynamic_cast<ModelGraphicsScene*>(scene());
+    if (modelScene != nullptr
+            && (modelScene->areConnectionGeometryUpdatesBlocked()
+                || modelScene->isGraphicalDataDefinitionsSyncInProgress())) {
+        return result;
+    }
+
+    QSet<GraphicalConnection*> uniqueConnections;
+    auto collectConnections = [&uniqueConnections](const QList<GraphicalComponentPort*>& ports) {
+        for (GraphicalComponentPort* port : ports) {
+            if (port == nullptr || port->getConnections() == nullptr) {
+                continue;
+            }
+            for (GraphicalConnection* connection : *port->getConnections()) {
+                if (connection != nullptr) {
+                    uniqueConnections.insert(connection);
+                }
+            }
+        }
+    };
+    collectConnections(_graphicalInputPorts);
+    collectConnections(_graphicalOutputPorts);
+
+    int updatedConnections = 0;
+    for (GraphicalConnection* connection : uniqueConnections) {
+        connection->updateDimensionsAndPosition();
+        connection->update();
+        ++updatedConnections;
+    }
+
+    qInfo() << "GraphicalModelComponent::itemChange refreshed connections" << updatedConnections
+            << "for component"
+            << (_component != nullptr ? QString::fromStdString(_component->getName()) : QString("<null>"));
+
+    return result;
 }
 
 QList<GraphicalComponentPort *> GraphicalModelComponent::getGraphicalOutputPorts() const {

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/GraphicalModelComponent.h
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/GraphicalModelComponent.h
@@ -47,6 +47,7 @@ private:
 	QColor myrgba(uint64_t color); // TODO: Should NOT be here, but in UtilGUI.h, but then it generates multiple definitions error
 protected: // virtual
 	virtual bool sceneEvent(QEvent *event) override;
+    QVariant itemChange(GraphicsItemChange change, const QVariant& value) override;
 	//virtual void	hoverEnterEvent(QGraphicsSceneHoverEvent * event)
 	//virtual void	hoverLeaveEvent(QGraphicsSceneHoverEvent * event)
 	//virtual void	hoverMoveEvent(QGraphicsSceneHoverEvent * event)
@@ -118,4 +119,3 @@ public:
 };
 
 #endif /* MODELCOMPONENTGRAPHICITEM_H */
-

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
@@ -664,6 +664,10 @@ void ModelGraphicsScene::removeGraphicalModelDataDefinition(GraphicalModelDataDe
     if (gmdd == nullptr) {
         return;
     }
+    if (dynamic_cast<GraphicalModelComponent*>(gmdd) != nullptr) {
+        qInfo() << "removeGraphicalModelDataDefinition: refusing to remove GraphicalModelComponent as data definition";
+        return;
+    }
 
     // Remove only data-definition items that are still alive in the scene snapshot.
     const QList<QGraphicsItem*> liveItems = items();
@@ -756,6 +760,10 @@ void ModelGraphicsScene::sanitizeGraphicalDataDefinitionsBookkeeping() {
     QSet<GraphicalDiagramConnection*> liveDiagramConnections;
 
     for (QGraphicsItem* item : liveItems) {
+        if (dynamic_cast<GraphicalModelComponent*>(item) != nullptr) {
+            qInfo() << "sanitizeGraphicalDataDefinitionsBookkeeping: ignoring GraphicalModelComponent item";
+            continue;
+        }
         if (auto* gmdd = dynamic_cast<GraphicalModelDataDefinition*>(item)) {
             liveDataDefinitions.insert(gmdd);
             continue;

--- a/source/applications/gui/qt/GenesysQtGUI/services/GraphicalModelBuilder.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/services/GraphicalModelBuilder.cpp
@@ -16,6 +16,7 @@
 
 #include <QTextEdit>
 #include <QSet>
+#include <QDebug>
 
 namespace {
 QPointF stableComponentPosition(GraphicalModelComponent* component) {
@@ -248,6 +249,11 @@ void GraphicalModelBuilder::synchronizeGraphicalDataDefinitionsLayer(Simulator* 
     std::map<ModelDataDefinition*, GraphicalModelDataDefinition*> existingDataDefinitions;
     const QList<QGraphicsItem*> liveItems = scene->items();
     for (QGraphicsItem* item : liveItems) {
+        if (auto* gmc = dynamic_cast<GraphicalModelComponent*>(item)) {
+            qInfo() << "synchronizeGraphicalDataDefinitionsLayer: ignoring GraphicalModelComponent in data-definition snapshot"
+                    << (gmc->getComponent() != nullptr ? QString::fromStdString(gmc->getComponent()->getName()) : QString("<null>"));
+            continue;
+        }
         GraphicalModelDataDefinition* gmdd = dynamic_cast<GraphicalModelDataDefinition*>(item);
         if (gmdd == nullptr || gmdd->getDataDefinition() == nullptr) {
             continue;
@@ -296,6 +302,11 @@ void GraphicalModelBuilder::synchronizeGraphicalDataDefinitionsLayer(Simulator* 
         }
     }
     for (GraphicalModelDataDefinition* stale : staleGraphicalDataDefinitions) {
+        const QString staleName = (stale->getDataDefinition() != nullptr)
+                ? QString::fromStdString(stale->getDataDefinition()->getName())
+                : QString("<null>");
+        qInfo() << "synchronizeGraphicalDataDefinitionsLayer: stale data definition removal"
+                << staleName;
         scene->removeGraphicalModelDataDefinition(stale);
     }
 


### PR DESCRIPTION
### Motivation
- Prevent `GraphicalModelComponent` instances from being misclassified as `GraphicalModelDataDefinition` during the builder synchronization, which could cause stale-removal of components and post-`Model Check` crashes. 
- Restore continuous redraw of connections while moving a component by making the component itself propagate geometry updates instead of relying only on port callbacks.

### Description
- In `GraphicalModelBuilder::synchronizeGraphicalDataDefinitionsLayer()` the live snapshot now ignores items that are `GraphicalModelComponent` (accept only pure `GraphicalModelDataDefinition`), and a `qInfo()` is emitted when a component is skipped.
- In `ModelGraphicsScene::sanitizeGraphicalDataDefinitionsBookkeeping()` the same distinction is enforced and a `qInfo()` is logged when a `GraphicalModelComponent` is ignored.
- Hardened `ModelGraphicsScene::removeGraphicalModelDataDefinition()` to refuse removing an item that is actually a `GraphicalModelComponent`, and added `qInfo()` logging on stale data-definition removals.
- Implemented `GraphicalModelComponent::itemChange(...)` (declared in the header and defined in the cpp), enabled `ItemSendsGeometryChanges` and `ItemSendsScenePositionChanges`, and on position changes the component collects all `GraphicalConnection*` from its input and output ports (deduplicated via `QSet`) and calls `updateDimensionsAndPosition()` and `update()` on each connection; this path respects `ModelGraphicsScene` guards `areConnectionGeometryUpdatesBlocked()` and `isGraphicalDataDefinitionsSyncInProgress()` and emits a `qInfo()` with the number of refreshed connections.
- Minor complement: set `ItemSendsScenePositionChanges` on `GraphicalComponentPort` to support scene-position notifications.
- Files modified: `GraphicalModelBuilder.cpp`, `ModelGraphicsScene.cpp`, `GraphicalModelComponent.h`, `GraphicalModelComponent.cpp`, `GraphicalComponentPort.cpp`.
- Git: base branch intended `WiP20261`; created work branch `codex/gui-fix-check-crash-and-live-connection-redraw` and committed as `2b230001f25a1dcb630f0c915fd0b7a2ee6d3fe9` with message `GUI: fix data-definition sync misclassification and live connection redraw`.

### Testing
- Attempted to configure and build the GUI with CMake: ran `cmake -S . -B build/gui-check -G Ninja -DCMAKE_BUILD_TYPE=Debug -DGENESYS_BUILD_KERNEL=ON -DGENESYS_BUILD_PARSER=ON -DGENESYS_BUILD_PLUGINS=ON -DGENESYS_BUILD_GUI_APPLICATION=ON -DGENESYS_BUILD_WEB_APPLICATION=OFF -DGENESYS_TERMINAL_APPLICATION=OFF`, which failed because `qmake`/Qt qmake is not available in this environment, so no binary was produced.
- Performed repository/branch actions locally: created branch `codex/gui-fix-check-crash-and-live-connection-redraw` and committed the changes (`2b230001f25...`).
- Runtime GUI validations requested (continuous connection redraw while dragging; scenario Create→Delay→Dispose→auto-connect→`Model Check` and confirm no crash and components remain) could not be executed in this container due to missing Qt tooling and lack of GUI runtime, so those dynamic tests remain to be run in a Qt-enabled environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbd003a564832188b12336925aa69a)