### PR TITLE
Fix double free in GraphicalConnection destructor

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/GraphicalConnection.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/GraphicalConnection.cpp
@@ -41,27 +41,47 @@ GraphicalConnection::GraphicalConnection(const GraphicalConnection& orig) {
 }
 
 GraphicalConnection::~GraphicalConnection() {
-    /**
-     * @brief Desfaz vínculo modelo<->gráfico da conexão.
-     *
-     * Ordem adotada:
-     * 1) remove relação no ConnectionManager do componente de origem;
-     * 2) remove ponteiros desta conexão nas portas gráficas;
-     * 3) libera objetos Connection auxiliares alocados neste item gráfico.
-     *
-     * @todo Avaliar migração de `_sourceConnection/_destinationConnection` para smart pointers.
-     */
-    if (_sourceConnection != nullptr && _sourceConnection->component != nullptr) {
-        _sourceConnection->component->getConnectionManager()->remove(_destinationConnection);
-    }
-    if (_sourceGraphicalPort != nullptr) {
-	    _sourceGraphicalPort->removeGraphicalConnection(this);
-    }
-    if (_destinationGraphicalPort != nullptr) {
-	    _destinationGraphicalPort->removeGraphicalConnection(this);
-    }
-    delete _destinationConnection;
-    delete _sourceConnection;
+	Connection* sourceConnection = _sourceConnection;
+	Connection* destinationConnection = _destinationConnection;
+	GraphicalComponentPort* sourceGraphicalPort = _sourceGraphicalPort;
+	GraphicalComponentPort* destinationGraphicalPort = _destinationGraphicalPort;
+
+	_sourceConnection = nullptr;
+	_destinationConnection = nullptr;
+	_sourceGraphicalPort = nullptr;
+	_destinationGraphicalPort = nullptr;
+
+	if (sourceGraphicalPort != nullptr) {
+		sourceGraphicalPort->removeGraphicalConnection(this);
+	}
+	if (destinationGraphicalPort != nullptr) {
+		destinationGraphicalPort->removeGraphicalConnection(this);
+	}
+
+	// Destination connection may already be destroyed by ConnectionManager::remove;
+	// avoid double free during scene/model teardown.
+	if (destinationConnection != nullptr) {
+		ConnectionManager* manager = nullptr;
+		if (sourceConnection != nullptr && sourceConnection->component != nullptr) {
+			manager = sourceConnection->component->getConnectionManager();
+		}
+		bool isManagedConnection = false;
+		if (manager != nullptr && manager->connections() != nullptr) {
+			for (const std::pair<const unsigned int, Connection*>& connectionPair : *manager->connections()) {
+				if (connectionPair.second == destinationConnection) {
+					isManagedConnection = true;
+					break;
+				}
+			}
+		}
+		if (isManagedConnection) {
+			manager->remove(destinationConnection);
+		} else {
+			delete destinationConnection;
+		}
+	}
+
+	delete sourceConnection;
 }
 
 GraphicalConnection::ConnectionType GraphicalConnection::connectionType() const


### PR DESCRIPTION
GUI

### Motivation
- The GUI teardown crashed due to a double free of `_destinationConnection` in `GraphicalConnection::~GraphicalConnection()` because `ConnectionManager::remove(Connection*)` already deletes the removed `Connection*` and the destructor also called `delete` on the same pointer.
- The change aims for a minimal, safe, and reversible fix that respects current ownership rules and avoids wide refactors or edits to `ConnectionManager`.

### Description
- Copied `_sourceConnection`, `_destinationConnection`, `_sourceGraphicalPort` and `_destinationGraphicalPort` into local variables at destructor entry and immediately nulled the instance members to reduce reentrancy/use-after-reset risks.
- Removed this graphical connection from both graphical ports using the local copies with null guards.
- Implemented ownership handling for `destinationConnection`: if it is currently present in the `ConnectionManager` retrieved from `sourceConnection->component`, call `manager->remove(destinationConnection)` (which destroys it); otherwise `delete destinationConnection` locally to avoid leaks.
- Kept `delete sourceConnection` at the end; added an English comment above the corrected block explaining that the destination connection may already be destroyed by `ConnectionManager::remove` to avoid double free.

### Testing
- `cmake -S . -B build` configured successfully in this environment (non-GUI build). 
- `cmake --build build -j2` progressed and compiled many targets successfully; no compilation errors were observed related to the change during the partial build.
- `cmake -S . -B build-gui -DGENESYS_BUILD_GUI_APPLICATION=ON` failed as expected due to missing `qmake` in PATH, preventing a full GUI build/run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbf07f48888321bfe3502d49a1c979)