### PR TITLE
Add public worker discovery endpoints for Stage 1 worker cycle

### DIFF
--- a/source/applications/web/README.md
+++ b/source/applications/web/README.md
@@ -19,6 +19,15 @@ First functional implementation of the **Web** application type for GenESyS.
   - `POST /api/v1/simulation/run` (requires `Authorization: Bearer <token>`)
   - `POST /api/v1/simulation/step` (requires `Authorization: Bearer <token>`)
 
+## Worker cycle Stage 1 (new cycle)
+The Web application is now also being evolved as a **worker API** that can be discovered by a future distributed orchestrator application.
+
+This stage adds two public worker discovery endpoints (no Bearer token required):
+- `GET /api/v1/worker/info`
+- `GET /api/v1/worker/capabilities`
+
+These routes expose worker identity metadata and current implementation capability flags. They are intentionally limited to discovery only and do not include job submission, polling, or background execution in this stage.
+
 ## How to run
 ```bash
 cmake -S . -B build/web-debug -G Ninja -DGENESYS_BUILD_WEB_APPLICATION=ON

--- a/source/applications/web/api/ApiRouter.cpp
+++ b/source/applications/web/api/ApiRouter.cpp
@@ -19,6 +19,28 @@ HttpResponse ApiRouter::handle(const HttpRequest& request) const {
         return HttpResponse{200, "application/json", "{\"ok\":true,\"status\":\"up\"}"};
     }
 
+    if (request.path == "/api/v1/worker/info") {
+        if (request.method != "GET") {
+            return _jsonError(405, "METHOD_NOT_ALLOWED", "Only GET is allowed for /api/v1/worker/info");
+        }
+
+        const auto info = _simulatorService.getWorkerInfo();
+        return HttpResponse{200, "application/json", "{\"ok\":true,\"data\":" + _workerInfoDataJson(info) + "}"};
+    }
+
+    if (request.path == "/api/v1/worker/capabilities") {
+        if (request.method != "GET") {
+            return _jsonError(405, "METHOD_NOT_ALLOWED", "Only GET is allowed for /api/v1/worker/capabilities");
+        }
+
+        const auto capabilities = _simulatorService.getWorkerCapabilities();
+        return HttpResponse{
+            200,
+            "application/json",
+            "{\"ok\":true,\"data\":" + _workerCapabilitiesDataJson(capabilities) + "}"
+        };
+    }
+
     if (request.path == "/api/v1/auth/session") {
         if (request.method != "POST") {
             return _jsonError(405, "METHOD_NOT_ALLOWED", "Only POST is allowed for /api/v1/auth/session");
@@ -428,4 +450,32 @@ std::string ApiRouter::_modelInfoDataJson(const SimulatorSessionService::ModelIn
            "\"version\":\"" + _escapeJson(info.version) + "\","
            "\"description\":\"" + _escapeJson(info.description) + "\","
            "\"componentCount\":" + std::to_string(info.componentCount) + "}";
+}
+
+std::string ApiRouter::_workerInfoDataJson(const SimulatorSessionService::WorkerInfoResult& info) {
+    return "{\"role\":\"" + _escapeJson(info.role) + "\","
+           "\"application\":\"" + _escapeJson(info.application) + "\","
+           "\"apiFamily\":\"" + _escapeJson(info.apiFamily) + "\","
+           "\"apiVersion\":\"" + _escapeJson(info.apiVersion) + "\","
+           "\"simulatorName\":\"" + _escapeJson(info.simulatorName) + "\","
+           "\"simulatorVersionName\":\"" + _escapeJson(info.simulatorVersionName) + "\","
+           "\"simulatorVersionNumber\":" + std::to_string(info.simulatorVersionNumber) + "}";
+}
+
+std::string ApiRouter::_workerCapabilitiesDataJson(const SimulatorSessionService::WorkerCapabilitiesResult& capabilities) {
+    return "{\"supportsSessionApi\":" + std::string(capabilities.supportsSessionApi ? "true" : "false") + ","
+           "\"supportsSessionScopedSimulator\":" + std::string(capabilities.supportsSessionScopedSimulator ? "true" : "false") +
+           ","
+           "\"supportsModelCreation\":" + std::string(capabilities.supportsModelCreation ? "true" : "false") + ","
+           "\"supportsModelPersistence\":" + std::string(capabilities.supportsModelPersistence ? "true" : "false") + ","
+           "\"supportsSimulationStatus\":" + std::string(capabilities.supportsSimulationStatus ? "true" : "false") + ","
+           "\"supportsSimulationConfig\":" + std::string(capabilities.supportsSimulationConfig ? "true" : "false") + ","
+           "\"supportsSynchronousRun\":" + std::string(capabilities.supportsSynchronousRun ? "true" : "false") + ","
+           "\"supportsSynchronousStep\":" + std::string(capabilities.supportsSynchronousStep ? "true" : "false") + ","
+           "\"supportsDistributedJobs\":" + std::string(capabilities.supportsDistributedJobs ? "true" : "false") + ","
+           "\"supportsJobPolling\":" + std::string(capabilities.supportsJobPolling ? "true" : "false") + ","
+           "\"supportsBackgroundExecution\":" + std::string(capabilities.supportsBackgroundExecution ? "true" : "false") +
+           ","
+           "\"supportsModelUpload\":" + std::string(capabilities.supportsModelUpload ? "true" : "false") + ","
+           "\"supportsStreamingEvents\":" + std::string(capabilities.supportsStreamingEvents ? "true" : "false") + "}";
 }

--- a/source/applications/web/api/ApiRouter.h
+++ b/source/applications/web/api/ApiRouter.h
@@ -6,24 +6,112 @@
 
 #include <optional>
 
+/**
+ * @brief Routes HTTP requests to Web API operations.
+ */
 class ApiRouter {
 public:
+    /**
+     * @brief Creates an API router bound to the simulator session service.
+     * @param simulatorService Service used to execute API operations.
+     */
     explicit ApiRouter(SimulatorSessionService& simulatorService);
 
+    /**
+     * @brief Handles one HTTP request and returns the corresponding response.
+     * @param request HTTP request containing method, path, headers, and body.
+     * @return HTTP response with status, content type, and JSON payload.
+     */
     HttpResponse handle(const HttpRequest& request) const;
 
 private:
     SimulatorSessionService& _simulatorService;
 
+    /**
+     * @brief Produces a standardized JSON error response.
+     * @param status HTTP status code.
+     * @param code Stable API error code.
+     * @param message Human-readable error message.
+     * @return JSON HTTP error response.
+     */
     static HttpResponse _jsonError(int status, const char* code, const char* message);
+    /**
+     * @brief Extracts the Bearer token from the Authorization header.
+     * @param request HTTP request containing headers.
+     * @return Token string or empty string when missing/invalid.
+     */
     static std::string _extractBearerToken(const HttpRequest& request);
+    /**
+     * @brief Parses a filename field from a JSON request body.
+     * @param body Raw request body.
+     * @param outFilename Receives parsed filename.
+     * @return True when a non-empty filename is parsed.
+     */
     static bool _tryExtractFilenameFromBody(const std::string& body, std::string& outFilename);
+    /**
+     * @brief Parses an unsigned integer field from a JSON request body.
+     * @param body Raw request body.
+     * @param fieldName Target JSON field name.
+     * @param outValue Receives parsed numeric value.
+     * @return True when parsing succeeds.
+     */
     static bool _tryExtractUnsignedIntField(const std::string& body, const std::string& fieldName, unsigned int& outValue);
+    /**
+     * @brief Parses a floating-point field from a JSON request body.
+     * @param body Raw request body.
+     * @param fieldName Target JSON field name.
+     * @param outValue Receives parsed numeric value.
+     * @return True when parsing succeeds.
+     */
     static bool _tryExtractDoubleField(const std::string& body, const std::string& fieldName, double& outValue);
+    /**
+     * @brief Parses a boolean field from a JSON request body.
+     * @param body Raw request body.
+     * @param fieldName Target JSON field name.
+     * @param outValue Receives parsed boolean value.
+     * @return True when parsing succeeds.
+     */
     static bool _tryExtractBooleanField(const std::string& body, const std::string& fieldName, bool& outValue);
+    /**
+     * @brief Parses the simulation configuration request payload.
+     * @param body Raw request body.
+     * @return Parsed configuration or empty optional when invalid.
+     */
     static std::optional<SimulatorSessionService::SimulationConfigInput> _parseSimulationConfigBody(const std::string& body);
+    /**
+     * @brief Serializes simulation status data into a JSON object string.
+     * @param status Simulation status result to serialize.
+     * @return JSON object string.
+     */
     static std::string _simulationStatusDataJson(const SimulatorSessionService::SimulationStatusResult& status);
+    /**
+     * @brief Maps model persistence errors to transport-level HTTP responses.
+     * @param result Persistence operation result.
+     * @return HTTP response containing mapped status and error body.
+     */
     static HttpResponse _mapPersistenceError(const SimulatorSessionService::ModelPersistenceResult& result);
+    /**
+     * @brief Escapes backslash and quote characters for JSON strings.
+     * @param value Raw string value.
+     * @return JSON-escaped string.
+     */
     static std::string _escapeJson(const std::string& value);
+    /**
+     * @brief Serializes model information into a JSON object string.
+     * @param info Model information result.
+     * @return JSON object string.
+     */
     static std::string _modelInfoDataJson(const SimulatorSessionService::ModelInfoResult& info);
+    /**
+     * @brief Serializes worker identity information into a JSON object string.
+     * @param info Worker information result.
+     * @return JSON object string.
+     */
+    static std::string _workerInfoDataJson(const SimulatorSessionService::WorkerInfoResult& info);
+    /**
+     * @brief Serializes worker capability flags into a JSON object string.
+     * @param capabilities Worker capabilities result.
+     * @return JSON object string.
+     */
+    static std::string _workerCapabilitiesDataJson(const SimulatorSessionService::WorkerCapabilitiesResult& capabilities);
 };

--- a/source/applications/web/service/SimulatorSessionService.cpp
+++ b/source/applications/web/service/SimulatorSessionService.cpp
@@ -65,6 +65,40 @@ bool SimulatorSessionService::tryGetSimulatorInfo(const std::string& accessToken
     return true;
 }
 
+SimulatorSessionService::WorkerInfoResult SimulatorSessionService::getWorkerInfo() const {
+    // A temporary simulator instance provides stable identity metadata for public worker discovery.
+    Simulator simulator;
+
+    WorkerInfoResult result{};
+    result.role = "worker";
+    result.application = "genesys_webhook";
+    result.apiFamily = "genesys-web-worker";
+    result.apiVersion = "v1";
+    result.simulatorName = simulator.getName();
+    result.simulatorVersionName = simulator.getVersion();
+    result.simulatorVersionNumber = simulator.getVersionNumber();
+    return result;
+}
+
+SimulatorSessionService::WorkerCapabilitiesResult SimulatorSessionService::getWorkerCapabilities() const {
+    WorkerCapabilitiesResult result{};
+    result.supportsSessionApi = true;
+    result.supportsSessionScopedSimulator = true;
+    result.supportsModelCreation = true;
+    result.supportsModelPersistence = true;
+    result.supportsSimulationStatus = true;
+    result.supportsSimulationConfig = true;
+    result.supportsSynchronousRun = true;
+    result.supportsSynchronousStep = true;
+    // Distributed job orchestration features are intentionally not available in stage 1.
+    result.supportsDistributedJobs = false;
+    result.supportsJobPolling = false;
+    result.supportsBackgroundExecution = false;
+    result.supportsModelUpload = false;
+    result.supportsStreamingEvents = false;
+    return result;
+}
+
 bool SimulatorSessionService::tryCreateModel(const std::string& accessToken, ModelInfoResult& outInfo) {
     SessionContext* session = _sessionManager.getSessionByToken(accessToken);
     if (session == nullptr || session->simulator == nullptr) {

--- a/source/applications/web/service/SimulatorSessionService.h
+++ b/source/applications/web/service/SimulatorSessionService.h
@@ -4,8 +4,14 @@
 
 #include <string>
 
+/**
+ * @brief Encapsulates session-scoped simulator operations exposed by the Web API.
+ */
 class SimulatorSessionService {
 public:
+    /**
+     * @brief Enumerates persistence-specific errors for save/load model operations.
+     */
     enum class PersistenceError {
         None,
         InvalidToken,
@@ -15,17 +21,58 @@ public:
         OperationFailed
     };
 
+    /**
+     * @brief Contains session creation identifiers returned to API clients.
+     */
     struct CreateSessionResult {
         std::string sessionId;
         std::string accessToken;
     };
 
+    /**
+     * @brief Describes simulator identity metadata for a token-scoped session.
+     */
     struct SimulatorInfoResult {
         std::string name;
         std::string versionName;
         unsigned int versionNumber;
     };
 
+    /**
+     * @brief Describes worker identity metadata for distributed discovery.
+     */
+    struct WorkerInfoResult {
+        std::string role;
+        std::string application;
+        std::string apiFamily;
+        std::string apiVersion;
+        std::string simulatorName;
+        std::string simulatorVersionName;
+        unsigned int simulatorVersionNumber = 0;
+    };
+
+    /**
+     * @brief Describes currently supported worker features.
+     */
+    struct WorkerCapabilitiesResult {
+        bool supportsSessionApi = false;
+        bool supportsSessionScopedSimulator = false;
+        bool supportsModelCreation = false;
+        bool supportsModelPersistence = false;
+        bool supportsSimulationStatus = false;
+        bool supportsSimulationConfig = false;
+        bool supportsSynchronousRun = false;
+        bool supportsSynchronousStep = false;
+        bool supportsDistributedJobs = false;
+        bool supportsJobPolling = false;
+        bool supportsBackgroundExecution = false;
+        bool supportsModelUpload = false;
+        bool supportsStreamingEvents = false;
+    };
+
+    /**
+     * @brief Describes the currently active model information for a session.
+     */
     struct ModelInfoResult {
         bool exists = false;
         unsigned int modelId = 0;
@@ -39,6 +86,9 @@ public:
         unsigned int componentCount = 0;
     };
 
+    /**
+     * @brief Contains save/load model operation output and error state.
+     */
     struct ModelPersistenceResult {
         bool success = false;
         PersistenceError error = PersistenceError::None;
@@ -46,6 +96,9 @@ public:
         ModelInfoResult modelInfo;
     };
 
+    /**
+     * @brief Captures the current simulation execution state.
+     */
     struct SimulationStatusResult {
         bool success = false;
         bool invalidToken = false;
@@ -63,6 +116,9 @@ public:
         bool initializeSystem = false;
     };
 
+    /**
+     * @brief Defines user-provided simulation parameters to apply to the current model.
+     */
     struct SimulationConfigInput {
         unsigned int numberOfReplications = 0;
         double replicationLength = 0.0;
@@ -73,6 +129,9 @@ public:
         bool initializeSystem = false;
     };
 
+    /**
+     * @brief Contains the result of applying simulation configuration.
+     */
     struct SimulationConfigResult {
         bool success = false;
         bool invalidToken = false;
@@ -80,6 +139,9 @@ public:
         SimulationStatusResult status;
     };
 
+    /**
+     * @brief Contains the result of a simulation action such as run or step.
+     */
     struct SimulationActionResult {
         bool success = false;
         bool invalidToken = false;
@@ -87,20 +149,94 @@ public:
         SimulationStatusResult status;
     };
 
+    /**
+     * @brief Builds a service bound to the provided session manager.
+     * @param sessionManager Session manager used to resolve active sessions.
+     */
     explicit SimulatorSessionService(SessionManager& sessionManager);
 
+    /**
+     * @brief Creates a new authenticated session.
+     * @return Session identifiers and token for API usage.
+     */
     CreateSessionResult createSession();
+    /**
+     * @brief Fetches simulator metadata using a session token.
+     * @param accessToken Bearer token associated with a session.
+     * @param outInfo Receives simulator identity information on success.
+     * @return True when token is valid and metadata was populated.
+     */
     bool tryGetSimulatorInfo(const std::string& accessToken, SimulatorInfoResult& outInfo);
+    /**
+     * @brief Fetches public worker identity metadata.
+     * @return Worker identity information for discovery endpoints.
+     */
+    WorkerInfoResult getWorkerInfo() const;
+    /**
+     * @brief Fetches worker capability flags for the current implementation state.
+     * @return Worker capability flags.
+     */
+    WorkerCapabilitiesResult getWorkerCapabilities() const;
+    /**
+     * @brief Creates a new model in the token-scoped simulator session.
+     * @param accessToken Bearer token associated with a session.
+     * @param outInfo Receives model information on success.
+     * @return True when the model was created and output was populated.
+     */
     bool tryCreateModel(const std::string& accessToken, ModelInfoResult& outInfo);
+    /**
+     * @brief Returns metadata for the current model in a session.
+     * @param accessToken Bearer token associated with a session.
+     * @param outInfo Receives current model data.
+     * @return True when token is valid and query completed.
+     */
     bool tryGetCurrentModelInfo(const std::string& accessToken, ModelInfoResult& outInfo);
+    /**
+     * @brief Returns simulation status for the session's current model.
+     * @param accessToken Bearer token associated with a session.
+     * @return Structured simulation status query result.
+     */
     SimulationStatusResult getSimulationStatus(const std::string& accessToken);
+    /**
+     * @brief Applies simulation configuration to the current model.
+     * @param accessToken Bearer token associated with a session.
+     * @param input Configuration values to apply.
+     * @return Structured configuration result and resulting status.
+     */
     SimulationConfigResult configureSimulation(const std::string& accessToken, const SimulationConfigInput& input);
+    /**
+     * @brief Executes a synchronous simulation run.
+     * @param accessToken Bearer token associated with a session.
+     * @return Structured action result and updated simulation status.
+     */
     SimulationActionResult runSimulation(const std::string& accessToken);
+    /**
+     * @brief Executes one synchronous simulation step.
+     * @param accessToken Bearer token associated with a session.
+     * @return Structured action result and updated simulation status.
+     */
     SimulationActionResult stepSimulation(const std::string& accessToken);
+    /**
+     * @brief Saves the current model into the session workspace.
+     * @param accessToken Bearer token associated with a session.
+     * @param filename Safe basename to use for persistence.
+     * @return Persistence output and error state.
+     */
     ModelPersistenceResult saveCurrentModel(const std::string& accessToken, const std::string& filename);
+    /**
+     * @brief Loads a model from the session workspace by filename.
+     * @param accessToken Bearer token associated with a session.
+     * @param filename Safe basename to load.
+     * @return Persistence output and error state.
+     */
     ModelPersistenceResult loadModel(const std::string& accessToken, const std::string& filename);
 
 private:
+    /**
+     * @brief Validates if a filename is safe for session workspace access.
+     * @param filename Candidate filename from API input.
+     * @return True when filename is a safe basename.
+     */
     static bool _isSafeFilename(const std::string& filename);
 
     SessionManager& _sessionManager;

--- a/source/tests/unit/test_web_api_router.cpp
+++ b/source/tests/unit/test_web_api_router.cpp
@@ -73,6 +73,96 @@ TEST(WebApiRouterTest, HealthEndpointReturnsUp) {
     EXPECT_NE(response.body.find("\"status\":\"up\""), std::string::npos);
 }
 
+TEST(WebApiRouterTest, WorkerInfoPublicEndpointReturnsOk) {
+    ApiRouterFixture fixture;
+
+    HttpRequest request;
+    request.method = "GET";
+    request.path = "/api/v1/worker/info";
+
+    const HttpResponse response = fixture.router.handle(request);
+
+    EXPECT_EQ(response.status, 200);
+    EXPECT_NE(response.body.find("\"ok\":true"), std::string::npos);
+}
+
+TEST(WebApiRouterTest, WorkerInfoContainsRoleAndSimulatorVersionFields) {
+    ApiRouterFixture fixture;
+
+    HttpRequest request;
+    request.method = "GET";
+    request.path = "/api/v1/worker/info";
+
+    const HttpResponse response = fixture.router.handle(request);
+
+    EXPECT_EQ(response.status, 200);
+    EXPECT_NE(response.body.find("\"role\":\"worker\""), std::string::npos);
+    EXPECT_NE(response.body.find("\"simulatorVersionName\":"), std::string::npos);
+    EXPECT_NE(response.body.find("\"simulatorVersionNumber\":"), std::string::npos);
+}
+
+TEST(WebApiRouterTest, WorkerInfoPostReturnsMethodNotAllowed) {
+    ApiRouterFixture fixture;
+
+    HttpRequest request;
+    request.method = "POST";
+    request.path = "/api/v1/worker/info";
+
+    const HttpResponse response = fixture.router.handle(request);
+
+    EXPECT_EQ(response.status, 405);
+}
+
+TEST(WebApiRouterTest, WorkerCapabilitiesPublicEndpointReturnsOk) {
+    ApiRouterFixture fixture;
+
+    HttpRequest request;
+    request.method = "GET";
+    request.path = "/api/v1/worker/capabilities";
+
+    const HttpResponse response = fixture.router.handle(request);
+
+    EXPECT_EQ(response.status, 200);
+    EXPECT_NE(response.body.find("\"ok\":true"), std::string::npos);
+}
+
+TEST(WebApiRouterTest, WorkerCapabilitiesReflectCurrentImplementation) {
+    ApiRouterFixture fixture;
+
+    HttpRequest request;
+    request.method = "GET";
+    request.path = "/api/v1/worker/capabilities";
+
+    const HttpResponse response = fixture.router.handle(request);
+
+    EXPECT_EQ(response.status, 200);
+    EXPECT_NE(response.body.find("\"supportsSessionApi\":true"), std::string::npos);
+    EXPECT_NE(response.body.find("\"supportsSessionScopedSimulator\":true"), std::string::npos);
+    EXPECT_NE(response.body.find("\"supportsModelCreation\":true"), std::string::npos);
+    EXPECT_NE(response.body.find("\"supportsModelPersistence\":true"), std::string::npos);
+    EXPECT_NE(response.body.find("\"supportsSimulationStatus\":true"), std::string::npos);
+    EXPECT_NE(response.body.find("\"supportsSimulationConfig\":true"), std::string::npos);
+    EXPECT_NE(response.body.find("\"supportsSynchronousRun\":true"), std::string::npos);
+    EXPECT_NE(response.body.find("\"supportsSynchronousStep\":true"), std::string::npos);
+    EXPECT_NE(response.body.find("\"supportsDistributedJobs\":false"), std::string::npos);
+    EXPECT_NE(response.body.find("\"supportsJobPolling\":false"), std::string::npos);
+    EXPECT_NE(response.body.find("\"supportsBackgroundExecution\":false"), std::string::npos);
+    EXPECT_NE(response.body.find("\"supportsModelUpload\":false"), std::string::npos);
+    EXPECT_NE(response.body.find("\"supportsStreamingEvents\":false"), std::string::npos);
+}
+
+TEST(WebApiRouterTest, WorkerCapabilitiesPostReturnsMethodNotAllowed) {
+    ApiRouterFixture fixture;
+
+    HttpRequest request;
+    request.method = "POST";
+    request.path = "/api/v1/worker/capabilities";
+
+    const HttpResponse response = fixture.router.handle(request);
+
+    EXPECT_EQ(response.status, 405);
+}
+
 TEST(WebApiRouterTest, AuthSessionThenSimulatorInfoWithBearerToken) {
     ApiRouterFixture fixture;
 


### PR DESCRIPTION
WEB

### Motivation
- Expose the Web application as a discoverable worker node for a future distributed orchestrator by providing a minimal public discovery surface.  
- Keep session/token APIs unchanged and encapsulate discovery logic inside the service layer to keep the router transport-focused.  
- Provide accurate, factual capability flags that reflect the current implementation (not aspirational features).  

### Description
- Added two public routes to the API router: `GET /api/v1/worker/info` and `GET /api/v1/worker/capabilities`, both return `200` on `GET` and `405 Method Not Allowed` for other methods, and require no Bearer token.  
- Extended `SimulatorSessionService` with `WorkerInfoResult` and `WorkerCapabilitiesResult` structs plus `getWorkerInfo()` and `getWorkerCapabilities()` methods; `getWorkerInfo()` uses a temporary `Simulator` instance for stable simulator metadata.  
- Added JSON serialization helpers in `ApiRouter` to keep transport logic separate from service logic.  
- Added Doxygen documentation for all touched classes and every touched method (including pre-existing methods that were touched) and small clarifying comments where useful.  
- Added focused unit tests in `source/tests/unit/test_web_api_router.cpp` covering success and `405` cases for both new endpoints, and updated the web README with a Stage 1 worker-cycle section documenting the new discovery endpoints.  

### Testing
- Added unit tests for the six requested scenarios for `worker/info` and `worker/capabilities` in `source/tests/unit/test_web_api_router.cpp`.  
- `cmake -S . -B build/web-debug -G Ninja -DGENESYS_BUILD_WEB_APPLICATION=ON` completed successfully.  
- `cmake --build build/web-debug --target genesys_webhook genesys_test_web_api_router` failed to finish due to a pre-existing linker error unrelated to these changes (`undefined reference` to `SinkModelComponent` from `Dispose.cpp`), preventing creation of the test binary.  

## Worker Stage 1 execution report

### What I completed
- Added public `GET /api/v1/worker/info` and `GET /api/v1/worker/capabilities` routes with correct 200/405 behavior and no authentication requirement.  
- Encapsulated worker discovery payloads inside `SimulatorSessionService` via `WorkerInfoResult`/`WorkerCapabilitiesResult` and query methods.  
- Implemented JSON serialization helpers in `ApiRouter` and kept router transport-focused.  
- Added Doxygen comments for touched classes and methods in `ApiRouter` and `SimulatorSessionService`.  
- Added focused unit tests for the requested endpoint behaviors.  
- Updated `source/applications/web/README.md` with a Stage 1 worker-cycle section documenting the two discovery endpoints.  

### What I could not complete
- Running the newly added unit tests to completion because the test executable was not linked.  

### Why anything remains incomplete
- The build fails at link time due to a pre-existing unresolved symbol (`SinkModelComponent` referenced by `Dispose.cpp`), which prevented generation of the test binary in this environment.  

### Validation performed
- CMake configuration succeeded for the Web application build.  
- Attempted build for `genesys_webhook` and the test target was started but failed at link time for unrelated pre-existing symbol errors.  
- Attempted `ctest` but could not run the router tests because the test executable was not produced.  

### Risks remaining
- The new unit tests and runtime behavior for the worker endpoints remain unverified by automated execution until the existing linker issue is resolved.  

### Files changed
- `source/applications/web/api/ApiRouter.h`  
- `source/applications/web/api/ApiRouter.cpp`  
- `source/applications/web/service/SimulatorSessionService.h`  
- `source/applications/web/service/SimulatorSessionService.cpp`  
- `source/tests/unit/test_web_api_router.cpp`  
- `source/applications/web/README.md`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dce0ba07b0832180e39aeea6ee15e7)