### PR TITLE
Add worker stage-2 authenticated language model import endpoint

### DIFF
--- a/source/applications/web/README.md
+++ b/source/applications/web/README.md
@@ -28,6 +28,14 @@ This stage adds two public worker discovery endpoints (no Bearer token required)
 
 These routes expose worker identity metadata and current implementation capability flags. They are intentionally limited to discovery only and do not include job submission, polling, or background execution in this stage.
 
+## Worker cycle Stage 2
+This stage starts worker model-ingress support with one authenticated and session-scoped endpoint:
+- `POST /api/v1/worker/models/import-language` (requires `Authorization: Bearer <token>`)
+
+The request body must be plain text GenESyS model language/specification. The worker imports this text into the session simulator as the current model.
+
+This stage still does **not** include multipart/binary upload, distributed job submission, polling, or background orchestration.
+
 ## How to run
 ```bash
 cmake -S . -B build/web-debug -G Ninja -DGENESYS_BUILD_WEB_APPLICATION=ON

--- a/source/applications/web/api/ApiRouter.cpp
+++ b/source/applications/web/api/ApiRouter.cpp
@@ -41,6 +41,24 @@ HttpResponse ApiRouter::handle(const HttpRequest& request) const {
         };
     }
 
+    if (request.path == "/api/v1/worker/models/import-language") {
+        if (request.method != "POST") {
+            return _jsonError(405, "METHOD_NOT_ALLOWED", "Only POST is allowed for /api/v1/worker/models/import-language");
+        }
+
+        const std::string token = _extractBearerToken(request);
+        if (token.empty()) {
+            return _jsonError(401, "UNAUTHORIZED", "Missing or invalid Bearer token");
+        }
+
+        const auto result = _simulatorService.importModelFromLanguage(token, request.body);
+        if (!result.success) {
+            return _mapModelImportError(result);
+        }
+
+        return HttpResponse{200, "application/json", "{\"ok\":true,\"data\":" + _modelInfoDataJson(result.modelInfo) + "}"};
+    }
+
     if (request.path == "/api/v1/auth/session") {
         if (request.method != "POST") {
             return _jsonError(405, "METHOD_NOT_ALLOWED", "Only POST is allowed for /api/v1/auth/session");
@@ -417,6 +435,22 @@ HttpResponse ApiRouter::_mapPersistenceError(const SimulatorSessionService::Mode
         case SimulatorSessionService::PersistenceError::None:
         default:
             return _jsonError(500, "INTERNAL_ERROR", "Unexpected persistence error state");
+    }
+}
+
+HttpResponse ApiRouter::_mapModelImportError(const SimulatorSessionService::ModelImportResult& result) {
+    switch (result.error) {
+        case SimulatorSessionService::ModelImportError::InvalidToken:
+            return _jsonError(401, "UNAUTHORIZED", "Invalid or expired session token");
+        case SimulatorSessionService::ModelImportError::EmptySpecification:
+            return _jsonError(400, "EMPTY_MODEL_SPECIFICATION", "Model specification body cannot be empty");
+        case SimulatorSessionService::ModelImportError::InvalidSpecification:
+            return _jsonError(400, "INVALID_MODEL_SPECIFICATION", "Model specification could not be parsed");
+        case SimulatorSessionService::ModelImportError::OperationFailed:
+            return _jsonError(500, "MODEL_IMPORT_FAILED", "Unable to import model specification");
+        case SimulatorSessionService::ModelImportError::None:
+        default:
+            return _jsonError(500, "INTERNAL_ERROR", "Unexpected model import error state");
     }
 }
 

--- a/source/applications/web/api/ApiRouter.h
+++ b/source/applications/web/api/ApiRouter.h
@@ -91,6 +91,12 @@ private:
      */
     static HttpResponse _mapPersistenceError(const SimulatorSessionService::ModelPersistenceResult& result);
     /**
+     * @brief Maps model import errors to transport-level HTTP responses.
+     * @param result Import operation result.
+     * @return HTTP response containing mapped status and error body.
+     */
+    static HttpResponse _mapModelImportError(const SimulatorSessionService::ModelImportResult& result);
+    /**
      * @brief Escapes backslash and quote characters for JSON strings.
      * @param value Raw string value.
      * @return JSON-escaped string.

--- a/source/applications/web/service/SimulatorSessionService.cpp
+++ b/source/applications/web/service/SimulatorSessionService.cpp
@@ -1,10 +1,18 @@
 #include "SimulatorSessionService.h"
 
+#include <algorithm>
+#include <cctype>
 #include <filesystem>
 #include <mutex>
 #include <regex>
 
 namespace {
+bool _isBlankSpecification(const std::string& specification) {
+    return std::all_of(specification.begin(), specification.end(), [](unsigned char character) {
+        return std::isspace(character) != 0;
+    });
+}
+
 void _populateModelInfoFromModel(Model* model, SimulatorSessionService::ModelInfoResult& outInfo) {
     outInfo.exists = true;
     outInfo.modelId = static_cast<unsigned int>(model->getId());
@@ -94,7 +102,8 @@ SimulatorSessionService::WorkerCapabilitiesResult SimulatorSessionService::getWo
     result.supportsDistributedJobs = false;
     result.supportsJobPolling = false;
     result.supportsBackgroundExecution = false;
-    result.supportsModelUpload = false;
+    // Stage 2 introduces a worker model-ingress endpoint based on plain text language import.
+    result.supportsModelUpload = true;
     result.supportsStreamingEvents = false;
     return result;
 }
@@ -346,6 +355,38 @@ SimulatorSessionService::ModelPersistenceResult SimulatorSessionService::loadMod
     result.success = true;
     result.error = PersistenceError::None;
     result.filename = filename;
+    _populateModelInfoFromModel(model, result.modelInfo);
+    return result;
+}
+
+SimulatorSessionService::ModelImportResult SimulatorSessionService::importModelFromLanguage(
+    const std::string& accessToken,
+    const std::string& modelSpecification
+) {
+    if (modelSpecification.empty() || _isBlankSpecification(modelSpecification)) {
+        return ModelImportResult{false, ModelImportError::EmptySpecification, ModelInfoResult{}};
+    }
+
+    SessionContext* session = _sessionManager.getSessionByToken(accessToken);
+    if (session == nullptr || session->simulator == nullptr) {
+        return ModelImportResult{false, ModelImportError::InvalidToken, ModelInfoResult{}};
+    }
+
+    std::scoped_lock lock(session->mutex);
+    ModelManager* modelManager = session->simulator->getModelManager();
+    if (modelManager == nullptr) {
+        return ModelImportResult{false, ModelImportError::OperationFailed, ModelInfoResult{}};
+    }
+
+    // Import uses the real kernel parser pathway that accepts the model language as plain text.
+    Model* model = modelManager->createFromLanguage(modelSpecification);
+    if (model == nullptr) {
+        return ModelImportResult{false, ModelImportError::InvalidSpecification, ModelInfoResult{}};
+    }
+
+    ModelImportResult result{};
+    result.success = true;
+    result.error = ModelImportError::None;
     _populateModelInfoFromModel(model, result.modelInfo);
     return result;
 }

--- a/source/applications/web/service/SimulatorSessionService.h
+++ b/source/applications/web/service/SimulatorSessionService.h
@@ -22,6 +22,17 @@ public:
     };
 
     /**
+     * @brief Enumerates model import errors for worker language-ingress operations.
+     */
+    enum class ModelImportError {
+        None,
+        InvalidToken,
+        EmptySpecification,
+        InvalidSpecification,
+        OperationFailed
+    };
+
+    /**
      * @brief Contains session creation identifiers returned to API clients.
      */
     struct CreateSessionResult {
@@ -93,6 +104,15 @@ public:
         bool success = false;
         PersistenceError error = PersistenceError::None;
         std::string filename;
+        ModelInfoResult modelInfo;
+    };
+
+    /**
+     * @brief Contains model import output and error state.
+     */
+    struct ModelImportResult {
+        bool success = false;
+        ModelImportError error = ModelImportError::None;
         ModelInfoResult modelInfo;
     };
 
@@ -230,6 +250,13 @@ public:
      * @return Persistence output and error state.
      */
     ModelPersistenceResult loadModel(const std::string& accessToken, const std::string& filename);
+    /**
+     * @brief Imports a model from plain text model language into the token-scoped session.
+     * @param accessToken Bearer token associated with a session.
+     * @param modelSpecification Plain text model language content.
+     * @return Import output and error state.
+     */
+    ModelImportResult importModelFromLanguage(const std::string& accessToken, const std::string& modelSpecification);
 
 private:
     /**

--- a/source/tests/unit/test_web_api_router.cpp
+++ b/source/tests/unit/test_web_api_router.cpp
@@ -44,6 +44,25 @@ std::string createSessionAndGetToken(ApiRouter& router) {
     EXPECT_FALSE(token.empty());
     return token;
 }
+
+std::string minimalValidModelSpecification() {
+    // Grounded in repository model syntax from models/Smart_Record.gen.
+    return
+        "# Genesys Simulation Model\n"
+        "# Simulator, Model and Simulation infos\n"
+        "0   Simulator  \"GenESyS - GENeric and Expansible SYstem Simulator\" versionNumber=230914 0   ModelInfo  \"Model 1\" "
+        "version=\"1.0\" projectTitle=\"\" description=\"\" analystName=\"\" 0   ModelSimulation \"\" traceLevel=9 "
+        "replicationLength=1000.000000 numberOfReplications=30 \n"
+        "# Model Data Definitions\n"
+        "68  Resource   \"Resource_1\" capacity=5 69  Queue      \"Queue_1\" \n"
+        "# Model Components\n"
+        "63  Create     \"Create_1\" entityType=\"entitytype\" nextId=64 64  Process    \"Process_1\" delayExpression=\"unif(2, 6)\" "
+        "queueable=\"Queue_1\" nextId=70 requestSeizable[0]=\"Resource_1\" 70  Record     \"Record_1\" "
+        "fileName=\"recordNumberInQueue.txt\" nextId=71 expressionName=\"Number in queue\" expression=\"nq(Queue_1)\" "
+        "71  Record     \"Record_2\" fileName=\"recordNumberBusy.txt\" nextId=72 expressionName=\"resource_1 number busy\" "
+        "expression=\"NR(Resource_1)\" 72  Record     \"Record_3\" fileName=\"recordBeta.txt\" nextId=73 "
+        "expressionName=\"Just a Beta distribution\" expression=\"beta(2,8,0,100)\" 73  Dispose    \"Dispose_1\" nexts=0  ";
+}
 }  // namespace
 
 TEST(WebSessionManagerTest, CreateSessionProducesUniqueTokens) {
@@ -147,7 +166,7 @@ TEST(WebApiRouterTest, WorkerCapabilitiesReflectCurrentImplementation) {
     EXPECT_NE(response.body.find("\"supportsDistributedJobs\":false"), std::string::npos);
     EXPECT_NE(response.body.find("\"supportsJobPolling\":false"), std::string::npos);
     EXPECT_NE(response.body.find("\"supportsBackgroundExecution\":false"), std::string::npos);
-    EXPECT_NE(response.body.find("\"supportsModelUpload\":false"), std::string::npos);
+    EXPECT_NE(response.body.find("\"supportsModelUpload\":true"), std::string::npos);
     EXPECT_NE(response.body.find("\"supportsStreamingEvents\":false"), std::string::npos);
 }
 
@@ -161,6 +180,68 @@ TEST(WebApiRouterTest, WorkerCapabilitiesPostReturnsMethodNotAllowed) {
     const HttpResponse response = fixture.router.handle(request);
 
     EXPECT_EQ(response.status, 405);
+}
+
+TEST(WebApiRouterTest, WorkerImportLanguageWithoutTokenReturnsUnauthorized) {
+    ApiRouterFixture fixture;
+
+    HttpRequest request;
+    request.method = "POST";
+    request.path = "/api/v1/worker/models/import-language";
+    request.body = minimalValidModelSpecification();
+
+    const HttpResponse response = fixture.router.handle(request);
+
+    EXPECT_EQ(response.status, 401);
+    EXPECT_NE(response.body.find("\"ok\":false"), std::string::npos);
+}
+
+TEST(WebApiRouterTest, WorkerImportLanguageWithEmptyBodyReturnsBadRequest) {
+    ApiRouterFixture fixture;
+    const std::string token = createSessionAndGetToken(fixture.router);
+
+    HttpRequest request;
+    request.method = "POST";
+    request.path = "/api/v1/worker/models/import-language";
+    request.headers["authorization"] = "Bearer " + token;
+    request.body = "";
+
+    const HttpResponse response = fixture.router.handle(request);
+
+    EXPECT_EQ(response.status, 400);
+    EXPECT_NE(response.body.find("\"EMPTY_MODEL_SPECIFICATION\""), std::string::npos);
+}
+
+TEST(WebApiRouterTest, WorkerImportLanguageGetMethodReturnsMethodNotAllowed) {
+    ApiRouterFixture fixture;
+
+    HttpRequest request;
+    request.method = "GET";
+    request.path = "/api/v1/worker/models/import-language";
+
+    const HttpResponse response = fixture.router.handle(request);
+
+    EXPECT_EQ(response.status, 405);
+}
+
+TEST(WebApiRouterTest, WorkerImportLanguageHappyPathReturnsModelMetadata) {
+    ApiRouterFixture fixture;
+    const std::string token = createSessionAndGetToken(fixture.router);
+
+    HttpRequest request;
+    request.method = "POST";
+    request.path = "/api/v1/worker/models/import-language";
+    request.headers["authorization"] = "Bearer " + token;
+    request.body = minimalValidModelSpecification();
+
+    const HttpResponse response = fixture.router.handle(request);
+
+    EXPECT_EQ(response.status, 200);
+    EXPECT_NE(response.body.find("\"ok\":true"), std::string::npos);
+    EXPECT_NE(response.body.find("\"exists\":true"), std::string::npos);
+    EXPECT_NE(response.body.find("\"modelId\":"), std::string::npos);
+    EXPECT_NE(response.body.find("\"name\":"), std::string::npos);
+    EXPECT_NE(response.body.find("\"componentCount\":"), std::string::npos);
 }
 
 TEST(WebApiRouterTest, AuthSessionThenSimulatorInfoWithBearerToken) {


### PR DESCRIPTION
WEB

### Motivation
- Provide a minimal worker model-ingress endpoint so orchestrators can push plain-text GenESyS model language into a session-scoped simulator.
- Keep kernel interaction encapsulated in the service layer and reuse existing model metadata serialization for responses.
- Maintain session Bearer authentication and coherent HTTP error mappings for orchestrator integration.

### Description
- Add `POST /api/v1/worker/models/import-language` to `ApiRouter` with method guard, Bearer token extraction, and response using `_modelInfoDataJson` on success.
- Extend `SimulatorSessionService` with `ModelImportError`, `ModelImportResult`, and `importModelFromLanguage(const std::string& accessToken, const std::string& modelSpecification)` and implement it to call `ModelManager::createFromLanguage(...)` under session lock, validating token and non-empty body.
- Add router-side mapping `_mapModelImportError(...)` that translates import errors into `401`, `400`, or `500` as appropriate.
- Update worker capabilities to report `supportsModelUpload = true` for stage 2, add focused unit tests for negative and happy paths, and update `source/applications/web/README.md` with stage 2 documentation.
- Added Doxygen-style comments to all touched public types/methods and short explanatory comments in the implementation where useful.

### Testing
- Configured the build: `cmake -S . -B build/web-debug -G Ninja -DGENESYS_BUILD_WEB_APPLICATION=ON` succeeded.
- Attempted build: `cmake --build build/web-debug --target genesys_webhook genesys_test_web_api_router` failed at link time due to a pre-existing unresolved `SinkModelComponent` symbol in plugin linkage, so the test binary was not produced.
- Attempted test run: `ctest --test-dir build/web-debug -R web_api_router` could not run because the test executable was not built; unit tests were added but could not be executed due to the linker failure.

```markdown
## Worker Stage 2 execution report

### What I completed
- Implemented `POST /api/v1/worker/models/import-language` as a Bearer-authenticated, session-scoped worker endpoint.
- Added service-layer encapsulation for language import using `ModelManager::createFromLanguage(...)` via `SimulatorSessionService::importModelFromLanguage(...)`.
- Added structured import result/error types and router-level HTTP error mapping.
- Reused existing model metadata serialization payload shape.
- Added focused route tests (401/400/405/happy-path) and updated worker capabilities.
- Updated worker stage documentation in `source/applications/web/README.md`.
- Added Doxygen documentation for touched class members/methods.

### What I could not complete
- Full executable linking and automated test execution did not complete due to an existing linker problem.

### Why anything remains incomplete
- `cmake --build ...` fails at link time with unresolved `SinkModelComponent` symbols while linking `genesys_webhook` and `genesys_test_web_api_router`, preventing test binary creation and execution.

### Validation performed
- Configured CMake + Ninja for the web application build successfully.
- Attempted to build `genesys_webhook` and `genesys_test_web_api_router` but hit the linker failure prior to running tests.
- Confirmed unit tests for the new endpoint exist and would exercise missing-token/empty-body/method-not-allowed/happy-path cases.

### Risks remaining
- Runtime verification of the new happy-path import endpoint is pending until the link-time issue is resolved.
- If the kernel import function returns different error semantics, the HTTP error mapping may need refinement.

### Files changed
- `source/applications/web/api/ApiRouter.h`
- `source/applications/web/api/ApiRouter.cpp`
- `source/applications/web/service/SimulatorSessionService.h`
- `source/applications/web/service/SimulatorSessionService.cpp`
- `source/tests/unit/test_web_api_router.cpp`
- `source/applications/web/README.md`
```

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dce5cd0f788321ad1ae5d7078fdeaa)