### PR TITLE
Worker stage 3: add queued job abstraction and job metadata endpoints

### DIFF
--- a/source/applications/web/BaseGenesysWebApplication.cpp
+++ b/source/applications/web/BaseGenesysWebApplication.cpp
@@ -5,6 +5,7 @@
 #include "http/SimpleHttpServer.h"
 #include "service/SimulatorSessionService.h"
 #include "session/SessionManager.h"
+#include "worker/WorkerJobManager.h"
 
 #include <charconv>
 #include <iostream>
@@ -20,7 +21,8 @@ int BaseGenesysWebApplication::main(int argc, char** argv) {
     SessionManager sessionManager(tokenService, [] {
         return std::make_unique<Simulator>();
     });
-    SimulatorSessionService simulatorSessionService(sessionManager);
+    WorkerJobManager workerJobManager;
+    SimulatorSessionService simulatorSessionService(sessionManager, workerJobManager);
     ApiRouter router(simulatorSessionService);
     SimpleHttpServer server(port);
 

--- a/source/applications/web/CMakeLists.txt
+++ b/source/applications/web/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(genesys_web_core STATIC
     http/SimpleHttpServer.cpp
     service/SimulatorSessionService.cpp
     session/SessionManager.cpp
+    worker/WorkerJobManager.cpp
 )
 
 target_include_directories(genesys_web_core

--- a/source/applications/web/README.md
+++ b/source/applications/web/README.md
@@ -36,6 +36,19 @@ The request body must be plain text GenESyS model language/specification. The wo
 
 This stage still does **not** include multipart/binary upload, distributed job submission, polling, or background orchestration.
 
+## Worker cycle Stage 3
+This stage introduces a minimal worker job abstraction with authenticated, session-scoped endpoints:
+- `POST /api/v1/worker/jobs` (requires `Authorization: Bearer <token>`)
+- `GET /api/v1/worker/jobs/{jobId}` (requires `Authorization: Bearer <token>`)
+
+Behavior in this stage:
+- job creation requires a valid current model in the session;
+- each job is created in in-memory storage with state `queued`;
+- job creation persists a session-workspace snapshot file (for example `job_<id>.gen`) to decouple future execution from live model mutations;
+- job metadata can be queried by id from the same authenticated session.
+
+This stage still does **not** execute jobs, provide result retrieval, add polling loops, or introduce background worker threads.
+
 ## How to run
 ```bash
 cmake -S . -B build/web-debug -G Ninja -DGENESYS_BUILD_WEB_APPLICATION=ON

--- a/source/applications/web/api/ApiRouter.cpp
+++ b/source/applications/web/api/ApiRouter.cpp
@@ -4,6 +4,7 @@
 #include <cctype>
 #include <cstdlib>
 #include <regex>
+#include <string_view>
 
 ApiRouter::ApiRouter(SimulatorSessionService& simulatorService) : _simulatorService(simulatorService) {}
 
@@ -57,6 +58,45 @@ HttpResponse ApiRouter::handle(const HttpRequest& request) const {
         }
 
         return HttpResponse{200, "application/json", "{\"ok\":true,\"data\":" + _modelInfoDataJson(result.modelInfo) + "}"};
+    }
+
+
+    if (request.path == "/api/v1/worker/jobs") {
+        if (request.method != "POST") {
+            return _jsonError(405, "METHOD_NOT_ALLOWED", "Only POST is allowed for /api/v1/worker/jobs");
+        }
+
+        const std::string token = _extractBearerToken(request);
+        if (token.empty()) {
+            return _jsonError(401, "UNAUTHORIZED", "Missing or invalid Bearer token");
+        }
+
+        const auto result = _simulatorService.createWorkerJob(token);
+        if (!result.success) {
+            return _mapWorkerJobError(result.error, true);
+        }
+
+        return HttpResponse{201, "application/json", "{\"ok\":true,\"data\":" + _workerJobDataJson(result.jobInfo) + "}"};
+    }
+
+    // Stage 3 requires only minimal path parsing for job inspection by id.
+    std::string workerJobId;
+    if (_tryExtractWorkerJobIdFromPath(request.path, workerJobId)) {
+        if (request.method != "GET") {
+            return _jsonError(405, "METHOD_NOT_ALLOWED", "Only GET is allowed for /api/v1/worker/jobs/{jobId}");
+        }
+
+        const std::string token = _extractBearerToken(request);
+        if (token.empty()) {
+            return _jsonError(401, "UNAUTHORIZED", "Missing or invalid Bearer token");
+        }
+
+        const auto result = _simulatorService.getWorkerJob(token, workerJobId);
+        if (!result.success) {
+            return _mapWorkerJobError(result.error, false);
+        }
+
+        return HttpResponse{200, "application/json", "{\"ok\":true,\"data\":" + _workerJobDataJson(result.jobInfo) + "}"};
     }
 
     if (request.path == "/api/v1/auth/session") {
@@ -512,4 +552,67 @@ std::string ApiRouter::_workerCapabilitiesDataJson(const SimulatorSessionService
            ","
            "\"supportsModelUpload\":" + std::string(capabilities.supportsModelUpload ? "true" : "false") + ","
            "\"supportsStreamingEvents\":" + std::string(capabilities.supportsStreamingEvents ? "true" : "false") + "}";
+}
+
+
+bool ApiRouter::_tryExtractWorkerJobIdFromPath(const std::string& path, std::string& outJobId) {
+    constexpr std::string_view prefix = "/api/v1/worker/jobs/";
+    if (path.rfind(prefix, 0) != 0 || path.size() <= prefix.size()) {
+        return false;
+    }
+
+    outJobId = path.substr(prefix.size());
+    if (outJobId.empty() || outJobId.find('/') != std::string::npos) {
+        return false;
+    }
+    return true;
+}
+
+const char* ApiRouter::_workerJobStateToString(WorkerJobState state) {
+    switch (state) {
+        case WorkerJobState::Queued:
+            return "queued";
+        case WorkerJobState::Running:
+            return "running";
+        case WorkerJobState::Finished:
+            return "finished";
+        case WorkerJobState::Failed:
+            return "failed";
+        default:
+            return "queued";
+    }
+}
+
+std::string ApiRouter::_workerJobDataJson(const SimulatorSessionService::WorkerJobInfoResult& job) {
+    return "{\"jobId\":\"" + _escapeJson(job.jobId) + "\","
+           "\"state\":\"" + std::string(_workerJobStateToString(job.state)) + "\","
+           "\"sessionId\":\"" + _escapeJson(job.sessionId) + "\","
+           "\"snapshotFilename\":\"" + _escapeJson(job.snapshotFilename) + "\","
+           "\"createdMarker\":\"" + _escapeJson(job.createdMarker) + "\","
+           "\"message\":\"" + _escapeJson(job.message) + "\"}";
+}
+
+HttpResponse ApiRouter::_mapWorkerJobError(
+    SimulatorSessionService::WorkerJobError error,
+    bool includeMissingModelMessage
+) {
+    switch (error) {
+        case SimulatorSessionService::WorkerJobError::InvalidToken:
+            return _jsonError(401, "UNAUTHORIZED", "Invalid or expired session token");
+        case SimulatorSessionService::WorkerJobError::MissingCurrentModel:
+            return _jsonError(
+                409,
+                "NO_CURRENT_MODEL",
+                includeMissingModelMessage ? "No current model available to create worker job" : "No current model available"
+            );
+        case SimulatorSessionService::WorkerJobError::JobNotFound:
+            return _jsonError(404, "WORKER_JOB_NOT_FOUND", "Worker job was not found");
+        case SimulatorSessionService::WorkerJobError::AccessDenied:
+            return _jsonError(404, "WORKER_JOB_NOT_FOUND", "Worker job was not found");
+        case SimulatorSessionService::WorkerJobError::OperationFailed:
+            return _jsonError(500, "WORKER_JOB_FAILED", "Unable to process worker job request");
+        case SimulatorSessionService::WorkerJobError::None:
+        default:
+            return _jsonError(500, "INTERNAL_ERROR", "Unexpected worker job error state");
+    }
 }

--- a/source/applications/web/api/ApiRouter.h
+++ b/source/applications/web/api/ApiRouter.h
@@ -120,4 +120,30 @@ private:
      * @return JSON object string.
      */
     static std::string _workerCapabilitiesDataJson(const SimulatorSessionService::WorkerCapabilitiesResult& capabilities);
+    /**
+     * @brief Tries to parse a worker job identifier from `/api/v1/worker/jobs/{jobId}`.
+     * @param path HTTP request path.
+     * @param outJobId Receives parsed job identifier when the path matches.
+     * @return True when the path format is valid and a non-empty id was extracted.
+     */
+    static bool _tryExtractWorkerJobIdFromPath(const std::string& path, std::string& outJobId);
+    /**
+     * @brief Converts worker job states into API string values.
+     * @param state Worker job state value.
+     * @return Lowercase state string expected by clients.
+     */
+    static const char* _workerJobStateToString(WorkerJobState state);
+    /**
+     * @brief Serializes worker job metadata into a JSON object string.
+     * @param job Worker job information result.
+     * @return JSON object string.
+     */
+    static std::string _workerJobDataJson(const SimulatorSessionService::WorkerJobInfoResult& job);
+    /**
+     * @brief Maps worker job operation errors to transport-level HTTP responses.
+     * @param error Worker job error code.
+     * @param includeMissingModelMessage Controls no-model message wording for create/get routes.
+     * @return HTTP response containing mapped status and error body.
+     */
+    static HttpResponse _mapWorkerJobError(SimulatorSessionService::WorkerJobError error, bool includeMissingModelMessage);
 };

--- a/source/applications/web/service/SimulatorSessionService.cpp
+++ b/source/applications/web/service/SimulatorSessionService.cpp
@@ -4,6 +4,7 @@
 #include <cctype>
 #include <filesystem>
 #include <mutex>
+#include <optional>
 #include <regex>
 
 namespace {
@@ -53,7 +54,8 @@ void _populateSimulationStatusFromModel(Model* model, SimulatorSessionService::S
 }
 }  // namespace
 
-SimulatorSessionService::SimulatorSessionService(SessionManager& sessionManager) : _sessionManager(sessionManager) {}
+SimulatorSessionService::SimulatorSessionService(SessionManager& sessionManager, WorkerJobManager& workerJobManager)
+    : _sessionManager(sessionManager), _workerJobManager(workerJobManager) {}
 
 SimulatorSessionService::CreateSessionResult SimulatorSessionService::createSession() {
     SessionContext* session = _sessionManager.createSession();
@@ -98,8 +100,8 @@ SimulatorSessionService::WorkerCapabilitiesResult SimulatorSessionService::getWo
     result.supportsSimulationConfig = true;
     result.supportsSynchronousRun = true;
     result.supportsSynchronousStep = true;
-    // Distributed job orchestration features are intentionally not available in stage 1.
-    result.supportsDistributedJobs = false;
+    // Stage 3 introduces job abstraction creation/inspection, but not execution yet.
+    result.supportsDistributedJobs = true;
     result.supportsJobPolling = false;
     result.supportsBackgroundExecution = false;
     // Stage 2 introduces a worker model-ingress endpoint based on plain text language import.
@@ -391,6 +393,66 @@ SimulatorSessionService::ModelImportResult SimulatorSessionService::importModelF
     return result;
 }
 
+
+SimulatorSessionService::WorkerJobCreationResult SimulatorSessionService::createWorkerJob(const std::string& accessToken) {
+    SessionContext* session = _sessionManager.getSessionByToken(accessToken);
+    if (session == nullptr || session->simulator == nullptr) {
+        return WorkerJobCreationResult{false, WorkerJobError::InvalidToken, WorkerJobInfoResult{}};
+    }
+
+    std::scoped_lock lock(session->mutex);
+    ModelManager* modelManager = session->simulator->getModelManager();
+    if (modelManager == nullptr) {
+        return WorkerJobCreationResult{false, WorkerJobError::OperationFailed, WorkerJobInfoResult{}};
+    }
+
+    Model* model = modelManager->current();
+    if (model == nullptr) {
+        return WorkerJobCreationResult{false, WorkerJobError::MissingCurrentModel, WorkerJobInfoResult{}};
+    }
+
+    WorkerJob job = _workerJobManager.createQueuedJob(session->sessionId);
+    const std::string snapshotFilename = std::string("job_") + job.jobId + ".gen";
+
+    // Persisting a snapshot decouples future worker execution from live model mutations.
+    const std::filesystem::path snapshotPath = session->workspacePath / snapshotFilename;
+    if (!model->save(snapshotPath.string())) {
+        return WorkerJobCreationResult{false, WorkerJobError::OperationFailed, WorkerJobInfoResult{}};
+    }
+
+    if (!_workerJobManager.setSnapshotFilename(job.jobId, snapshotFilename)) {
+        return WorkerJobCreationResult{false, WorkerJobError::OperationFailed, WorkerJobInfoResult{}};
+    }
+
+    const std::optional<WorkerJob> storedJob = _workerJobManager.getJob(job.jobId);
+    if (!storedJob.has_value()) {
+        return WorkerJobCreationResult{false, WorkerJobError::OperationFailed, WorkerJobInfoResult{}};
+    }
+
+    return WorkerJobCreationResult{true, WorkerJobError::None, _toWorkerJobInfoResult(storedJob.value())};
+}
+
+SimulatorSessionService::WorkerJobQueryResult SimulatorSessionService::getWorkerJob(
+    const std::string& accessToken,
+    const std::string& jobId
+) {
+    SessionContext* session = _sessionManager.getSessionByToken(accessToken);
+    if (session == nullptr || session->simulator == nullptr) {
+        return WorkerJobQueryResult{false, WorkerJobError::InvalidToken, WorkerJobInfoResult{}};
+    }
+
+    const std::optional<WorkerJob> job = _workerJobManager.getJob(jobId);
+    if (!job.has_value()) {
+        return WorkerJobQueryResult{false, WorkerJobError::JobNotFound, WorkerJobInfoResult{}};
+    }
+
+    if (job->sessionId != session->sessionId) {
+        return WorkerJobQueryResult{false, WorkerJobError::AccessDenied, WorkerJobInfoResult{}};
+    }
+
+    return WorkerJobQueryResult{true, WorkerJobError::None, _toWorkerJobInfoResult(job.value())};
+}
+
 bool SimulatorSessionService::_isSafeFilename(const std::string& filename) {
     if (filename.empty()) {
         return false;
@@ -408,4 +470,15 @@ bool SimulatorSessionService::_isSafeFilename(const std::string& filename) {
 
     static const std::regex safeNamePattern("^[A-Za-z0-9._-]+$");
     return std::regex_match(filename, safeNamePattern);
+}
+
+SimulatorSessionService::WorkerJobInfoResult SimulatorSessionService::_toWorkerJobInfoResult(const WorkerJob& job) {
+    WorkerJobInfoResult result{};
+    result.jobId = job.jobId;
+    result.sessionId = job.sessionId;
+    result.state = job.state;
+    result.snapshotFilename = job.snapshotFilename;
+    result.createdMarker = job.createdMarker;
+    result.message = job.message;
+    return result;
 }

--- a/source/applications/web/service/SimulatorSessionService.h
+++ b/source/applications/web/service/SimulatorSessionService.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "../session/SessionManager.h"
+#include "../worker/WorkerJob.h"
+#include "../worker/WorkerJobManager.h"
 
 #include <string>
 
@@ -29,6 +31,18 @@ public:
         InvalidToken,
         EmptySpecification,
         InvalidSpecification,
+        OperationFailed
+    };
+
+    /**
+     * @brief Enumerates worker job operation errors.
+     */
+    enum class WorkerJobError {
+        None,
+        InvalidToken,
+        MissingCurrentModel,
+        JobNotFound,
+        AccessDenied,
         OperationFailed
     };
 
@@ -117,6 +131,36 @@ public:
     };
 
     /**
+     * @brief Describes worker job metadata exposed by worker stage 3 endpoints.
+     */
+    struct WorkerJobInfoResult {
+        std::string jobId;
+        std::string sessionId;
+        WorkerJobState state = WorkerJobState::Queued;
+        std::string snapshotFilename;
+        std::string createdMarker;
+        std::string message;
+    };
+
+    /**
+     * @brief Contains worker job creation output and error state.
+     */
+    struct WorkerJobCreationResult {
+        bool success = false;
+        WorkerJobError error = WorkerJobError::None;
+        WorkerJobInfoResult jobInfo;
+    };
+
+    /**
+     * @brief Contains worker job lookup output and error state.
+     */
+    struct WorkerJobQueryResult {
+        bool success = false;
+        WorkerJobError error = WorkerJobError::None;
+        WorkerJobInfoResult jobInfo;
+    };
+
+    /**
      * @brief Captures the current simulation execution state.
      */
     struct SimulationStatusResult {
@@ -172,8 +216,9 @@ public:
     /**
      * @brief Builds a service bound to the provided session manager.
      * @param sessionManager Session manager used to resolve active sessions.
+     * @param workerJobManager In-memory worker job storage manager.
      */
-    explicit SimulatorSessionService(SessionManager& sessionManager);
+    explicit SimulatorSessionService(SessionManager& sessionManager, WorkerJobManager& workerJobManager);
 
     /**
      * @brief Creates a new authenticated session.
@@ -257,6 +302,19 @@ public:
      * @return Import output and error state.
      */
     ModelImportResult importModelFromLanguage(const std::string& accessToken, const std::string& modelSpecification);
+    /**
+     * @brief Creates a queued worker job for the token-scoped session model snapshot.
+     * @param accessToken Bearer token associated with a session.
+     * @return Worker job creation output and error state.
+     */
+    WorkerJobCreationResult createWorkerJob(const std::string& accessToken);
+    /**
+     * @brief Returns worker job metadata for a token-scoped session.
+     * @param accessToken Bearer token associated with a session.
+     * @param jobId Worker job identifier to query.
+     * @return Worker job lookup output and error state.
+     */
+    WorkerJobQueryResult getWorkerJob(const std::string& accessToken, const std::string& jobId);
 
 private:
     /**
@@ -266,5 +324,13 @@ private:
      */
     static bool _isSafeFilename(const std::string& filename);
 
+    /**
+     * @brief Converts internal worker job storage record into API service output shape.
+     * @param job Internal job record.
+     * @return API-facing worker job metadata.
+     */
+    static WorkerJobInfoResult _toWorkerJobInfoResult(const WorkerJob& job);
+
     SessionManager& _sessionManager;
+    WorkerJobManager& _workerJobManager;
 };

--- a/source/applications/web/worker/WorkerJob.h
+++ b/source/applications/web/worker/WorkerJob.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <string>
+
+/**
+ * @brief Enumerates lifecycle states for a worker job.
+ */
+enum class WorkerJobState {
+    Queued,
+    Running,
+    Finished,
+    Failed
+};
+
+/**
+ * @brief Stores metadata for a worker job snapshot owned by the web worker.
+ */
+struct WorkerJob {
+    std::string jobId;
+    std::string sessionId;
+    WorkerJobState state = WorkerJobState::Queued;
+    std::string snapshotFilename;
+    std::string createdMarker;
+    std::string message;
+};

--- a/source/applications/web/worker/WorkerJobManager.cpp
+++ b/source/applications/web/worker/WorkerJobManager.cpp
@@ -1,0 +1,42 @@
+#include "WorkerJobManager.h"
+
+WorkerJob WorkerJobManager::createQueuedJob(const std::string& sessionId) {
+    std::scoped_lock lock(_mutex);
+
+    const unsigned long long numericId = _nextJobNumber++;
+    WorkerJob job;
+    job.jobId = std::string("job-") + std::to_string(numericId);
+    job.sessionId = sessionId;
+    job.state = WorkerJobState::Queued;
+    job.createdMarker = _makeCreationMarker(numericId);
+
+    _jobs[job.jobId] = job;
+    return job;
+}
+
+bool WorkerJobManager::setSnapshotFilename(const std::string& jobId, const std::string& snapshotFilename) {
+    std::scoped_lock lock(_mutex);
+
+    const auto iterator = _jobs.find(jobId);
+    if (iterator == _jobs.end()) {
+        return false;
+    }
+
+    iterator->second.snapshotFilename = snapshotFilename;
+    return true;
+}
+
+std::optional<WorkerJob> WorkerJobManager::getJob(const std::string& jobId) const {
+    std::scoped_lock lock(_mutex);
+
+    const auto iterator = _jobs.find(jobId);
+    if (iterator == _jobs.end()) {
+        return std::nullopt;
+    }
+
+    return iterator->second;
+}
+
+std::string WorkerJobManager::_makeCreationMarker(unsigned long long numericId) {
+    return std::string("seq-") + std::to_string(numericId);
+}

--- a/source/applications/web/worker/WorkerJobManager.h
+++ b/source/applications/web/worker/WorkerJobManager.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "WorkerJob.h"
+
+#include <mutex>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+/**
+ * @brief Owns worker job records in memory and assigns unique identifiers.
+ */
+class WorkerJobManager {
+public:
+    /**
+     * @brief Creates and stores a queued worker job with generated identifiers.
+     * @param sessionId Identifier of the owning session.
+     * @return Newly stored worker job metadata.
+     */
+    WorkerJob createQueuedJob(const std::string& sessionId);
+
+    /**
+     * @brief Replaces the snapshot filename for an existing job.
+     * @param jobId Job identifier to update.
+     * @param snapshotFilename Snapshot filename persisted in session workspace.
+     * @return True when the job exists and was updated.
+     */
+    bool setSnapshotFilename(const std::string& jobId, const std::string& snapshotFilename);
+
+    /**
+     * @brief Fetches a previously stored job record.
+     * @param jobId Job identifier.
+     * @return Copy of the job when found.
+     */
+    std::optional<WorkerJob> getJob(const std::string& jobId) const;
+
+private:
+    /**
+     * @brief Returns a creation marker string tied to generation sequence.
+     * @param numericId Numeric sequence id assigned to a new job.
+     * @return Stable string marker for creation ordering.
+     */
+    static std::string _makeCreationMarker(unsigned long long numericId);
+
+    mutable std::mutex _mutex;
+    std::unordered_map<std::string, WorkerJob> _jobs;
+    unsigned long long _nextJobNumber = 1;
+};

--- a/source/tests/unit/test_web_api_router.cpp
+++ b/source/tests/unit/test_web_api_router.cpp
@@ -3,6 +3,7 @@
 #include "applications/web/api/ApiRouter.h"
 #include "applications/web/auth/TokenService.h"
 #include "applications/web/service/SimulatorSessionService.h"
+#include "applications/web/worker/WorkerJobManager.h"
 #include "applications/web/session/SessionManager.h"
 
 #include <array>
@@ -13,7 +14,8 @@ namespace {
 struct ApiRouterFixture {
     TokenService tokenService;
     SessionManager sessionManager{tokenService, [] { return std::make_unique<Simulator>(); }};
-    SimulatorSessionService simulatorService{sessionManager};
+    WorkerJobManager workerJobManager;
+    SimulatorSessionService simulatorService{sessionManager, workerJobManager};
     ApiRouter router{simulatorService};
 };
 
@@ -163,7 +165,7 @@ TEST(WebApiRouterTest, WorkerCapabilitiesReflectCurrentImplementation) {
     EXPECT_NE(response.body.find("\"supportsSimulationConfig\":true"), std::string::npos);
     EXPECT_NE(response.body.find("\"supportsSynchronousRun\":true"), std::string::npos);
     EXPECT_NE(response.body.find("\"supportsSynchronousStep\":true"), std::string::npos);
-    EXPECT_NE(response.body.find("\"supportsDistributedJobs\":false"), std::string::npos);
+    EXPECT_NE(response.body.find("\"supportsDistributedJobs\":true"), std::string::npos);
     EXPECT_NE(response.body.find("\"supportsJobPolling\":false"), std::string::npos);
     EXPECT_NE(response.body.find("\"supportsBackgroundExecution\":false"), std::string::npos);
     EXPECT_NE(response.body.find("\"supportsModelUpload\":true"), std::string::npos);
@@ -242,6 +244,121 @@ TEST(WebApiRouterTest, WorkerImportLanguageHappyPathReturnsModelMetadata) {
     EXPECT_NE(response.body.find("\"modelId\":"), std::string::npos);
     EXPECT_NE(response.body.find("\"name\":"), std::string::npos);
     EXPECT_NE(response.body.find("\"componentCount\":"), std::string::npos);
+}
+
+TEST(WebApiRouterTest, WorkerJobsCreateWithoutTokenReturnsUnauthorized) {
+    ApiRouterFixture fixture;
+
+    HttpRequest request;
+    request.method = "POST";
+    request.path = "/api/v1/worker/jobs";
+
+    const HttpResponse response = fixture.router.handle(request);
+
+    EXPECT_EQ(response.status, 401);
+    EXPECT_NE(response.body.find("\"ok\":false"), std::string::npos);
+}
+
+TEST(WebApiRouterTest, WorkerJobsCreateWithoutCurrentModelReturnsConflict) {
+    ApiRouterFixture fixture;
+    const std::string token = createSessionAndGetToken(fixture.router);
+
+    HttpRequest request;
+    request.method = "POST";
+    request.path = "/api/v1/worker/jobs";
+    request.headers["authorization"] = "Bearer " + token;
+
+    const HttpResponse response = fixture.router.handle(request);
+
+    EXPECT_EQ(response.status, 409);
+    EXPECT_NE(response.body.find("\"NO_CURRENT_MODEL\""), std::string::npos);
+}
+
+TEST(WebApiRouterTest, WorkerJobsCreateWithCurrentModelReturnsCreatedQueuedMetadata) {
+    ApiRouterFixture fixture;
+    const std::string token = createSessionAndGetToken(fixture.router);
+
+    HttpRequest importRequest;
+    importRequest.method = "POST";
+    importRequest.path = "/api/v1/worker/models/import-language";
+    importRequest.headers["authorization"] = "Bearer " + token;
+    importRequest.body = minimalValidModelSpecification();
+    const HttpResponse importResponse = fixture.router.handle(importRequest);
+    ASSERT_EQ(importResponse.status, 200);
+
+    HttpRequest createJobRequest;
+    createJobRequest.method = "POST";
+    createJobRequest.path = "/api/v1/worker/jobs";
+    createJobRequest.headers["authorization"] = "Bearer " + token;
+
+    const HttpResponse createJobResponse = fixture.router.handle(createJobRequest);
+
+    EXPECT_EQ(createJobResponse.status, 201);
+    EXPECT_NE(createJobResponse.body.find("\"ok\":true"), std::string::npos);
+    EXPECT_NE(createJobResponse.body.find("\"jobId\":"), std::string::npos);
+    EXPECT_NE(createJobResponse.body.find("\"state\":\"queued\""), std::string::npos);
+    EXPECT_NE(createJobResponse.body.find("\"snapshotFilename\":\"job_"), std::string::npos);
+}
+
+TEST(WebApiRouterTest, WorkerJobsGetWithoutTokenReturnsUnauthorized) {
+    ApiRouterFixture fixture;
+
+    HttpRequest request;
+    request.method = "GET";
+    request.path = "/api/v1/worker/jobs/job-1";
+
+    const HttpResponse response = fixture.router.handle(request);
+
+    EXPECT_EQ(response.status, 401);
+    EXPECT_NE(response.body.find("\"ok\":false"), std::string::npos);
+}
+
+TEST(WebApiRouterTest, WorkerJobsGetUnknownIdReturnsNotFound) {
+    ApiRouterFixture fixture;
+    const std::string token = createSessionAndGetToken(fixture.router);
+
+    HttpRequest request;
+    request.method = "GET";
+    request.path = "/api/v1/worker/jobs/job-9999";
+    request.headers["authorization"] = "Bearer " + token;
+
+    const HttpResponse response = fixture.router.handle(request);
+
+    EXPECT_EQ(response.status, 404);
+    EXPECT_NE(response.body.find("\"WORKER_JOB_NOT_FOUND\""), std::string::npos);
+}
+
+TEST(WebApiRouterTest, WorkerJobsCreateThenGetReturnsSameQueuedJobMetadata) {
+    ApiRouterFixture fixture;
+    const std::string token = createSessionAndGetToken(fixture.router);
+
+    HttpRequest importRequest;
+    importRequest.method = "POST";
+    importRequest.path = "/api/v1/worker/models/import-language";
+    importRequest.headers["authorization"] = "Bearer " + token;
+    importRequest.body = minimalValidModelSpecification();
+    const HttpResponse importResponse = fixture.router.handle(importRequest);
+    ASSERT_EQ(importResponse.status, 200);
+
+    HttpRequest createJobRequest;
+    createJobRequest.method = "POST";
+    createJobRequest.path = "/api/v1/worker/jobs";
+    createJobRequest.headers["authorization"] = "Bearer " + token;
+    const HttpResponse createJobResponse = fixture.router.handle(createJobRequest);
+    ASSERT_EQ(createJobResponse.status, 201);
+
+    const std::string jobId = extractJsonStringField(createJobResponse.body, "jobId");
+    ASSERT_FALSE(jobId.empty());
+
+    HttpRequest getJobRequest;
+    getJobRequest.method = "GET";
+    getJobRequest.path = "/api/v1/worker/jobs/" + jobId;
+    getJobRequest.headers["authorization"] = "Bearer " + token;
+    const HttpResponse getJobResponse = fixture.router.handle(getJobRequest);
+
+    EXPECT_EQ(getJobResponse.status, 200);
+    EXPECT_NE(getJobResponse.body.find("\"state\":\"queued\""), std::string::npos);
+    EXPECT_NE(getJobResponse.body.find("\"jobId\":\"" + jobId + "\""), std::string::npos);
 }
 
 TEST(WebApiRouterTest, AuthSessionThenSimulatorInfoWithBearerToken) {


### PR DESCRIPTION
### Motivation
- Provide a minimal, safe worker job abstraction so an orchestrator can create and inspect jobs that reference a model snapshot without executing anything.
- Ensure jobs are decoupled from live session models by persisting a session-scoped model snapshot on creation and return queued metadata for inspection.
- Keep API surface limited and encapsulated in the service layer to prepare for future distributed execution without adding background workers or result retrieval yet.

### Description
- Add a compact in-memory worker layer under `source/applications/web/worker` with `WorkerJobState`, `WorkerJob`, and `WorkerJobManager` implementing id generation, storage, and lookup. (files: `WorkerJob.h`, `WorkerJobManager.h`, `WorkerJobManager.cpp`).
- Extend `SimulatorSessionService` to accept a `WorkerJobManager` and add `WorkerJobError`, `WorkerJobInfoResult`, `WorkerJobCreationResult`, `WorkerJobQueryResult`, plus methods `createWorkerJob(const std::string&)` and `getWorkerJob(const std::string&, const std::string&)` that validate token/session, require a current model, snapshot the model into the session workspace (`job_<id>.gen`), and register a queued job (no execution). (files: `SimulatorSessionService.h`, `SimulatorSessionService.cpp`).
- Implement two HTTP endpoints in `ApiRouter`: `POST /api/v1/worker/jobs` to create a queued job and return `201`, and `GET /api/v1/worker/jobs/{jobId}` to return job metadata or mapped errors; add a minimal path parser, JSON serializer, and error mapper. (files: `ApiRouter.h`, `ApiRouter.cpp`).
- Wire a `WorkerJobManager` into application bootstrap and build system, and add Doxygen-style documentation for all touched classes and methods. (files: `BaseGenesysWebApplication.cpp`, `CMakeLists.txt`).
- Add focused unit tests covering auth, missing-model, create/happy-path, unknown-job, and create-then-get behavior; update worker capability expectation to reflect job-abstraction availability. (file: `source/tests/unit/test_web_api_router.cpp`).
- Update README to document worker stage 3 endpoints, snapshot semantics, and explicit non-goals (no execution/polling/results yet). (file: `source/applications/web/README.md`).

### Testing
- Configured the project with CMake for the web application: `cmake -S . -B build/web-debug -G Ninja -DGENESYS_BUILD_WEB_APPLICATION=ON` (succeeded).
- Attempted full build: `cmake --build build/web-debug --target genesys_webhook genesys_test_web_api_router`, but the final link step failed due to pre-existing unresolved `SinkModelComponent` symbols in plugin linkage, which prevented producing the executables (failure unrelated to the web changes).
- Attempted to run `ctest --test-dir build/web-debug --output-on-failure -R web_api_router`, but the test runner could not run because the test binary was not produced due to the linker failure.

```markdown
## Worker Stage 3 execution report

### What I completed
- Added a compact stage-3 worker job abstraction (`WorkerJobState`, `WorkerJob`, `WorkerJobManager`) with in-memory ownership and unique job IDs.
- Extended `SimulatorSessionService` with structured worker-job result/error types and methods for create/query.
- Implemented `POST /api/v1/worker/jobs` and `GET /api/v1/worker/jobs/{jobId}` in `ApiRouter`, including minimal local path parsing and HTTP error mapping.
- Implemented model snapshot persistence during job creation so jobs reference saved model snapshots, not live model pointers.
- Updated worker capabilities to indicate distributed-job abstraction support while keeping polling/background execution disabled.
- Extended unit tests for required route behaviors and happy path.
- Updated web README with worker stage 3 scope and limitations.
- Committed all changes on branch `WiP20261` and created a PR record via `make_pr`.

### What I could not complete
- End-to-end execution of `genesys_webhook` and `genesys_test_web_api_router` binaries.
- Running `ctest` for `web_api_router` as a passing test suite.

### Why anything remains incomplete
- The repository build currently fails at link time due unresolved `SinkModelComponent` references in plugin linkage (`Dispose.cpp.o`), which prevents generating the target executables required for test execution.

### Validation performed
- Configured project with CMake + Ninja.
- Built requested targets until linker stage.
- Attempted `ctest` for `web_api_router`; it reported test executable not built because of the linker issue.

### Risks remaining
- Runtime behavior of new worker job endpoints is validated by compilation and unit test definitions, but not by executed test binaries in this environment due the pre-existing linker blocker.
- Any hidden integration issues beyond compile-time checks may remain until the linker baseline issue is resolved.

### Files changed
- source/applications/web/CMakeLists.txt
- source/applications/web/BaseGenesysWebApplication.cpp
- source/applications/web/api/ApiRouter.h
- source/applications/web/api/ApiRouter.cpp
- source/applications/web/service/SimulatorSessionService.h
- source/applications/web/service/SimulatorSessionService.cpp
- source/applications/web/worker/WorkerJob.h
- source/applications/web/worker/WorkerJobManager.h
- source/applications/web/worker/WorkerJobManager.cpp
- source/tests/unit/test_web_api_router.cpp
- source/applications/web/README.md
```

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcfd73347883219e38b837efacf875)