### PR TITLE
Fix CppCompiler::unloadLibrary state handling and add unit test

### DIFF
--- a/source/plugins/data/CppCompiler.cpp
+++ b/source/plugins/data/CppCompiler.cpp
@@ -305,16 +305,17 @@ bool CppCompiler::loadLibrary(std::string& errorMessage) {
 }
 
 bool CppCompiler::unloadLibrary() {
-	if (_libraryLoaded) {
-		try {
-			dlclose(_dynamicLibraryHandle);
-			_dynamicLibraryHandle = nullptr;
-			_libraryLoaded = false;
-			return true;
-		} catch (const std::exception& e) {
-			return false;
-		}
+	if (!_libraryLoaded || _dynamicLibraryHandle == nullptr) {
+		_dynamicLibraryHandle = nullptr;
+		_libraryLoaded = false;
+		return true;
 	}
+
+	const int closeResult = dlclose(_dynamicLibraryHandle);
+	if (closeResult != 0) {
+		return false;
+	}
+
 	_dynamicLibraryHandle = nullptr;
 	_libraryLoaded = false;
 	return true;

--- a/source/tests/unit/test_simulator_runtime.cpp
+++ b/source/tests/unit/test_simulator_runtime.cpp
@@ -4713,3 +4713,15 @@ TEST(SimulatorRuntimeTest, CppCompilerUnloadLibraryIsSafeWhenNoLibraryIsLoaded) 
     EXPECT_TRUE(compiler.unloadLibrary());
     EXPECT_FALSE(compiler.IsLibraryLoaded());
 }
+
+TEST(SimulatorRuntimeTest, CppCompilerUnloadLibraryNormalizesStateWhenFlagSetWithoutHandle) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    CppCompilerProbe compiler(model, "CppCompilerUnloadInconsistent");
+    compiler.setLibraryLoaded(true);
+    EXPECT_TRUE(compiler.unloadLibrary());
+    EXPECT_FALSE(compiler.IsLibraryLoaded());
+    EXPECT_EQ(compiler.getDynamicLibraryHandler(), nullptr);
+}


### PR DESCRIPTION
### Motivation
- Remove a dead/inconsistent code path in `CppCompiler::unloadLibrary()` that left `_libraryLoaded` and `_dynamicLibraryHandle` in an ambiguous state and relied on exception-based flow for `dlclose`.
- Add a focused unit test to assert safe behavior when the object reports `libraryLoaded` but has no dynamic-handle, closing a coverage gap.

### Description
- Change `CppCompiler::unloadLibrary()` to early-return (and normalize internal state) when `_libraryLoaded` is false or `_dynamicLibraryHandle` is null, and call `dlclose()` only when a valid handle exists while checking its integer return value.
- Remove unreachable exception-based path and replace it with straightforward return-code handling for `dlclose` to make the flow explicit and testable.
- Add `CppCompilerUnloadLibraryNormalizesStateWhenFlagSetWithoutHandle` unit test to `source/tests/unit/test_simulator_runtime.cpp` that sets `_libraryLoaded = true` without a handle and verifies `unloadLibrary()` normalizes the state.
- Files changed: `source/plugins/data/CppCompiler.cpp`, `source/tests/unit/test_simulator_runtime.cpp`.

### Testing
- Configured and built tests with: `cmake -S . -B build -G Ninja -DGENESYS_BUILD_TESTS=ON -DGENESYS_BUILD_KERNEL=ON -DGENESYS_BUILD_PARSER=ON -DGENESYS_BUILD_PLUGINS=ON -DGENESYS_TERMINAL_APPLICATION=OFF -DGENESYS_BUILD_GUI_APPLICATION=OFF -DGENESYS_BUILD_WEB_APPLICATION=OFF`, which completed successfully.
- Built runtime tests: `cmake --build build --target genesys_test_simulator_runtime`, which succeeded and produced the test binary.
- Ran focused CppCompiler tests: `ctest --test-dir build -R "SimulatorRuntimeTest.*CppCompiler" --output-on-failure`, all CppCompiler tests passed (9/9).
- Ran broader smoke filter: `ctest --test-dir build -LE smoke --output-on-failure`, which reported several `*_NOT_BUILT` tests (expected for this build configuration) but did not show regressions in the CppCompiler runtime tests.

```markdown
- o que você realizou de fato;
  - Corrigi a lógica de `unloadLibrary()` para normalizar estado quando não há handle válido e para chamar `dlclose()` apenas com handle válido; adicionei verificação do código de retorno de `dlclose`.
  - Adicionei um teste unitário que cobre o caso em que `_libraryLoaded` está true mas o handle é nulo.
  - Executei configuração, build do alvo de teste de runtime e rodadas focadas de testes unitários.

- o que não realizou;
  - Não modifiquei `source/plugins/data/CppCompiler.h` porque a correção pôde ser feita somente em `CppCompiler.cpp` e nos testes.
  - Não alterei outras responsabilidades do subsistema de compilação (por escopo solicitado).
  - Não forcei a construção de todos os alvos opcionais do projeto que aparecem como `_NOT_BUILT` na execução ampla de testes.

- por que não realizou;
  - Mantive o escopo mínimo e seguro pedido: corrigir o fluxo morto/inconsistente de `unloadLibrary()` e adicionar cobertura de teste associada.
  - A construção de alguns testes depende de configurações/targets não habilitados nesta execução.

- riscos remanescentes;
  - `_invokeCompiler()` ainda usa `system()` e depende do ambiente/shell; comportamentos específicos de toolchain permanecem fora do escopo desta mudança.
  - Possíveis platform-specific edge-cases de `dlclose` (por exemplo, comportamento do runtime) permanecem e podem exigir tratamento adicional no futuro.

- observações relevantes;
  - Mudança pequena e localizada; evita fluxo morto e torna o estado interno consistente em todas as saídas de `unloadLibrary()`.
  - Os testes de CppCompiler no arquivo de runtime passaram no filtro específico.
  - Commit realizado para este ajuste: alteração em `CppCompiler.cpp` e adição de teste em `test_simulator_runtime.cpp`.

- arquivos alterados;
  - `source/plugins/data/CppCompiler.cpp`
  - `source/tests/unit/test_simulator_runtime.cpp`

- comandos executados e resultados resumidos.
  - `cmake -S . -B build -G Ninja ...` → sucesso (configuração gerada em `build`).
  - `cmake --build build --target genesys_test_simulator_runtime` → sucesso (test binary built).
  - `ctest --test-dir build -R "SimulatorRuntimeTest.*CppCompiler" --output-on-failure` → passed (9/9 tests for CppCompiler).
  - `ctest --test-dir build -LE smoke --output-on-failure` → completed with several `*_NOT_BUILT` entries (expected for this configuration) but no regressions for CppCompiler tests.
```

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcfe3793d88321932d234c34f66808)