### PR TITLE
Finalize SPICERunner as configurable persistent external runner

### DIFF
--- a/source/plugins/data/SPICERunner.cpp
+++ b/source/plugins/data/SPICERunner.cpp
@@ -11,6 +11,7 @@
  */
 
 #include "SPICERunner.h"
+#include "../../kernel/simulator/Model.h"
 
 #ifdef PLUGINCONNECT_DYNAMIC
 
@@ -61,6 +62,33 @@ std::pair<std::string, double> ParseTrigLine(std::string line){
 //
 
 SPICERunner::SPICERunner(Model* model, std::string name) : ModelDataDefinition(model, Util::TypeOf<SPICERunner>(), name) {
+    SimulationControlGeneric<std::string>* propRunnerCommand = new SimulationControlGeneric<std::string>(
+            std::bind(&SPICERunner::getRunnerCommand, this), std::bind(&SPICERunner::setRunnerCommand, this, std::placeholders::_1),
+            Util::TypeOf<SPICERunner>(), getName(), "RunnerCommand", "");
+    SimulationControlGeneric<std::string>* propModelsPath = new SimulationControlGeneric<std::string>(
+            std::bind(&SPICERunner::getModelsPath, this), std::bind(&SPICERunner::setModelsPath, this, std::placeholders::_1),
+            Util::TypeOf<SPICERunner>(), getName(), "ModelsPath", "");
+    SimulationControlGeneric<std::string>* propWorkingInputFilename = new SimulationControlGeneric<std::string>(
+            std::bind(&SPICERunner::getWorkingInputFilename, this), std::bind(&SPICERunner::setWorkingInputFilename, this, std::placeholders::_1),
+            Util::TypeOf<SPICERunner>(), getName(), "WorkingInputFilename", "");
+    SimulationControlGeneric<std::string>* propWorkingOutputFilename = new SimulationControlGeneric<std::string>(
+            std::bind(&SPICERunner::getWorkingOutputFilename, this), std::bind(&SPICERunner::setWorkingOutputFilename, this, std::placeholders::_1),
+            Util::TypeOf<SPICERunner>(), getName(), "WorkingOutputFilename", "");
+    SimulationControlGeneric<std::string>* propWorkingDirectory = new SimulationControlGeneric<std::string>(
+            std::bind(&SPICERunner::getWorkingDirectory, this), std::bind(&SPICERunner::setWorkingDirectory, this, std::placeholders::_1),
+            Util::TypeOf<SPICERunner>(), getName(), "WorkingDirectory", "");
+
+    _parentModel->getControls()->insert(propRunnerCommand);
+    _parentModel->getControls()->insert(propModelsPath);
+    _parentModel->getControls()->insert(propWorkingInputFilename);
+    _parentModel->getControls()->insert(propWorkingOutputFilename);
+    _parentModel->getControls()->insert(propWorkingDirectory);
+
+    _addProperty(propRunnerCommand);
+    _addProperty(propModelsPath);
+    _addProperty(propWorkingInputFilename);
+    _addProperty(propWorkingOutputFilename);
+    _addProperty(propWorkingDirectory);
 }
 
 SPICERunner::~SPICERunner() {
@@ -78,7 +106,7 @@ std::string SPICERunner::CompileSpiceFile() {
 
     std::string spicefile = "GenESyS generated circuit\n\n";//set spicebehavior=all\n\n";
     // Resolves all model dependencies
-	for (std::string model: models) spicefile += ".include " + models_path + model + ".cir\n";
+	for (std::string model: models) spicefile += ".include " + _modelsPath + model + ".cir\n";
     spicefile += "\n";
     // Compiles all subcircuit templates
     for (std::string subcircuit: subcircuits) spicefile += subcircuit + "\n";
@@ -117,7 +145,7 @@ void SPICERunner::PlotVRelative(std::string comparison_base, std::string net) {
 template<typename... Args>
 void SPICERunner::PlotVRelative(std::string comparison_base, std::string net, Args... args) {
 	vplots.push_back("v("+ net + ")-v(" + comparison_base + ") ");
-    PlotVPlotVRelative(comparison_base, args...);
+    PlotVRelative(comparison_base, args...);
 }
 
 void SPICERunner::PlotI(std::string net) {
@@ -127,7 +155,7 @@ void SPICERunner::PlotI(std::string net) {
 template<typename... Args>
 void SPICERunner::PlotI(std::string net, Args... args) {
 	iplots.push_back("i("+net+") ");
-    PlotV(args...);
+    PlotI(args...);
 }
 
 void SPICERunner::PlotIRelative(std::string comparison_base, std::string net) {
@@ -137,7 +165,7 @@ void SPICERunner::PlotIRelative(std::string comparison_base, std::string net) {
 template<typename... Args>
 void SPICERunner::PlotIRelative(std::string comparison_base, std::string net, Args... args) {
 	iplots.push_back("i("+ net + ")-i(" + comparison_base + ") ");
-    PlotVPlotIRelative(comparison_base, args...);
+    PlotIRelative(comparison_base, args...);
 }
 
 double* SPICERunner::MeasurePeak(std::string label, std::string peak, std::string quantity, std::string node, float start, float finish) {
@@ -155,7 +183,8 @@ double* SPICERunner::MeasureTrigTarg(std::string label, std::string trig, float 
 }
 
 void SPICERunner::ParseOutput(){
-    std::ifstream data("output");
+    std::string outputFilepath = _workingDirectory.empty() ? _workingOutputFilename : (_workingDirectory + Util::DirSeparator() + _workingOutputFilename);
+    std::ifstream data(outputFilepath);
     if (!data.is_open()) return;
     std::string line;
     while (getline(data, line)){
@@ -200,16 +229,19 @@ void SPICERunner::ConfigSim(double duration, double step) {
 }
 
 void SPICERunner::Run() {
-    std::string output = CompileSpiceFile();
+    const std::string compiledInput = CompileSpiceFile();
+    std::string inputFilepath = _workingDirectory.empty() ? _workingInputFilename : (_workingDirectory + Util::DirSeparator() + _workingInputFilename);
+    std::string outputFilepath = _workingDirectory.empty() ? _workingOutputFilename : (_workingDirectory + Util::DirSeparator() + _workingOutputFilename);
     std::string s;
-    std::ofstream out("input.cir");
-    out << output;
+    std::ofstream out(inputFilepath);
+    out << compiledInput;
     out.close();
 
-	int code = std::system("ngspice < input.cir 2> /dev/null");
+	_lastRunCommand = _runnerCommand + " -b -o \"" + outputFilepath + "\" \"" + inputFilepath + "\"";
+	int code = std::system(_lastRunCommand.c_str());
 
     if (code == 0) {
-        std::ifstream in("output");
+        std::ifstream in(outputFilepath);
         while (std::getline(in, s)) {
             std::cout << s << '\n';
         }
@@ -227,7 +259,16 @@ void SPICERunner::Run() {
 //
 
 std::string SPICERunner::show() {
-	return ModelDataDefinition::show();
+	return ModelDataDefinition::show() +
+            ",runnerCommand=\"" + _runnerCommand + "\"" +
+            ",modelsPath=\"" + _modelsPath + "\"" +
+            ",workingInputFilename=\"" + _workingInputFilename + "\"" +
+            ",workingOutputFilename=\"" + _workingOutputFilename + "\"" +
+            ",workingDirectory=\"" + _workingDirectory + "\"" +
+            ",subscribers=" + std::to_string(subscribers.size()) +
+            ",instances=" + std::to_string(instances.size()) +
+            ",plots=" + std::to_string(vplots.size() + iplots.size()) +
+            ",measures=" + std::to_string(measures.size());
 }
 
 
@@ -265,19 +306,86 @@ ModelDataDefinition* SPICERunner::NewInstance(Model* model, std::string name) {
 bool SPICERunner::_loadInstance(PersistenceRecord *fields) {
 	bool res = ModelDataDefinition::_loadInstance(fields);
 	if (res) {
-		try {
-			this->_someString = fields->loadField("someString", DEFAULT.someString);
-			this->_someUint = fields->loadField("someUint", DEFAULT.someUint);
-		} catch (...) {
-		}
+		_runnerCommand = fields->loadField("runnerCommand", DEFAULT.runnerCommand);
+		_modelsPath = fields->loadField("modelsPath", DEFAULT.modelsPath);
+		_workingInputFilename = fields->loadField("workingInputFilename", DEFAULT.workingInputFilename);
+		_workingOutputFilename = fields->loadField("workingOutputFilename", DEFAULT.workingOutputFilename);
+		_workingDirectory = fields->loadField("workingDirectory", DEFAULT.workingDirectory);
 	}
 	return res;
 }
 
 void SPICERunner::_saveInstance(PersistenceRecord *fields, bool saveDefaultValues) {
 	ModelDataDefinition::_saveInstance(fields, saveDefaultValues);
-	fields->saveField("someUint", _someUint, DEFAULT.someUint);
-	fields->saveField("someString", _someString, DEFAULT.someString);
+	fields->saveField("runnerCommand", _runnerCommand, DEFAULT.runnerCommand, saveDefaultValues);
+	fields->saveField("modelsPath", _modelsPath, DEFAULT.modelsPath, saveDefaultValues);
+	fields->saveField("workingInputFilename", _workingInputFilename, DEFAULT.workingInputFilename, saveDefaultValues);
+	fields->saveField("workingOutputFilename", _workingOutputFilename, DEFAULT.workingOutputFilename, saveDefaultValues);
+	fields->saveField("workingDirectory", _workingDirectory, DEFAULT.workingDirectory, saveDefaultValues);
 }
 
+bool SPICERunner::_check(std::string& errorMessage) {
+    bool resultAll = true;
+    if (_runnerCommand.empty()) {
+        errorMessage += "RunnerCommand must not be empty. ";
+        resultAll = false;
+    }
+    if (_workingInputFilename.empty()) {
+        errorMessage += "WorkingInputFilename must not be empty. ";
+        resultAll = false;
+    }
+    if (_workingOutputFilename.empty()) {
+        errorMessage += "WorkingOutputFilename must not be empty. ";
+        resultAll = false;
+    }
+    if (!models.empty() && _modelsPath.empty()) {
+        errorMessage += "ModelsPath must not be empty when model includes are used. ";
+        resultAll = false;
+    }
+    return resultAll;
+}
+
+void SPICERunner::setRunnerCommand(std::string runnerCommand) {
+    _runnerCommand = runnerCommand;
+}
+
+std::string SPICERunner::getRunnerCommand() const {
+    return _runnerCommand;
+}
+
+void SPICERunner::setModelsPath(std::string modelsPath) {
+    _modelsPath = modelsPath;
+}
+
+std::string SPICERunner::getModelsPath() const {
+    return _modelsPath;
+}
+
+void SPICERunner::setWorkingInputFilename(std::string workingInputFilename) {
+    _workingInputFilename = workingInputFilename;
+}
+
+std::string SPICERunner::getWorkingInputFilename() const {
+    return _workingInputFilename;
+}
+
+void SPICERunner::setWorkingOutputFilename(std::string workingOutputFilename) {
+    _workingOutputFilename = workingOutputFilename;
+}
+
+std::string SPICERunner::getWorkingOutputFilename() const {
+    return _workingOutputFilename;
+}
+
+void SPICERunner::setWorkingDirectory(std::string workingDirectory) {
+    _workingDirectory = workingDirectory;
+}
+
+std::string SPICERunner::getWorkingDirectory() const {
+    return _workingDirectory;
+}
+
+std::string SPICERunner::getLastRunCommand() const {
+    return _lastRunCommand;
+}
 

--- a/source/plugins/data/SPICERunner.h
+++ b/source/plugins/data/SPICERunner.h
@@ -58,6 +58,17 @@ public: /// new public user methods for this component
 	double* MeasurePeak(std::string label, std::string peak, std::string quantity, std::string node, float start, float finish);
 	double* MeasureTrigTarg(std::string label, std::string trig, float trig_value, std::string trig_inclin, std::string targ, float targ_value, std::string targ_inclin);
 	void ParseOutput();
+	void setRunnerCommand(std::string runnerCommand);
+	std::string getRunnerCommand() const;
+	void setModelsPath(std::string modelsPath);
+	std::string getModelsPath() const;
+	void setWorkingInputFilename(std::string workingInputFilename);
+	std::string getWorkingInputFilename() const;
+	void setWorkingOutputFilename(std::string workingOutputFilename);
+	std::string getWorkingOutputFilename() const;
+	void setWorkingDirectory(std::string workingDirectory);
+	std::string getWorkingDirectory() const;
+	std::string getLastRunCommand() const;
 
 public: /// virtual public methods
 	virtual std::string show() override;
@@ -75,7 +86,7 @@ protected: /// virtual protected method that must be overriden
 
 protected: /// virtual protected methods that could be overriden by derived classes, if needed
 	/*! This method is called by ModelChecker during model check. The component should check itself to verify if user parameters are ok (ex: correct syntax for the parser) and everithing in its parameters allow the model too run without errors in this component */
-	// virtual bool _check(std::string& errorMessage);
+	virtual bool _check(std::string& errorMessage) override;
 	/*! This method returns all changes in the parser that are needed by plugins of this ModelDatas. When connecting a new plugin, ParserChangesInformation are used to change parser source code, whch is after compiled and dinamically linked to to simulator kernel to reflect the changes */
 	// virtual ParserChangesInformation* _getParserChangesInformation();
 	/*! This method is called by ModelSimulation when initianting the replication. The model should set all value for a new replication (Ex: setting back to 0 any internal counter, clearing lists, etc. */
@@ -90,12 +101,18 @@ private: /// new private user methods
 
 private: /// Attributes that should be loaded or saved with this component (Persistent Fields)
 	const struct DEFAULT_VALUES {
-		const std::string someString = "Test";
-		const unsigned int someUint = 1;
-        const std::string somePath = "./";
+		const std::string runnerCommand = "ngspice";
+		const std::string modelsPath = "./";
+		const std::string workingInputFilename = "input.cir";
+		const std::string workingOutputFilename = "output";
+		const std::string workingDirectory = "";
 	} DEFAULT;
-	std::string _someString = DEFAULT.someString;
-	unsigned int _someUint = DEFAULT.someUint;
+	std::string _runnerCommand = DEFAULT.runnerCommand;
+	std::string _modelsPath = DEFAULT.modelsPath;
+	std::string _workingInputFilename = DEFAULT.workingInputFilename;
+	std::string _workingOutputFilename = DEFAULT.workingOutputFilename;
+	std::string _workingDirectory = DEFAULT.workingDirectory;
+	std::string _lastRunCommand = "";
 
 	std::set<std::string> subcircuits;
 	std::set<std::string> models;
@@ -111,7 +128,6 @@ private: /// Attributes that should be loaded or saved with this component (Pers
 	std::vector<std::string> measures;
 	std::map<std::string, double*> promises;
 
-    std::string models_path = DEFAULT.somePath;
     std::string config;
 
 private: /// internal DataElements (Composition)
@@ -122,4 +138,3 @@ private: /// attached DataElements (Agrregation)
 };
 
 #endif /* SPICERUNNER_H */
-

--- a/source/tests/unit/test_simulator_runtime.cpp
+++ b/source/tests/unit/test_simulator_runtime.cpp
@@ -29,6 +29,7 @@
 #include "plugins/data/Storage.h"
 #include "plugins/data/File.h"
 #include "plugins/data/CppCompiler.h"
+#include "plugins/data/SPICERunner.h"
 #include "kernel/util/Util.h"
 #define private public
 #define protected public
@@ -814,6 +815,23 @@ public:
 
     CompilationResult InvokeCompilerProbe(const std::string& command) {
         return _invokeCompiler(command);
+    }
+};
+
+class SPICERunnerProbe : public SPICERunner {
+public:
+    SPICERunnerProbe(Model* model, const std::string& name = "") : SPICERunner(model, name) {}
+
+    bool CheckProbe(std::string& errorMessage) {
+        return _check(errorMessage);
+    }
+
+    bool LoadInstanceProbe(PersistenceRecord* fields) {
+        return _loadInstance(fields);
+    }
+
+    void SaveInstanceProbe(PersistenceRecord* fields, bool saveDefaultValues = false) {
+        _saveInstance(fields, saveDefaultValues);
     }
 };
 
@@ -4724,4 +4742,169 @@ TEST(SimulatorRuntimeTest, CppCompilerUnloadLibraryNormalizesStateWhenFlagSetWit
     EXPECT_TRUE(compiler.unloadLibrary());
     EXPECT_FALSE(compiler.IsLibraryLoaded());
     EXPECT_EQ(compiler.getDynamicLibraryHandler(), nullptr);
+}
+
+TEST(SimulatorRuntimeTest, SPICERunnerDefaultsExposeOperationalConfiguration) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    SPICERunnerProbe runner(model, "SPICERunnerDefaults");
+    EXPECT_EQ(runner.getRunnerCommand(), "ngspice");
+    EXPECT_EQ(runner.getModelsPath(), "./");
+    EXPECT_EQ(runner.getWorkingInputFilename(), "input.cir");
+    EXPECT_EQ(runner.getWorkingOutputFilename(), "output");
+    EXPECT_EQ(runner.getWorkingDirectory(), "");
+}
+
+TEST(SimulatorRuntimeTest, SPICERunnerSettersAndGettersPreserveMainFields) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    SPICERunnerProbe runner(model, "SPICERunnerSetGet");
+    runner.setRunnerCommand("xyce");
+    runner.setModelsPath("models/");
+    runner.setWorkingInputFilename("custom_input.cir");
+    runner.setWorkingOutputFilename("custom_output.log");
+    runner.setWorkingDirectory("workdir");
+
+    EXPECT_EQ(runner.getRunnerCommand(), "xyce");
+    EXPECT_EQ(runner.getModelsPath(), "models/");
+    EXPECT_EQ(runner.getWorkingInputFilename(), "custom_input.cir");
+    EXPECT_EQ(runner.getWorkingOutputFilename(), "custom_output.log");
+    EXPECT_EQ(runner.getWorkingDirectory(), "workdir");
+}
+
+TEST(SimulatorRuntimeTest, SPICERunnerCheckRejectsInvalidConfiguration) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    SPICERunnerProbe runner(model, "SPICERunnerCheckInvalid");
+    runner.setRunnerCommand("");
+    runner.setWorkingInputFilename("");
+    runner.setWorkingOutputFilename("");
+    std::string instance = "R1 a b 1k";
+    runner.SendComponent(&instance, "", "nmosp");
+    runner.setModelsPath("");
+
+    std::string errorMessage;
+    EXPECT_FALSE(runner.CheckProbe(errorMessage));
+    EXPECT_NE(errorMessage.find("RunnerCommand must not be empty"), std::string::npos);
+    EXPECT_NE(errorMessage.find("WorkingInputFilename must not be empty"), std::string::npos);
+    EXPECT_NE(errorMessage.find("WorkingOutputFilename must not be empty"), std::string::npos);
+    EXPECT_NE(errorMessage.find("ModelsPath must not be empty"), std::string::npos);
+}
+
+TEST(SimulatorRuntimeTest, SPICERunnerCheckAcceptsMinimalValidConfiguration) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    SPICERunnerProbe runner(model, "SPICERunnerCheckValid");
+    runner.setRunnerCommand("ngspice");
+    runner.setWorkingInputFilename("input_valid.cir");
+    runner.setWorkingOutputFilename("output_valid.log");
+
+    std::string errorMessage;
+    EXPECT_TRUE(runner.CheckProbe(errorMessage)) << errorMessage;
+}
+
+TEST(SimulatorRuntimeTest, SPICERunnerShowIncludesOperationalObservability) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    SPICERunnerProbe runner(model, "SPICERunnerShow");
+    runner.setRunnerCommand("xyce");
+    runner.setModelsPath("models/");
+    runner.setWorkingInputFilename("show_input.cir");
+    runner.setWorkingOutputFilename("show_output.log");
+    std::string instance = "Rshow in out 1k";
+    runner.SendComponent(&instance);
+    runner.PlotV("out");
+    runner.MeasurePeak("p1", "max", "v", "out", 0.0f, 1.0f);
+
+    const std::string shown = runner.show();
+    EXPECT_NE(shown.find("runnerCommand=\"xyce\""), std::string::npos);
+    EXPECT_NE(shown.find("modelsPath=\"models/\""), std::string::npos);
+    EXPECT_NE(shown.find("workingInputFilename=\"show_input.cir\""), std::string::npos);
+    EXPECT_NE(shown.find("workingOutputFilename=\"show_output.log\""), std::string::npos);
+    EXPECT_NE(shown.find("instances=1"), std::string::npos);
+    EXPECT_NE(shown.find("plots=1"), std::string::npos);
+    EXPECT_NE(shown.find("measures=1"), std::string::npos);
+}
+
+TEST(SimulatorRuntimeTest, SPICERunnerPersistenceRoundTripPreservesOperationalFields) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    SPICERunnerProbe source(model, "SPICERunnerPersistSource");
+    source.setRunnerCommand("xyce");
+    source.setModelsPath("persist_models/");
+    source.setWorkingInputFilename("persist_input.cir");
+    source.setWorkingOutputFilename("persist_output.log");
+    source.setWorkingDirectory("persist_workdir");
+
+    FakeModelPersistenceRuntime persistence;
+    PersistenceRecord fields(persistence);
+    source.SaveInstanceProbe(&fields, true);
+
+    SPICERunnerProbe loaded(model, "SPICERunnerPersistLoaded");
+    ASSERT_TRUE(loaded.LoadInstanceProbe(&fields));
+    EXPECT_EQ(loaded.getRunnerCommand(), "xyce");
+    EXPECT_EQ(loaded.getModelsPath(), "persist_models/");
+    EXPECT_EQ(loaded.getWorkingInputFilename(), "persist_input.cir");
+    EXPECT_EQ(loaded.getWorkingOutputFilename(), "persist_output.log");
+    EXPECT_EQ(loaded.getWorkingDirectory(), "persist_workdir");
+}
+
+TEST(SimulatorRuntimeTest, SPICERunnerCompileSpiceFileStillBuildsExpectedNetlistSegments) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    SPICERunnerProbe runner(model, "SPICERunnerCompile");
+    runner.setModelsPath("my_models/");
+    std::string instance = "R1 in out 1k";
+    runner.SendComponent(&instance, ".subckt my_sub in out\nRsub in out 2k\n.ends", "my_model");
+    runner.ConfigSim(1.0, 0.1);
+
+    const std::string compiled = runner.CompileSpiceFile();
+    EXPECT_NE(compiled.find(".include my_models/my_model.cir"), std::string::npos);
+    EXPECT_NE(compiled.find(".subckt my_sub in out"), std::string::npos);
+    EXPECT_NE(compiled.find("R1 in out 1k"), std::string::npos);
+    EXPECT_NE(compiled.find("tran"), std::string::npos);
+    EXPECT_NE(compiled.find(".end"), std::string::npos);
+}
+
+TEST(SimulatorRuntimeTest, SPICERunnerRunUsesConfiguredOperationalFilenamesInCommand) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    const std::string workingDir = Util::RunningPath() + Util::DirSeparator() + "spice_runner_runtime";
+    ::mkdir(workingDir.c_str(), 0755);
+
+    SPICERunnerProbe runner(model, "SPICERunnerRunCommand");
+    runner.setRunnerCommand("true");
+    runner.setWorkingDirectory(workingDir);
+    runner.setWorkingInputFilename("runtime_input_test.cir");
+    runner.setWorkingOutputFilename("runtime_output_test.log");
+    runner.Run();
+
+    const std::string command = runner.getLastRunCommand();
+    EXPECT_NE(command.find("runtime_input_test.cir"), std::string::npos);
+    EXPECT_NE(command.find("runtime_output_test.log"), std::string::npos);
+    EXPECT_NE(command.find(" -b -o "), std::string::npos);
+
+    const std::string inputPath = workingDir + Util::DirSeparator() + "runtime_input_test.cir";
+    EXPECT_TRUE(Util::FileExists(inputPath));
+
+    Util::FileDelete(inputPath);
+    const std::string outputPath = workingDir + Util::DirSeparator() + "runtime_output_test.log";
+    Util::FileDelete(outputPath);
+    ::rmdir(workingDir.c_str());
 }


### PR DESCRIPTION
### Motivation
- Replace template/dummy persistence and hardcoded behavior so SPICERunner can be configured, persisted and inspected for realistic external-runner integration. 
- Provide minimal validation, observability and portability without redesigning the external-simulator subsystem. 
- Add unit tests that exercise configuration, persistence, compilation output generation and the command assembly used to invoke the simulator.

### Description
- Introduced persistent operational fields `runnerCommand`, `modelsPath`, `workingInputFilename`, `workingOutputFilename`, and `workingDirectory` with getters/setters and `getLastRunCommand()` for runtime probing. (files: `SPICERunner.h`, `SPICERunner.cpp`)
- Registered these fields as `SimulationControlGeneric` entries in the model controls and as owned properties via `_addProperty(...)` in the constructor. (file: `SPICERunner.cpp`)
- Implemented symmetric `_loadInstance()` / `_saveInstance()` persistence for the new fields and removed the `someString`/`someUint` template fields. (files: `SPICERunner.h`, `SPICERunner.cpp`)
- Added a minimal `_check()` that validates `runnerCommand`, `workingInputFilename`, `workingOutputFilename`, and `modelsPath` when model includes are used, and improved `show()` to include runner configuration and operational counters. (file: `SPICERunner.cpp`)
- Made `Run()` and `ParseOutput()` use configured filenames/working directory instead of hardcoded `input.cir`/`output` and removed stderr redirection; the command is built from `runnerCommand` and stored in `_lastRunCommand` for tests. (file: `SPICERunner.cpp`)
- Fixed variadic helper chaining bugs in `PlotVRelative`, `PlotI` and `PlotIRelative` so recursive calls correctly forward remaining args. (file: `SPICERunner.cpp`)
- Added focused unit tests and a probe class for `SPICERunner` to `source/tests/unit/test_simulator_runtime.cpp` covering defaults, setters/getters, invalid/valid `_check()`, `show()`, persistence round-trip, `CompileSpiceFile()` content, and verification that `Run()` assembles/uses configured filenames. (file: `test_simulator_runtime.cpp`)

### Testing
- Configured and generated build files with `cmake -S . -B build -G Ninja -DGENESYS_BUILD_TESTS=ON -DGENESYS_BUILD_KERNEL=ON -DGENESYS_BUILD_PARSER=ON -DGENESYS_BUILD_PLUGINS=ON -DGENESYS_TERMINAL_APPLICATION=OFF -DGENESYS_BUILD_GUI_APPLICATION=OFF -DGENESYS_BUILD_WEB_APPLICATION=OFF` and the configuration step completed successfully. 
- Built the runtime test executable with `cmake --build build --target genesys_test_simulator_runtime` and the build completed successfully. 
- Ran the focused test set with `ctest --test-dir build -R "SimulatorRuntimeTest.*SPICERunner" --output-on-failure` and all SPICERunner tests passed (8/8). 
- Ran a broader smoke selection with `ctest --test-dir build -LE smoke --output-on-failure` where unrelated `*_NOT_BUILT` targets prevented some tests from running, but the SPICERunner-related runtime tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd038ff73083218942a6760fe0b502)