### PR TITLE
Implement synchronous worker job run endpoint (Worker Stage 4)

### DIFF
--- a/source/applications/web/README.md
+++ b/source/applications/web/README.md
@@ -49,6 +49,18 @@ Behavior in this stage:
 
 This stage still does **not** execute jobs, provide result retrieval, add polling loops, or introduce background worker threads.
 
+## Worker cycle Stage 4
+This stage adds explicit, synchronous execution of existing worker jobs:
+- `POST /api/v1/worker/jobs/{jobId}/run` (requires `Authorization: Bearer <token>`)
+
+Behavior in this stage:
+- execution is triggered only for an existing job id;
+- job state is updated in memory through `queued -> running -> finished|failed`;
+- execution is synchronous and performed by the session simulator using the job snapshot file;
+- `GET /api/v1/worker/jobs/{jobId}` remains the basic state inspection/polling mechanism after run requests.
+
+This stage still does **not** include background execution, queue worker loops, cancellation, streaming updates, or a dedicated job result endpoint.
+
 ## How to run
 ```bash
 cmake -S . -B build/web-debug -G Ninja -DGENESYS_BUILD_WEB_APPLICATION=ON

--- a/source/applications/web/api/ApiRouter.cpp
+++ b/source/applications/web/api/ApiRouter.cpp
@@ -79,7 +79,27 @@ HttpResponse ApiRouter::handle(const HttpRequest& request) const {
         return HttpResponse{201, "application/json", "{\"ok\":true,\"data\":" + _workerJobDataJson(result.jobInfo) + "}"};
     }
 
-    // Stage 3 requires only minimal path parsing for job inspection by id.
+    // Stage 4 adds explicit synchronous worker job execution.
+    std::string workerRunJobId;
+    if (_tryExtractWorkerJobRunIdFromPath(request.path, workerRunJobId)) {
+        if (request.method != "POST") {
+            return _jsonError(405, "METHOD_NOT_ALLOWED", "Only POST is allowed for /api/v1/worker/jobs/{jobId}/run");
+        }
+
+        const std::string token = _extractBearerToken(request);
+        if (token.empty()) {
+            return _jsonError(401, "UNAUTHORIZED", "Missing or invalid Bearer token");
+        }
+
+        const auto result = _simulatorService.runWorkerJob(token, workerRunJobId);
+        if (!result.success) {
+            return _mapWorkerJobError(result.error, false);
+        }
+
+        return HttpResponse{200, "application/json", "{\"ok\":true,\"data\":" + _workerJobDataJson(result.jobInfo) + "}"};
+    }
+
+    // Stage 3 and stage 4 use this endpoint as basic job metadata inspection/polling.
     std::string workerJobId;
     if (_tryExtractWorkerJobIdFromPath(request.path, workerJobId)) {
         if (request.method != "GET") {
@@ -565,6 +585,26 @@ bool ApiRouter::_tryExtractWorkerJobIdFromPath(const std::string& path, std::str
     if (outJobId.empty() || outJobId.find('/') != std::string::npos) {
         return false;
     }
+    return true;
+}
+
+bool ApiRouter::_tryExtractWorkerJobRunIdFromPath(const std::string& path, std::string& outJobId) {
+    constexpr std::string_view prefix = "/api/v1/worker/jobs/";
+    constexpr std::string_view suffix = "/run";
+
+    if (path.rfind(prefix, 0) != 0 || path.size() <= prefix.size() + suffix.size()) {
+        return false;
+    }
+
+    if (path.compare(path.size() - suffix.size(), suffix.size(), suffix) != 0) {
+        return false;
+    }
+
+    outJobId = path.substr(prefix.size(), path.size() - prefix.size() - suffix.size());
+    if (outJobId.empty() || outJobId.find('/') != std::string::npos) {
+        return false;
+    }
+
     return true;
 }
 

--- a/source/applications/web/api/ApiRouter.h
+++ b/source/applications/web/api/ApiRouter.h
@@ -128,6 +128,13 @@ private:
      */
     static bool _tryExtractWorkerJobIdFromPath(const std::string& path, std::string& outJobId);
     /**
+     * @brief Tries to parse a worker job identifier from `/api/v1/worker/jobs/{jobId}/run`.
+     * @param path HTTP request path.
+     * @param outJobId Receives parsed job identifier when the path matches.
+     * @return True when the path format is valid and a non-empty id was extracted.
+     */
+    static bool _tryExtractWorkerJobRunIdFromPath(const std::string& path, std::string& outJobId);
+    /**
      * @brief Converts worker job states into API string values.
      * @param state Worker job state value.
      * @return Lowercase state string expected by clients.

--- a/source/applications/web/service/SimulatorSessionService.cpp
+++ b/source/applications/web/service/SimulatorSessionService.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <exception>
 #include <filesystem>
 #include <mutex>
 #include <optional>
@@ -100,9 +101,9 @@ SimulatorSessionService::WorkerCapabilitiesResult SimulatorSessionService::getWo
     result.supportsSimulationConfig = true;
     result.supportsSynchronousRun = true;
     result.supportsSynchronousStep = true;
-    // Stage 3 introduces job abstraction creation/inspection, but not execution yet.
+    // Stage 4 keeps synchronous execution and exposes state inspection via job lookup.
     result.supportsDistributedJobs = true;
-    result.supportsJobPolling = false;
+    result.supportsJobPolling = true;
     result.supportsBackgroundExecution = false;
     // Stage 2 introduces a worker model-ingress endpoint based on plain text language import.
     result.supportsModelUpload = true;
@@ -451,6 +452,86 @@ SimulatorSessionService::WorkerJobQueryResult SimulatorSessionService::getWorker
     }
 
     return WorkerJobQueryResult{true, WorkerJobError::None, _toWorkerJobInfoResult(job.value())};
+}
+
+SimulatorSessionService::WorkerJobRunResult SimulatorSessionService::runWorkerJob(
+    const std::string& accessToken,
+    const std::string& jobId
+) {
+    SessionContext* session = _sessionManager.getSessionByToken(accessToken);
+    if (session == nullptr || session->simulator == nullptr) {
+        return WorkerJobRunResult{false, WorkerJobError::InvalidToken, WorkerJobInfoResult{}};
+    }
+
+    const std::optional<WorkerJob> job = _workerJobManager.getJob(jobId);
+    if (!job.has_value()) {
+        return WorkerJobRunResult{false, WorkerJobError::JobNotFound, WorkerJobInfoResult{}};
+    }
+
+    if (job->sessionId != session->sessionId) {
+        return WorkerJobRunResult{false, WorkerJobError::AccessDenied, WorkerJobInfoResult{}};
+    }
+
+    if (job->snapshotFilename.empty()) {
+        _workerJobManager.setState(jobId, WorkerJobState::Failed);
+        _workerJobManager.setMessage(jobId, "Worker job snapshot filename is missing");
+        return WorkerJobRunResult{false, WorkerJobError::OperationFailed, WorkerJobInfoResult{}};
+    }
+
+    if (!_workerJobManager.setState(jobId, WorkerJobState::Running)) {
+        return WorkerJobRunResult{false, WorkerJobError::OperationFailed, WorkerJobInfoResult{}};
+    }
+    _workerJobManager.setMessage(jobId, "");
+
+    std::string failureMessage;
+    bool executionSucceeded = false;
+
+    {
+        std::scoped_lock lock(session->mutex);
+        ModelManager* modelManager = session->simulator->getModelManager();
+        if (modelManager == nullptr) {
+            failureMessage = "Unable to access model manager";
+        } else {
+            try {
+                // Stage 4 executes directly from the persisted worker job snapshot in the same session simulator.
+                const std::filesystem::path snapshotPath = session->workspacePath / job->snapshotFilename;
+                Model* loadedModel = modelManager->loadModel(snapshotPath.string());
+                if (loadedModel == nullptr) {
+                    failureMessage = "Unable to load worker snapshot model";
+                } else {
+                    ModelSimulation* simulation = loadedModel->getSimulation();
+                    if (simulation == nullptr) {
+                        failureMessage = "Unable to access model simulation";
+                    } else {
+                        simulation->start();
+                        executionSucceeded = true;
+                    }
+                }
+            } catch (const std::exception& exception) {
+                failureMessage = exception.what();
+            } catch (...) {
+                failureMessage = "Unexpected simulation execution failure";
+            }
+        }
+    }
+
+    if (!executionSucceeded) {
+        _workerJobManager.setState(jobId, WorkerJobState::Failed);
+        _workerJobManager.setMessage(jobId, failureMessage);
+        return WorkerJobRunResult{false, WorkerJobError::OperationFailed, WorkerJobInfoResult{}};
+    }
+
+    if (!_workerJobManager.setState(jobId, WorkerJobState::Finished)) {
+        return WorkerJobRunResult{false, WorkerJobError::OperationFailed, WorkerJobInfoResult{}};
+    }
+    _workerJobManager.setMessage(jobId, "");
+
+    const std::optional<WorkerJob> storedJob = _workerJobManager.getJob(jobId);
+    if (!storedJob.has_value()) {
+        return WorkerJobRunResult{false, WorkerJobError::OperationFailed, WorkerJobInfoResult{}};
+    }
+
+    return WorkerJobRunResult{true, WorkerJobError::None, _toWorkerJobInfoResult(storedJob.value())};
 }
 
 bool SimulatorSessionService::_isSafeFilename(const std::string& filename) {

--- a/source/applications/web/service/SimulatorSessionService.h
+++ b/source/applications/web/service/SimulatorSessionService.h
@@ -161,6 +161,15 @@ public:
     };
 
     /**
+     * @brief Contains worker job run output and error state.
+     */
+    struct WorkerJobRunResult {
+        bool success = false;
+        WorkerJobError error = WorkerJobError::None;
+        WorkerJobInfoResult jobInfo;
+    };
+
+    /**
      * @brief Captures the current simulation execution state.
      */
     struct SimulationStatusResult {
@@ -315,6 +324,13 @@ public:
      * @return Worker job lookup output and error state.
      */
     WorkerJobQueryResult getWorkerJob(const std::string& accessToken, const std::string& jobId);
+    /**
+     * @brief Executes a worker job synchronously in the token-scoped simulator session.
+     * @param accessToken Bearer token associated with a session.
+     * @param jobId Worker job identifier to execute.
+     * @return Worker job run output and error state.
+     */
+    WorkerJobRunResult runWorkerJob(const std::string& accessToken, const std::string& jobId);
 
 private:
     /**

--- a/source/applications/web/worker/WorkerJobManager.cpp
+++ b/source/applications/web/worker/WorkerJobManager.cpp
@@ -26,6 +26,30 @@ bool WorkerJobManager::setSnapshotFilename(const std::string& jobId, const std::
     return true;
 }
 
+bool WorkerJobManager::setState(const std::string& jobId, WorkerJobState state) {
+    std::scoped_lock lock(_mutex);
+
+    const auto iterator = _jobs.find(jobId);
+    if (iterator == _jobs.end()) {
+        return false;
+    }
+
+    iterator->second.state = state;
+    return true;
+}
+
+bool WorkerJobManager::setMessage(const std::string& jobId, const std::string& message) {
+    std::scoped_lock lock(_mutex);
+
+    const auto iterator = _jobs.find(jobId);
+    if (iterator == _jobs.end()) {
+        return false;
+    }
+
+    iterator->second.message = message;
+    return true;
+}
+
 std::optional<WorkerJob> WorkerJobManager::getJob(const std::string& jobId) const {
     std::scoped_lock lock(_mutex);
 

--- a/source/applications/web/worker/WorkerJobManager.h
+++ b/source/applications/web/worker/WorkerJobManager.h
@@ -26,6 +26,21 @@ public:
      * @return True when the job exists and was updated.
      */
     bool setSnapshotFilename(const std::string& jobId, const std::string& snapshotFilename);
+    /**
+     * @brief Updates the lifecycle state for an existing job.
+     * @param jobId Job identifier to update.
+     * @param state New worker job state.
+     * @return True when the job exists and was updated.
+     */
+    bool setState(const std::string& jobId, WorkerJobState state);
+
+    /**
+     * @brief Replaces the message text for an existing job.
+     * @param jobId Job identifier to update.
+     * @param message Human-readable status or error message.
+     * @return True when the job exists and was updated.
+     */
+    bool setMessage(const std::string& jobId, const std::string& message);
 
     /**
      * @brief Fetches a previously stored job record.

--- a/source/tests/unit/test_web_api_router.cpp
+++ b/source/tests/unit/test_web_api_router.cpp
@@ -166,7 +166,7 @@ TEST(WebApiRouterTest, WorkerCapabilitiesReflectCurrentImplementation) {
     EXPECT_NE(response.body.find("\"supportsSynchronousRun\":true"), std::string::npos);
     EXPECT_NE(response.body.find("\"supportsSynchronousStep\":true"), std::string::npos);
     EXPECT_NE(response.body.find("\"supportsDistributedJobs\":true"), std::string::npos);
-    EXPECT_NE(response.body.find("\"supportsJobPolling\":false"), std::string::npos);
+    EXPECT_NE(response.body.find("\"supportsJobPolling\":true"), std::string::npos);
     EXPECT_NE(response.body.find("\"supportsBackgroundExecution\":false"), std::string::npos);
     EXPECT_NE(response.body.find("\"supportsModelUpload\":true"), std::string::npos);
     EXPECT_NE(response.body.find("\"supportsStreamingEvents\":false"), std::string::npos);
@@ -328,6 +328,46 @@ TEST(WebApiRouterTest, WorkerJobsGetUnknownIdReturnsNotFound) {
     EXPECT_NE(response.body.find("\"WORKER_JOB_NOT_FOUND\""), std::string::npos);
 }
 
+TEST(WebApiRouterTest, WorkerJobsRunWithoutTokenReturnsUnauthorized) {
+    ApiRouterFixture fixture;
+
+    HttpRequest request;
+    request.method = "POST";
+    request.path = "/api/v1/worker/jobs/job-1/run";
+
+    const HttpResponse response = fixture.router.handle(request);
+
+    EXPECT_EQ(response.status, 401);
+    EXPECT_NE(response.body.find("\"ok\":false"), std::string::npos);
+}
+
+TEST(WebApiRouterTest, WorkerJobsRunWrongMethodReturnsMethodNotAllowed) {
+    ApiRouterFixture fixture;
+
+    HttpRequest request;
+    request.method = "GET";
+    request.path = "/api/v1/worker/jobs/job-1/run";
+
+    const HttpResponse response = fixture.router.handle(request);
+
+    EXPECT_EQ(response.status, 405);
+}
+
+TEST(WebApiRouterTest, WorkerJobsRunUnknownIdReturnsNotFound) {
+    ApiRouterFixture fixture;
+    const std::string token = createSessionAndGetToken(fixture.router);
+
+    HttpRequest request;
+    request.method = "POST";
+    request.path = "/api/v1/worker/jobs/job-9999/run";
+    request.headers["authorization"] = "Bearer " + token;
+
+    const HttpResponse response = fixture.router.handle(request);
+
+    EXPECT_EQ(response.status, 404);
+    EXPECT_NE(response.body.find("\"WORKER_JOB_NOT_FOUND\""), std::string::npos);
+}
+
 TEST(WebApiRouterTest, WorkerJobsCreateThenGetReturnsSameQueuedJobMetadata) {
     ApiRouterFixture fixture;
     const std::string token = createSessionAndGetToken(fixture.router);
@@ -359,6 +399,49 @@ TEST(WebApiRouterTest, WorkerJobsCreateThenGetReturnsSameQueuedJobMetadata) {
     EXPECT_EQ(getJobResponse.status, 200);
     EXPECT_NE(getJobResponse.body.find("\"state\":\"queued\""), std::string::npos);
     EXPECT_NE(getJobResponse.body.find("\"jobId\":\"" + jobId + "\""), std::string::npos);
+}
+
+TEST(WebApiRouterTest, WorkerJobsRunThenGetShowsUpdatedFinishedState) {
+    ApiRouterFixture fixture;
+    const std::string token = createSessionAndGetToken(fixture.router);
+
+    HttpRequest importRequest;
+    importRequest.method = "POST";
+    importRequest.path = "/api/v1/worker/models/import-language";
+    importRequest.headers["authorization"] = "Bearer " + token;
+    importRequest.body = minimalValidModelSpecification();
+    const HttpResponse importResponse = fixture.router.handle(importRequest);
+    ASSERT_EQ(importResponse.status, 200);
+
+    HttpRequest createJobRequest;
+    createJobRequest.method = "POST";
+    createJobRequest.path = "/api/v1/worker/jobs";
+    createJobRequest.headers["authorization"] = "Bearer " + token;
+    const HttpResponse createJobResponse = fixture.router.handle(createJobRequest);
+    ASSERT_EQ(createJobResponse.status, 201);
+
+    const std::string jobId = extractJsonStringField(createJobResponse.body, "jobId");
+    ASSERT_FALSE(jobId.empty());
+
+    HttpRequest runJobRequest;
+    runJobRequest.method = "POST";
+    runJobRequest.path = "/api/v1/worker/jobs/" + jobId + "/run";
+    runJobRequest.headers["authorization"] = "Bearer " + token;
+    const HttpResponse runJobResponse = fixture.router.handle(runJobRequest);
+
+    EXPECT_EQ(runJobResponse.status, 200);
+    EXPECT_NE(runJobResponse.body.find("\"jobId\":\"" + jobId + "\""), std::string::npos);
+    EXPECT_NE(runJobResponse.body.find("\"state\":\"finished\""), std::string::npos);
+
+    HttpRequest getJobRequest;
+    getJobRequest.method = "GET";
+    getJobRequest.path = "/api/v1/worker/jobs/" + jobId;
+    getJobRequest.headers["authorization"] = "Bearer " + token;
+    const HttpResponse getJobResponse = fixture.router.handle(getJobRequest);
+
+    EXPECT_EQ(getJobResponse.status, 200);
+    EXPECT_NE(getJobResponse.body.find("\"jobId\":\"" + jobId + "\""), std::string::npos);
+    EXPECT_NE(getJobResponse.body.find("\"state\":\"finished\""), std::string::npos);
 }
 
 TEST(WebApiRouterTest, AuthSessionThenSimulatorInfoWithBearerToken) {


### PR DESCRIPTION
WEB

### Motivation
- Provide Stage 4 behavior to explicitly run an existing worker job synchronously and persist lifecycle transitions in job metadata. 
- Allow clients to trigger execution via a simple authenticated HTTP endpoint and continue to use `GET /api/v1/worker/jobs/{jobId}` to poll for updated state.

### Description
- Add `POST /api/v1/worker/jobs/{jobId}/run` route handling in `ApiRouter` with method checking, Bearer token extraction, and transport-level error mapping for `401`, `404`, `405`, and `500` responses. (files: `ApiRouter.cpp`, `ApiRouter.h`).
- Extend `WorkerJobManager` with minimal mutation APIs `setState()` and `setMessage()` to persist lifecycle transitions in the in-memory job store while keeping existing locking semantics. (files: `WorkerJobManager.h`, `WorkerJobManager.cpp`).
- Add a service-layer contract `WorkerJobRunResult` and implement `SimulatorSessionService::runWorkerJob(const std::string& accessToken, const std::string& jobId)` that validates token and ownership, marks the job `Running`, loads the job snapshot into the session simulator, calls `start()` synchronously, and persists `Finished` or `Failed` with a human message on error. (files: `SimulatorSessionService.h`, `SimulatorSessionService.cpp`).
- Update worker capability flags to reflect Stage 4 behavior (`supportsJobPolling = true`, `supportsBackgroundExecution = false`). (file: `SimulatorSessionService.cpp`).
- Add focused unit tests for the new run endpoint covering unauthorized, wrong method, unknown job id, and the happy path that creates a session/model/job, runs the job, and asserts the terminal state is visible through `GET /api/v1/worker/jobs/{jobId}`; also update capability expectation in tests. (file: `test_web_api_router.cpp`).
- Document Worker cycle Stage 4 in the Web README indicating synchronous execution, reuse of the `GET` job endpoint for inspection/polling, and non-goals (no background execution, no dedicated result endpoint yet). (file: `source/applications/web/README.md`).

### Testing
- Ran CMake configure successfully with `-DGENESYS_BUILD_WEB_APPLICATION=ON`.
- Attempted to build `genesys_webhook` and `genesys_test_web_api_router`; build failed at link time with pre-existing unresolved `SinkModelComponent` symbols that prevent producing the test executable, so the modified unit tests could not be executed in this environment.
- Observed the following during validation: `cmake` configure succeeded; `cmake --build ... --target genesys_webhook genesys_test_web_api_router` and `cmake --build ... --target genesys_test_web_api_router` failed at link with unresolved symbol errors; `ctest` could not run the router tests because the test binary was not produced.

## Worker Stage 4 execution report

### What I completed
- Implemented `POST /api/v1/worker/jobs/{jobId}/run` in the API router with method/auth/error mapping aligned to the requested contract.
- Added minimal `WorkerJobManager` mutation APIs for job state and message persistence.
- Implemented synchronous service-layer execution (`runWorkerJob`) using the session simulator and snapshot loading, with state transitions `queued -> running -> finished|failed`.
- Kept existing stage 1/2/3 endpoints intact and used existing `GET /api/v1/worker/jobs/{jobId}` for post-run inspection.
- Updated worker capabilities (`supportsJobPolling=true`, `supportsBackgroundExecution=false`).
- Added focused unit tests for run endpoint unauthorized, wrong method, unknown job, and happy path + polling state consistency.
- Updated `source/applications/web/README.md` with Worker Stage 4 documentation.

### What I could not complete
- Full build and execution of the updated unit tests in this environment.

### Why anything remains incomplete
- A pre-existing linker failure (unresolved `SinkModelComponent` symbols) prevents linking `genesys_webhook` and the `genesys_test_web_api_router` test binary, blocking test execution.

### Validation performed
- Ran `cmake -S . -B build/web-debug -G Ninja -DGENESYS_BUILD_WEB_APPLICATION=ON` (succeeded).
- Ran `cmake --build build/web-debug --target genesys_webhook genesys_test_web_api_router` (failed at link with unresolved external symbols).
- Ran `cmake --build build/web-debug --target genesys_test_web_api_router` (same linker failure).
- Ran `ctest --test-dir build/web-debug -R web_api_router` (no test binary found because of linker failure).

### Risks remaining
- The test suite changes could not be executed due to the unrelated linker issue, so runtime verification is incomplete in this environment.
- Re-running a job that is already terminal is currently allowed by this implementation and may require future policy enforcement.

### Files changed
- source/applications/web/api/ApiRouter.h
- source/applications/web/api/ApiRouter.cpp
- source/applications/web/service/SimulatorSessionService.h
- source/applications/web/service/SimulatorSessionService.cpp
- source/applications/web/worker/WorkerJobManager.h
- source/applications/web/worker/WorkerJobManager.cpp
- source/tests/unit/test_web_api_router.cpp
- source/applications/web/README.md

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd02efeca48321b8ab11f2a67e1d0a)