### PR TITLE
Fix AssignmentItem lifecycle and type coherence across save/load

### DIFF
--- a/source/plugins/data/AssignmentItem.cpp
+++ b/source/plugins/data/AssignmentItem.cpp
@@ -41,13 +41,12 @@ Assignment::Assignment(Model* model, std::string destination, std::string expres
 		if (model->getDataManager()->getDataDefinition(Util::TypeOf<Attribute>(), destination) == nullptr) {
 			model->getDataManager()->insert(Util::TypeOf<Attribute>(), new Attribute(model, destination));
 		}
-		_typeDC = Util::TypeOf<Attribute>();
 	} else {
 		if (model->getDataManager()->getDataDefinition(Util::TypeOf<Variable>(), destination) == nullptr) {
 			model->getDataManager()->insert(Util::TypeOf<Variable>(), new Variable(model, destination));
 		}
-		_typeDC = Util::TypeOf<Variable>();
 	}
+	_updateTypeDC();
 
 	SimulationControlGeneric<std::string>* propDestination = new SimulationControlGeneric<std::string>(
 				std::bind(&Assignment::getDestination, this),
@@ -78,7 +77,12 @@ Assignment::Assignment(std::string destination, std::string expression, bool isA
 	this->_isAttributeNotVariable = isAttributeNotVariable;
 	// an assignment is always in the form:
 	// (destinationType) destination = expression
+	_updateTypeDC();
 };
+
+Assignment::~Assignment() {
+	delete _properties;
+}
 
 void Assignment::setDestination(std::string _destination) {
 	this->_destination = _destination;
@@ -102,12 +106,7 @@ std::string Assignment::getExpression() const {
 
 void Assignment::setAttributeNotVariable(bool isAttributeNotVariable) {
 	this->_isAttributeNotVariable = isAttributeNotVariable;
-
-	if (_isAttributeNotVariable) {
-		_typeDC = Util::TypeOf<Attribute>();
-	} else {
-		_typeDC = Util::TypeOf<Variable>();
-	}
+	_updateTypeDC();
 }
 
 bool Assignment::isAttributeNotVariable() const {
@@ -126,12 +125,20 @@ bool Assignment::loadInstance(PersistenceRecord *fields, unsigned int parentInde
 	_destination = fields->loadField("assignDest" + Util::StrIndex(parentIndex), "");
 	_expression = fields->loadField("assignExpr" + Util::StrIndex(parentIndex), "");
 	_isAttributeNotVariable = fields->loadField("assignIsAttrib" + Util::StrIndex(parentIndex), true);
+	_updateTypeDC();
 	return true;
 }
 
 void Assignment::saveInstance(PersistenceRecord *fields, unsigned int parentIndex, bool saveDefaultValues) {
-	std::string num = Util::StrIndex(parentIndex);
 	fields->saveField("assignDest" + Util::StrIndex(parentIndex), getDestination(), "", saveDefaultValues);
 	fields->saveField("assignExpr" + Util::StrIndex(parentIndex), getExpression(), "", saveDefaultValues);
 	fields->saveField("assignIsAttrib" + Util::StrIndex(parentIndex), isAttributeNotVariable(), true, saveDefaultValues);
+}
+
+void Assignment::_updateTypeDC() {
+	if (_isAttributeNotVariable) {
+		_typeDC = Util::TypeOf<Attribute>();
+	} else {
+		_typeDC = Util::TypeOf<Variable>();
+	}
 }

--- a/source/plugins/data/AssignmentItem.h
+++ b/source/plugins/data/AssignmentItem.h
@@ -41,6 +41,7 @@ class Assignment {
 public:
 	Assignment(Model* model, std::string destination, std::string expression="1", bool isAttributeNotVariable = true);
 	Assignment(std::string destination, std::string expression, bool isAttributeNotVariable = true);
+	virtual ~Assignment();
 	void setDestination(std::string _destination);
 	std::string getDestination() const;
 	void setExpression(std::string _expression);
@@ -59,6 +60,7 @@ public:
 	bool loadInstance(PersistenceRecord *fields, unsigned int parentIndex);
 	void saveInstance(PersistenceRecord *fields, unsigned int parentIndex, bool saveDefault);
 private:
+	void _updateTypeDC();
 	std::string _destination = "";
 	std::string _expression = "";
 	bool _isAttributeNotVariable = true;
@@ -69,4 +71,3 @@ private:
 
 
 #endif /* ASSIGNMENTITEM_H */
-

--- a/source/tests/unit/test_simulator_runtime.cpp
+++ b/source/tests/unit/test_simulator_runtime.cpp
@@ -30,6 +30,7 @@
 #include "plugins/data/File.h"
 #include "plugins/data/CppCompiler.h"
 #include "plugins/data/SPICERunner.h"
+#include "plugins/data/AssignmentItem.h"
 #include "kernel/util/Util.h"
 #define private public
 #define protected public
@@ -4329,6 +4330,69 @@ TEST(SimulatorRuntimeTest, AssignSaveLoadPreservesMultipleAssignmentsWithoutInde
     EXPECT_EQ((*it)->getDestination(), "vCounter");
     EXPECT_EQ((*it)->getExpression(), "7");
     EXPECT_FALSE((*it)->isAttributeNotVariable());
+}
+
+TEST(SimulatorRuntimeTest, AssignmentConstructorInitializesTypeConsistently) {
+    Assignment asAttribute("Entity.attrCtor", "1", true);
+    EXPECT_TRUE(asAttribute.isAttributeNotVariable());
+    EXPECT_EQ(asAttribute.getTypeDC(), Util::TypeOf<Attribute>());
+
+    Assignment asVariable("varCtor", "2", false);
+    EXPECT_FALSE(asVariable.isAttributeNotVariable());
+    EXPECT_EQ(asVariable.getTypeDC(), Util::TypeOf<Variable>());
+}
+
+TEST(SimulatorRuntimeTest, AssignmentSetterUpdatesTypeConsistently) {
+    Assignment assignment("Entity.attrSetter", "1", true);
+    EXPECT_EQ(assignment.getTypeDC(), Util::TypeOf<Attribute>());
+
+    assignment.setAttributeNotVariable(false);
+    EXPECT_FALSE(assignment.isAttributeNotVariable());
+    EXPECT_EQ(assignment.getTypeDC(), Util::TypeOf<Variable>());
+
+    assignment.setAttributeNotVariable(true);
+    EXPECT_TRUE(assignment.isAttributeNotVariable());
+    EXPECT_EQ(assignment.getTypeDC(), Util::TypeOf<Attribute>());
+}
+
+TEST(SimulatorRuntimeTest, AssignmentSaveLoadRoundTripPreservesDestinationExpressionAndType) {
+    Assignment source("Entity.attrRoundTrip", "3+4", true);
+    source.setAttributeNotVariable(false);
+    source.setDestination("varRoundTrip");
+    source.setExpression("5*6");
+
+    FakeModelPersistenceRuntime persistence;
+    PersistenceRecord fields(persistence);
+    source.saveInstance(&fields, 0, true);
+
+    Assignment loaded("placeholder", "0", true);
+    ASSERT_TRUE(loaded.loadInstance(&fields, 0));
+    EXPECT_EQ(loaded.getDestination(), "varRoundTrip");
+    EXPECT_EQ(loaded.getExpression(), "5*6");
+    EXPECT_FALSE(loaded.isAttributeNotVariable());
+    EXPECT_EQ(loaded.getTypeDC(), Util::TypeOf<Variable>());
+}
+
+TEST(SimulatorRuntimeTest, AssignmentPropertiesContainerLifecycleWithModelConstructorIsSafe) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    auto* assignment = new Assignment(model, "Entity.attrProps", "1", true);
+    auto* properties = assignment->getProperties();
+    ASSERT_NE(properties, nullptr);
+    EXPECT_EQ(properties->size(), 3u);
+
+    delete assignment;
+    SUCCEED();
+}
+
+TEST(SimulatorRuntimeTest, AssignmentSimpleConstructorWithoutModelKeepsCoherentState) {
+    Assignment assignment("varSimpleCtor", "9", false);
+    EXPECT_EQ(assignment.getDestination(), "varSimpleCtor");
+    EXPECT_EQ(assignment.getExpression(), "9");
+    EXPECT_FALSE(assignment.isAttributeNotVariable());
+    EXPECT_EQ(assignment.getTypeDC(), Util::TypeOf<Variable>());
 }
 
 TEST(SimulatorRuntimeTest, AssignCheckFailsForInvalidExpression) {


### PR DESCRIPTION
### Motivation
- Prevent memory leak of the `_properties` container and avoid double-deleting externally-owned `SimulationControl*` entries. 
- Ensure `_typeDC` (destination data-class type) is always coherent after construction, setter changes and persistence round-trip. 
- Centralize fragile/duplicated type-update logic and remove obvious dead/noise code.

### Description
- Add `virtual ~Assignment()` to explicitly delete the `_properties` container without deleting contained `SimulationControl*` pointers. 
- Introduce a private helper `void _updateTypeDC()` and call it from both constructors, `setAttributeNotVariable(...)` and `loadInstance(...)` to keep `_typeDC` consistent. 
- Remove an unused local variable in `saveInstance()` and preserve existing persistence keys (`assignDest{i}`, `assignExpr{i}`, `assignIsAttrib{i}`). 
- Add unit tests in `source/tests/unit/test_simulator_runtime.cpp` that cover constructor initialization, setter toggling, save/load round-trip, properties container lifecycle with `Model*` constructor, and simple constructor without `Model*`.

### Testing
- Ran CMake configure: `cmake -S . -B build -G Ninja -DGENESYS_BUILD_TESTS=ON -DGENESYS_BUILD_KERNEL=ON -DGENESYS_BUILD_PARSER=ON -DGENESYS_BUILD_PLUGINS=ON -DGENESYS_TERMINAL_APPLICATION=OFF -DGENESYS_BUILD_GUI_APPLICATION=OFF -DGENESYS_BUILD_WEB_APPLICATION=OFF`, which configured successfully. 
- Built the runtime tests target: `cmake --build build --target genesys_test_simulator_runtime`, which compiled and linked successfully. 
- Executed assignment-focused tests: `ctest --test-dir build -R "SimulatorRuntimeTest.*Assignment" --output-on-failure`, and all targeted tests passed (8/8). 
- Ran broader smoke selection: `ctest --test-dir build -LE smoke --output-on-failure`, which returned non-zero due to several `*_NOT_BUILT` executables not present in this build configuration and not due to regressions in the changed code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd0890f5788321a37c5a2f331177b2)