### PR TITLE
Worker stage 5: add /worker/jobs/{jobId}/result terminal result endpoint

### DIFF
--- a/source/applications/web/README.md
+++ b/source/applications/web/README.md
@@ -2,7 +2,7 @@
 
 First functional implementation of the **Web** application type for GenESyS.
 
-## Current Stage 5 scope
+## Current scope
 - CMake executable: `genesys_webhook` (enabled with `-DGENESYS_BUILD_WEB_APPLICATION=ON`).
 - Layered architecture for HTTP transport, API routing, session/token, and simulator service.
 - Stateful session management with one `Simulator` per session and per-session workspace directories.
@@ -60,6 +60,19 @@ Behavior in this stage:
 - `GET /api/v1/worker/jobs/{jobId}` remains the basic state inspection/polling mechanism after run requests.
 
 This stage still does **not** include background execution, queue worker loops, cancellation, streaming updates, or a dedicated job result endpoint.
+
+
+## Worker cycle Stage 5
+This stage adds terminal result retrieval for previously executed worker jobs:
+- `GET /api/v1/worker/jobs/{jobId}/result` (requires `Authorization: Bearer <token>`)
+
+Behavior in this stage:
+- result retrieval is available only after the job reaches a terminal state (`finished` or `failed`);
+- queued or running jobs return a conflict response because no terminal result exists yet;
+- the endpoint returns a minimal structured simulation summary persisted at the end of synchronous execution;
+- execution remains synchronous and non-background (`POST /run` still performs the run inline);
+- cancellation is still not available;
+- distributed orchestration remains out of scope.
 
 ## How to run
 ```bash

--- a/source/applications/web/api/ApiRouter.cpp
+++ b/source/applications/web/api/ApiRouter.cpp
@@ -79,6 +79,26 @@ HttpResponse ApiRouter::handle(const HttpRequest& request) const {
         return HttpResponse{201, "application/json", "{\"ok\":true,\"data\":" + _workerJobDataJson(result.jobInfo) + "}"};
     }
 
+    // Stage 5 adds explicit terminal worker job result retrieval.
+    std::string workerResultJobId;
+    if (_tryExtractWorkerJobResultIdFromPath(request.path, workerResultJobId)) {
+        if (request.method != "GET") {
+            return _jsonError(405, "METHOD_NOT_ALLOWED", "Only GET is allowed for /api/v1/worker/jobs/{jobId}/result");
+        }
+
+        const std::string token = _extractBearerToken(request);
+        if (token.empty()) {
+            return _jsonError(401, "UNAUTHORIZED", "Missing or invalid Bearer token");
+        }
+
+        const auto result = _simulatorService.getWorkerJobResult(token, workerResultJobId);
+        if (!result.success) {
+            return _mapWorkerJobError(result.error, false);
+        }
+
+        return HttpResponse{200, "application/json", "{\"ok\":true,\"data\":" + _workerJobResultDataJson(result.jobResult) + "}"};
+    }
+
     // Stage 4 adds explicit synchronous worker job execution.
     std::string workerRunJobId;
     if (_tryExtractWorkerJobRunIdFromPath(request.path, workerRunJobId)) {
@@ -571,7 +591,9 @@ std::string ApiRouter::_workerCapabilitiesDataJson(const SimulatorSessionService
            "\"supportsBackgroundExecution\":" + std::string(capabilities.supportsBackgroundExecution ? "true" : "false") +
            ","
            "\"supportsModelUpload\":" + std::string(capabilities.supportsModelUpload ? "true" : "false") + ","
-           "\"supportsStreamingEvents\":" + std::string(capabilities.supportsStreamingEvents ? "true" : "false") + "}";
+           "\"supportsStreamingEvents\":" + std::string(capabilities.supportsStreamingEvents ? "true" : "false") + ","
+           "\"supportsJobResultRetrieval\":" + std::string(capabilities.supportsJobResultRetrieval ? "true" : "false") +
+           "}";
 }
 
 
@@ -591,6 +613,26 @@ bool ApiRouter::_tryExtractWorkerJobIdFromPath(const std::string& path, std::str
 bool ApiRouter::_tryExtractWorkerJobRunIdFromPath(const std::string& path, std::string& outJobId) {
     constexpr std::string_view prefix = "/api/v1/worker/jobs/";
     constexpr std::string_view suffix = "/run";
+
+    if (path.rfind(prefix, 0) != 0 || path.size() <= prefix.size() + suffix.size()) {
+        return false;
+    }
+
+    if (path.compare(path.size() - suffix.size(), suffix.size(), suffix) != 0) {
+        return false;
+    }
+
+    outJobId = path.substr(prefix.size(), path.size() - prefix.size() - suffix.size());
+    if (outJobId.empty() || outJobId.find('/') != std::string::npos) {
+        return false;
+    }
+
+    return true;
+}
+
+bool ApiRouter::_tryExtractWorkerJobResultIdFromPath(const std::string& path, std::string& outJobId) {
+    constexpr std::string_view prefix = "/api/v1/worker/jobs/";
+    constexpr std::string_view suffix = "/result";
 
     if (path.rfind(prefix, 0) != 0 || path.size() <= prefix.size() + suffix.size()) {
         return false;
@@ -632,6 +674,24 @@ std::string ApiRouter::_workerJobDataJson(const SimulatorSessionService::WorkerJ
            "\"message\":\"" + _escapeJson(job.message) + "\"}";
 }
 
+std::string ApiRouter::_workerJobResultDataJson(const SimulatorSessionService::WorkerJobResultInfo& result) {
+    std::string json = "{\"jobId\":\"" + _escapeJson(result.jobId) + "\","
+                       "\"state\":\"" + std::string(_workerJobStateToString(result.state)) + "\","
+                       "\"message\":\"" + _escapeJson(result.message) + "\","
+                       "\"simulatedTime\":" + std::to_string(result.simulatedTime) + ","
+                       "\"currentReplicationNumber\":" + std::to_string(result.currentReplicationNumber) + ","
+                       "\"numberOfReplications\":" + std::to_string(result.numberOfReplications) + ","
+                       "\"replicationLength\":" + std::to_string(result.replicationLength) + ","
+                       "\"warmUpPeriod\":" + std::to_string(result.warmUpPeriod);
+
+    if (result.hasIsPaused) {
+        json += ",\"isPaused\":" + std::string(result.isPaused ? "true" : "false");
+    }
+
+    json += "}";
+    return json;
+}
+
 HttpResponse ApiRouter::_mapWorkerJobError(
     SimulatorSessionService::WorkerJobError error,
     bool includeMissingModelMessage
@@ -651,6 +711,8 @@ HttpResponse ApiRouter::_mapWorkerJobError(
             return _jsonError(404, "WORKER_JOB_NOT_FOUND", "Worker job was not found");
         case SimulatorSessionService::WorkerJobError::OperationFailed:
             return _jsonError(500, "WORKER_JOB_FAILED", "Unable to process worker job request");
+        case SimulatorSessionService::WorkerJobError::ResultNotReady:
+            return _jsonError(409, "WORKER_JOB_RESULT_NOT_READY", "Worker job result is not available yet");
         case SimulatorSessionService::WorkerJobError::None:
         default:
             return _jsonError(500, "INTERNAL_ERROR", "Unexpected worker job error state");

--- a/source/applications/web/api/ApiRouter.h
+++ b/source/applications/web/api/ApiRouter.h
@@ -135,6 +135,13 @@ private:
      */
     static bool _tryExtractWorkerJobRunIdFromPath(const std::string& path, std::string& outJobId);
     /**
+     * @brief Tries to parse a worker job identifier from `/api/v1/worker/jobs/{jobId}/result`.
+     * @param path HTTP request path.
+     * @param outJobId Receives parsed job identifier when the path matches.
+     * @return True when the path format is valid and a non-empty id was extracted.
+     */
+    static bool _tryExtractWorkerJobResultIdFromPath(const std::string& path, std::string& outJobId);
+    /**
      * @brief Converts worker job states into API string values.
      * @param state Worker job state value.
      * @return Lowercase state string expected by clients.
@@ -146,6 +153,12 @@ private:
      * @return JSON object string.
      */
     static std::string _workerJobDataJson(const SimulatorSessionService::WorkerJobInfoResult& job);
+    /**
+     * @brief Serializes worker terminal result metadata into a JSON object string.
+     * @param result Worker job terminal result information.
+     * @return JSON object string.
+     */
+    static std::string _workerJobResultDataJson(const SimulatorSessionService::WorkerJobResultInfo& result);
     /**
      * @brief Maps worker job operation errors to transport-level HTTP responses.
      * @param error Worker job error code.

--- a/source/applications/web/service/SimulatorSessionService.cpp
+++ b/source/applications/web/service/SimulatorSessionService.cpp
@@ -108,6 +108,7 @@ SimulatorSessionService::WorkerCapabilitiesResult SimulatorSessionService::getWo
     // Stage 2 introduces a worker model-ingress endpoint based on plain text language import.
     result.supportsModelUpload = true;
     result.supportsStreamingEvents = false;
+    result.supportsJobResultRetrieval = true;
     return result;
 }
 
@@ -485,6 +486,7 @@ SimulatorSessionService::WorkerJobRunResult SimulatorSessionService::runWorkerJo
 
     std::string failureMessage;
     bool executionSucceeded = false;
+    WorkerJobTerminalResult terminalResult{};
 
     {
         std::scoped_lock lock(session->mutex);
@@ -493,7 +495,7 @@ SimulatorSessionService::WorkerJobRunResult SimulatorSessionService::runWorkerJo
             failureMessage = "Unable to access model manager";
         } else {
             try {
-                // Stage 4 executes directly from the persisted worker job snapshot in the same session simulator.
+                // Stage 4/5 keep synchronous execution from the persisted job snapshot.
                 const std::filesystem::path snapshotPath = session->workspacePath / job->snapshotFilename;
                 Model* loadedModel = modelManager->loadModel(snapshotPath.string());
                 if (loadedModel == nullptr) {
@@ -505,6 +507,14 @@ SimulatorSessionService::WorkerJobRunResult SimulatorSessionService::runWorkerJo
                     } else {
                         simulation->start();
                         executionSucceeded = true;
+
+                        // Persist a minimal terminal summary that can be queried by /result.
+                        terminalResult.simulatedTime = simulation->getSimulatedTime();
+                        terminalResult.currentReplicationNumber = simulation->getCurrentReplicationNumber();
+                        terminalResult.numberOfReplications = simulation->getNumberOfReplications();
+                        terminalResult.replicationLength = simulation->getReplicationLength();
+                        terminalResult.warmUpPeriod = simulation->getWarmUpPeriod();
+                        terminalResult.isPaused = simulation->isPaused();
                     }
                 }
             } catch (const std::exception& exception) {
@@ -516,12 +526,18 @@ SimulatorSessionService::WorkerJobRunResult SimulatorSessionService::runWorkerJo
     }
 
     if (!executionSucceeded) {
-        _workerJobManager.setState(jobId, WorkerJobState::Failed);
+        if (_workerJobManager.setState(jobId, WorkerJobState::Failed)) {
+            // Even on failures, keep a safe partial terminal summary for stage 5 result retrieval.
+            _workerJobManager.setTerminalResult(jobId, terminalResult);
+        }
         _workerJobManager.setMessage(jobId, failureMessage);
         return WorkerJobRunResult{false, WorkerJobError::OperationFailed, WorkerJobInfoResult{}};
     }
 
     if (!_workerJobManager.setState(jobId, WorkerJobState::Finished)) {
+        return WorkerJobRunResult{false, WorkerJobError::OperationFailed, WorkerJobInfoResult{}};
+    }
+    if (!_workerJobManager.setTerminalResult(jobId, terminalResult)) {
         return WorkerJobRunResult{false, WorkerJobError::OperationFailed, WorkerJobInfoResult{}};
     }
     _workerJobManager.setMessage(jobId, "");
@@ -532,6 +548,31 @@ SimulatorSessionService::WorkerJobRunResult SimulatorSessionService::runWorkerJo
     }
 
     return WorkerJobRunResult{true, WorkerJobError::None, _toWorkerJobInfoResult(storedJob.value())};
+}
+
+SimulatorSessionService::WorkerJobResultQueryResult SimulatorSessionService::getWorkerJobResult(
+    const std::string& accessToken,
+    const std::string& jobId
+) {
+    SessionContext* session = _sessionManager.getSessionByToken(accessToken);
+    if (session == nullptr || session->simulator == nullptr) {
+        return WorkerJobResultQueryResult{false, WorkerJobError::InvalidToken, WorkerJobResultInfo{}};
+    }
+
+    const std::optional<WorkerJob> job = _workerJobManager.getJob(jobId);
+    if (!job.has_value()) {
+        return WorkerJobResultQueryResult{false, WorkerJobError::JobNotFound, WorkerJobResultInfo{}};
+    }
+
+    if (job->sessionId != session->sessionId) {
+        return WorkerJobResultQueryResult{false, WorkerJobError::AccessDenied, WorkerJobResultInfo{}};
+    }
+
+    if (job->state == WorkerJobState::Queued || job->state == WorkerJobState::Running || !job->hasTerminalResult) {
+        return WorkerJobResultQueryResult{false, WorkerJobError::ResultNotReady, WorkerJobResultInfo{}};
+    }
+
+    return WorkerJobResultQueryResult{true, WorkerJobError::None, _toWorkerJobResultInfo(job.value())};
 }
 
 bool SimulatorSessionService::_isSafeFilename(const std::string& filename) {
@@ -561,5 +602,20 @@ SimulatorSessionService::WorkerJobInfoResult SimulatorSessionService::_toWorkerJ
     result.snapshotFilename = job.snapshotFilename;
     result.createdMarker = job.createdMarker;
     result.message = job.message;
+    return result;
+}
+
+SimulatorSessionService::WorkerJobResultInfo SimulatorSessionService::_toWorkerJobResultInfo(const WorkerJob& job) {
+    WorkerJobResultInfo result{};
+    result.jobId = job.jobId;
+    result.state = job.state;
+    result.message = job.message;
+    result.simulatedTime = job.terminalResult.simulatedTime;
+    result.currentReplicationNumber = job.terminalResult.currentReplicationNumber;
+    result.numberOfReplications = job.terminalResult.numberOfReplications;
+    result.replicationLength = job.terminalResult.replicationLength;
+    result.warmUpPeriod = job.terminalResult.warmUpPeriod;
+    result.hasIsPaused = job.terminalResult.isPaused.has_value();
+    result.isPaused = job.terminalResult.isPaused.value_or(false);
     return result;
 }

--- a/source/applications/web/service/SimulatorSessionService.h
+++ b/source/applications/web/service/SimulatorSessionService.h
@@ -43,7 +43,8 @@ public:
         MissingCurrentModel,
         JobNotFound,
         AccessDenied,
-        OperationFailed
+        OperationFailed,
+        ResultNotReady
     };
 
     /**
@@ -93,6 +94,7 @@ public:
         bool supportsBackgroundExecution = false;
         bool supportsModelUpload = false;
         bool supportsStreamingEvents = false;
+        bool supportsJobResultRetrieval = false;
     };
 
     /**
@@ -167,6 +169,31 @@ public:
         bool success = false;
         WorkerJobError error = WorkerJobError::None;
         WorkerJobInfoResult jobInfo;
+    };
+
+    /**
+     * @brief Describes terminal worker job result data exposed by worker stage 5 endpoint.
+     */
+    struct WorkerJobResultInfo {
+        std::string jobId;
+        WorkerJobState state = WorkerJobState::Queued;
+        std::string message;
+        double simulatedTime = 0.0;
+        unsigned int currentReplicationNumber = 0;
+        unsigned int numberOfReplications = 0;
+        double replicationLength = 0.0;
+        double warmUpPeriod = 0.0;
+        bool hasIsPaused = false;
+        bool isPaused = false;
+    };
+
+    /**
+     * @brief Contains worker job terminal result lookup output and error state.
+     */
+    struct WorkerJobResultQueryResult {
+        bool success = false;
+        WorkerJobError error = WorkerJobError::None;
+        WorkerJobResultInfo jobResult;
     };
 
     /**
@@ -331,6 +358,13 @@ public:
      * @return Worker job run output and error state.
      */
     WorkerJobRunResult runWorkerJob(const std::string& accessToken, const std::string& jobId);
+    /**
+     * @brief Returns persisted terminal result data for a token-scoped worker job.
+     * @param accessToken Bearer token associated with a session.
+     * @param jobId Worker job identifier to query.
+     * @return Worker job terminal result lookup output and error state.
+     */
+    WorkerJobResultQueryResult getWorkerJobResult(const std::string& accessToken, const std::string& jobId);
 
 private:
     /**
@@ -346,6 +380,13 @@ private:
      * @return API-facing worker job metadata.
      */
     static WorkerJobInfoResult _toWorkerJobInfoResult(const WorkerJob& job);
+
+    /**
+     * @brief Converts internal worker job storage record into stage 5 result output shape.
+     * @param job Internal job record.
+     * @return API-facing worker job terminal result metadata.
+     */
+    static WorkerJobResultInfo _toWorkerJobResultInfo(const WorkerJob& job);
 
     SessionManager& _sessionManager;
     WorkerJobManager& _workerJobManager;

--- a/source/applications/web/worker/WorkerJob.h
+++ b/source/applications/web/worker/WorkerJob.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include <string>
 
 /**
@@ -13,6 +14,18 @@ enum class WorkerJobState {
 };
 
 /**
+ * @brief Stores the terminal simulation summary persisted for a finished or failed worker job.
+ */
+struct WorkerJobTerminalResult {
+    double simulatedTime = 0.0;
+    unsigned int currentReplicationNumber = 0;
+    unsigned int numberOfReplications = 0;
+    double replicationLength = 0.0;
+    double warmUpPeriod = 0.0;
+    std::optional<bool> isPaused;
+};
+
+/**
  * @brief Stores metadata for a worker job snapshot owned by the web worker.
  */
 struct WorkerJob {
@@ -22,4 +35,6 @@ struct WorkerJob {
     std::string snapshotFilename;
     std::string createdMarker;
     std::string message;
+    bool hasTerminalResult = false;
+    WorkerJobTerminalResult terminalResult;
 };

--- a/source/applications/web/worker/WorkerJobManager.cpp
+++ b/source/applications/web/worker/WorkerJobManager.cpp
@@ -50,6 +50,19 @@ bool WorkerJobManager::setMessage(const std::string& jobId, const std::string& m
     return true;
 }
 
+bool WorkerJobManager::setTerminalResult(const std::string& jobId, const WorkerJobTerminalResult& terminalResult) {
+    std::scoped_lock lock(_mutex);
+
+    const auto iterator = _jobs.find(jobId);
+    if (iterator == _jobs.end()) {
+        return false;
+    }
+
+    iterator->second.terminalResult = terminalResult;
+    iterator->second.hasTerminalResult = true;
+    return true;
+}
+
 std::optional<WorkerJob> WorkerJobManager::getJob(const std::string& jobId) const {
     std::scoped_lock lock(_mutex);
 

--- a/source/applications/web/worker/WorkerJobManager.h
+++ b/source/applications/web/worker/WorkerJobManager.h
@@ -43,6 +43,14 @@ public:
     bool setMessage(const std::string& jobId, const std::string& message);
 
     /**
+     * @brief Persists the terminal simulation summary for an existing job.
+     * @param jobId Job identifier to update.
+     * @param terminalResult Terminal simulation summary values.
+     * @return True when the job exists and was updated.
+     */
+    bool setTerminalResult(const std::string& jobId, const WorkerJobTerminalResult& terminalResult);
+
+    /**
      * @brief Fetches a previously stored job record.
      * @param jobId Job identifier.
      * @return Copy of the job when found.

--- a/source/tests/unit/test_web_api_router.cpp
+++ b/source/tests/unit/test_web_api_router.cpp
@@ -170,6 +170,7 @@ TEST(WebApiRouterTest, WorkerCapabilitiesReflectCurrentImplementation) {
     EXPECT_NE(response.body.find("\"supportsBackgroundExecution\":false"), std::string::npos);
     EXPECT_NE(response.body.find("\"supportsModelUpload\":true"), std::string::npos);
     EXPECT_NE(response.body.find("\"supportsStreamingEvents\":false"), std::string::npos);
+    EXPECT_NE(response.body.find("\"supportsJobResultRetrieval\":true"), std::string::npos);
 }
 
 TEST(WebApiRouterTest, WorkerCapabilitiesPostReturnsMethodNotAllowed) {
@@ -328,6 +329,67 @@ TEST(WebApiRouterTest, WorkerJobsGetUnknownIdReturnsNotFound) {
     EXPECT_NE(response.body.find("\"WORKER_JOB_NOT_FOUND\""), std::string::npos);
 }
 
+
+TEST(WebApiRouterTest, WorkerJobsResultWithoutTokenReturnsUnauthorized) {
+    ApiRouterFixture fixture;
+
+    HttpRequest request;
+    request.method = "GET";
+    request.path = "/api/v1/worker/jobs/job-1/result";
+
+    const HttpResponse response = fixture.router.handle(request);
+
+    EXPECT_EQ(response.status, 401);
+    EXPECT_NE(response.body.find("\"ok\":false"), std::string::npos);
+}
+
+TEST(WebApiRouterTest, WorkerJobsResultUnknownIdReturnsNotFound) {
+    ApiRouterFixture fixture;
+    const std::string token = createSessionAndGetToken(fixture.router);
+
+    HttpRequest request;
+    request.method = "GET";
+    request.path = "/api/v1/worker/jobs/job-9999/result";
+    request.headers["authorization"] = "Bearer " + token;
+
+    const HttpResponse response = fixture.router.handle(request);
+
+    EXPECT_EQ(response.status, 404);
+    EXPECT_NE(response.body.find("\"WORKER_JOB_NOT_FOUND\""), std::string::npos);
+}
+
+TEST(WebApiRouterTest, WorkerJobsResultQueuedJobReturnsConflict) {
+    ApiRouterFixture fixture;
+    const std::string token = createSessionAndGetToken(fixture.router);
+
+    HttpRequest importRequest;
+    importRequest.method = "POST";
+    importRequest.path = "/api/v1/worker/models/import-language";
+    importRequest.headers["authorization"] = "Bearer " + token;
+    importRequest.body = minimalValidModelSpecification();
+    ASSERT_EQ(fixture.router.handle(importRequest).status, 200);
+
+    HttpRequest createJobRequest;
+    createJobRequest.method = "POST";
+    createJobRequest.path = "/api/v1/worker/jobs";
+    createJobRequest.headers["authorization"] = "Bearer " + token;
+    const HttpResponse createJobResponse = fixture.router.handle(createJobRequest);
+    ASSERT_EQ(createJobResponse.status, 201);
+
+    const std::string jobId = extractJsonStringField(createJobResponse.body, "jobId");
+    ASSERT_FALSE(jobId.empty());
+
+    HttpRequest resultRequest;
+    resultRequest.method = "GET";
+    resultRequest.path = "/api/v1/worker/jobs/" + jobId + "/result";
+    resultRequest.headers["authorization"] = "Bearer " + token;
+
+    const HttpResponse response = fixture.router.handle(resultRequest);
+
+    EXPECT_EQ(response.status, 409);
+    EXPECT_NE(response.body.find("\"WORKER_JOB_RESULT_NOT_READY\""), std::string::npos);
+}
+
 TEST(WebApiRouterTest, WorkerJobsRunWithoutTokenReturnsUnauthorized) {
     ApiRouterFixture fixture;
 
@@ -399,6 +461,51 @@ TEST(WebApiRouterTest, WorkerJobsCreateThenGetReturnsSameQueuedJobMetadata) {
     EXPECT_EQ(getJobResponse.status, 200);
     EXPECT_NE(getJobResponse.body.find("\"state\":\"queued\""), std::string::npos);
     EXPECT_NE(getJobResponse.body.find("\"jobId\":\"" + jobId + "\""), std::string::npos);
+}
+
+
+TEST(WebApiRouterTest, WorkerJobsRunThenResultReturnsTerminalSummary) {
+    ApiRouterFixture fixture;
+    const std::string token = createSessionAndGetToken(fixture.router);
+
+    HttpRequest importRequest;
+    importRequest.method = "POST";
+    importRequest.path = "/api/v1/worker/models/import-language";
+    importRequest.headers["authorization"] = "Bearer " + token;
+    importRequest.body = minimalValidModelSpecification();
+    ASSERT_EQ(fixture.router.handle(importRequest).status, 200);
+
+    HttpRequest createJobRequest;
+    createJobRequest.method = "POST";
+    createJobRequest.path = "/api/v1/worker/jobs";
+    createJobRequest.headers["authorization"] = "Bearer " + token;
+    const HttpResponse createJobResponse = fixture.router.handle(createJobRequest);
+    ASSERT_EQ(createJobResponse.status, 201);
+
+    const std::string jobId = extractJsonStringField(createJobResponse.body, "jobId");
+    ASSERT_FALSE(jobId.empty());
+
+    HttpRequest runJobRequest;
+    runJobRequest.method = "POST";
+    runJobRequest.path = "/api/v1/worker/jobs/" + jobId + "/run";
+    runJobRequest.headers["authorization"] = "Bearer " + token;
+    ASSERT_EQ(fixture.router.handle(runJobRequest).status, 200);
+
+    HttpRequest resultRequest;
+    resultRequest.method = "GET";
+    resultRequest.path = "/api/v1/worker/jobs/" + jobId + "/result";
+    resultRequest.headers["authorization"] = "Bearer " + token;
+
+    const HttpResponse resultResponse = fixture.router.handle(resultRequest);
+
+    EXPECT_EQ(resultResponse.status, 200);
+    EXPECT_NE(resultResponse.body.find("\"jobId\":\"" + jobId + "\""), std::string::npos);
+    EXPECT_NE(resultResponse.body.find("\"state\":\"finished\""), std::string::npos);
+    EXPECT_NE(resultResponse.body.find("\"simulatedTime\":"), std::string::npos);
+    EXPECT_NE(resultResponse.body.find("\"currentReplicationNumber\":"), std::string::npos);
+    EXPECT_NE(resultResponse.body.find("\"numberOfReplications\":"), std::string::npos);
+    EXPECT_NE(resultResponse.body.find("\"replicationLength\":"), std::string::npos);
+    EXPECT_NE(resultResponse.body.find("\"warmUpPeriod\":"), std::string::npos);
 }
 
 TEST(WebApiRouterTest, WorkerJobsRunThenGetShowsUpdatedFinishedState) {


### PR DESCRIPTION
### Motivation
- Provide a dedicated API to retrieve a minimal, factual terminal summary for executed worker jobs, enabling clients to get structured execution outcomes without changing the synchronous execution model.
- Persist a small terminal summary (simulated time and replication metadata) at the end of synchronous `run` so the result can be retrieved later.
- Keep changes narrowly scoped to stage 5 requirements (no background execution, no streaming, no cancellation, preserve existing job endpoints).

### Description
- Extended the in-memory worker job model with a compact terminal result struct and availability flag by updating `WorkerJob` to include `WorkerJobTerminalResult` and `hasTerminalResult` (Doxygen comments added to touched types). (files: `WorkerJob.h`, `WorkerJobManager.h`, `WorkerJobManager.cpp`)
- Added `WorkerJobManager::setTerminalResult(...)` to persist terminal summaries using the existing locking/ownership approach. (file: `WorkerJobManager.*`)
- Extended the service layer with stage-5 contracts: `WorkerJobResultInfo`, `WorkerJobResultQueryResult`, `getWorkerJobResult(...)`, and `_toWorkerJobResultInfo(...)`, and updated `runWorkerJob(...)` to populate and persist a terminal summary on success and a safe partial summary on failure; Doxygen documentation added for touched methods. (files: `SimulatorSessionService.h`, `SimulatorSessionService.cpp`)
- Added an authenticated endpoint `GET /api/v1/worker/jobs/{jobId}/result` to `ApiRouter`, including path parsing, authorization check, error mapping (`401`, `404`, `409`, `500`), and JSON serialization of the terminal result. (files: `ApiRouter.h`, `ApiRouter.cpp`)
- Exposed the new capability flag `supportsJobResultRetrieval = true` in `WorkerCapabilitiesResult` and included it in the capabilities JSON serialization. (files: `SimulatorSessionService.*`, `ApiRouter.cpp`)
- Expanded unit tests in `test_web_api_router.cpp` to cover the result route: unauthorized access (`401`), unknown job (`404`), queued job not-ready (`409`), and the happy path (create/import model → create job → run job → request `/result` and assert `200` with result fields).
- Updated `source/applications/web/README.md` documenting Worker cycle Stage 5 behavior and explicit out-of-scope items.

### Testing
- Ran CMake configure: `cmake -S . -B build/web-debug -G Ninja -DGENESYS_BUILD_WEB_APPLICATION=ON` which succeeded.
- Attempted to build targets: `cmake --build build/web-debug --target genesys_webhook genesys_test_web_api_router`; build progressed but failed at link time with a pre-existing unresolved symbol issue in plugin objects (`SinkModelComponent` references) unrelated to the stage-5 code changes, preventing the test binary from being produced.
- Attempted tests: `ctest --test-dir build/web-debug --output-on-failure -R web_api_router` could not run because the test executable was not built due to the linker failure.

## Worker Stage 5 execution report

### What I completed
- Added stage-5 terminal result persistence to worker jobs and manager update API.
- Added service-layer result contracts and implemented `getWorkerJobResult(...)`.
- Updated synchronous `runWorkerJob(...)` to persist terminal summary on success and a safe partial summary on failure.
- Added authenticated `GET /api/v1/worker/jobs/{jobId}/result` route with correct auth/session/error behavior and JSON serialization.
- Added `supportsJobResultRetrieval` capability and updated capability payload serialization.
- Extended `test_web_api_router.cpp` with required stage-5 route tests.
- Updated README with Worker cycle Stage 5 behavior and explicit out-of-scope items.

### What I could not complete
- Full build+test run to execute the new unit tests because the build failed at link time due to an existing unresolved `SinkModelComponent` symbol in plugin objects.

### Why anything remains incomplete
- The linker failure prevents producing `genesys_webhook` and `genesys_test_web_api_router` binaries; this is a pre-existing baseline issue in the repository's link stage and is unrelated to the changes made for stage 5.

### Validation performed
- Configured the web build with CMake successfully.
- Built up to link stage; observed linker errors referencing plugin symbols (`SinkModelComponent`) which blocked final linking and test execution.

### Risks remaining
- Terminal result route behavior and tests remain unvalidated at runtime until the repository linker issue is resolved.
- If the kernel or plugin build configuration changes, re-run the same build+ctest commands to confirm no regressions.

### Files changed
- source/applications/web/worker/WorkerJob.h
- source/applications/web/worker/WorkerJobManager.h
- source/applications/web/worker/WorkerJobManager.cpp
- source/applications/web/service/SimulatorSessionService.h
- source/applications/web/service/SimulatorSessionService.cpp
- source/applications/web/api/ApiRouter.h
- source/applications/web/api/ApiRouter.cpp
- source/tests/unit/test_web_api_router.cpp
- source/applications/web/README.md

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd07c815d883218806a56a39f4aa6b)