### PR TITLE
Stage 6: Harden SimpleHttpServer transport — incremental reads, size limit, timeouts

### DIFF
--- a/source/applications/web/README.md
+++ b/source/applications/web/README.md
@@ -74,6 +74,17 @@ Behavior in this stage:
 - cancellation is still not available;
 - distributed orchestration remains out of scope.
 
+
+## Worker cycle Stage 6
+This stage hardens HTTP transport behavior for existing worker and session APIs without changing route contracts:
+- request reading is now incremental (`recv` loop) instead of single-shot reads;
+- request assembly is bounded by a transport limit of **1 MiB** (larger payloads return `413 Payload Too Large`);
+- socket receive/send timeouts are configured to **5 seconds** per client connection;
+- when timeout happens before a complete request is assembled, the server returns `408 Request Timeout`;
+- transport-level error payloads remain JSON-shaped and consistent with current server error responses.
+
+This stage is explicitly operational hardening only. Application-layer endpoints and worker cycle stages 1-5 contracts remain unchanged.
+
 ## How to run
 ```bash
 cmake -S . -B build/web-debug -G Ninja -DGENESYS_BUILD_WEB_APPLICATION=ON

--- a/source/applications/web/http/SimpleHttpServer.cpp
+++ b/source/applications/web/http/SimpleHttpServer.cpp
@@ -8,9 +8,14 @@
 #include <optional>
 #include <sstream>
 #include <sys/socket.h>
+#include <sys/time.h>
 #include <unistd.h>
 
 namespace {
+constexpr std::size_t kMaxRequestBytes = 1024 * 1024;  // 1 MiB transport guardrail.
+constexpr int kSocketTimeoutSeconds = 5;
+constexpr std::size_t kReadChunkSize = 4096;
+
 std::string statusText(int status) {
     switch (status) {
         case 200:
@@ -25,6 +30,10 @@ std::string statusText(int status) {
             return "Not Found";
         case 405:
             return "Method Not Allowed";
+        case 408:
+            return "Request Timeout";
+        case 413:
+            return "Payload Too Large";
         case 500:
             return "Internal Server Error";
         default:
@@ -37,6 +46,50 @@ std::string toLower(std::string value) {
         c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
     }
     return value;
+}
+
+std::optional<std::size_t> parseContentLengthFromHeaders(const std::string& requestText) {
+    const std::string separator = "\r\n\r\n";
+    const auto headersEnd = requestText.find(separator);
+    if (headersEnd == std::string::npos) {
+        return std::nullopt;
+    }
+
+    std::istringstream headerStream(requestText.substr(0, headersEnd));
+    std::string line;
+    std::getline(headerStream, line);  // Skip request line.
+
+    while (std::getline(headerStream, line)) {
+        if (!line.empty() && line.back() == '\r') {
+            line.pop_back();
+        }
+        if (line.empty()) {
+            continue;
+        }
+
+        const auto colonPos = line.find(':');
+        if (colonPos == std::string::npos) {
+            continue;
+        }
+
+        std::string name = toLower(line.substr(0, colonPos));
+        if (name != "content-length") {
+            continue;
+        }
+
+        std::string value = line.substr(colonPos + 1);
+        while (!value.empty() && value.front() == ' ') {
+            value.erase(value.begin());
+        }
+
+        try {
+            return static_cast<std::size_t>(std::stoul(value));
+        } catch (...) {
+            return std::nullopt;
+        }
+    }
+
+    return 0;
 }
 
 std::optional<HttpRequest> parseRequest(const std::string& requestText) {
@@ -105,6 +158,67 @@ std::optional<HttpRequest> parseRequest(const std::string& requestText) {
     return request;
 }
 
+enum class ReadRequestResult {
+    Complete,
+    Timeout,
+    TooLarge,
+    Invalid,
+    SocketError,
+    Closed
+};
+
+ReadRequestResult readHttpRequest(int clientFd, std::string& requestText) {
+    requestText.clear();
+    requestText.reserve(kReadChunkSize);
+
+    std::optional<std::size_t> contentLength;
+    std::size_t expectedTotalSize = 0;
+
+    while (true) {
+        char chunk[kReadChunkSize];
+        const ssize_t bytesRead = recv(clientFd, chunk, sizeof(chunk), 0);
+        if (bytesRead == 0) {
+            return requestText.empty() ? ReadRequestResult::Closed : ReadRequestResult::Invalid;
+        }
+        if (bytesRead < 0) {
+            // Timeout from SO_RCVTIMEO.
+            if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                return ReadRequestResult::Timeout;
+            }
+            if (errno == EINTR) {
+                continue;
+            }
+            return ReadRequestResult::SocketError;
+        }
+
+        requestText.append(chunk, static_cast<std::size_t>(bytesRead));
+        if (requestText.size() > kMaxRequestBytes) {
+            return ReadRequestResult::TooLarge;
+        }
+
+        if (!contentLength.has_value()) {
+            const std::string separator = "\r\n\r\n";
+            const auto headersEnd = requestText.find(separator);
+            if (headersEnd != std::string::npos) {
+                contentLength = parseContentLengthFromHeaders(requestText);
+                if (!contentLength.has_value()) {
+                    return ReadRequestResult::Invalid;
+                }
+
+                expectedTotalSize = headersEnd + separator.size() + *contentLength;
+                if (expectedTotalSize > kMaxRequestBytes) {
+                    return ReadRequestResult::TooLarge;
+                }
+            }
+        }
+
+        if (contentLength.has_value() && requestText.size() >= expectedTotalSize) {
+            requestText.resize(expectedTotalSize);
+            return ReadRequestResult::Complete;
+        }
+    }
+}
+
 std::string buildResponse(const HttpResponse& response) {
     const std::string payload = response.body;
     std::ostringstream builder;
@@ -123,8 +237,28 @@ HttpResponse badRequestResponse() {
     return HttpResponse{400, "application/json", "{\"ok\":false,\"error\":{\"code\":\"BAD_REQUEST\",\"message\":\"Invalid HTTP request\"}}"};
 }
 
+HttpResponse requestTimeoutResponse() {
+    return HttpResponse{408,
+                        "application/json",
+                        "{\"ok\":false,\"error\":{\"code\":\"REQUEST_TIMEOUT\",\"message\":\"Timed out while reading HTTP request\"}}"};
+}
+
+HttpResponse payloadTooLargeResponse() {
+    return HttpResponse{413,
+                        "application/json",
+                        "{\"ok\":false,\"error\":{\"code\":\"PAYLOAD_TOO_LARGE\",\"message\":\"HTTP request exceeds transport limit\"}}"};
+}
+
 HttpResponse internalErrorResponse() {
     return HttpResponse{500, "application/json", "{\"ok\":false,\"error\":{\"code\":\"INTERNAL_SERVER_ERROR\",\"message\":\"Unhandled server error\"}}"};
+}
+
+void configureSocketTimeouts(int fd) {
+    timeval timeout{};
+    timeout.tv_sec = kSocketTimeoutSeconds;
+    timeout.tv_usec = 0;
+    (void)setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
+    (void)setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout));
 }
 }  // namespace
 
@@ -167,23 +301,33 @@ bool SimpleHttpServer::serve(const RequestHandler& handler, unsigned long maxReq
             return false;
         }
 
-        char buffer[16384];
-        const ssize_t bytesRead = recv(clientFd, buffer, sizeof(buffer) - 1, 0);
-        if (bytesRead <= 0) {
-            close(clientFd);
-            continue;
-        }
-        buffer[bytesRead] = '\0';
+        configureSocketTimeouts(clientFd);
+
+        std::string requestText;
+        const ReadRequestResult readResult = readHttpRequest(clientFd, requestText);
 
         HttpResponse response;
-        if (auto request = parseRequest(std::string(buffer, static_cast<std::size_t>(bytesRead))); request.has_value()) {
-            try {
-                response = handler(*request);
-            } catch (...) {
-                response = internalErrorResponse();
+        if (readResult == ReadRequestResult::Complete) {
+            if (auto request = parseRequest(requestText); request.has_value()) {
+                try {
+                    response = handler(*request);
+                } catch (...) {
+                    response = internalErrorResponse();
+                }
+            } else {
+                response = badRequestResponse();
             }
-        } else {
+        } else if (readResult == ReadRequestResult::Timeout) {
+            response = requestTimeoutResponse();
+        } else if (readResult == ReadRequestResult::TooLarge) {
+            response = payloadTooLargeResponse();
+        } else if (readResult == ReadRequestResult::Invalid) {
             response = badRequestResponse();
+        } else if (readResult == ReadRequestResult::SocketError) {
+            response = internalErrorResponse();
+        } else {
+            close(clientFd);
+            continue;
         }
 
         const std::string wire = buildResponse(response);

--- a/source/applications/web/http/SimpleHttpServer.h
+++ b/source/applications/web/http/SimpleHttpServer.h
@@ -5,12 +5,28 @@
 
 #include <functional>
 
+/**
+ * @brief Minimal blocking HTTP/1.1 server for single-request-per-connection handling.
+ *
+ * This server intentionally keeps the transport model simple (no keep-alive, no chunked
+ * transfer decoding) and delegates application routing to a request handler callback.
+ */
 class SimpleHttpServer {
 public:
     using RequestHandler = std::function<HttpResponse(const HttpRequest&)>;
 
+    /**
+     * @brief Construct a server bound to a TCP port.
+     * @param port TCP port that the server will bind/listen on.
+     */
     explicit SimpleHttpServer(unsigned short port);
 
+    /**
+     * @brief Serve HTTP requests until the optional request limit is reached.
+     * @param handler Callback used to transform a parsed request into a response.
+     * @param maxRequests Maximum number of client requests to process (0 means unlimited).
+     * @return true when the serving loop ends normally; false on socket setup/runtime failure.
+     */
     bool serve(const RequestHandler& handler, unsigned long maxRequests = 0);
 
 private:


### PR DESCRIPTION
### Motivation
- The existing `SimpleHttpServer` assumed a single `recv` and fixed stack buffer, which fails for larger or fragmented requests and provides no transport-level timeouts or size bounds.
- Harden the HTTP transport for worker APIs by adding incremental reading, explicit request-size limits, socket timeouts, and clearer transport error responses while preserving existing routing and API contracts.

### Description
- Reworked request ingestion in `SimpleHttpServer` to read in a `recv` loop until headers are complete, parse `Content-Length`, and continue reading until the full body has been assembled; parsing model and routing are preserved. (files: `source/applications/web/http/SimpleHttpServer.cpp`, `source/applications/web/http/HttpRequest.h`)
- Introduced transport guardrail constants: `kMaxRequestBytes = 1 MiB`, `kSocketTimeoutSeconds = 5`, and a `kReadChunkSize` for incremental reads; oversized requests now map to `413 Payload Too Large`.
- Configured per-client socket timeouts (`SO_RCVTIMEO` and `SO_SNDTIMEO`) and mapped read-timeout conditions to `408 Request Timeout` transport responses.
- Added helper machinery: `ReadRequestResult` enum, `readHttpRequest()` and `parseContentLengthFromHeaders()` helpers, transport-level JSON error builders, and updated `statusText` mapping for new statuses.
- Added Doxygen documentation for the touched `SimpleHttpServer` class and its public methods and small explanatory comments in implementation.
- Documented Stage 6 operational hardening in `source/applications/web/README.md` with high-level notes that this is transport-level hardening only and does not change application-layer APIs.

### Testing
- Ran CMake configure: `cmake -S . -B build/web-debug -G Ninja -DGENESYS_BUILD_WEB_APPLICATION=ON`, which completed successfully.
- Attempted full build: `cmake --build build/web-debug --target genesys_webhook genesys_test_web_api_router` failed at link time due to a pre-existing undefined symbol (`SinkModelComponent`) unrelated to the HTTP transport changes, so test binary generation and `ctest` execution were blocked.
- Confirmed compilation reached and compiled the modified `SimpleHttpServer` sources before the global link failure; no new unit/integration tests were added in this stage to keep scope minimal.

```markdown
## Worker Stage 6 execution report

### What I completed
- Implemented incremental HTTP request assembly in `SimpleHttpServer` with repeated `recv` reads and `Content-Length`-aware completion.
- Added conservative request-size bounding (1 MiB), timeout configuration (`SO_RCVTIMEO` and `SO_SNDTIMEO`), and explicit transport error mapping (`408`, `413`).
- Kept router/service contracts and existing stage 1/2/3/4/5 worker endpoints intact.
- Added Doxygen docs for the touched class and methods.
- Updated `source/applications/web/README.md` with Stage 6 hardening notes.

### What I could not complete
- Full target build/test execution (`genesys_webhook`, `genesys_test_web_api_router`, and `ctest -R web_api_router`) could not be completed successfully due to a linker error unrelated to the HTTP changes.

### Why anything remains incomplete
- The build fails at link time with unresolved `SinkModelComponent` symbols from plugin objects, which blocked test binary generation and therefore `ctest` execution.

### Validation performed
- Ran configure and build commands; compilation progressed and the modified HTTP server compiled, but the global link stage failed before test execution.

### Risks remaining
- Timeout and payload-too-large runtime paths are implemented but not covered by automated tests in this environment because the pre-existing linker issue prevented full test execution.
- The server intentionally remains minimal (no chunked transfer, keep-alive, or HTTP/2) per stage constraints.

### Files changed
- `source/applications/web/http/SimpleHttpServer.h`
- `source/applications/web/http/SimpleHttpServer.cpp`
- `source/applications/web/README.md`
```

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd0c73d35083218f540f64ad313850)