### PR TITLE
Make DummyElement a coherent ModelDataDefinition template

### DIFF
--- a/source/plugins/data/DummyElement.cpp
+++ b/source/plugins/data/DummyElement.cpp
@@ -11,6 +11,8 @@
  */
 
 #include "DummyElement.h"
+#include "../../kernel/simulator/Model.h"
+#include "../../kernel/simulator/SimulationControlAndResponse.h"
 
 #ifdef PLUGINCONNECT_DYNAMIC
 
@@ -25,6 +27,18 @@ extern "C" StaticGetPluginInformation GetPluginInformation() {
 //
 
 DummyElement::DummyElement(Model* model, std::string name) : ModelDataDefinition(model, Util::TypeOf<DummyElement>(), name) {
+	SimulationControlString* propSomeString = new SimulationControlString(
+					 std::bind(&DummyElement::getSomeString, this),
+					 std::bind(&DummyElement::setSomeString, this, std::placeholders::_1),
+					 Util::TypeOf<DummyElement>(), getName(), "SomeString");
+	SimulationControlDouble* propSomeUint = new SimulationControlDouble(
+					 [this]() { return static_cast<double>(this->getSomeUint()); },
+					 [this](double value) { this->setSomeUint(value < 0.0 ? 0u : static_cast<unsigned int>(value)); },
+					 Util::TypeOf<DummyElement>(), getName(), "SomeUint");
+	_parentModel->getControls()->insert(propSomeString);
+	_parentModel->getControls()->insert(propSomeUint);
+	_addProperty(propSomeString);
+	_addProperty(propSomeUint);
 }
 
 
@@ -32,7 +46,21 @@ DummyElement::DummyElement(Model* model, std::string name) : ModelDataDefinition
 // public: /// new public user methods for this component
 //
 
-// ...
+void DummyElement::setSomeString(const std::string& someString) {
+	_someString = someString;
+}
+
+std::string DummyElement::getSomeString() const {
+	return _someString;
+}
+
+void DummyElement::setSomeUint(unsigned int someUint) {
+	_someUint = someUint;
+}
+
+unsigned int DummyElement::getSomeUint() const {
+	return _someUint;
+}
 
 
 //
@@ -40,7 +68,9 @@ DummyElement::DummyElement(Model* model, std::string name) : ModelDataDefinition
 //
 
 std::string DummyElement::show() {
-	return ModelDataDefinition::show();
+	return ModelDataDefinition::show() +
+			", someString=\"" + _someString + "\"" +
+			", someUint=" + std::to_string(_someUint);
 }
 
 
@@ -52,7 +82,9 @@ std::string DummyElement::show() {
 
 PluginInformation* DummyElement::GetPluginInformation() {
 	PluginInformation* info = new PluginInformation(Util::TypeOf<DummyElement>(), &DummyElement::LoadInstance, &DummyElement::NewInstance);
-	//info->setCategory("Discrete Processing");
+	info->setCategory("Data Definition");
+	info->setDescriptionHelp("Template/example ModelDataDefinition plugin used as a base for creating new data definitions.");
+	info->setObservation("This plugin is a skeleton/template and not a final domain-specific data element.");
 	//info->setMinimumInputs(1);
 	//info->setMinimumOutputs(1);
 	//info->setMaximumInputs(1);
@@ -114,14 +146,15 @@ void DummyElement::_saveInstance(PersistenceRecord *fields, bool saveDefaultValu
 // protected: /// virtual methods that could be overriden by derived classes, if needed
 //
 
-/*
-bool DummyElementt::_check(std::string& errorMessage) {
-	bool resultAll = true;
-	resultAll &= _someString != "";
-	resultAll &= _someUint > 0;
-	return resultAll;
+bool DummyElement::_check(std::string& errorMessage) {
+	if (_someString.empty()) {
+		errorMessage += "SomeString must not be empty. ";
+	}
+	if (_someUint == 0u) {
+		errorMessage += "SomeUint must be greater than zero. ";
+	}
+	return errorMessage.empty();
 }
-*/
 
 /*
 ParserChangesInformation* DummyElementt::_getParserChangesInformation() {

--- a/source/plugins/data/DummyElement.h
+++ b/source/plugins/data/DummyElement.h
@@ -22,7 +22,10 @@ public: /// constructors
 	virtual ~DummyElement() = default;
 
 public: /// new public user methods for this component
-	// ...
+	void setSomeString(const std::string& someString);
+	std::string getSomeString() const;
+	void setSomeUint(unsigned int someUint);
+	unsigned int getSomeUint() const;
 
 public: /// virtual public methods
 	virtual std::string show() override;
@@ -35,6 +38,7 @@ public: /// static public methods that must have implementations (Load and New j
 protected: /// virtual protected method that must be overriden
 	virtual bool _loadInstance(PersistenceRecord *fields) override;
 	virtual void _saveInstance(PersistenceRecord *fields, bool saveDefaultValues) override;
+	virtual bool _check(std::string& errorMessage) override;
 
 protected: /// virtual protected methods that could be overriden by derived classes, if needed
 	/*! This method is called by ModelChecker during model check. The component should check itself to verify if user parameters are ok (ex: correct syntax for the parser) and everithing in its parameters allow the model too run without errors in this component */
@@ -67,4 +71,3 @@ private: /// attached DataElements (Agrregation)
 };
 
 #endif /* DUMMYELEMENT_H */
-

--- a/source/tests/unit/test_simulator_runtime.cpp
+++ b/source/tests/unit/test_simulator_runtime.cpp
@@ -31,6 +31,7 @@
 #include "plugins/data/CppCompiler.h"
 #include "plugins/data/SPICERunner.h"
 #include "plugins/data/AssignmentItem.h"
+#include "plugins/data/DummyElement.h"
 #include "kernel/util/Util.h"
 #define private public
 #define protected public
@@ -254,6 +255,23 @@ public:
 
     void InitBetweenReplicationsProbe() {
         _initBetweenReplications();
+    }
+
+    void SaveInstanceProbe(PersistenceRecord* fields, bool saveDefaultValues = false) {
+        _saveInstance(fields, saveDefaultValues);
+    }
+
+    bool LoadInstanceProbe(PersistenceRecord* fields) {
+        return _loadInstance(fields);
+    }
+};
+
+class DummyElementProbe : public DummyElement {
+public:
+    DummyElementProbe(Model* model, const std::string& name = "") : DummyElement(model, name) {}
+
+    bool CheckProbe(std::string& errorMessage) {
+        return _check(errorMessage);
     }
 
     void SaveInstanceProbe(PersistenceRecord* fields, bool saveDefaultValues = false) {
@@ -2639,6 +2657,113 @@ TEST(SimulatorRuntimeTest, StorageRegistersMainControlsAsOwnedProperties) {
     EXPECT_TRUE(hasCapacity);
     EXPECT_TRUE(hasTotalArea);
     EXPECT_TRUE(hasUnitsPerArea);
+}
+
+TEST(SimulatorRuntimeTest, DummyElementDefaultsAreInitializedAsExpected) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    DummyElement element(model, "DummyDefaults");
+    EXPECT_EQ(element.getSomeString(), "Test");
+    EXPECT_EQ(element.getSomeUint(), 1u);
+}
+
+TEST(SimulatorRuntimeTest, DummyElementSettersAndGettersRemainCoherent) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    DummyElement element(model, "DummySetters");
+    element.setSomeString("TemplateValue");
+    element.setSomeUint(42u);
+
+    EXPECT_EQ(element.getSomeString(), "TemplateValue");
+    EXPECT_EQ(element.getSomeUint(), 42u);
+}
+
+TEST(SimulatorRuntimeTest, DummyElementCheckFailsForInvalidConfiguration) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    DummyElementProbe element(model, "DummyInvalid");
+    element.setSomeString("");
+    element.setSomeUint(0u);
+
+    std::string errorMessage;
+    EXPECT_FALSE(element.CheckProbe(errorMessage));
+    EXPECT_NE(errorMessage.find("SomeString must not be empty"), std::string::npos);
+    EXPECT_NE(errorMessage.find("SomeUint must be greater than zero"), std::string::npos);
+}
+
+TEST(SimulatorRuntimeTest, DummyElementCheckPassesForValidConfiguration) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    DummyElementProbe element(model, "DummyValid");
+    element.setSomeString("Ok");
+    element.setSomeUint(3u);
+
+    std::string errorMessage;
+    EXPECT_TRUE(element.CheckProbe(errorMessage));
+    EXPECT_TRUE(errorMessage.empty());
+}
+
+TEST(SimulatorRuntimeTest, DummyElementShowIncludesMainConfiguredFields) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    DummyElement element(model, "DummyShow");
+    element.setSomeString("Alpha");
+    element.setSomeUint(8u);
+
+    const std::string info = element.show();
+    EXPECT_NE(info.find("someString=\"Alpha\""), std::string::npos);
+    EXPECT_NE(info.find("someUint=8"), std::string::npos);
+}
+
+TEST(SimulatorRuntimeTest, DummyElementSaveAndLoadRoundTripPreservesParameters) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    DummyElementProbe source(model, "DummySource");
+    source.setSomeString("Persisted");
+    source.setSomeUint(77u);
+
+    FakeModelPersistenceRuntime persistence;
+    PersistenceRecord fields(persistence);
+    source.SaveInstanceProbe(&fields, true);
+
+    DummyElementProbe loaded(model, "DummyLoaded");
+    ASSERT_TRUE(loaded.LoadInstanceProbe(&fields));
+    EXPECT_EQ(loaded.getSomeString(), "Persisted");
+    EXPECT_EQ(loaded.getSomeUint(), 77u);
+}
+
+TEST(SimulatorRuntimeTest, DummyElementRegistersMainControlsAsOwnedProperties) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    DummyElement element(model, "DummyProperties");
+    auto* controls = element.getSimulationControls();
+    ASSERT_NE(controls, nullptr);
+    EXPECT_GE(controls->size(), 2u);
+
+    bool hasSomeString = false;
+    bool hasSomeUint = false;
+    for (SimulationControl* control : *controls->list()) {
+        ASSERT_NE(control, nullptr);
+        hasSomeString = hasSomeString || control->getName() == "SomeString";
+        hasSomeUint = hasSomeUint || control->getName() == "SomeUint";
+    }
+
+    EXPECT_TRUE(hasSomeString);
+    EXPECT_TRUE(hasSomeUint);
 }
 
 TEST(SimulatorRuntimeTest, StationCreateInternalInitiallyCreatesCollectorsWhenStatisticsEnabled) {


### PR DESCRIPTION
### Motivation
- The existing `DummyElement` was a skeletal `ModelDataDefinition` missing public accessors, registered controls/properties, meaningful `show()` and `_check()`, and informative plugin metadata, making it an unclear template for developers. 
- The goal was to make the element a minimal, self-contained, and self-explanatory template without turning it into a domain-specific data element.

### Description
- Added public getters/setters `setSomeString`/`getSomeString` and `setSomeUint`/`getSomeUint`, and declared `_check` in the header. 
- Registered two simulation controls (`SomeString` as `SimulationControlString` and `SomeUint` as `SimulationControlDouble`) in the constructor and tracked them as owned properties via `_addProperty(...)`. 
- Implemented `show()` to include `someString` and `someUint`, implemented `_check()` to validate non-empty `SomeString` and `_someUint > 0` with clear `errorMessage` text, and improved `GetPluginInformation()` to identify the plugin as a template/example. 
- Kept persistence keys symmetric (`someString`, `someUint`) and added focused unit tests (probe subclass and test cases) covering defaults, setters/getters, invalid/valid `_check()`, `show()`, save/load round-trip, and property registration.

### Testing
- Configured and generated the build with `cmake -S . -B build -G Ninja -DGENESYS_BUILD_TESTS=ON -DGENESYS_BUILD_KERNEL=ON -DGENESYS_BUILD_PARSER=ON -DGENESYS_BUILD_PLUGINS=ON -DGENESYS_TERMINAL_APPLICATION=OFF -DGENESYS_BUILD_GUI_APPLICATION=OFF -DGENESYS_BUILD_WEB_APPLICATION=OFF` which completed successfully. 
- Built the test target with `cmake --build build --target genesys_test_simulator_runtime` which completed successfully and produced the test runner. 
- Ran the focused tests with `ctest --test-dir build -R "SimulatorRuntimeTest.*DummyElement" --output-on-failure` and all DummyElement tests passed (7/7 passed); a broader `ctest --test-dir build -LE smoke --output-on-failure` run reported unrelated `*_NOT_BUILT` entries from this build profile but did not indicate failures in the DummyElement coverage.

Files changed: `source/plugins/data/DummyElement.h`, `source/plugins/data/DummyElement.cpp`, `source/tests/unit/test_simulator_runtime.cpp`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd0ccc6a048321ba8302c1696ebbe1)