### PR TITLE
Fix GUI model loading crashes and auto-open companion .gui

### DIFF
--- a/source/applications/gui/qt/GenesysQtGUI/controllers/ModelLifecycleController.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/controllers/ModelLifecycleController.cpp
@@ -40,6 +40,19 @@ QString findCompanionGuiFile(const QFileInfo& selectedInfo) {
     }
     return {};
 }
+
+void clearUndoStackIfAvailable(Ui::MainWindow* ui) {
+    if (ui == nullptr || ui->graphicsView == nullptr) {
+        return;
+    }
+    if (ui->graphicsView->getScene() == nullptr) {
+        return;
+    }
+    if (ui->graphicsView->getScene()->getUndoStack() == nullptr) {
+        return;
+    }
+    ui->graphicsView->getScene()->getUndoStack()->clear();
+}
 }
 
 // Store the lifecycle dependencies for Phase 7 delegation from MainWindow.
@@ -112,20 +125,8 @@ bool ModelLifecycleController::openModelFileInternal(const QString& fileName, bo
     if (selectedInfo.suffix().compare("gen", Qt::CaseInsensitive) == 0) {
         const QString pairedGuiPath = findCompanionGuiFile(selectedInfo);
         if (!pairedGuiPath.isEmpty()) {
-            bool preferGui = true;
-            if (showDialogs) {
-                QMessageBox::StandardButton reply = QMessageBox::question(
-                    _ownerWidget,
-                    "Open Model",
-                    QObject::tr("A companion .gui file was found for this .gen model.\n"
-                                "Do you want to open the .gui file to preserve the graphical layout?"),
-                    QMessageBox::Yes | QMessageBox::No,
-                    QMessageBox::Yes);
-                preferGui = (reply == QMessageBox::Yes);
-            }
-            if (preferGui) {
-                resolvedFileName = pairedGuiPath;
-            }
+            // In GUI-open flow, always prefer the companion .gui to preserve the graphical layout.
+            resolvedFileName = pairedGuiPath;
         }
     }
 
@@ -151,7 +152,7 @@ bool ModelLifecycleController::openModelFileInternal(const QString& fileName, bo
         _callbacks.actualizeActions();
         _callbacks.actualizeTabPanes();
     }
-    _ui->graphicsView->getScene()->getUndoStack()->clear();
+    clearUndoStackIfAvailable(_ui);
     return model != nullptr;
 }
 
@@ -207,7 +208,7 @@ void ModelLifecycleController::onActionModelSaveTriggered() const {
         QMessageBox::information(_ownerWidget, "Save Model", "Model successfully saved");
     }
     _callbacks.actualizeActions();
-    _ui->graphicsView->getScene()->getUndoStack()->clear();
+    clearUndoStackIfAvailable(_ui);
 }
 
 // Move model close orchestration out of MainWindow while preserving signal wiring and cleanup sequence.
@@ -229,9 +230,13 @@ void ModelLifecycleController::onActionModelCloseTriggered() const {
     _callbacks.insertCommandInConsole("close");
 
     // Preserve scene clearing order to avoid regressions in existing UI flows.
+    if (_ui->graphicsView == nullptr || _ui->graphicsView->getScene() == nullptr) {
+        return;
+    }
+
     _ui->graphicsView->getScene()->grid()->clear();
     _ui->actionShowGrid->setChecked(false);
-    _ui->graphicsView->getScene()->getUndoStack()->clear();
+    clearUndoStackIfAvailable(_ui);
     _ui->graphicsView->getScene()->clearAnimationsQueue();
     _ui->graphicsView->getScene()->getGraphicalModelComponents()->clear();
     _ui->graphicsView->getScene()->getGraphicalConnections()->clear();

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsScene.cpp
@@ -907,7 +907,6 @@ void ModelGraphicsScene::sanitizeGraphicalDataDefinitionsBookkeeping() {
 
     for (QGraphicsItem* item : liveItems) {
         if (dynamic_cast<GraphicalModelComponent*>(item) != nullptr) {
-            qInfo() << "sanitizeGraphicalDataDefinitionsBookkeeping: ignoring GraphicalModelComponent item";
             continue;
         }
         if (auto* gmdd = dynamic_cast<GraphicalModelDataDefinition*>(item)) {
@@ -1471,6 +1470,23 @@ void ModelGraphicsScene::GRID::clear() {
 }
 
 void ModelGraphicsScene::showGrid() {
+    if (_grid.lines == nullptr) {
+        _grid.visible = false;
+        return;
+    }
+
+    // Reconcile grid bookkeeping with live scene items before touching line pointers.
+    const QList<QGraphicsItem*> liveItems = items();
+    const QSet<QGraphicsItem*> liveItemSet(liveItems.begin(), liveItems.end());
+    for (auto it = _grid.lines->begin(); it != _grid.lines->end();) {
+        QGraphicsLineItem* line = *it;
+        if (line == nullptr || !liveItemSet.contains(line)) {
+            it = _grid.lines->erase(it);
+        } else {
+            ++it;
+        }
+    }
+
     // pego a informação se o grid está visível
     // obs.: o grid é criado uma única vez para a cena e habilitado como visível ou não. =
 

--- a/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsView.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/graphicals/ModelGraphicsView.cpp
@@ -77,6 +77,10 @@ void ModelGraphicsView::showGrid() {
 }
 
 void ModelGraphicsView::clear() {
+	ModelGraphicsScene* modelScene = getScene();
+	if (modelScene != nullptr && modelScene->grid() != nullptr) {
+		modelScene->grid()->clear();
+	}
 	scene()->clear();
 }
 

--- a/source/applications/gui/qt/GenesysQtGUI/services/GraphicalModelBuilder.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/services/GraphicalModelBuilder.cpp
@@ -954,11 +954,6 @@ void GraphicalModelBuilder::synchronizeGraphicalDataDefinitionsLayer(Simulator* 
     const QList<QGraphicsItem*> liveItems = scene->items();
     for (QGraphicsItem* item : liveItems) {
         if (auto* gmc = dynamic_cast<GraphicalModelComponent*>(item)) {
-            qInfo() <<
-                "synchronizeGraphicalDataDefinitionsLayer: ignoring GraphicalModelComponent in data-definition snapshot"
-                << (gmc->getComponent() != nullptr
-                        ? QString::fromStdString(gmc->getComponent()->getName())
-                        : QString("<null>"));
             continue;
         }
         GraphicalModelDataDefinition* gmdd = dynamic_cast<GraphicalModelDataDefinition*>(item);

--- a/source/applications/gui/qt/GenesysQtGUI/services/GraphicalModelSerializer.cpp
+++ b/source/applications/gui/qt/GenesysQtGUI/services/GraphicalModelSerializer.cpp
@@ -28,6 +28,7 @@
 #include <QFont>
 #include <QMessageBox>
 #include <QPlainTextEdit>
+#include <QPointer>
 #include <QRegularExpression>
 #include <QScrollBar>
 #include <QSlider>
@@ -1307,9 +1308,16 @@ Model* GraphicalModelSerializer::loadGraphicalModel(const std::string& filename)
         scene->setRestoringPersistedGuiLayout(false);
         scene->requestGraphicalDataDefinitionsSync();
         if (hasPersistedViewState) {
-            QTimer::singleShot(0, _ownerWidget, [this, restoredViewpointX, restoredViewpointY]() {
-                QScrollBar* hBar = _graphicsView->horizontalScrollBar();
-                QScrollBar* vBar = _graphicsView->verticalScrollBar();
+            QPointer<ModelGraphicsView> targetView(_graphicsView);
+            QTimer::singleShot(0, _ownerWidget, [targetView, restoredViewpointX, restoredViewpointY]() {
+                if (targetView.isNull()) {
+                    return;
+                }
+                QScrollBar* hBar = targetView->horizontalScrollBar();
+                QScrollBar* vBar = targetView->verticalScrollBar();
+                if (hBar == nullptr || vBar == nullptr) {
+                    return;
+                }
                 hBar->setValue(qBound(hBar->minimum(), restoredViewpointX, hBar->maximum()));
                 vBar->setValue(qBound(vBar->minimum(), restoredViewpointY, vBar->maximum()));
             });


### PR DESCRIPTION
## Summary
- fix crash on deferred scrollbar restore during graphical model load by using guarded `QPointer<ModelGraphicsView>` in `QTimer::singleShot`
- harden grid visibility toggle against stale/removed grid line pointers
- clear grid bookkeeping before scene clear in `ModelGraphicsView::clear`
- remove noisy data-definition sync logs for ignored `GraphicalModelComponent` items
- always prefer companion `.gui` when user opens a `.gen` from GUI (no confirmation dialog)

## Validation
- `cmake --build build/gui-app --target genesys_qt_gui_application -j4`
- startup auto-load smoke test in offscreen mode with `modelAtStart=last` and `lastModelFile=.../NOVO22.gen` completed without crash (`timeout`, exit 124)
