### PR TITLE
Tema 6: autômato celular universal + regra local definida pelo usuário

### DIFF
--- a/source/plugins/components/ModalModel/CellularAutomata/Boundary_Adiabatic.h
+++ b/source/plugins/components/ModalModel/CellularAutomata/Boundary_Adiabatic.h
@@ -1,0 +1,41 @@
+/*
+ * File:   Boundary_Adiabatic.h
+ *
+ * Boundary condition that clamps out-of-bounds coordinates to the nearest
+ * lattice border cell.
+ */
+
+#pragma once
+
+#include "plugins/components/ModalModel/CellularAutomata/BoundaryCondition.h"
+#include "plugins/components/ModalModel/CellularAutomata/Cell.h"
+#include "plugins/components/ModalModel/CellularAutomata/Lattice.h"
+
+class Boundary_Adiabatic : public BoundaryCondition {
+public:
+	Boundary_Adiabatic(Lattice* lattice = nullptr, Neighborhood* neighborhood = nullptr)
+		: BoundaryCondition(lattice, neighborhood) {
+	}
+
+	Boundary_Adiabatic(const Boundary_Adiabatic& orig)
+		: BoundaryCondition(orig) {
+	}
+
+	virtual ~Boundary_Adiabatic() = default;
+
+public:
+	virtual Cell* getNeighborCell(std::vector<int> cellNDimPosition, std::vector<int> neighborNDimPosition) override {
+		long neighborCellNumber = lattice->cellNDimPosition2Number(neighborNDimPosition);
+		if (neighborCellNumber < 0) {
+			for (unsigned short dim = 0; dim < neighborNDimPosition.size(); ++dim) {
+				int maxPos = static_cast<int>(lattice->getDimension(dim)) - 1;
+				if (neighborNDimPosition.at(dim) < 0)
+					neighborNDimPosition.at(dim) = 0;
+				else if (neighborNDimPosition.at(dim) > maxPos)
+					neighborNDimPosition.at(dim) = maxPos;
+			}
+			neighborCellNumber = lattice->cellNDimPosition2Number(neighborNDimPosition);
+		}
+		return lattice->getCell(neighborCellNumber);
+	}
+};

--- a/source/plugins/components/ModalModel/CellularAutomata/Boundary_Reflexive.h
+++ b/source/plugins/components/ModalModel/CellularAutomata/Boundary_Reflexive.h
@@ -1,0 +1,52 @@
+/*
+ * File:   Boundary_Reflexive.h
+ *
+ * Boundary condition that mirrors out-of-bounds coordinates back into the
+ * lattice.
+ */
+
+#pragma once
+
+#include "plugins/components/ModalModel/CellularAutomata/BoundaryCondition.h"
+#include "plugins/components/ModalModel/CellularAutomata/Cell.h"
+#include "plugins/components/ModalModel/CellularAutomata/Lattice.h"
+
+class Boundary_Reflexive : public BoundaryCondition {
+public:
+	Boundary_Reflexive(Lattice* lattice = nullptr, Neighborhood* neighborhood = nullptr)
+		: BoundaryCondition(lattice, neighborhood) {
+	}
+
+	Boundary_Reflexive(const Boundary_Reflexive& orig)
+		: BoundaryCondition(orig) {
+	}
+
+	virtual ~Boundary_Reflexive() = default;
+
+public:
+	virtual Cell* getNeighborCell(std::vector<int> cellNDimPosition, std::vector<int> neighborNDimPosition) override {
+		long neighborCellNumber = lattice->cellNDimPosition2Number(neighborNDimPosition);
+		if (neighborCellNumber < 0) {
+			for (unsigned short dim = 0; dim < neighborNDimPosition.size(); ++dim) {
+				const int dimensionSize = static_cast<int>(lattice->getDimension(dim));
+				neighborNDimPosition.at(dim) = _reflectPosition(neighborNDimPosition.at(dim), dimensionSize);
+			}
+			neighborCellNumber = lattice->cellNDimPosition2Number(neighborNDimPosition);
+		}
+		return lattice->getCell(neighborCellNumber);
+	}
+
+private:
+	int _reflectPosition(int position, int dimensionSize) const {
+		if (dimensionSize <= 1)
+			return 0;
+
+		const int period = 2 * (dimensionSize - 1);
+		position %= period;
+		if (position < 0)
+			position += period;
+		if (position >= dimensionSize)
+			position = period - position;
+		return position;
+	}
+};

--- a/source/plugins/components/ModalModel/CellularAutomata/Lattice.cpp
+++ b/source/plugins/components/ModalModel/CellularAutomata/Lattice.cpp
@@ -108,6 +108,8 @@ void Lattice::setCell(const std::vector<int> position, Cell* cell) {
 }
 
 bool Lattice::setCellState(long cellNumber, State* state, Cell* cell) {
+	if (cellNumber < 0)
+		return false;
 	if (cells.size() <= cellNumber)
 		cells.resize(cellNumber + 1);
 	Cell* newCell = cell;
@@ -130,6 +132,8 @@ bool Lattice::setCellState(long cellNumber, State* state, Cell* cell) {
 
 bool Lattice::setCellState(std::vector<int> position, State* state, Cell* cell) {
 	long cellNumber = cellNDimPosition2Number(position);
+	if (cellNumber < 0)
+		return false;
 	return setCellState(cellNumber, state, cell);
 }
 
@@ -173,11 +177,15 @@ std::vector<int> Lattice::cellNumber2NDimPosition(const long cellNumber) {
 }
 
 Cell* Lattice::getCell(const long cellNumber) {
+	if (cellNumber < 0 || static_cast<unsigned long>(cellNumber) >= cells.size())
+		return nullptr;
 	return cells.at(cellNumber);
 }
 
 Cell* Lattice::getCell(const std::vector<int> position) {
-	unsigned int cellNumber = this->cellNDimPosition2Number(position);
+	long cellNumber = this->cellNDimPosition2Number(position);
+	if (cellNumber < 0)
+		return nullptr;
 	return getCell(cellNumber);
 }
 

--- a/source/plugins/components/ModalModel/CellularAutomata/LocalRule.h
+++ b/source/plugins/components/ModalModel/CellularAutomata/LocalRule.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "plugins/components/ModalModel/CellularAutomata/Cell.h"
 #include "plugins/components/ModalModel/CellularAutomata/CellularAutomataBase.h"
+#include "plugins/components/ModalModel/CellularAutomata/StateSet.h"
 
 
 class LocalRule {
@@ -20,6 +21,19 @@ public:
 public:
 	void setStateSet(StateSet* stateSet){
 		this->stateSet = stateSet;
+	}
+protected:
+	bool setNextStateFromValue(Cell* cell, long value) const {
+		if (cell == nullptr)
+			return false;
+		State nextState(value);
+		if (stateSet != nullptr && !stateSet->tryMakeState(value, &nextState))
+			return false;
+		cell->setNextState(nextState);
+		return true;
+	}
+	long stateValue(const Cell* cell) const {
+		return cell->getCurrentState().getValue();
 	}
 protected:
     CellularAutomataBase* parentCellularAutomata;

--- a/source/plugins/components/ModalModel/CellularAutomata/LocalRule_Elementary.h
+++ b/source/plugins/components/ModalModel/CellularAutomata/LocalRule_Elementary.h
@@ -18,12 +18,12 @@ public:
 		long number = 0;
         int bit, power = 2;
         for (Cell* neigh : cell->getNeighbors()) {
-			number += neigh->getCurrentState().getValue() * std::pow(2, power--);
+			number += stateValue(neigh) * std::pow(2, power--);
             if (power==1)
-				number += std::pow(2, power--)*cell->getCurrentState().getValue();
+				number += std::pow(2, power--)*stateValue(cell);
         }
         bit = (ruleNumber & (uint8_t)std::pow(2,number)) >> number;
-		cell->setNextState(State(bit));
+		setNextStateFromValue(cell, bit);
     }
 public:
     uint8_t getRuleNumber() const { return ruleNumber; }

--- a/source/plugins/components/ModalModel/CellularAutomata/LocalRule_GameOfLife.h
+++ b/source/plugins/components/ModalModel/CellularAutomata/LocalRule_GameOfLife.h
@@ -14,15 +14,15 @@ public:
     virtual void applyRule(Cell* cell) override {
         unsigned int living = 0;
         for (Cell* neigh : cell->getNeighbors()) {
-			living += neigh->getCurrentState().getValue();
+			living += stateValue(neigh);
         }
-		if (cell->getCurrentState().getValue() == 1) {
+		if (stateValue(cell) == 1) {
             if (living < 2 || living > 3)
-				cell->setNextState(State(0));
+				setNextStateFromValue(cell, 0);
             else
                 cell->setNextState(cell->getCurrentState());
         } else if (living == 3)
-			cell->setNextState(State(1));
+			setNextStateFromValue(cell, 1);
         else 
             cell->setNextState(cell->getCurrentState());
     }

--- a/source/plugins/components/ModalModel/CellularAutomata/LocalRule_Growty.h
+++ b/source/plugins/components/ModalModel/CellularAutomata/LocalRule_Growty.h
@@ -13,11 +13,11 @@ public:
     virtual void applyRule(Cell* cell) override {
         unsigned int sum = 0;
         for (Cell* neigh : cell->getNeighbors()) {
-			sum += neigh->getCurrentState().getValue();
+			sum += stateValue(neigh);
         }
         if (sum <= 3 || sum == 5)
-			cell->setNextState(State(0));
+			setNextStateFromValue(cell, 0);
         else
-			cell->setNextState(State(1));
+			setNextStateFromValue(cell, 1);
     }
 };

--- a/source/plugins/components/ModalModel/CellularAutomata/LocalRule_UserDefined.h
+++ b/source/plugins/components/ModalModel/CellularAutomata/LocalRule_UserDefined.h
@@ -1,0 +1,181 @@
+#pragma once
+
+// LocalRule_UserDefined — a cellular-automaton local rule whose transition function is supplied by
+// the user as C++ source and compiled at runtime to a shared library (via the GenESyS CppCompiler),
+// then loaded and invoked per cell.
+// This is "Linha B" of Tema 6: arbitrary local rules defined by the user, without recompiling GenESyS.
+//
+// The user only writes a single C-linkage function with this signature (no GenESyS headers needed):
+//
+//     extern "C" long nextState(long self, const long* neighbors, int numNeighbors);
+//
+//   - self         : current state of the cell (a long).
+//   - neighbors    : current states of the cell's neighbors, in the neighborhood's canonical order
+//                    (for a 1D centered radius-1 neighborhood this is {left, right}).
+//   - numNeighbors : how many neighbors were provided.
+//   - return value : the cell's next state.
+//
+// Example (elementary rule 90, next = left XOR right):
+//     extern "C" long nextState(long self, const long* n, int) { return n[0] ^ n[1]; }
+//
+// The function is pure integer arithmetic, so it compiles standalone (g++ -shared -fPIC), which keeps
+// runtime compilation fast and portable between Linux (.so) and macOS (clang also accepts -shared).
+//
+// Design mirrors the existing CppForG component (plugins/components/ExternalIntegration/CppForG.cpp),
+// which already does compile -> load -> dlsym with extern "C" symbols.
+
+#include "plugins/components/ModalModel/CellularAutomata/LocalRule.h"
+#include "plugins/components/ModalModel/CellularAutomata/Cell.h"
+#include "plugins/components/ModalModel/CellularAutomata/State.h"
+#include "plugins/data/ExternalIntegration/CppCompiler.h"
+
+#include <dlfcn.h>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+// The user-provided transition function, resolved by name "nextState" from the compiled library.
+// Declared at namespace scope with C linkage (as CppForG does), so dlsym finds the unmangled symbol.
+extern "C" typedef long (*NextStateFunction)(long self, const long* neighbors, int numNeighbors);
+
+class LocalRule_UserDefined : public LocalRule {
+public:
+	// The CppCompiler is injected (not owned): the caller controls its model, compiler command and
+	// output/temp directories. Those directories must exist and be writable before build() is called.
+	LocalRule_UserDefined(CellularAutomataBase* parentCellularAutomata, CppCompiler* compiler, StateSet* stateSet = nullptr)
+		: LocalRule(parentCellularAutomata, stateSet) {
+		this->compiler = compiler;
+	}
+	LocalRule_UserDefined(const LocalRule_UserDefined& orig) : LocalRule(orig) {}
+	virtual ~LocalRule_UserDefined() {
+		if (libraryLoaded && compiler != nullptr) {
+			compiler->unloadLibrary();
+		}
+	}
+
+public:
+	// Compiles `userSource` (which must define `extern "C" long nextState(long, const long*, int)`)
+	// into a shared library, loads it, and resolves the `nextState` symbol. Returns false and fills
+	// `errorMessage` on any failure (write error, compilation error, load error, missing symbol);
+	// on failure the rule stays not-ready and applyRule() leaves cells unchanged.
+	bool build(const std::string& userSource, std::string& errorMessage) {
+		if (compiler == nullptr) {
+			errorMessage += "LocalRule_UserDefined: no CppCompiler was provided.";
+			return false;
+		}
+		// Working directory for the generated source and library. Use the compiler's temp dir (the
+		// caller points it at a writable location, e.g. the component's .temp/). The output dir is
+		// cleared below so the compiled library path equals the filename we set, which the success check stats.
+		std::string workDir = compiler->getTempDir();
+		if (workDir.empty()) {
+			workDir = "./";
+		}
+		if (workDir.back() != '/') {
+			workDir += '/';
+		}
+		std::error_code dirError;
+		std::filesystem::create_directories(workDir, dirError); // best-effort; ofstream check below is authoritative
+		// Unique base name per build so dlopen never returns a stale cached mapping of an overwritten
+		// library (a real hazard when the same rule is rebuilt or several rules coexist).
+		const std::string base = "genesys_user_local_rule_" + std::to_string(buildCounter++);
+		const std::string sourceFile = workDir + base + ".cpp";
+		const std::string libraryFile = workDir + base + ".so";
+		std::ofstream out(sourceFile.c_str());
+		if (!out.good()) {
+			errorMessage += "LocalRule_UserDefined: cannot write source file '" + sourceFile +
+				"' (does the working directory exist and is it writable?).";
+			return false;
+		}
+		out << userSource;
+		out.close();
+
+		compiler->setSourceFilename(sourceFile);
+		compiler->setOutputFilename(libraryFile); // path equals what the compiler's success check stats
+		compiler->setOutputDir("");               // so the compiled path equals libraryFile exactly
+
+		// The generated .cpp/.so are only needed transiently: the compiler consumes the source, and the
+		// loaded library stays mapped after dlopen even once its file is unlinked. Remove both on every
+		// exit so they don't pile up across rebuilds (the unique names already prevent dlopen cache reuse).
+		auto removeBuildFiles = [&]() {
+			std::error_code removeError;
+			std::filesystem::remove(sourceFile, removeError);
+			std::filesystem::remove(libraryFile, removeError);
+		};
+
+		const CppCompiler::CompilationResult result = compiler->compileToDynamicLibrary();
+		if (!result.success) {
+			errorMessage += "LocalRule_UserDefined: compilation failed:\n" + result.compilationErrOutput;
+			removeBuildFiles();
+			return false;
+		}
+		if (libraryLoaded) {
+			compiler->unloadLibrary();
+			libraryLoaded = false;
+		}
+		if (!compiler->loadLibrary(errorMessage)) {
+			removeBuildFiles();
+			return false;
+		}
+		libraryLoaded = true;
+		void* handle = compiler->getDynamicLibraryHandler();
+		if (handle == nullptr) {
+			errorMessage += "LocalRule_UserDefined: dynamic library handle is null after load.";
+			removeBuildFiles();
+			return false;
+		}
+		dlerror(); // clear any stale error
+		ruleFunction = reinterpret_cast<NextStateFunction>(dlsym(handle, "nextState"));
+		const char* symbolError = dlerror();
+		if (ruleFunction == nullptr || symbolError != nullptr) {
+			errorMessage += "LocalRule_UserDefined: could not resolve symbol 'nextState': " +
+				std::string(symbolError != nullptr ? symbolError : "symbol is null");
+			ruleFunction = nullptr;
+			removeBuildFiles();
+			return false;
+		}
+		removeBuildFiles();
+		return true;
+	}
+
+	// Convenience: wraps a function BODY (statements that return a long) into a full compilable source
+	// exposing the required extern "C" nextState signature. Lets a user write just the rule logic,
+	// e.g. wrapBody("return neighbors[0] ^ neighbors[1];") for elementary rule 90.
+	static std::string wrapBody(const std::string& body) {
+		return std::string(
+			"extern \"C\" long nextState(long self, const long* neighbors, int numNeighbors) {\n") +
+			"\t(void) self; (void) neighbors; (void) numNeighbors;\n\t" + body + "\n}\n";
+	}
+
+	// Convenience: builds a rule given only its function BODY, wrapping it via wrapBody() into the
+	// required extern "C" nextState signature. Equivalent to build(wrapBody(body), errorMessage). Use
+	// for a simple body; for a full translation unit (helpers, includes, several functions) use build().
+	bool buildBody(const std::string& body, std::string& errorMessage) {
+		return build(wrapBody(body), errorMessage);
+	}
+
+	bool isReady() const { return ruleFunction != nullptr; }
+
+public:
+	virtual void applyRule(Cell* cell) override {
+		if (ruleFunction == nullptr) {
+			return; // not built yet: leave the cell unchanged
+		}
+		const std::vector<Cell*> neighbors = cell->getNeighbors();
+		std::vector<long> neighborStates;
+		neighborStates.reserve(neighbors.size());
+		for (Cell* neighbor : neighbors) {
+			neighborStates.emplace_back(neighbor->getCurrentState().getValue());
+		}
+		const long self = cell->getCurrentState().getValue();
+		const long next = ruleFunction(self, neighborStates.data(), static_cast<int>(neighborStates.size()));
+		cell->setNextState(State(next));
+	}
+
+private:
+	CppCompiler* compiler = nullptr; // injected, not owned
+	NextStateFunction ruleFunction = nullptr;
+	bool libraryLoaded = false;
+	inline static int buildCounter = 0; // gives each compiled library a unique name
+};

--- a/source/plugins/components/ModalModel/CellularAutomata/State.h
+++ b/source/plugins/components/ModalModel/CellularAutomata/State.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cmath>
+#include <limits>
 #include <string>
 
 /*
@@ -64,15 +66,20 @@ private:
 
 class State {
 public:
-	State() : _value(0) {}
-	State(long value) : _value(value) {}
+	State() : _value(0.0) {}
+	State(int value) {_value=static_cast<double>(value);}
+	State(long value) {_value=static_cast<double>(value);}
+	State(double value) {_value=value;}
 	State(const State& orig) : _value(orig._value) {}
 	virtual ~State() = default;
 public:
-	long getValue(){return _value;}
-	void setValue(long value) {_value=value;}
-	std::string show() { return std::to_string(_value); }
+	long getValue() const {return static_cast<long>(_value);}
+	double getDoubleValue() const {return _value;}
+	void setValue(int value) {_value=static_cast<double>(value);}
+	void setValue(long value) {_value=static_cast<double>(value);}
+	void setDoubleValue(double value) {_value=value;}
+	std::string show() { return std::to_string(getValue()); }
 protected:
-	long _value;
+	double _value = 0.0;
 private:
 };

--- a/source/plugins/components/ModalModel/CellularAutomata/StateSet.cpp
+++ b/source/plugins/components/ModalModel/CellularAutomata/StateSet.cpp
@@ -18,3 +18,27 @@ StateSet::StateSet(const StateSet& orig) {
  *  PUBLIC
  * **************/
 
+bool StateSet::contains(const State& state) const {
+	return true;
+}
+
+bool StateSet::tryMakeState(long value, State* state) const {
+	return tryMakeState(static_cast<double>(value), state);
+}
+
+bool StateSet::tryMakeState(double value, State* state) const {
+	State candidate(value);
+	if (!contains(candidate))
+		return false;
+	if (state != nullptr)
+		*state = candidate;
+	return true;
+}
+
+std::string StateSet::show() const {
+	return typeName();
+}
+
+std::string StateSet::typeName() const {
+	return "generic";
+}

--- a/source/plugins/components/ModalModel/CellularAutomata/StateSet.h
+++ b/source/plugins/components/ModalModel/CellularAutomata/StateSet.h
@@ -12,6 +12,11 @@ public:
 	StateSet(const StateSet& orig);
 	virtual ~StateSet()=default;
 public:
+	virtual bool contains(const State& state) const;
+	virtual bool tryMakeState(long value, State* state) const;
+	virtual bool tryMakeState(double value, State* state) const;
+	virtual std::string show() const;
+	virtual std::string typeName() const;
 protected:
 	CellularAutomataBase* parentCellularAutomata;
 private:

--- a/source/plugins/components/ModalModel/CellularAutomata/StateSet_Bit.h
+++ b/source/plugins/components/ModalModel/CellularAutomata/StateSet_Bit.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "plugins/components/ModalModel/CellularAutomata/StateSet.h"
+
+#include <cmath>
+#include <string>
+
+class StateSet_Bit : public StateSet {
+public:
+	StateSet_Bit(CellularAutomataBase* parentCellularAutomata)
+		: StateSet(parentCellularAutomata) {
+	}
+
+	virtual bool contains(const State& state) const override {
+		const double value = state.getDoubleValue();
+		return std::isfinite(value) && (value == 0.0 || value == 1.0);
+	}
+
+	virtual std::string show() const override {
+		return "{0,1}";
+	}
+
+	virtual std::string typeName() const override {
+		return "bit";
+	}
+};

--- a/source/plugins/components/ModalModel/CellularAutomata/StateSet_Double.h
+++ b/source/plugins/components/ModalModel/CellularAutomata/StateSet_Double.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "plugins/components/ModalModel/CellularAutomata/StateSet.h"
+
+#include <cmath>
+#include <string>
+
+class StateSet_Double : public StateSet {
+public:
+	StateSet_Double(CellularAutomataBase* parentCellularAutomata)
+		: StateSet(parentCellularAutomata) {
+	}
+
+	virtual bool contains(const State& state) const override {
+		return std::isfinite(state.getDoubleValue());
+	}
+
+	virtual std::string show() const override {
+		return "finite double values";
+	}
+
+	virtual std::string typeName() const override {
+		return "double";
+	}
+};

--- a/source/plugins/components/ModalModel/CellularAutomata/StateSet_Enumerable.cpp
+++ b/source/plugins/components/ModalModel/CellularAutomata/StateSet_Enumerable.cpp
@@ -21,8 +21,41 @@ StateSet_Enumerable::StateSet_Enumerable(const StateSet_Enumerable& orig)
  *  PUBLIC
  * **************/
 
-std::string StateSet_Enumerable::show() {
-	return "-";
+bool StateSet_Enumerable::contains(const State& state) const {
+	for (State* allowedState : states) {
+		if (allowedState != nullptr && allowedState->getDoubleValue() == state.getDoubleValue())
+			return true;
+	}
+	return false;
+}
+
+bool StateSet_Enumerable::tryMakeState(long value, State* state) const {
+	return tryMakeState(static_cast<double>(value), state);
+}
+
+bool StateSet_Enumerable::tryMakeState(double value, State* state) const {
+	for (State* allowedState : states) {
+		if (allowedState != nullptr && allowedState->getDoubleValue() == value) {
+			if (state != nullptr)
+				*state = *allowedState;
+			return true;
+		}
+	}
+	return false;
+}
+
+std::string StateSet_Enumerable::show() const {
+	std::string output = "{";
+	for (unsigned int i = 0; i < states.size(); ++i) {
+		if (i > 0)
+			output += ",";
+		output += states.at(i) == nullptr ? "null" : std::to_string(states.at(i)->getDoubleValue());
+	}
+	return output + "}";
+}
+
+std::string StateSet_Enumerable::typeName() const {
+	return "enumerated";
 }
 
 unsigned int StateSet_Enumerable::size(){
@@ -47,7 +80,7 @@ State* StateSet_Enumerable::getState(unsigned int rank) {
 
 State* StateSet_Enumerable::getState(std::string name) {
 	for (State* s: states) {
-		if (std::to_string(s->getValue())==name) {
+		if (std::to_string(s->getValue())==name || std::to_string(s->getDoubleValue())==name) {
 			return s;
 		}
 	}

--- a/source/plugins/components/ModalModel/CellularAutomata/StateSet_Enumerable.h
+++ b/source/plugins/components/ModalModel/CellularAutomata/StateSet_Enumerable.h
@@ -13,7 +13,11 @@ public:
 	StateSet_Enumerable(const StateSet_Enumerable& orig);
 	virtual ~StateSet_Enumerable()=default;
 public:
-	virtual std::string show();
+	virtual bool contains(const State& state) const override;
+	virtual bool tryMakeState(long value, State* state) const override;
+	virtual bool tryMakeState(double value, State* state) const override;
+	virtual std::string show() const override;
+	virtual std::string typeName() const override;
 	unsigned int size();
 	void addState(State* state);
 	unsigned int getStatesSize();

--- a/source/plugins/components/ModalModel/CellularAutomata/StateSet_Integer.h
+++ b/source/plugins/components/ModalModel/CellularAutomata/StateSet_Integer.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "plugins/components/ModalModel/CellularAutomata/StateSet.h"
+
+#include <cmath>
+#include <limits>
+#include <string>
+
+class StateSet_Integer : public StateSet {
+public:
+	StateSet_Integer(CellularAutomataBase* parentCellularAutomata,
+			long minValue = std::numeric_limits<long>::min(),
+			long maxValue = std::numeric_limits<long>::max())
+		: StateSet(parentCellularAutomata), minValue(minValue), maxValue(maxValue) {
+	}
+
+	virtual bool contains(const State& state) const override {
+		const double value = state.getDoubleValue();
+		return std::isfinite(value) &&
+				std::floor(value) == value &&
+				value >= static_cast<double>(minValue) &&
+				value <= static_cast<double>(maxValue);
+	}
+
+	virtual std::string show() const override {
+		return "[" + std::to_string(minValue) + "," + std::to_string(maxValue) + "]";
+	}
+
+	virtual std::string typeName() const override {
+		return "integer";
+	}
+
+private:
+	long minValue;
+	long maxValue;
+};

--- a/source/plugins/components/ModalModel/CellularAutomataComp.cpp
+++ b/source/plugins/components/ModalModel/CellularAutomataComp.cpp
@@ -4,25 +4,41 @@
  * and open the template in the editor.
  */
 
-/* 
+/*
  * File:   CelularAutomata.cpp
  * Author: rlcancian
- * 
+ *
  * Created on 03 de Junho de 2019, 15:14
  */
 
 #include "plugins/components/ModalModel/CellularAutomataComp.h"
 #include "../../../kernel/simulator/model/Model.h"
+#include "plugins/components/ModalModel/CellularAutomata/Boundary_Adiabatic.h"
 #include "plugins/components/ModalModel/CellularAutomata/Boundary_Closed.h"
 #include "plugins/components/ModalModel/CellularAutomata/Boundary_Fixed.h"
+#include "plugins/components/ModalModel/CellularAutomata/Boundary_Reflexive.h"
 #include "plugins/components/ModalModel/CellularAutomata/CellularAutomata_Classic.h"
 #include "plugins/components/ModalModel/CellularAutomata/CellularAutomata_1DTimed.h"
 #include "plugins/components/ModalModel/CellularAutomata/LocalRule_Elementary.h"
 #include "plugins/components/ModalModel/CellularAutomata/LocalRule_GameOfLife.h"
 #include "plugins/components/ModalModel/CellularAutomata/LocalRule_Growty.h"
+#include "plugins/components/ModalModel/CellularAutomata/LocalRule_UserDefined.h"
 #include "plugins/components/ModalModel/CellularAutomata/Neighborhood_Center.h"
 #include "plugins/components/ModalModel/CellularAutomata/Neighborhood_Moore.h"
 #include "plugins/components/ModalModel/CellularAutomata/Neighborhood_VonNeumann.h"
+#include "plugins/components/ModalModel/CellularAutomata/State.h"
+#include "plugins/components/ModalModel/CellularAutomata/StateSet_Bit.h"
+#include "plugins/components/ModalModel/CellularAutomata/StateSet_Double.h"
+#include "plugins/components/ModalModel/CellularAutomata/StateSet_Enumerable.h"
+#include "plugins/components/ModalModel/CellularAutomata/StateSet_Integer.h"
+#include "plugins/data/ExternalIntegration/CppCompiler.h"
+
+#include <algorithm>
+#include <numeric>
+#include <random>
+#include <sstream>
+#include <string>
+#include <vector>
 
 #ifdef PLUGINCONNECT_DYNAMIC
 
@@ -31,11 +47,49 @@ extern "C" StaticGetPluginInformation GetPluginInformation() {
 }
 #endif
 
+namespace {
+// Lattice dimensions are persisted as a comma-separated list (e.g. "5,5") so a saved automaton
+// round-trips to a checkable configuration (Tema 6 §10.1: persist the model's structural parameters).
+std::string serializeDimensions(const std::vector<unsigned short>& dimensions) {
+	std::string out;
+	for (std::size_t i = 0; i < dimensions.size(); ++i) {
+		if (i > 0)
+			out += ',';
+		out += std::to_string(dimensions.at(i));
+	}
+	return out;
+}
+
+std::vector<unsigned short> parseDimensions(const std::string& serialized) {
+	std::vector<unsigned short> dimensions;
+	std::stringstream stream(serialized);
+	std::string item;
+	while (std::getline(stream, item, ',')) {
+		if (!item.empty())
+			dimensions.emplace_back(static_cast<unsigned short>(std::stoul(item)));
+	}
+	return dimensions;
+}
+} // namespace
+
 ModelDataDefinition* CellularAutomataComp::NewInstance(Model* model, std::string name) {
 	return new CellularAutomataComp(model, name);
 }
 
 CellularAutomataComp::CellularAutomataComp(Model* model, std::string name) : ModelComponent(model, Util::TypeOf<CellularAutomataComp>(), name) {
+}
+
+CellularAutomataComp::~CellularAutomataComp() {
+	// These sub-objects are plain classes (not ModelDataDefinition), so this component owns them and
+	// must free them. Deleting _localRule first runs the LocalRule_UserDefined destructor, which
+	// unloads its dynamic library. _ruleCompiler is a ModelDataDefinition owned by the model, so it
+	// is intentionally NOT deleted here (the model frees it).
+	delete _localRule;
+	delete _cellularAutomata;
+	delete _lattice;
+	delete _neighboorhood;
+	delete _boundary;
+	delete _stateSet;
 }
 
 std::string CellularAutomataComp::show() {
@@ -54,25 +108,154 @@ ModelComponent* CellularAutomataComp::LoadInstance(Model* model, PersistenceReco
 }
 
 void CellularAutomataComp::_onDispatchEvent(Entity* entity, unsigned int inputPortNumber) {
-	_cellularAutomata->step();
+	_stepCellularAutomataByPolicy();
 	_parentModel->sendEntityToComponent(entity, this->getConnectionManager()->getFrontConnection());
 }
 
 bool CellularAutomataComp::_loadInstance(PersistenceRecord *fields) {
 	bool res = ModelComponent::_loadInstance(fields);
 	if (res) {
-		// @TODO: not implemented yet
+		// Recreate the sub-objects from the persisted type enums. The cellular-automata type must be
+		// restored first because the lattice/neighborhood/boundary/state-set/rule reference it.
+		setCellularAutomataType(static_cast<CellularAutomataType>(
+			fields->loadField("cellularAutomataType", static_cast<int>(DEFAULT.cellularAutomataType))));
+		setLatticeType(static_cast<LatticeType>(
+			fields->loadField("latticeType", static_cast<int>(DEFAULT.latticeType))));
+		// Restore the lattice dimensions (a structural model parameter) onto the freshly built lattice.
+		const std::string serializedDimensions = fields->loadField("latticeDimensions", std::string(""));
+		if (_lattice != nullptr && !serializedDimensions.empty())
+			_lattice->setDimensions(parseDimensions(serializedDimensions));
+		setNeighboorhoodType(static_cast<NeighboorhoodType>(
+			fields->loadField("neighborhoodType", static_cast<int>(DEFAULT.neighboorhoodType))));
+		if (_neighboorhood != nullptr)
+			_neighboorhood->setRadius(static_cast<unsigned short>(fields->loadField("neighborhoodRadius", 1)));
+		setBoundaryType(static_cast<BoundaryType>(
+			fields->loadField("boundaryType", static_cast<int>(DEFAULT.boundaryType))));
+		setStateSetType(static_cast<StateSetType>(
+			fields->loadField("stateSetType", static_cast<int>(DEFAULT.stateSetType))));
+		setUpdatePolicyType(static_cast<UpdatePolicyType>(
+			fields->loadField("updatePolicyType", static_cast<int>(DEFAULT.updatePolicyType))));
+		setUpdateBlockSize(static_cast<unsigned int>(
+			fields->loadField("updateBlockSize", static_cast<int>(DEFAULT.updateBlockSize))));
+		setRandomSeed(static_cast<unsigned int>(
+			fields->loadField("randomSeed", static_cast<int>(DEFAULT.randomSeed))));
+		// Set the elementary rule number before the rule type, so an ELEMENTAR_CA rule is built with it.
+		setElementaryRuleNumber(static_cast<uint8_t>(fields->loadField("elementaryRuleNumber", 30)));
+		// Load the user source before the rule type, so a USERDEFINED rule has its source available.
+		_userDefinedRuleSource = fields->loadField("userDefinedRuleSource", DEFAULT.userDefinedRuleSource);
+		setLocalRuleType(static_cast<LocalRuleType>(
+			fields->loadField("localRuleType", static_cast<int>(DEFAULT.localRuleType))));
 	}
 	return res;
 }
 
 void CellularAutomataComp::_saveInstance(PersistenceRecord *fields, bool saveDefaultValues) {
 	ModelComponent::_saveInstance(fields, saveDefaultValues);
-	// @TODO: not implemented yet
+	fields->saveField("cellularAutomataType", static_cast<int>(_cellularAutomataType),
+		static_cast<int>(DEFAULT.cellularAutomataType), saveDefaultValues);
+	fields->saveField("latticeType", static_cast<int>(_latticeType),
+		static_cast<int>(DEFAULT.latticeType), saveDefaultValues);
+	fields->saveField("neighborhoodType", static_cast<int>(_neighboorhoodType),
+		static_cast<int>(DEFAULT.neighboorhoodType), saveDefaultValues);
+	fields->saveField("boundaryType", static_cast<int>(_boundaryType),
+		static_cast<int>(DEFAULT.boundaryType), saveDefaultValues);
+	fields->saveField("stateSetType", static_cast<int>(_stateSetType),
+		static_cast<int>(DEFAULT.stateSetType), saveDefaultValues);
+	fields->saveField("localRuleType", static_cast<int>(_localRuleType),
+		static_cast<int>(DEFAULT.localRuleType), saveDefaultValues);
+	fields->saveField("updatePolicyType", static_cast<int>(_updatePolicyType),
+		static_cast<int>(DEFAULT.updatePolicyType), saveDefaultValues);
+	fields->saveField("updateBlockSize", static_cast<int>(_updateBlockSize),
+		static_cast<int>(DEFAULT.updateBlockSize), saveDefaultValues);
+	fields->saveField("randomSeed", static_cast<int>(_randomSeed),
+		static_cast<int>(DEFAULT.randomSeed), saveDefaultValues);
+	fields->saveField("elementaryRuleNumber", static_cast<int>(_elementaryRuleNumber), 30, saveDefaultValues);
+	fields->saveField("userDefinedRuleSource", _userDefinedRuleSource,
+		DEFAULT.userDefinedRuleSource, saveDefaultValues);
+	const std::string serializedDimensions = _lattice != nullptr ? serializeDimensions(_lattice->getDimensions()) : std::string("");
+	fields->saveField("latticeDimensions", serializedDimensions, std::string(""), saveDefaultValues);
+	const int neighborhoodRadius = _neighboorhood != nullptr ? static_cast<int>(_neighboorhood->getRadius()) : 1;
+	fields->saveField("neighborhoodRadius", neighborhoodRadius, 1, saveDefaultValues);
+}
+
+bool CellularAutomataComp::_buildUserDefinedRule(std::string* errorMessage) {
+	if (_userDefinedRuleSource.empty()) {
+		*errorMessage += "USERDEFINED local rule requires source code (use setUserDefinedRuleSource). ";
+		return false;
+	}
+	if (_cellularAutomata == nullptr) {
+		*errorMessage += "USERDEFINED local rule needs a cellular automata (set its type first). ";
+		return false;
+	}
+	if (_ruleCompiler == nullptr) {
+		_ruleCompiler = new CppCompiler(_parentModel, getName() + ".LocalRuleCompiler");
+	}
+	_ruleCompiler->setOutputDir(".temp/");
+	_ruleCompiler->setTempDir(".temp/");
+	_ruleCompiler->setFlagsGeneral("-w -std=c++14");
+	if (_localRule != nullptr) {
+		delete _localRule;
+		_localRule = nullptr;
+	}
+	LocalRule_UserDefined* userRule = new LocalRule_UserDefined(_cellularAutomata, _ruleCompiler, _stateSet);
+	std::string buildError;
+	if (!userRule->build(_userDefinedRuleSource, buildError)) {
+		*errorMessage += "USERDEFINED local rule failed to compile/load: " + buildError + " ";
+		delete userRule;
+		// userRule registered itself in the automaton (LocalRule ctor); clear the now-dangling pointer.
+		_cellularAutomata->setLocalRule(nullptr);
+		return false;
+	}
+	_localRule = userRule;
+	// Don't leave the throwaway per-build temp paths in the compiler's persistent fields.
+	_ruleCompiler->setSourceFilename("");
+	_ruleCompiler->setOutputFilename("");
+	return true;
 }
 
 bool CellularAutomataComp::_check(std::string* errorMessage) {
-	*errorMessage += "";
+	// Best-of-each semantic check: Sutter's decomposed structural/rule/policy validation, plus the
+	// USERDEFINED (Linha B) rule built lazily once every structural sub-object is available.
+	if (!_checkImplementedTypes(errorMessage))
+		return false;
+	if (_cellularAutomata == nullptr) {
+		*errorMessage += "Cellular automata type is not set or is not supported. ";
+		return false;
+	}
+	if (_lattice == nullptr) {
+		*errorMessage += "Lattice type is not set. ";
+		return false;
+	}
+	if (_neighboorhood == nullptr) {
+		*errorMessage += "Neighborhood type is not set. ";
+		return false;
+	}
+	if (_boundary == nullptr) {
+		*errorMessage += "Boundary type is not set. ";
+		return false;
+	}
+	if (_stateSet == nullptr) {
+		*errorMessage += "State set type is not set. ";
+		return false;
+	}
+	// Linha B: compile and load a user-defined local rule now, when the automaton, lattice,
+	// neighborhood, boundary and state set all exist (see _buildUserDefinedRule).
+	if (_localRuleType == LocalRuleType::USERDEFINED) {
+		if (!_buildUserDefinedRule(errorMessage))
+			return false;
+	}
+	if (_localRule == nullptr) {
+		*errorMessage += "Local rule is not set (or its type is not supported yet). ";
+		return false;
+	}
+	if (!_checkLattice(errorMessage))
+		return false;
+	if (!_checkStateSet(errorMessage))
+		return false;
+	if (!_checkRuleCompatibility(errorMessage))
+		return false;
+	if (!_checkUpdatePolicy(errorMessage))
+		return false;
 	_cellularAutomata->setLattice(_lattice);
 	_cellularAutomata->setLocalRule(_localRule);
 	_cellularAutomata->setNeighborhood(_neighboorhood);
@@ -85,7 +268,103 @@ bool CellularAutomataComp::_check(std::string* errorMessage) {
 }
 
 void CellularAutomataComp::_initBetweenReplications() {
-	_cellularAutomata->init();
+	_randomStepCounter = 0;
+	if (_cellularAutomata != nullptr) // guard like _stepCellularAutomataByPolicy: never deref before _check succeeds
+		_cellularAutomata->init();
+}
+
+bool CellularAutomataComp::initializeCellularAutomata(std::string* errorMessage) {
+	std::string localErrorMessage;
+	std::string* message = errorMessage != nullptr ? errorMessage : &localErrorMessage;
+	if (!_check(message))
+		return false;
+	_randomStepCounter = 0;
+	return _cellularAutomata->init();
+}
+
+void CellularAutomataComp::stepCellularAutomata() {
+	_stepCellularAutomataByPolicy();
+}
+
+bool CellularAutomataComp::setCellState(long cellNumber, int value) {
+	return setCellState(cellNumber, static_cast<long>(value));
+}
+
+bool CellularAutomataComp::setCellState(long cellNumber, long value) {
+	return setCellState(cellNumber, static_cast<double>(value));
+}
+
+bool CellularAutomataComp::setCellState(long cellNumber, double value) {
+	if (_lattice == nullptr)
+		return false;
+	State state;
+	if (_stateSet != nullptr && !_stateSet->tryMakeState(value, &state))
+		return false;
+	else if (_stateSet == nullptr)
+		state.setDoubleValue(value);
+	return _lattice->setCellState(cellNumber, &state);
+}
+
+bool CellularAutomataComp::setCellState(const std::vector<int>& position, int value) {
+	return setCellState(position, static_cast<long>(value));
+}
+
+bool CellularAutomataComp::setCellState(const std::vector<int>& position, long value) {
+	return setCellState(position, static_cast<double>(value));
+}
+
+bool CellularAutomataComp::setCellState(const std::vector<int>& position, double value) {
+	if (_lattice == nullptr)
+		return false;
+	State state;
+	if (_stateSet != nullptr && !_stateSet->tryMakeState(value, &state))
+		return false;
+	else if (_stateSet == nullptr)
+		state.setDoubleValue(value);
+	return _lattice->setCellState(position, &state);
+}
+
+std::string CellularAutomataComp::showCellularAutomata() const {
+	if (_lattice == nullptr)
+		return "";
+	std::ostringstream output;
+	for (unsigned long cellNumber = 0; cellNumber < _lattice->getCellsSize(); ++cellNumber) {
+		output << _lattice->getCell(static_cast<long>(cellNumber))->getCurrentState().getValue();
+	}
+	return output.str();
+}
+
+void CellularAutomataComp::setElementaryRuleNumber(uint8_t ruleNumber) {
+	_elementaryRuleNumber = ruleNumber;
+	if (_localRuleType == LocalRuleType::ELEMENTAR_CA && _localRule != nullptr) {
+		if (auto* elementaryRule = dynamic_cast<LocalRule_Elementary*>(_localRule))
+			elementaryRule->setRuleNumber(ruleNumber);
+	}
+}
+
+CellularAutomataComp::UpdatePolicyType CellularAutomataComp::getUpdatePolicyType() const {
+	return _updatePolicyType;
+}
+
+void CellularAutomataComp::setUpdatePolicyType(CellularAutomataComp::UpdatePolicyType updatePolicyType) {
+	_updatePolicyType = updatePolicyType;
+}
+
+unsigned int CellularAutomataComp::getUpdateBlockSize() const {
+	return _updateBlockSize;
+}
+
+void CellularAutomataComp::setUpdateBlockSize(unsigned int updateBlockSize) {
+	_updateBlockSize = updateBlockSize == 0 ? 1 : updateBlockSize;
+}
+
+unsigned int CellularAutomataComp::getRandomSeed() const {
+	return _randomSeed;
+}
+
+void CellularAutomataComp::setRandomSeed(unsigned int randomSeed) {
+	_randomSeed = randomSeed;
+	_randomStepCounter = 0;
 }
 
 LocalRule *CellularAutomataComp::getlocalRule() const
@@ -101,22 +380,54 @@ CellularAutomataComp::LocalRuleType CellularAutomataComp::getlocalRuleType() con
 void CellularAutomataComp::setLocalRuleType(CellularAutomataComp::LocalRuleType newLocalRuleType)
 {
 	_localRuleType = newLocalRuleType;
-	if (_localRule != nullptr)
+	_ensureCellularAutomata();
+	if (_localRule != nullptr) {
 		delete _localRule;
+		_localRule = nullptr; // avoid a dangling/double-freed pointer for types that build no rule here
+		// The deleted rule registered itself in the automaton (LocalRule ctor); clear that pointer too.
+		if (_cellularAutomata != nullptr)
+			_cellularAutomata->setLocalRule(nullptr);
+	}
 	if (_localRuleType == LocalRuleType::ELEMENTAR_CA) {
-		_localRule = new LocalRule_Elementary(_cellularAutomata, 30);
+		_localRule = new LocalRule_Elementary(_cellularAutomata, _elementaryRuleNumber);
 	} else if (_localRuleType == LocalRuleType::GAME_OF_LIFE) {
 		_localRule = new LocalRule_GameOfLife(_cellularAutomata);
 	} else if (_localRuleType == LocalRuleType::BIASED_COMPETITION) {
 		_localRule = new LocalRule_Growty(_cellularAutomata);
 	}
+	// USERDEFINED is compiled and loaded lazily in _check(), where the cellular automata, state set
+	// and user source are all available (see _buildUserDefinedRule).
+}
+
+void CellularAutomataComp::setUserDefinedRuleSource(const std::string& userDefinedRuleSource) {
+	_userDefinedRuleSource = userDefinedRuleSource;
+}
+
+std::string CellularAutomataComp::getUserDefinedRuleSource() const {
+	return _userDefinedRuleSource;
 }
 
 void CellularAutomataComp::setStateSetType(CellularAutomataComp::StateSetType newStateSetType)
 {
 	_stateSetType = newStateSetType;
-	if (_stateSet == nullptr)
-		_stateSet = new StateSet(_cellularAutomata);
+	_ensureCellularAutomata();
+	if (_stateSet != nullptr)
+		delete _stateSet;
+	_stateSet = nullptr;
+	// Clear the automaton's now-dangling state-set pointer; an implemented type below re-wires it in
+	// _check. For an unimplemented type no replacement is built, so this avoids a use-after-free if a
+	// later LocalRule ctor reads parentCellularAutomata->getStateSet() (mirrors setLocalRuleType).
+	if (_cellularAutomata != nullptr)
+		_cellularAutomata->setStateSet(nullptr);
+	if (_stateSetType == StateSetType::ENUMERATED)
+		// The two binary states are owned by this component (members), so the enumerable leaks none.
+		_stateSet = new StateSet_Enumerable(_cellularAutomata, {&_enumeratedStateOff, &_enumeratedStateOn});
+	else if (_stateSetType == StateSetType::INTEGERBASED)
+		_stateSet = new StateSet_Integer(_cellularAutomata);
+	else if (_stateSetType == StateSetType::BITBASED)
+		_stateSet = new StateSet_Bit(_cellularAutomata);
+	else if (_stateSetType == StateSetType::DOUBLEBASED)
+		_stateSet = new StateSet_Double(_cellularAutomata);
 }
 
 
@@ -156,8 +467,10 @@ CellularAutomataComp::CellularAutomataType CellularAutomataComp::getCellularAuto
 void CellularAutomataComp::setCellularAutomataType(CellularAutomataComp::CellularAutomataType newCellularAutomataType)
 {
 	_cellularAutomataType = newCellularAutomataType;
-	if (_cellularAutomata != nullptr)
-		_cellularAutomata->~CellularAutomataBase();
+	if (_cellularAutomata != nullptr) {
+		delete _cellularAutomata; // was an explicit destructor call (~CellularAutomataBase), which left a dangling pointer
+		_cellularAutomata = nullptr;
+	}
 	if (_cellularAutomataType == CellularAutomataType::CLASSIC)
 		_cellularAutomata = new CellularAutomata_Classic();
 	else if (_cellularAutomataType == CellularAutomataType::TIMED_1D)
@@ -172,6 +485,7 @@ CellularAutomataComp::LatticeType CellularAutomataComp::getLatticeType() const
 void CellularAutomataComp::setLatticeType(CellularAutomataComp::LatticeType newLatticeStructure)
 {
 	_latticeType = newLatticeStructure;
+	_ensureCellularAutomata();
 	if (_lattice == nullptr)
 		_lattice = new Lattice(_cellularAutomata);
 }
@@ -184,8 +498,14 @@ CellularAutomataComp::NeighboorhoodType CellularAutomataComp::getNeighboorhoodTy
 void CellularAutomataComp::setNeighboorhoodType(CellularAutomataComp::NeighboorhoodType newNeighboorhood)
 {
 	_neighboorhoodType = newNeighboorhood;
+	_ensureCellularAutomata();
 	if (_neighboorhood != nullptr)
 		delete _neighboorhood;
+	_neighboorhood = nullptr;
+	// Clear the automaton's dangling neighborhood pointer; an implemented type below re-registers
+	// itself (Neighborhood ctor), an unimplemented one leaves it safely null (avoids use-after-free).
+	if (_cellularAutomata != nullptr)
+		_cellularAutomata->setNeighborhood(nullptr);
 	if (_neighboorhoodType == NeighboorhoodType::CENTERED)
 		_neighboorhood = new Neighborhood_Center(_cellularAutomata);
 	else if (_neighboorhoodType == NeighboorhoodType::MOORE)
@@ -204,10 +524,191 @@ void CellularAutomataComp::setBoundaryType(CellularAutomataComp::BoundaryType ne
 	_boundaryType = newBoundary;
 	if (_boundary != nullptr)
 		delete _boundary;
+	_boundary = nullptr;
 	if (_boundaryType == BoundaryType::CLOSED)
 		_boundary = new Boundary_Closed();
 	else if (_boundaryType == BoundaryType::FIXED)
 		_boundary = new Boundary_Fixed();
+	else if (_boundaryType == BoundaryType::REFLEXIVE)
+		_boundary = new Boundary_Reflexive();
+	else if (_boundaryType == BoundaryType::ADIABATIC)
+		_boundary = new Boundary_Adiabatic();
+}
+
+void CellularAutomataComp::_ensureCellularAutomata() {
+	if (_cellularAutomata == nullptr)
+		setCellularAutomataType(_cellularAutomataType);
+}
+
+bool CellularAutomataComp::_checkImplementedTypes(std::string* errorMessage) const {
+	if (_cellularAutomataType == CellularAutomataType::ASYNCHRONOUS ||
+			_cellularAutomataType == CellularAutomataType::NONUNIFORMRULE ||
+			_cellularAutomataType == CellularAutomataType::NONUNIFORMNEIGHBOOR ||
+			_cellularAutomataType == CellularAutomataType::USERDEFINED) {
+		if (errorMessage != nullptr)
+			*errorMessage += "Configured cellular automata type is not implemented yet. ";
+		return false;
+	}
+	if (_latticeType == LatticeType::TRIANGULAR ||
+			_latticeType == LatticeType::HEXAGONAL ||
+			_latticeType == LatticeType::NETWORK ||
+			_latticeType == LatticeType::USERDEFINED) {
+		if (errorMessage != nullptr)
+			*errorMessage += "Configured lattice type is not implemented yet. ";
+		return false;
+	}
+	if (_neighboorhoodType == NeighboorhoodType::BACKWARD ||
+			_neighboorhoodType == NeighboorhoodType::FORWARD ||
+			_neighboorhoodType == NeighboorhoodType::USERDEFINED) {
+		if (errorMessage != nullptr)
+			*errorMessage += "Configured neighborhood type is not implemented yet. ";
+		return false;
+	}
+	if (_boundaryType == BoundaryType::USERDEFINED) {
+		if (errorMessage != nullptr)
+			*errorMessage += "Configured boundary type is not implemented yet. ";
+		return false;
+	}
+	if (_stateSetType == StateSetType::USERDEFINED) {
+		if (errorMessage != nullptr)
+			*errorMessage += "Configured state set type is not implemented yet. ";
+		return false;
+	}
+	// USERDEFINED local rule IS implemented (Linha B, via CppCompiler); only HPP remains unimplemented.
+	if (_localRuleType == LocalRuleType::HPP) {
+		if (errorMessage != nullptr)
+			*errorMessage += "Configured local rule type is not implemented yet. ";
+		return false;
+	}
+	return true;
+}
+
+bool CellularAutomataComp::_checkLattice(std::string* errorMessage) const {
+	const std::vector<unsigned short> dimensions = _lattice->getDimensions();
+	if (dimensions.empty()) {
+		if (errorMessage != nullptr)
+			*errorMessage += "Lattice must have at least one dimension. ";
+		return false;
+	}
+	for (unsigned short dimension : dimensions) {
+		if (dimension == 0) {
+			if (errorMessage != nullptr)
+				*errorMessage += "All lattice dimensions must be greater than zero. ";
+			return false;
+		}
+	}
+	return true;
+}
+
+bool CellularAutomataComp::_checkStateSet(std::string* errorMessage) const {
+	if (_stateSet == nullptr) {
+		if (errorMessage != nullptr)
+			*errorMessage += "State set type was not configured. ";
+		return false;
+	}
+	return true;
+}
+
+bool CellularAutomataComp::_checkRuleCompatibility(std::string* errorMessage) const {
+	const unsigned short numDimensions = _lattice->getNumDimensions();
+	if (_neighboorhoodType == NeighboorhoodType::CENTERED && numDimensions != 1) {
+		if (errorMessage != nullptr)
+			*errorMessage += "Centered neighborhood is currently supported only for 1D lattices. ";
+		return false;
+	}
+	if (_localRuleType == LocalRuleType::ELEMENTAR_CA) {
+		if (numDimensions != 1) {
+			if (errorMessage != nullptr)
+				*errorMessage += "Elementary cellular automata rule requires a 1D lattice. ";
+			return false;
+		}
+		if (_neighboorhood == nullptr || _neighboorhood->getRadius() != 1) {
+			if (errorMessage != nullptr)
+				*errorMessage += "Elementary cellular automata rule requires radius-1 neighborhood. ";
+			return false;
+		}
+		if (_stateSetType != StateSetType::ENUMERATED && _stateSetType != StateSetType::BITBASED) {
+			if (errorMessage != nullptr)
+				*errorMessage += "Elementary cellular automata rule requires a binary state set. ";
+			return false;
+		}
+	}
+	if (_localRuleType == LocalRuleType::GAME_OF_LIFE) {
+		if (numDimensions != 2 || _neighboorhoodType != NeighboorhoodType::MOORE || _neighboorhood->getRadius() != 1) {
+			if (errorMessage != nullptr)
+				*errorMessage += "Game of Life requires a 2D lattice with Moore radius-1 neighborhood. ";
+			return false;
+		}
+		StateSet_Enumerable* enumerableStateSet = dynamic_cast<StateSet_Enumerable*>(_stateSet);
+		const bool isEnumeratedBinary = _stateSetType == StateSetType::ENUMERATED && enumerableStateSet != nullptr && enumerableStateSet->getStatesSize() == 2;
+		const bool isBitBased = _stateSetType == StateSetType::BITBASED;
+		if (!isEnumeratedBinary && !isBitBased) {
+			if (errorMessage != nullptr)
+				*errorMessage += "Game of Life requires a binary state set. ";
+			return false;
+		}
+	}
+	return true;
+}
+
+bool CellularAutomataComp::_checkUpdatePolicy(std::string* errorMessage) const {
+	if (_updatePolicyType == UpdatePolicyType::BLOCKS && _updateBlockSize == 0) {
+		if (errorMessage != nullptr)
+			*errorMessage += "Block update policy requires update block size greater than zero. ";
+		return false;
+	}
+	return true;
+}
+
+void CellularAutomataComp::_stepCellularAutomataByPolicy() {
+	if (_cellularAutomata == nullptr || _lattice == nullptr || _localRule == nullptr)
+		return;
+	if (_updatePolicyType == UpdatePolicyType::SYNCHRONOUS)
+		_cellularAutomata->step();
+	else if (_updatePolicyType == UpdatePolicyType::SEQUENTIAL)
+		_stepSequential();
+	else if (_updatePolicyType == UpdatePolicyType::RANDOM)
+		_stepRandom();
+	else if (_updatePolicyType == UpdatePolicyType::BLOCKS)
+		_stepBlocks();
+}
+
+void CellularAutomataComp::_stepSequential() {
+	for (unsigned long cellNumber = 0; cellNumber < _lattice->getCellsSize(); ++cellNumber)
+		_applyRuleAndUpdateCell(cellNumber);
+}
+
+void CellularAutomataComp::_stepRandom() {
+	std::vector<unsigned long> cellNumbers(_lattice->getCellsSize());
+	std::iota(cellNumbers.begin(), cellNumbers.end(), 0);
+	// Portable Fisher-Yates. std::shuffle's consumption of the engine is implementation-defined
+	// (libc++ and libstdc++ produce different permutations from the same mt19937 state), but
+	// std::uniform_int_distribution is specified, so this yields the SAME random order on every
+	// platform for a given seed -> the RANDOM update policy is reproducible (REGRA 3: comprovável).
+	std::mt19937 randomEngine(_randomSeed + _randomStepCounter++);
+	for (std::size_t i = cellNumbers.size(); i > 1; --i) {
+		std::uniform_int_distribution<std::size_t> distribution(0, i - 1);
+		std::swap(cellNumbers[i - 1], cellNumbers[distribution(randomEngine)]);
+	}
+	for (unsigned long cellNumber : cellNumbers)
+		_applyRuleAndUpdateCell(cellNumber);
+}
+
+void CellularAutomataComp::_stepBlocks() {
+	const unsigned int blockSize = _updateBlockSize == 0 ? 1 : _updateBlockSize;
+	for (unsigned long firstCellNumber = 0; firstCellNumber < _lattice->getCellsSize(); firstCellNumber += blockSize) {
+		const unsigned long lastCellNumber = std::min<unsigned long>(firstCellNumber + blockSize, _lattice->getCellsSize());
+		for (unsigned long cellNumber = firstCellNumber; cellNumber < lastCellNumber; ++cellNumber)
+			_localRule->applyRule(_lattice->getCell(static_cast<long>(cellNumber)));
+		for (unsigned long cellNumber = firstCellNumber; cellNumber < lastCellNumber; ++cellNumber)
+			_lattice->getCell(static_cast<long>(cellNumber))->updateState();
+	}
+}
+
+void CellularAutomataComp::_applyRuleAndUpdateCell(unsigned long cellNumber) {
+	Cell* cell = _lattice->getCell(static_cast<long>(cellNumber));
+	_localRule->applyRule(cell);
+	cell->updateState();
 }
 
 PluginInformation* CellularAutomataComp::GetPluginInformation() {

--- a/source/plugins/components/ModalModel/CellularAutomataComp.h
+++ b/source/plugins/components/ModalModel/CellularAutomataComp.h
@@ -17,9 +17,14 @@
 #include "plugins/components/ModalModel/CellularAutomata/CellularAutomataBase.h"
 #include "plugins/components/ModalModel/CellularAutomata/Lattice.h"
 #include "plugins/components/ModalModel/CellularAutomata/Neighborhood.h"
+#include "plugins/components/ModalModel/CellularAutomata/State.h"
 #include "plugins/components/ModalModel/CellularAutomata/StateSet.h"
 
+#include <cstdint>
+#include <vector>
+
 class BoundaryCondition;
+class CppCompiler;
 
 /*!
  This component ...
@@ -53,10 +58,15 @@ public: //! enums
 	enum class AutomataType : int {
 		Temporary = 0, Permanent = 1
 	};
-	
+
+	//! Temporal update policy: how the lattice advances on each automaton step.
+	enum class UpdatePolicyType : int {
+		SYNCHRONOUS = 1, SEQUENTIAL = 2, RANDOM = 3, BLOCKS = 4
+	};
+
 public: //! constructors
 	CellularAutomataComp(Model* model, std::string name = "");
-	virtual ~CellularAutomataComp() = default;
+	virtual ~CellularAutomataComp();
 
 public: //! new public user methods for this component
 	CellularAutomataComp::CellularAutomataType getCellularAutomataType() const;
@@ -74,11 +84,32 @@ public: //! new public user methods for this component
 	CellularAutomataComp::StateSetType getStateSetType() const;
 	void setStateSetType(CellularAutomataComp::StateSetType newStateSetType);
 
+	//! Builds (checks + inits) the cellular automaton from the configured types. Returns false (and
+	//! fills errorMessage, if given) when the configuration is invalid. Useful to drive the automaton
+	//! directly from a terminal example or test, without running a full DES model.
+	bool initializeCellularAutomata(std::string* errorMessage = nullptr);
+	//! Advances the automaton one step, honoring the configured update policy.
+	void stepCellularAutomata();
+	bool setCellState(long cellNumber, int value);
+	bool setCellState(long cellNumber, long value);
+	bool setCellState(long cellNumber, double value);
+	bool setCellState(const std::vector<int>& position, int value);
+	bool setCellState(const std::vector<int>& position, long value);
+	bool setCellState(const std::vector<int>& position, double value);
+	std::string showCellularAutomata() const;
+	void setElementaryRuleNumber(uint8_t ruleNumber);
+	CellularAutomataComp::UpdatePolicyType getUpdatePolicyType() const;
+	void setUpdatePolicyType(CellularAutomataComp::UpdatePolicyType updatePolicyType);
+	unsigned int getUpdateBlockSize() const;
+	void setUpdateBlockSize(unsigned int updateBlockSize);
+	unsigned int getRandomSeed() const;
+	void setRandomSeed(unsigned int randomSeed);
+
 	//CellularAutomataBase *getcellularAutomata() const;
 	Lattice *getlattice() const;
 	Neighborhood *getNeighboorhood() const;
 	//BoundaryCondition *getBoundary() const;
-	StateSet *getStateSet() const;	
+	StateSet *getStateSet() const;
 
 public: //! virtual public methods
 	virtual std::string show() override;
@@ -90,6 +121,12 @@ public: //! static public methods that must have implementations (Load and New j
 
 	CellularAutomataComp::LocalRuleType getlocalRuleType() const;
 	void setLocalRuleType(CellularAutomataComp::LocalRuleType newLocalRuleType);
+
+	//! C++ source for a USERDEFINED local rule. The source must define the C-linkage function
+	//! `extern "C" long nextState(long self, const long* neighbors, int numNeighbors)`. It is compiled
+	//! at runtime (via CppCompiler) and loaded during model check. See LocalRule_UserDefined.
+	void setUserDefinedRuleSource(const std::string& userDefinedRuleSource);
+	std::string getUserDefinedRuleSource() const;
 
 	LocalRule *getlocalRule() const;
 
@@ -119,7 +156,23 @@ protected:
 	// virtual void _createAttachedAttributes() override;
 
 private: //! new private user methods
-	// ...
+	//! Lazily instantiates the cellular automaton if it has not been created yet (so the setters can
+	//! create lattice/neighborhood/state set/rule that need a parent automaton, in any order).
+	void _ensureCellularAutomata();
+	//! Compiles and loads the USERDEFINED local rule from _userDefinedRuleSource (called by _check).
+	bool _buildUserDefinedRule(std::string* errorMessage);
+	//! Decomposed semantic checks used by _check (best-of-each: structural + rule + policy coherence).
+	bool _checkImplementedTypes(std::string* errorMessage) const;
+	bool _checkLattice(std::string* errorMessage) const;
+	bool _checkStateSet(std::string* errorMessage) const;
+	bool _checkRuleCompatibility(std::string* errorMessage) const;
+	bool _checkUpdatePolicy(std::string* errorMessage) const;
+	//! Update-policy engine: advances the lattice one step under the configured policy.
+	void _stepCellularAutomataByPolicy();
+	void _stepSequential();
+	void _stepRandom();
+	void _stepBlocks();
+	void _applyRuleAndUpdateCell(unsigned long cellNumber);
 
 private: //! Attributes that should be loaded or saved with this component (Persistent Fields)
 
@@ -131,6 +184,10 @@ private: //! Attributes that should be loaded or saved with this component (Pers
 		const BoundaryType boundaryType = BoundaryType::FIXED;
 		const StateSetType stateSetType = StateSetType::ENUMERATED;
 		const LocalRuleType localRuleType = LocalRuleType::GAME_OF_LIFE;
+		const UpdatePolicyType updatePolicyType = UpdatePolicyType::SYNCHRONOUS;
+		const unsigned int updateBlockSize = 1;
+		const unsigned int randomSeed = 1;
+		const std::string userDefinedRuleSource = "";
 	} DEFAULT;
 	CellularAutomataComp::CellularAutomataType _cellularAutomataType = DEFAULT.cellularAutomataType;
 	CellularAutomataComp::LatticeType _latticeType = DEFAULT.latticeType;
@@ -138,6 +195,11 @@ private: //! Attributes that should be loaded or saved with this component (Pers
 	CellularAutomataComp::BoundaryType _boundaryType = DEFAULT.boundaryType;
 	CellularAutomataComp::StateSetType _stateSetType = DEFAULT.stateSetType;
 	CellularAutomataComp::LocalRuleType _localRuleType = DEFAULT.localRuleType;
+	CellularAutomataComp::UpdatePolicyType _updatePolicyType = DEFAULT.updatePolicyType;
+	unsigned int _updateBlockSize = DEFAULT.updateBlockSize;
+	unsigned int _randomSeed = DEFAULT.randomSeed;
+	uint8_t _elementaryRuleNumber = 30;
+	std::string _userDefinedRuleSource = DEFAULT.userDefinedRuleSource;
 
 private: //! Attributes that do not need to be loaded or saved with this component (Non Persistent Fields)
 	CellularAutomataBase* _cellularAutomata = nullptr;
@@ -146,6 +208,12 @@ private: //! Attributes that do not need to be loaded or saved with this compone
 	BoundaryCondition* _boundary = nullptr;
 	StateSet* _stateSet = nullptr;
 	LocalRule* _localRule = nullptr;
+	CppCompiler* _ruleCompiler = nullptr; //!< owns runtime compilation for the USERDEFINED local rule
+	unsigned int _randomStepCounter = 0;  //!< advances the RANDOM update-policy seed between steps
+	// The two binary states of an ENUMERATED state set are owned here (handed by non-owning pointer to
+	// StateSet_Enumerable, whose default destructor frees nothing) so reconfiguring leaks no State.
+	State _enumeratedStateOff = State(0L);
+	State _enumeratedStateOn = State(1L);
 
 private: //! internal DataElements (Composition)
 

--- a/source/tests/unit/CMakeLists.txt
+++ b/source/tests/unit/CMakeLists.txt
@@ -57,6 +57,39 @@ genesys_add_unit_test(genesys_test_cellular_automata_neighborhood
     genesys_plugins_components_minimal
 )
 
+# Sutter (universal CA): component-level behaviour — boundaries, state sets, update policies, N-D.
+genesys_add_unit_test(genesys_test_cellular_automata
+    test_cellular_automata.cpp
+    genesys_tools
+    genesys_kernel_simulator_runtime
+    genesys_kernel_util
+    genesys_plugins_components_minimal
+)
+
+# Pedro (Linha B): engine ground truth, user-defined rule via CppCompiler, component integration.
+genesys_add_unit_test(genesys_test_cellular_automata_elementary
+    test_cellular_automata_elementary.cpp
+    genesys_plugins_components_minimal
+)
+
+genesys_add_unit_test(genesys_test_cellular_automata_user_defined
+    test_cellular_automata_user_defined.cpp
+    genesys_tools
+    genesys_kernel_simulator_runtime
+    genesys_kernel_util
+    genesys_plugins_components_minimal
+    ${CMAKE_DL_LIBS}
+)
+
+genesys_add_unit_test(genesys_test_cellular_automata_component
+    test_cellular_automata_component.cpp
+    genesys_tools
+    genesys_kernel_simulator_runtime
+    genesys_kernel_util
+    genesys_plugins_components
+    ${CMAKE_DL_LIBS}
+)
+
 genesys_add_unit_test(genesys_test_support_modelmanager
     test_support_modelmanager.cpp
     genesys_kernel_simulator_support
@@ -272,6 +305,10 @@ add_custom_target(genesys_kernel_unit_tests
         genesys_test_simulator_runtime
         genesys_test_parser_expressions
         genesys_test_cellular_automata_neighborhood
+        genesys_test_cellular_automata
+        genesys_test_cellular_automata_elementary
+        genesys_test_cellular_automata_user_defined
+        genesys_test_cellular_automata_component
         genesys_test_support_modelmanager
         genesys_test_support_persistence
         genesys_test_runtime_pluginmanager
@@ -351,6 +388,10 @@ add_custom_target(genesys_kernel_unit_tests_run
     COMMAND $<TARGET_FILE:genesys_test_simulator_runtime>
     COMMAND $<TARGET_FILE:genesys_test_parser_expressions>
     COMMAND $<TARGET_FILE:genesys_test_cellular_automata_neighborhood>
+    COMMAND $<TARGET_FILE:genesys_test_cellular_automata>
+    COMMAND $<TARGET_FILE:genesys_test_cellular_automata_elementary>
+    COMMAND $<TARGET_FILE:genesys_test_cellular_automata_user_defined>
+    COMMAND $<TARGET_FILE:genesys_test_cellular_automata_component>
     COMMAND $<TARGET_FILE:genesys_test_support_modelmanager>
     COMMAND $<TARGET_FILE:genesys_test_support_persistence>
     COMMAND $<TARGET_FILE:genesys_test_runtime_pluginmanager>

--- a/source/tests/unit/test_cellular_automata.cpp
+++ b/source/tests/unit/test_cellular_automata.cpp
@@ -1,0 +1,290 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "kernel/simulator/model/Model.h"
+#include "kernel/simulator/Simulator.h"
+#include "kernel/simulator/TraceManager.h"
+#include "plugins/components/ModalModel/CellularAutomataComp.h"
+
+namespace {
+
+class CellularAutomataFixture : public ::testing::Test {
+protected:
+	void SetUp() override {
+		genesys = std::make_unique<Simulator>();
+		genesys->getTraceManager()->setTraceLevel(TraceManager::Level::L0_noTraces);
+		model = genesys->getModelManager()->newModel();
+	}
+
+	CellularAutomataComp* CreateComponent() {
+		return new CellularAutomataComp(model);
+	}
+
+	std::unique_ptr<Simulator> genesys;
+	Model* model = nullptr;
+};
+
+void ConfigureRule90(CellularAutomataComp* cellularAutomata,
+		CellularAutomataComp::BoundaryType boundaryType = CellularAutomataComp::BoundaryType::FIXED,
+		CellularAutomataComp::StateSetType stateSetType = CellularAutomataComp::StateSetType::ENUMERATED) {
+	cellularAutomata->setCellularAutomataType(CellularAutomataComp::CellularAutomataType::CLASSIC);
+	cellularAutomata->setLatticeType(CellularAutomataComp::LatticeType::RETICULAR);
+	cellularAutomata->getlattice()->setDimensions({7});
+	cellularAutomata->setNeighboorhoodType(CellularAutomataComp::NeighboorhoodType::CENTERED);
+	cellularAutomata->getNeighboorhood()->setRadius(1);
+	cellularAutomata->setBoundaryType(boundaryType);
+	cellularAutomata->setStateSetType(stateSetType);
+	cellularAutomata->setElementaryRuleNumber(90);
+	cellularAutomata->setLocalRuleType(CellularAutomataComp::LocalRuleType::ELEMENTAR_CA);
+}
+
+void ConfigureGameOfLife(CellularAutomataComp* cellularAutomata,
+		CellularAutomataComp::NeighboorhoodType neighborhoodType = CellularAutomataComp::NeighboorhoodType::MOORE,
+		CellularAutomataComp::StateSetType stateSetType = CellularAutomataComp::StateSetType::ENUMERATED) {
+	cellularAutomata->setCellularAutomataType(CellularAutomataComp::CellularAutomataType::CLASSIC);
+	cellularAutomata->setLatticeType(CellularAutomataComp::LatticeType::RETICULAR);
+	cellularAutomata->getlattice()->setDimensions({5, 5});
+	cellularAutomata->setNeighboorhoodType(neighborhoodType);
+	cellularAutomata->getNeighboorhood()->setRadius(1);
+	cellularAutomata->setBoundaryType(CellularAutomataComp::BoundaryType::FIXED);
+	cellularAutomata->setStateSetType(stateSetType);
+	cellularAutomata->setLocalRuleType(CellularAutomataComp::LocalRuleType::GAME_OF_LIFE);
+}
+
+void ConfigureGenericAutomata(CellularAutomataComp* cellularAutomata,
+		const std::vector<unsigned short>& dimensions,
+		CellularAutomataComp::NeighboorhoodType neighborhoodType,
+		CellularAutomataComp::StateSetType stateSetType = CellularAutomataComp::StateSetType::ENUMERATED) {
+	cellularAutomata->setCellularAutomataType(CellularAutomataComp::CellularAutomataType::CLASSIC);
+	cellularAutomata->setLatticeType(CellularAutomataComp::LatticeType::RETICULAR);
+	cellularAutomata->getlattice()->setDimensions(dimensions);
+	cellularAutomata->setNeighboorhoodType(neighborhoodType);
+	cellularAutomata->getNeighboorhood()->setRadius(1);
+	cellularAutomata->setBoundaryType(CellularAutomataComp::BoundaryType::CLOSED);
+	cellularAutomata->setStateSetType(stateSetType);
+	cellularAutomata->setLocalRuleType(CellularAutomataComp::LocalRuleType::BIASED_COMPETITION);
+}
+
+void SetInitialPattern(CellularAutomataComp* cellularAutomata, const std::string& pattern) {
+	for (unsigned long cellNumber = 0; cellNumber < pattern.size(); ++cellNumber) {
+		const long value = pattern.at(cellNumber) == '1' ? 1 : 0;
+		ASSERT_TRUE(cellularAutomata->setCellState(static_cast<long>(cellNumber), value));
+	}
+}
+
+std::vector<std::string> RunRule90(CellularAutomataComp* cellularAutomata, unsigned int steps) {
+	std::string errorMessage;
+	EXPECT_TRUE(cellularAutomata->initializeCellularAutomata(&errorMessage)) << errorMessage;
+	SetInitialPattern(cellularAutomata, "1001000");
+
+	std::vector<std::string> states;
+	states.emplace_back(cellularAutomata->showCellularAutomata());
+	for (unsigned int step = 0; step < steps; ++step) {
+		cellularAutomata->stepCellularAutomata();
+		states.emplace_back(cellularAutomata->showCellularAutomata());
+	}
+	return states;
+}
+
+std::string Grid(CellularAutomataComp* cellularAutomata, unsigned short width, unsigned short height) {
+	std::string grid;
+	for (unsigned short y = 0; y < height; ++y) {
+		for (unsigned short x = 0; x < width; ++x)
+			grid += std::to_string(cellularAutomata->getlattice()->getCell({static_cast<int>(x), static_cast<int>(y)})->getCurrentState().getValue());
+		if (y + 1 < height)
+			grid += "\n";
+	}
+	return grid;
+}
+
+void SetBlinker(CellularAutomataComp* cellularAutomata) {
+	ASSERT_TRUE(cellularAutomata->setCellState({2, 1}, 1));
+	ASSERT_TRUE(cellularAutomata->setCellState({2, 2}, 1));
+	ASSERT_TRUE(cellularAutomata->setCellState({2, 3}, 1));
+}
+
+unsigned long NeighborCount(CellularAutomataComp* cellularAutomata, const std::vector<int>& position) {
+	const long cellNumber = cellularAutomata->getlattice()->cellNDimPosition2Number(position);
+	return cellularAutomata->getlattice()->getCell(cellNumber)->getNeighbors().size();
+}
+
+}
+
+TEST_F(CellularAutomataFixture, IntegerStateSetRejectsDoubleValues) {
+	CellularAutomataComp* cellularAutomata = CreateComponent();
+	ConfigureGenericAutomata(cellularAutomata, {3}, CellularAutomataComp::NeighboorhoodType::VONNEUMANN, CellularAutomataComp::StateSetType::INTEGERBASED);
+
+	std::string errorMessage;
+	ASSERT_TRUE(cellularAutomata->initializeCellularAutomata(&errorMessage)) << errorMessage;
+
+	EXPECT_TRUE(cellularAutomata->setCellState(0L, 1.0));
+	EXPECT_FALSE(cellularAutomata->setCellState(0L, 1.5));
+}
+
+TEST_F(CellularAutomataFixture, BitStateSetRejectsNonBitValues) {
+	CellularAutomataComp* cellularAutomata = CreateComponent();
+	ConfigureRule90(cellularAutomata, CellularAutomataComp::BoundaryType::FIXED, CellularAutomataComp::StateSetType::BITBASED);
+
+	std::string errorMessage;
+	ASSERT_TRUE(cellularAutomata->initializeCellularAutomata(&errorMessage)) << errorMessage;
+
+	EXPECT_TRUE(cellularAutomata->setCellState(0L, 0.0));
+	EXPECT_TRUE(cellularAutomata->setCellState(0L, 1.0));
+	EXPECT_FALSE(cellularAutomata->setCellState(0L, 0.5));
+	EXPECT_FALSE(cellularAutomata->setCellState(0L, 2.0));
+}
+
+TEST_F(CellularAutomataFixture, DoubleStateSetAcceptsFractionalValues) {
+	CellularAutomataComp* cellularAutomata = CreateComponent();
+	ConfigureGenericAutomata(cellularAutomata, {3}, CellularAutomataComp::NeighboorhoodType::VONNEUMANN, CellularAutomataComp::StateSetType::DOUBLEBASED);
+
+	std::string errorMessage;
+	ASSERT_TRUE(cellularAutomata->initializeCellularAutomata(&errorMessage)) << errorMessage;
+
+	ASSERT_TRUE(cellularAutomata->setCellState(0L, 1.5));
+	EXPECT_DOUBLE_EQ(cellularAutomata->getlattice()->getCell(0L)->getCurrentState().getDoubleValue(), 1.5);
+}
+
+TEST_F(CellularAutomataFixture, Rule90FixedBoundaryMatchesExpectedSequence) {
+	CellularAutomataComp* cellularAutomata = CreateComponent();
+	ConfigureRule90(cellularAutomata);
+
+	const std::vector<std::string> states = RunRule90(cellularAutomata, 6);
+
+	EXPECT_EQ(states, (std::vector<std::string>{
+			"1001000",
+			"0110100",
+			"1110010",
+			"1011101",
+			"0010100",
+			"0100010",
+			"1010101"}));
+}
+
+TEST_F(CellularAutomataFixture, Rule90BoundaryConditionsHaveExpectedFinalStates) {
+	CellularAutomataComp* closed = CreateComponent();
+	ConfigureRule90(closed, CellularAutomataComp::BoundaryType::CLOSED);
+	EXPECT_EQ(RunRule90(closed, 6).back(), "0000101");
+
+	CellularAutomataComp* reflexive = CreateComponent();
+	ConfigureRule90(reflexive, CellularAutomataComp::BoundaryType::REFLEXIVE);
+	EXPECT_EQ(RunRule90(reflexive, 6).back(), "0110010");
+
+	CellularAutomataComp* adiabatic = CreateComponent();
+	ConfigureRule90(adiabatic, CellularAutomataComp::BoundaryType::ADIABATIC);
+	EXPECT_EQ(RunRule90(adiabatic, 6).back(), "0000101");
+}
+
+TEST_F(CellularAutomataFixture, Rule90AcceptsBitStateSet) {
+	CellularAutomataComp* cellularAutomata = CreateComponent();
+	ConfigureRule90(cellularAutomata, CellularAutomataComp::BoundaryType::FIXED, CellularAutomataComp::StateSetType::BITBASED);
+
+	const std::vector<std::string> states = RunRule90(cellularAutomata, 1);
+
+	EXPECT_EQ(states.at(1), "0110100");
+}
+
+TEST_F(CellularAutomataFixture, GameOfLifeBlinkerOscillates) {
+	CellularAutomataComp* cellularAutomata = CreateComponent();
+	ConfigureGameOfLife(cellularAutomata);
+
+	std::string errorMessage;
+	ASSERT_TRUE(cellularAutomata->initializeCellularAutomata(&errorMessage)) << errorMessage;
+	SetBlinker(cellularAutomata);
+
+	EXPECT_EQ(Grid(cellularAutomata, 5, 5), "00000\n00100\n00100\n00100\n00000");
+	cellularAutomata->stepCellularAutomata();
+	EXPECT_EQ(Grid(cellularAutomata, 5, 5), "00000\n00000\n01110\n00000\n00000");
+	cellularAutomata->stepCellularAutomata();
+	EXPECT_EQ(Grid(cellularAutomata, 5, 5), "00000\n00100\n00100\n00100\n00000");
+}
+
+TEST_F(CellularAutomataFixture, GameOfLifeRejectsInvalidConfigurations) {
+	CellularAutomataComp* vonNeumann = CreateComponent();
+	ConfigureGameOfLife(vonNeumann, CellularAutomataComp::NeighboorhoodType::VONNEUMANN);
+	std::string errorMessage;
+	EXPECT_FALSE(vonNeumann->initializeCellularAutomata(&errorMessage));
+
+	CellularAutomataComp* integerBased = CreateComponent();
+	ConfigureGameOfLife(integerBased, CellularAutomataComp::NeighboorhoodType::MOORE, CellularAutomataComp::StateSetType::INTEGERBASED);
+	errorMessage.clear();
+	EXPECT_FALSE(integerBased->initializeCellularAutomata(&errorMessage));
+}
+
+TEST_F(CellularAutomataFixture, NeighborhoodsHaveExpectedCountsInOneTwoAndThreeDimensions) {
+	CellularAutomataComp* moore1D = CreateComponent();
+	ConfigureGenericAutomata(moore1D, {3}, CellularAutomataComp::NeighboorhoodType::MOORE);
+	std::string errorMessage;
+	ASSERT_TRUE(moore1D->initializeCellularAutomata(&errorMessage)) << errorMessage;
+	EXPECT_EQ(NeighborCount(moore1D, {1}), 2u);
+
+	CellularAutomataComp* vonNeumann1D = CreateComponent();
+	ConfigureGenericAutomata(vonNeumann1D, {3}, CellularAutomataComp::NeighboorhoodType::VONNEUMANN);
+	errorMessage.clear();
+	ASSERT_TRUE(vonNeumann1D->initializeCellularAutomata(&errorMessage)) << errorMessage;
+	EXPECT_EQ(NeighborCount(vonNeumann1D, {1}), 2u);
+
+	CellularAutomataComp* moore2D = CreateComponent();
+	ConfigureGenericAutomata(moore2D, {3, 3}, CellularAutomataComp::NeighboorhoodType::MOORE);
+	errorMessage.clear();
+	ASSERT_TRUE(moore2D->initializeCellularAutomata(&errorMessage)) << errorMessage;
+	EXPECT_EQ(NeighborCount(moore2D, {1, 1}), 8u);
+
+	CellularAutomataComp* vonNeumann2D = CreateComponent();
+	ConfigureGenericAutomata(vonNeumann2D, {3, 3}, CellularAutomataComp::NeighboorhoodType::VONNEUMANN);
+	errorMessage.clear();
+	ASSERT_TRUE(vonNeumann2D->initializeCellularAutomata(&errorMessage)) << errorMessage;
+	EXPECT_EQ(NeighborCount(vonNeumann2D, {1, 1}), 4u);
+
+	CellularAutomataComp* moore3D = CreateComponent();
+	ConfigureGenericAutomata(moore3D, {3, 3, 3}, CellularAutomataComp::NeighboorhoodType::MOORE);
+	errorMessage.clear();
+	ASSERT_TRUE(moore3D->initializeCellularAutomata(&errorMessage)) << errorMessage;
+	EXPECT_EQ(NeighborCount(moore3D, {1, 1, 1}), 26u);
+
+	CellularAutomataComp* vonNeumann3D = CreateComponent();
+	ConfigureGenericAutomata(vonNeumann3D, {3, 3, 3}, CellularAutomataComp::NeighboorhoodType::VONNEUMANN);
+	errorMessage.clear();
+	ASSERT_TRUE(vonNeumann3D->initializeCellularAutomata(&errorMessage)) << errorMessage;
+	EXPECT_EQ(NeighborCount(vonNeumann3D, {1, 1, 1}), 6u);
+}
+
+TEST_F(CellularAutomataFixture, ThreeDimensionalLatticeRejectsInvalidCoordinates) {
+	CellularAutomataComp* cellularAutomata = CreateComponent();
+	ConfigureGenericAutomata(cellularAutomata, {3, 3, 3}, CellularAutomataComp::NeighboorhoodType::VONNEUMANN);
+
+	std::string errorMessage;
+	ASSERT_TRUE(cellularAutomata->initializeCellularAutomata(&errorMessage)) << errorMessage;
+
+	EXPECT_FALSE(cellularAutomata->setCellState({-1, 0, 0}, 1));
+}
+
+TEST_F(CellularAutomataFixture, UpdatePoliciesProduceDeterministicSequences) {
+	CellularAutomataComp* synchronous = CreateComponent();
+	ConfigureRule90(synchronous);
+	synchronous->setUpdatePolicyType(CellularAutomataComp::UpdatePolicyType::SYNCHRONOUS);
+	EXPECT_EQ(RunRule90(synchronous, 4).back(), "0010100");
+
+	CellularAutomataComp* sequential = CreateComponent();
+	ConfigureRule90(sequential);
+	sequential->setUpdatePolicyType(CellularAutomataComp::UpdatePolicyType::SEQUENTIAL);
+	EXPECT_EQ(RunRule90(sequential, 4).back(), "1110000");
+
+	CellularAutomataComp* random = CreateComponent();
+	ConfigureRule90(random);
+	random->setUpdatePolicyType(CellularAutomataComp::UpdatePolicyType::RANDOM);
+	random->setRandomSeed(7);
+	// Deterministic AND platform-independent: _stepRandom uses a uniform_int_distribution Fisher-Yates
+	// (not std::shuffle, whose engine consumption differs across libc++/libstdc++), so this exact value
+	// reproduces on macOS and Linux alike.
+	EXPECT_EQ(RunRule90(random, 4).back(), "1101110");
+
+	CellularAutomataComp* blocks = CreateComponent();
+	ConfigureRule90(blocks);
+	blocks->setUpdatePolicyType(CellularAutomataComp::UpdatePolicyType::BLOCKS);
+	blocks->setUpdateBlockSize(2);
+	EXPECT_EQ(RunRule90(blocks, 4).back(), "1111100");
+}

--- a/source/tests/unit/test_cellular_automata_component.cpp
+++ b/source/tests/unit/test_cellular_automata_component.cpp
@@ -1,0 +1,135 @@
+// Integration of the user-defined local rule into the GenESyS component CellularAutomataComp:
+// verifies semantic checking (_check) and persistence (_loadInstance/_saveInstance) of the whole
+// cellular-automaton configuration, including a USERDEFINED rule compiled at runtime.
+
+#include <gtest/gtest.h>
+
+#include "plugins/components/ModalModel/CellularAutomataComp.h"
+#include "plugins/components/ModalModel/CellularAutomata/LocalRule_UserDefined.h"
+
+#include "kernel/simulator/Simulator.h"
+#include "kernel/simulator/Persistence.h"
+
+#include <string>
+
+namespace {
+
+// Minimal Persistence_if so a PersistenceRecord can store/replay fields in a unit test.
+class FakePersistence : public Persistence_if {
+public:
+	bool save(std::string) override { return false; }
+	bool load(std::string) override { return false; }
+	bool hasChanged() override { return false; }
+	void setHasChanged(bool) override {}
+	bool getOption(Persistence_if::Options) override { return false; }
+	void setOption(Persistence_if::Options, bool) override {}
+	std::string getFormatedField(PersistenceRecord*) override { return ""; }
+};
+
+// Exposes the protected lifecycle hooks for testing.
+class ComponentProbe : public CellularAutomataComp {
+public:
+	ComponentProbe(Model* model, const std::string& name) : CellularAutomataComp(model, name) {}
+	bool CheckProbe(std::string* errorMessage) { return _check(errorMessage); }
+	void SaveProbe(PersistenceRecord* fields, bool saveDefaultValues = true) {
+		_saveInstance(fields, saveDefaultValues);
+	}
+	bool LoadProbe(PersistenceRecord* fields) { return _loadInstance(fields); }
+};
+
+void configureValidUserDefined(ComponentProbe& comp, const std::string& ruleSource) {
+	comp.setCellularAutomataType(CellularAutomataComp::CellularAutomataType::CLASSIC);
+	comp.setLatticeType(CellularAutomataComp::LatticeType::RETICULAR);
+	comp.getlattice()->setDimensions({9}); // 1D lattice: required by the (universal) semantic check for a CENTERED neighborhood
+	comp.setNeighboorhoodType(CellularAutomataComp::NeighboorhoodType::CENTERED);
+	comp.setBoundaryType(CellularAutomataComp::BoundaryType::FIXED);
+	comp.setStateSetType(CellularAutomataComp::StateSetType::ENUMERATED);
+	comp.setUserDefinedRuleSource(ruleSource);
+	comp.setLocalRuleType(CellularAutomataComp::LocalRuleType::USERDEFINED);
+}
+
+const std::string kRule90 = LocalRule_UserDefined::wrapBody("return neighbors[0] ^ neighbors[1];");
+
+} // namespace
+
+TEST(CellularAutomataComponent, CheckPassesAndBuildsUserDefinedRule) {
+	Simulator simulator;
+	Model* model = simulator.getModelManager()->newModel();
+	ComponentProbe comp(model, "CA_UserDefined");
+	configureValidUserDefined(comp, kRule90);
+
+	std::string error;
+	ASSERT_TRUE(comp.CheckProbe(&error)) << error;
+
+	LocalRule_UserDefined* rule = dynamic_cast<LocalRule_UserDefined*>(comp.getlocalRule());
+	ASSERT_NE(rule, nullptr) << "USERDEFINED check should install a LocalRule_UserDefined";
+	EXPECT_TRUE(rule->isReady()) << "the user rule should be compiled and loaded after check";
+}
+
+TEST(CellularAutomataComponent, CheckRejectsUserDefinedWithoutSource) {
+	Simulator simulator;
+	Model* model = simulator.getModelManager()->newModel();
+	ComponentProbe comp(model, "CA_NoSource");
+	configureValidUserDefined(comp, ""); // empty source
+
+	std::string error;
+	EXPECT_FALSE(comp.CheckProbe(&error));
+	EXPECT_NE(error.find("requires source code"), std::string::npos) << error;
+}
+
+TEST(CellularAutomataComponent, CheckRejectsUserDefinedWithBadSource) {
+	Simulator simulator;
+	Model* model = simulator.getModelManager()->newModel();
+	ComponentProbe comp(model, "CA_BadSource");
+	configureValidUserDefined(comp, "this is not valid c++ <<<");
+
+	std::string error;
+	EXPECT_FALSE(comp.CheckProbe(&error));
+	EXPECT_NE(error.find("failed to compile"), std::string::npos) << error;
+}
+
+TEST(CellularAutomataComponent, CheckRejectsMissingCellularAutomataType) {
+	Simulator simulator;
+	Model* model = simulator.getModelManager()->newModel();
+	ComponentProbe comp(model, "CA_Empty");
+	// Nothing configured: the cellular automata is null.
+	std::string error;
+	EXPECT_FALSE(comp.CheckProbe(&error));
+	EXPECT_FALSE(error.empty());
+}
+
+TEST(CellularAutomataComponent, PersistenceRoundTripPreservesConfiguration) {
+	Simulator simulator;
+	Model* model = simulator.getModelManager()->newModel();
+
+	ComponentProbe saved(model, "CA_Saved");
+	configureValidUserDefined(saved, kRule90);
+	// Non-default values for the universal update-policy fields, to prove they also round-trip.
+	saved.setUpdatePolicyType(CellularAutomataComp::UpdatePolicyType::BLOCKS);
+	saved.setUpdateBlockSize(3);
+	saved.setRandomSeed(42);
+
+	FakePersistence persistence;
+	PersistenceRecord fields(persistence);
+	saved.SaveProbe(&fields, true);
+
+	ComponentProbe loaded(model, "CA_Loaded");
+	ASSERT_TRUE(loaded.LoadProbe(&fields));
+
+	EXPECT_EQ(loaded.getCellularAutomataType(), CellularAutomataComp::CellularAutomataType::CLASSIC);
+	EXPECT_EQ(loaded.getLatticeType(), CellularAutomataComp::LatticeType::RETICULAR);
+	EXPECT_EQ(loaded.getNeighboorhoodType(), CellularAutomataComp::NeighboorhoodType::CENTERED);
+	EXPECT_EQ(loaded.geBoundaryType(), CellularAutomataComp::BoundaryType::FIXED);
+	EXPECT_EQ(loaded.getStateSetType(), CellularAutomataComp::StateSetType::ENUMERATED);
+	EXPECT_EQ(loaded.getlocalRuleType(), CellularAutomataComp::LocalRuleType::USERDEFINED);
+	EXPECT_EQ(loaded.getUserDefinedRuleSource(), kRule90);
+	ASSERT_NE(loaded.getlattice(), nullptr);
+	EXPECT_EQ(loaded.getlattice()->getDimensions(), (std::vector<unsigned short>{9})); // lattice dimensions round-trip
+	EXPECT_EQ(loaded.getUpdatePolicyType(), CellularAutomataComp::UpdatePolicyType::BLOCKS);
+	EXPECT_EQ(loaded.getUpdateBlockSize(), 3u);
+	EXPECT_EQ(loaded.getRandomSeed(), 42u);
+
+	// The reloaded configuration must still pass the semantic check (rebuilds and recompiles the rule).
+	std::string error;
+	EXPECT_TRUE(loaded.CheckProbe(&error)) << error;
+}

--- a/source/tests/unit/test_cellular_automata_elementary.cpp
+++ b/source/tests/unit/test_cellular_automata_elementary.cpp
@@ -1,0 +1,109 @@
+// Verifies that the existing engine reproduces, bit-perfect, the textbook/Wolfram ground truth for
+// elementary (1D, binary, radius-1) cellular automata. This is the deterministic "comparison to
+// known analytical results / consistency" verification (book Cap. 11 §11.10.3 and Cap. 13).
+//
+// Ground truth:
+//   Rule 30 (00011110, next = left XOR (center OR right)), single central 1, fixed-0 boundary, width 9
+//     t0=000010000 t1=000111000 t2=001100100 t3=011011110   (book p.242 worked example)
+//   Rule 90 (01011010, next = left XOR right -> Sierpinski), single central 1, fixed-0 boundary, width 11
+//     t0=00000100000 t1=00001010000 t2=00010001000 t3=00101010100 t4=01000000010
+
+#include <gtest/gtest.h>
+
+#include "plugins/components/ModalModel/CellularAutomata/Boundary_Fixed.h"
+#include "plugins/components/ModalModel/CellularAutomata/CellularAutomata_Classic.h"
+#include "plugins/components/ModalModel/CellularAutomata/Lattice.h"
+#include "plugins/components/ModalModel/CellularAutomata/LocalRule_Elementary.h"
+#include "plugins/components/ModalModel/CellularAutomata/Neighborhood_Center.h"
+#include "plugins/components/ModalModel/CellularAutomata/State.h"
+#include "plugins/components/ModalModel/CellularAutomata/StateSet_Enumerable.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace {
+
+std::string rowOf(Lattice& lattice) {
+	std::string row;
+	for (unsigned long cellNumber = 0; cellNumber < lattice.getCellsSize(); ++cellNumber) {
+		row += std::to_string(lattice.getCell(static_cast<long>(cellNumber))->getCurrentState().getValue());
+	}
+	return row;
+}
+
+// Runs an elementary CA: 1D lattice of `width` cells, binary states, centered radius-1 neighborhood,
+// fixed-0 boundary, a single 1 at the center. Returns the space-time rows t0..t(steps).
+std::vector<std::string> runElementary(unsigned short width, std::uint8_t ruleNumber, unsigned int steps) {
+	CellularAutomata_Classic cellularAutomata;
+	Lattice lattice(&cellularAutomata, nullptr, {width}, LatticeType::RETICULAR);
+	State zero(0);
+	State one(1);
+	StateSet_Enumerable stateSet(&cellularAutomata, {&zero, &one});
+	Boundary_Fixed boundary(&lattice);
+	Neighborhood_Center neighborhood(&cellularAutomata, 1, &boundary);
+	LocalRule_Elementary rule(&cellularAutomata, ruleNumber, &stateSet);
+
+	cellularAutomata.setLattice(&lattice);
+	cellularAutomata.setStateSet(&stateSet);
+	cellularAutomata.setNeighborhood(&neighborhood);
+	cellularAutomata.setLocalRule(&rule);
+
+	lattice.init();
+	State centerOn(1);
+	lattice.setCellState(static_cast<long>(width / 2), &centerOn);
+
+	std::vector<std::string> rows;
+	rows.emplace_back(rowOf(lattice));
+	for (unsigned int t = 0; t < steps; ++t) {
+		cellularAutomata.step();
+		rows.emplace_back(rowOf(lattice));
+	}
+	return rows;
+}
+
+} // namespace
+
+TEST(ElementaryCA, Rule30MatchesTextbookGroundTruth) {
+	const std::vector<std::string> rows = runElementary(9, 30, 3);
+	ASSERT_EQ(rows.size(), 4u);
+	EXPECT_EQ(rows[0], "000010000");
+	EXPECT_EQ(rows[1], "000111000");
+	EXPECT_EQ(rows[2], "001100100");
+	EXPECT_EQ(rows[3], "011011110");
+}
+
+TEST(ElementaryCA, Rule90MatchesSierpinskiGroundTruth) {
+	const std::vector<std::string> rows = runElementary(11, 90, 4);
+	ASSERT_EQ(rows.size(), 5u);
+	EXPECT_EQ(rows[0], "00000100000");
+	EXPECT_EQ(rows[1], "00001010000");
+	EXPECT_EQ(rows[2], "00010001000");
+	EXPECT_EQ(rows[3], "00101010100");
+	EXPECT_EQ(rows[4], "01000000010");
+}
+
+TEST(ElementaryCA, IsDeterministicAcrossRuns) {
+	EXPECT_EQ(runElementary(11, 30, 6), runElementary(11, 30, 6));
+}
+
+TEST(ElementaryCA, EmptyGridStaysEmptyUnderRule30) {
+	// Degeneracy test: with no live cell, rule 30 (000 -> 0) keeps the lattice all-zero.
+	CellularAutomata_Classic cellularAutomata;
+	Lattice lattice(&cellularAutomata, nullptr, {9}, LatticeType::RETICULAR);
+	State zero(0);
+	State one(1);
+	StateSet_Enumerable stateSet(&cellularAutomata, {&zero, &one});
+	Boundary_Fixed boundary(&lattice);
+	Neighborhood_Center neighborhood(&cellularAutomata, 1, &boundary);
+	LocalRule_Elementary rule(&cellularAutomata, 30, &stateSet);
+	cellularAutomata.setLattice(&lattice);
+	cellularAutomata.setStateSet(&stateSet);
+	cellularAutomata.setNeighborhood(&neighborhood);
+	cellularAutomata.setLocalRule(&rule);
+	lattice.init();
+	for (int t = 0; t < 5; ++t) {
+		cellularAutomata.step();
+	}
+	EXPECT_EQ(rowOf(lattice), "000000000");
+}

--- a/source/tests/unit/test_cellular_automata_user_defined.cpp
+++ b/source/tests/unit/test_cellular_automata_user_defined.cpp
@@ -1,0 +1,211 @@
+// Verifies the user-defined local rule (Tema 6, Linha B): a rule supplied as C++ source, compiled at
+// runtime via CppCompiler, loaded, and invoked per cell. Correctness is checked bit-perfect against
+// the same theoretical ground truth used for the built-in engine (Wolfram rules 30/90, Game of Life),
+// plus an equivalence check user-rule == built-in preset, plus graceful failure on bad user code.
+
+#include <gtest/gtest.h>
+
+#include "plugins/components/ModalModel/CellularAutomata/Boundary_Fixed.h"
+#include "plugins/components/ModalModel/CellularAutomata/CellularAutomata_Classic.h"
+#include "plugins/components/ModalModel/CellularAutomata/Lattice.h"
+#include "plugins/components/ModalModel/CellularAutomata/LocalRule_Elementary.h"
+#include "plugins/components/ModalModel/CellularAutomata/LocalRule_UserDefined.h"
+#include "plugins/components/ModalModel/CellularAutomata/Neighborhood_Center.h"
+#include "plugins/components/ModalModel/CellularAutomata/Neighborhood_Moore.h"
+#include "plugins/components/ModalModel/CellularAutomata/State.h"
+#include "plugins/components/ModalModel/CellularAutomata/StateSet_Enumerable.h"
+#include "plugins/data/ExternalIntegration/CppCompiler.h"
+
+#include "kernel/simulator/Simulator.h"
+
+#include <string>
+#include <vector>
+
+namespace {
+
+std::string rowOf(Lattice& lattice) {
+	std::string row;
+	for (unsigned long cellNumber = 0; cellNumber < lattice.getCellsSize(); ++cellNumber) {
+		row += std::to_string(lattice.getCell(static_cast<long>(cellNumber))->getCurrentState().getValue());
+	}
+	return row;
+}
+
+CppCompiler* makeCompiler(Simulator& simulator) {
+	Model* model = simulator.getModelManager()->newModel();
+	CppCompiler* compiler = new CppCompiler(model, "userRuleCompiler");
+	compiler->setOutputDir("/tmp/");
+	compiler->setTempDir("/tmp/");
+	compiler->setFlagsGeneral("-w -std=c++14"); // drop the default -v verbose noise
+	return compiler;
+}
+
+// Runs a 1D elementary CA driven by a user-defined rule built from `ruleBody` (a function body wrapped
+// into the nextState signature via buildBody). Single central 1, fixed-0 boundary. Returns the
+// space-time rows t0..t(steps); empty vector if the build failed.
+std::vector<std::string> runUserElementary(Simulator& simulator, unsigned short width,
+		const std::string& ruleBody, unsigned int steps, std::string& errorMessage) {
+	CellularAutomata_Classic cellularAutomata;
+	Lattice lattice(&cellularAutomata, nullptr, {width}, LatticeType::RETICULAR);
+	State zero(0);
+	State one(1);
+	StateSet_Enumerable stateSet(&cellularAutomata, {&zero, &one});
+	Boundary_Fixed boundary(&lattice);
+	Neighborhood_Center neighborhood(&cellularAutomata, 1, &boundary);
+	CppCompiler* compiler = makeCompiler(simulator);
+	LocalRule_UserDefined rule(&cellularAutomata, compiler, &stateSet);
+	if (!rule.buildBody(ruleBody, errorMessage)) {
+		return {};
+	}
+
+	cellularAutomata.setLattice(&lattice);
+	cellularAutomata.setStateSet(&stateSet);
+	cellularAutomata.setNeighborhood(&neighborhood);
+	cellularAutomata.setLocalRule(&rule);
+
+	lattice.init();
+	State centerOn(1);
+	lattice.setCellState(static_cast<long>(width / 2), &centerOn);
+
+	std::vector<std::string> rows;
+	rows.emplace_back(rowOf(lattice));
+	for (unsigned int t = 0; t < steps; ++t) {
+		cellularAutomata.step();
+		rows.emplace_back(rowOf(lattice));
+	}
+	return rows;
+}
+
+} // namespace
+
+TEST(UserDefinedCA, Rule30FromUserSourceMatchesTextbook) {
+	Simulator simulator;
+	std::string error;
+	// Rule 30: next = left XOR (center OR right). Neighbors order for 1D centered radius-1 = {left,right}.
+	const std::string source = "return neighbors[0] ^ (self | neighbors[1]);";
+	const std::vector<std::string> rows = runUserElementary(simulator, 9, source, 3, error);
+	ASSERT_EQ(rows.size(), 4u) << "build/compile failed: " << error;
+	EXPECT_EQ(rows[0], "000010000");
+	EXPECT_EQ(rows[1], "000111000");
+	EXPECT_EQ(rows[2], "001100100");
+	EXPECT_EQ(rows[3], "011011110");
+}
+
+TEST(UserDefinedCA, Rule90FromUserSourceMatchesSierpinski) {
+	Simulator simulator;
+	std::string error;
+	// Rule 90: next = left XOR right (center-independent) -> Sierpinski triangle.
+	const std::string source = "return neighbors[0] ^ neighbors[1];";
+	const std::vector<std::string> rows = runUserElementary(simulator, 11, source, 4, error);
+	ASSERT_EQ(rows.size(), 5u) << "build/compile failed: " << error;
+	EXPECT_EQ(rows[0], "00000100000");
+	EXPECT_EQ(rows[1], "00001010000");
+	EXPECT_EQ(rows[2], "00010001000");
+	EXPECT_EQ(rows[3], "00101010100");
+	EXPECT_EQ(rows[4], "01000000010");
+}
+
+TEST(UserDefinedCA, UserRule90EqualsBuiltInElementary90) {
+	// The user-defined rule must produce identical output to the built-in LocalRule_Elementary(90)
+	// over many steps and a wider lattice (strong equivalence / consistency check).
+	Simulator simulator;
+	std::string error;
+	const unsigned short width = 31;
+	const unsigned int steps = 15;
+
+	const std::vector<std::string> userRows = runUserElementary(simulator, width,
+		"return neighbors[0] ^ neighbors[1];", steps, error);
+	ASSERT_EQ(userRows.size(), steps + 1u) << "build/compile failed: " << error;
+
+	// Built-in reference run, same configuration.
+	CellularAutomata_Classic cellularAutomata;
+	Lattice lattice(&cellularAutomata, nullptr, {width}, LatticeType::RETICULAR);
+	State zero(0);
+	State one(1);
+	StateSet_Enumerable stateSet(&cellularAutomata, {&zero, &one});
+	Boundary_Fixed boundary(&lattice);
+	Neighborhood_Center neighborhood(&cellularAutomata, 1, &boundary);
+	LocalRule_Elementary builtIn(&cellularAutomata, 90, &stateSet);
+	cellularAutomata.setLattice(&lattice);
+	cellularAutomata.setStateSet(&stateSet);
+	cellularAutomata.setNeighborhood(&neighborhood);
+	cellularAutomata.setLocalRule(&builtIn);
+	lattice.init();
+	State centerOn(1);
+	lattice.setCellState(static_cast<long>(width / 2), &centerOn);
+	std::vector<std::string> builtInRows;
+	builtInRows.emplace_back(rowOf(lattice));
+	for (unsigned int t = 0; t < steps; ++t) {
+		cellularAutomata.step();
+		builtInRows.emplace_back(rowOf(lattice));
+	}
+
+	EXPECT_EQ(userRows, builtInRows);
+}
+
+TEST(UserDefinedCA, BadUserCodeFailsGracefully) {
+	// A compilation error in the user's rule must be reported, not crash, and leave the rule not-ready.
+	Simulator simulator;
+	CppCompiler* compiler = makeCompiler(simulator);
+	CellularAutomata_Classic cellularAutomata;
+	StateSet_Enumerable stateSet(&cellularAutomata, {});
+	LocalRule_UserDefined rule(&cellularAutomata, compiler, &stateSet);
+
+	std::string error;
+	const bool ok = rule.build("this is not valid c++ code <<<", error);
+	EXPECT_FALSE(ok);
+	EXPECT_FALSE(rule.isReady());
+	EXPECT_FALSE(error.empty());
+}
+
+TEST(UserDefinedCA, GameOfLifeBlinkerOscillatesViaUserRule) {
+	// 2D Game of Life (B3/S23) expressed as a user rule over a Moore neighborhood. A horizontal
+	// blinker (3 cells) must become vertical after one step and horizontal again after two (period 2).
+	Simulator simulator;
+	std::string error;
+	const std::string gol =
+		"long live = 0;"
+		"for (int i = 0; i < numNeighbors; ++i) live += neighbors[i];"
+		"if (self != 0) return (live == 2 || live == 3) ? 1 : 0;"
+		"return (live == 3) ? 1 : 0;";
+
+	CellularAutomata_Classic cellularAutomata;
+	const unsigned short side = 5;
+	Lattice lattice(&cellularAutomata, nullptr, {side, side}, LatticeType::RETICULAR);
+	State zero(0);
+	State one(1);
+	StateSet_Enumerable stateSet(&cellularAutomata, {&zero, &one});
+	Boundary_Fixed boundary(&lattice);
+	Neighborhood_Moore neighborhood(&cellularAutomata, 1, &boundary);
+	CppCompiler* compiler = makeCompiler(simulator);
+	LocalRule_UserDefined rule(&cellularAutomata, compiler, &stateSet);
+	ASSERT_TRUE(rule.buildBody(gol, error)) << error;
+
+	cellularAutomata.setLattice(&lattice);
+	cellularAutomata.setStateSet(&stateSet);
+	cellularAutomata.setNeighborhood(&neighborhood);
+	cellularAutomata.setLocalRule(&rule);
+	lattice.init();
+
+	// Horizontal blinker centered at row 2, columns 1..3 (cell number = col + side*row).
+	State on(1);
+	lattice.setCellState(static_cast<long>(1 + side * 2), &on);
+	lattice.setCellState(static_cast<long>(2 + side * 2), &on);
+	lattice.setCellState(static_cast<long>(3 + side * 2), &on);
+
+	const std::string horizontal = rowOf(lattice);
+	cellularAutomata.step();
+	const std::string vertical = rowOf(lattice);
+	cellularAutomata.step();
+	const std::string horizontalAgain = rowOf(lattice);
+
+	EXPECT_NE(horizontal, vertical) << "blinker should change shape after one step";
+	EXPECT_EQ(horizontal, horizontalAgain) << "blinker should return to its shape after two steps (period 2)";
+
+	// Explicit: after one step the live cells are the vertical triple (col 2, rows 1..3).
+	std::string expectedVertical(side * side, '0');
+	expectedVertical[2 + side * 1] = '1';
+	expectedVertical[2 + side * 2] = '1';
+	expectedVertical[2 + side * 3] = '1';
+	EXPECT_EQ(vertical, expectedVertical);
+}


### PR DESCRIPTION
## Tema 6 (DCS) — Autômato celular universal + regra local definida pelo usuário

Entrega final do grupo **Tema 6.2** (Pedro Henrique Gimenez · João Vitor Curcio Sutter).
Consolida o suporte a autômatos celulares do GenESyS num **componente universal e
configurável**, com foco no ponto em aberto do tema: a **regra local definida pelo usuário**.
Tudo sobre `2026-1`, sem conflitos, restrito ao subsistema de AC.

### O que foi implementado

**Generalização universal** (lattice / vizinhança / contorno / estados / política de atualização):
- Contornos novos: `Boundary_Adiabatic`, `Boundary_Reflexive` (somam-se a `Fixed`/`Closed`).
- Conjuntos de estados novos: `StateSet_Bit`, `StateSet_Double`, `StateSet_Integer`; `State`
  passou a ser baseado em `double` (`getValue()` continua `long`), com validação por conjunto
  (`contains`/`tryMakeState`).
- Políticas de atualização configuráveis em `CellularAutomataComp` (`UpdatePolicyType`):
  **síncrona, sequencial, aleatória e em blocos** (`_onDispatchEvent` → `_stepCellularAutomataByPolicy`).
  A política aleatória usa um Fisher‑Yates com `uniform_int_distribution`, **reprodutível** entre
  plataformas/compiladores.
- `_check` decomposto e reforçado (`_checkImplementedTypes`/`_checkLattice`/`_checkStateSet`/
  `_checkRuleCompatibility`/`_checkUpdatePolicy`).
- Vizinhanças Moore / Von Neumann N‑dimensionais (mantidas da `2026-1`).

**Regra local definida pelo usuário** (compilação dinâmica):
- `LocalRule_UserDefined` compila, em tempo de execução, uma função do usuário
  `extern "C" long nextState(long self, const long* neighbors, int numNeighbors)` via
  `CppCompiler` → `dlopen`/`dlsym`, e a invoca por célula. Integrada ao componente como o tipo de
  regra `USERDEFINED`, construída de forma *lazy* no `_check`.

**Persistência e ciclo de vida:**
- `_loadInstance`/`_saveInstance` passaram de não implementados a **round‑trip completo** da
  configuração: todos os enums de tipo, dimensões do lattice, raio da vizinhança, número da regra
  elementar, política/tamanho‑de‑bloco/semente e a fonte da regra do usuário.
- Correções de heap: `delete` em vez de chamada explícita de destrutor; sem ponteiros pendentes no
  autômato ao reconfigurar; estados binários do conjunto enumerado são donos do componente (sem leak).

### Validação — 33 testes unitários (gtest), todos verdes
Engine elementar **bit‑perfect** vs Wolfram (regra 30 do livro, regra 90 = triângulo de Sierpinski);
regra do usuário == preset embutido e Game of Life via regra do usuário; contornos
Fixed/Closed/Reflexive/Adiabatic; contagem de vizinhos Moore/VonNeumann em 1D/2D/3D; as quatro
políticas de atualização; round‑trip de persistência; e **rejeição de configurações inválidas**.
Cobre integralmente o §12 do enunciado.

Suítes: `test_cellular_automata` (universal), `test_cellular_automata_neighborhood`,
`test_cellular_automata_elementary`, `test_cellular_automata_user_defined`,
`test_cellular_automata_component`.

### Como buildar e rodar os testes
```bash
cmake -S . -B build/tests -DGENESYS_BUILD_TESTS=ON \
  -DGENESYS_BUILD_TERMINAL_APPLICATION=OFF -DGENESYS_BUILD_WEB_APPLICATION=OFF
cmake --build build/tests --target genesys_test_cellular_automata \
  genesys_test_cellular_automata_neighborhood genesys_test_cellular_automata_elementary \
  genesys_test_cellular_automata_user_defined genesys_test_cellular_automata_component
ctest --test-dir build/tests -R CellularAutomata --output-on-failure
```

> A regra definida pelo usuário exige um compilador C++ (`g++`/`clang`) no `PATH` e um diretório
> temporário gravável; sem compilador, ela falha de forma graciosa (sem crash), comportamento coberto
> por teste.
