### PR TITLE
DCS Theme 6.2: Universal cellular automaton component with user-defined local rule

### DIFF
--- a/source/applications/terminal/examples/smarts/Smart_CellularAutomataCompRule90.cpp
+++ b/source/applications/terminal/examples/smarts/Smart_CellularAutomataCompRule90.cpp
@@ -1,0 +1,108 @@
+/*
+ * File:   Smart_CellularAutomataCompRule90.cpp
+ *
+ * Minimal terminal example that runs elementary cellular automaton Rule 90
+ * through the GenESyS CellularAutomataComp component.
+ */
+
+#include "Smart_CellularAutomataCompRule90.h"
+
+#include "kernel/simulator/Simulator.h"
+#include "plugins/components/ModalModel/CellularAutomataComp.h"
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace {
+
+void SetInitialPattern(CellularAutomataComp* cellularAutomata, const std::string& pattern) {
+	for (unsigned long cellNumber = 0; cellNumber < pattern.size(); ++cellNumber) {
+		const long value = pattern.at(cellNumber) == '1' ? 1 : 0;
+		cellularAutomata->setCellState(static_cast<long>(cellNumber), value);
+	}
+}
+
+void PrintNeighborhoodCount(Model* model, CellularAutomataComp::NeighboorhoodType neighborhoodType, const std::string& neighborhoodName, const std::vector<unsigned short>& dimensions) {
+	CellularAutomataComp* cellularAutomata = new CellularAutomataComp(model);
+	cellularAutomata->setCellularAutomataType(CellularAutomataComp::CellularAutomataType::CLASSIC);
+	cellularAutomata->setLatticeType(CellularAutomataComp::LatticeType::RETICULAR);
+	cellularAutomata->getlattice()->setDimensions(dimensions);
+	cellularAutomata->setNeighboorhoodType(neighborhoodType);
+	cellularAutomata->getNeighboorhood()->setRadius(1);
+	cellularAutomata->setBoundaryType(CellularAutomataComp::BoundaryType::CLOSED);
+	cellularAutomata->setStateSetType(CellularAutomataComp::StateSetType::ENUMERATED);
+	cellularAutomata->setLocalRuleType(CellularAutomataComp::LocalRuleType::BIASED_COMPETITION);
+
+	std::string errorMessage;
+	if (!cellularAutomata->initializeCellularAutomata(&errorMessage)) {
+		std::cout << neighborhoodName << " " << dimensions.size() << "D radius 1: initialization failed - " << errorMessage << std::endl;
+		return;
+	}
+
+	std::vector<int> centerPosition;
+	for (unsigned short dimension : dimensions)
+		centerPosition.emplace_back(static_cast<int>(dimension / 2));
+
+	const long centerCellNumber = cellularAutomata->getlattice()->cellNDimPosition2Number(centerPosition);
+	const unsigned long neighbors = cellularAutomata->getlattice()->getCell(centerCellNumber)->getNeighbors().size();
+	std::cout << neighborhoodName << " " << dimensions.size() << "D radius 1: " << neighbors << " neighbors" << std::endl;
+}
+
+void RunRule90(Model* model, CellularAutomataComp::BoundaryType boundaryType, const std::string& boundaryName) {
+	CellularAutomataComp* cellularAutomata = new CellularAutomataComp(model);
+	cellularAutomata->setCellularAutomataType(CellularAutomataComp::CellularAutomataType::CLASSIC);
+	cellularAutomata->setLatticeType(CellularAutomataComp::LatticeType::RETICULAR);
+	cellularAutomata->getlattice()->setDimensions({7});
+	cellularAutomata->setNeighboorhoodType(CellularAutomataComp::NeighboorhoodType::CENTERED);
+	cellularAutomata->getNeighboorhood()->setRadius(1);
+	cellularAutomata->setBoundaryType(boundaryType);
+	cellularAutomata->setStateSetType(CellularAutomataComp::StateSetType::ENUMERATED);
+	cellularAutomata->setElementaryRuleNumber(90);
+	cellularAutomata->setLocalRuleType(CellularAutomataComp::LocalRuleType::ELEMENTAR_CA);
+
+	std::string errorMessage;
+	if (!cellularAutomata->initializeCellularAutomata(&errorMessage)) {
+		std::cout << "Could not initialize CellularAutomataComp: " << errorMessage << std::endl;
+		return;
+	}
+
+	SetInitialPattern(cellularAutomata, "1001000");
+
+	std::cout << "1D lattice, 7 cells, centered radius-1 neighborhood, " << boundaryName << " boundary" << std::endl;
+	std::cout << std::endl;
+
+	const unsigned int steps = 6;
+	std::cout << "t0: " << cellularAutomata->showCellularAutomata() << std::endl;
+	for (unsigned int step = 1; step <= steps; ++step) {
+		cellularAutomata->stepCellularAutomata();
+		std::cout << "t" << step << ": " << cellularAutomata->showCellularAutomata() << std::endl;
+	}
+}
+
+}
+
+Smart_CellularAutomataCompRule90::Smart_CellularAutomataCompRule90() {
+}
+
+int Smart_CellularAutomataCompRule90::main(int argc, char** argv) {
+	Simulator* genesys = new Simulator();
+	genesys->getTraceManager()->setTraceLevel(TraceManager::Level::L0_noTraces);
+	setDefaultTraceHandlers(genesys->getTraceManager());
+
+	Model* model = genesys->getModelManager()->newModel();
+
+	std::cout << "Elementary cellular automaton through CellularAutomataComp - Rule 90" << std::endl;
+	std::cout << std::endl;
+
+	RunRule90(model, CellularAutomataComp::BoundaryType::CLOSED, "closed");
+	std::cout << std::endl;
+	RunRule90(model, CellularAutomataComp::BoundaryType::FIXED, "fixed");
+	std::cout << std::endl;
+	RunRule90(model, CellularAutomataComp::BoundaryType::REFLEXIVE, "reflexive");
+	std::cout << std::endl;
+	RunRule90(model, CellularAutomataComp::BoundaryType::ADIABATIC, "adiabatic");
+
+	delete genesys;
+	return 0;
+}

--- a/source/applications/terminal/examples/smarts/Smart_CellularAutomataCompRule90.h
+++ b/source/applications/terminal/examples/smarts/Smart_CellularAutomataCompRule90.h
@@ -1,0 +1,19 @@
+/*
+ * File:   Smart_CellularAutomataCompRule90.h
+ *
+ * Terminal example for manually debugging Rule 90 through CellularAutomataComp.
+ */
+
+#ifndef SMART_CELLULARAUTOMATACOMPRULE90_H
+#define SMART_CELLULARAUTOMATACOMPRULE90_H
+
+#include "../../../BaseGenesysTerminalApplication.h"
+
+class Smart_CellularAutomataCompRule90 : public BaseGenesysTerminalApplication {
+public:
+	Smart_CellularAutomataCompRule90();
+public:
+	virtual int main(int argc, char** argv) override;
+};
+
+#endif /* SMART_CELLULARAUTOMATACOMPRULE90_H */

--- a/source/applications/terminal/examples/smarts/Smart_CellularAutomataUserRule.cpp
+++ b/source/applications/terminal/examples/smarts/Smart_CellularAutomataUserRule.cpp
@@ -1,0 +1,125 @@
+/*
+ * File:   Smart_CellularAutomataUserRule.cpp
+ *
+ * Tema 6, line B: the cellular automaton's local rule is written by the USER as C++
+ * source and compiled at runtime by the component
+ * (CellularAutomataComp -> LocalRule_UserDefined -> CppCompiler -> dlopen/dlsym).
+ *
+ * Shows how a user drives GenESyS to see any rule: just change the rule string.
+ * Here it runs rule 90 (Sierpinski triangle) and rule 30 (chaotic).
+ *
+ * Optionally, set the environment variable CA_RULE to the body of a rule to run only
+ * that rule, without recompiling the simulator (only the rule is compiled at runtime):
+ *     CA_RULE="return n[0] ^ n[1];" ./genesys_terminal_application
+ */
+
+#include "Smart_CellularAutomataUserRule.h"
+
+#include "kernel/simulator/Simulator.h"
+#include "plugins/components/ModalModel/CellularAutomataComp.h"
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace {
+
+// Wraps the BODY of a rule (statements that return a long) into the full extern "C"
+// nextState signature, so the user can write just the logic, e.g. "return n[0] ^ n[1];".
+std::string WrapBody(const std::string& body) {
+	return "extern \"C\" long nextState(long self, const long* n, int k) {"
+	       " (void) self; (void) n; (void) k; " + body + " }";
+}
+
+// Renders a row of cells in a readable way: 0 -> '.', 1 -> '#'.
+std::string Render(const std::string& cells) {
+	std::string out;
+	for (char c : cells) out += (c == '0' ? '.' : '#');
+	return out;
+}
+
+// Runs a 1D cellular automaton whose local rule was written by the user as C++ source.
+//   ruleName   : label for printing
+//   ruleSource : full user-defined C++ source (defines nextState)
+//   width/steps: lattice size and number of steps
+void RunUserRule(Model* model, const std::string& ruleName, const std::string& ruleSource,
+		unsigned short width, unsigned int steps) {
+	CellularAutomataComp* ca = new CellularAutomataComp(model);
+
+	// --- automaton configuration, exactly as a user would do through the public API ---
+	ca->setCellularAutomataType(CellularAutomataComp::CellularAutomataType::CLASSIC);
+	ca->setLatticeType(CellularAutomataComp::LatticeType::RETICULAR);
+	ca->getlattice()->setDimensions({width});                 // 1D, `width` cells
+	ca->setNeighboorhoodType(CellularAutomataComp::NeighboorhoodType::CENTERED);
+	ca->getNeighboorhood()->setRadius(1);                     // neighbors = {left, right}
+	ca->setBoundaryType(CellularAutomataComp::BoundaryType::FIXED);   // outside the lattice is 0
+	ca->setStateSetType(CellularAutomataComp::StateSetType::ENUMERATED);
+
+	// --- the user-defined rule (line B): the transition written by the user in C++ ---
+	ca->setUserDefinedRuleSource(ruleSource);
+	ca->setLocalRuleType(CellularAutomataComp::LocalRuleType::USERDEFINED);
+
+	// initialize calls _check, which COMPILES the user rule at runtime.
+	std::string errorMessage;
+	if (!ca->initializeCellularAutomata(&errorMessage)) {
+		std::cout << ruleName << ": initialization failed (rule did not compile) -> "
+		          << errorMessage << std::endl;
+		return;
+	}
+
+	// Initial state: a single cell turned on at the center.
+	ca->setCellState(static_cast<long>(width / 2), 1);
+
+	std::cout << "=== " << ruleName << " ===" << std::endl;
+	std::cout << "user rule (C++): " << ruleSource << std::endl;
+	std::cout << "1D lattice, " << width << " cells, centered radius-1 neighborhood, fixed boundary"
+	          << std::endl << std::endl;
+
+	const std::string t0 = ca->showCellularAutomata();
+	std::cout << "t 0  " << Render(t0) << "   " << t0 << std::endl;
+	for (unsigned int step = 1; step <= steps; ++step) {
+		ca->stepCellularAutomata();                          // applies the user rule per cell
+		const std::string row = ca->showCellularAutomata();
+		std::cout << "t" << (step < 10 ? " " : "") << step << "  " << Render(row)
+		          << "   " << row << std::endl;
+	}
+	std::cout << std::endl;
+}
+
+} // namespace
+
+Smart_CellularAutomataUserRule::Smart_CellularAutomataUserRule() {
+}
+
+int Smart_CellularAutomataUserRule::main(int argc, char** argv) {
+	Simulator* genesys = new Simulator();
+	genesys->getTraceManager()->setTraceLevel(TraceManager::Level::L0_noTraces);
+	setDefaultTraceHandlers(genesys->getTraceManager());
+
+	Model* model = genesys->getModelManager()->newModel();
+
+	std::cout << "Cellular automaton with a USER-DEFINED local rule (Tema 6, line B)" << std::endl;
+	std::cout << "The rule is written in C++ and compiled at runtime by the component."
+	          << std::endl << std::endl;
+
+	// If the CA_RULE environment variable is set, run ONLY that rule (the user writes just the
+	// body, e.g. CA_RULE="return n[0] & n[1];"). Useful for a live demo: changing the rule does
+	// NOT recompile the simulator, only the rule is compiled at runtime.
+	const char* envRule = std::getenv("CA_RULE");
+	if (envRule != nullptr && envRule[0] != '\0') {
+		RunUserRule(model, "User rule (CA_RULE)", WrapBody(envRule), 31, 15);
+		delete genesys;
+		return 0;
+	}
+
+	// Without CA_RULE: show two classic rules written by the user.
+	// Rule 90: next = left XOR right  -> Sierpinski triangle.
+	RunUserRule(model, "Rule 90 (Sierpinski)", WrapBody("return n[0] ^ n[1];"), 31, 15);
+
+	// Rule 30: next = left XOR (center OR right)  -> chaotic pattern.
+	RunUserRule(model, "Rule 30 (chaotic)", WrapBody("return n[0] ^ (self | n[1]);"), 31, 15);
+
+	delete genesys;
+	return 0;
+}

--- a/source/applications/terminal/examples/smarts/Smart_CellularAutomataUserRule.h
+++ b/source/applications/terminal/examples/smarts/Smart_CellularAutomataUserRule.h
@@ -1,0 +1,23 @@
+/*
+ * File:   Smart_CellularAutomataUserRule.h
+ *
+ * Terminal example (Tema 6, line B): runs a cellular automaton whose local rule
+ * is written by the USER as C++ source and compiled at runtime through
+ * CellularAutomataComp (LocalRule_UserDefined + CppCompiler). Demonstrates how a
+ * user drives GenESyS to see any rule (e.g. rule 90, rule 30) without recompiling
+ * the simulator.
+ */
+
+#ifndef SMART_CELLULARAUTOMATAUSERRULE_H
+#define SMART_CELLULARAUTOMATAUSERRULE_H
+
+#include "../../../BaseGenesysTerminalApplication.h"
+
+class Smart_CellularAutomataUserRule : public BaseGenesysTerminalApplication {
+public:
+	Smart_CellularAutomataUserRule();
+public:
+	virtual int main(int argc, char** argv) override;
+};
+
+#endif /* SMART_CELLULARAUTOMATAUSERRULE_H */

--- a/source/plugins/components/ModalModel/CellularAutomata/Boundary_Adiabatic.h
+++ b/source/plugins/components/ModalModel/CellularAutomata/Boundary_Adiabatic.h
@@ -1,0 +1,41 @@
+/*
+ * File:   Boundary_Adiabatic.h
+ *
+ * Boundary condition that clamps out-of-bounds coordinates to the nearest
+ * lattice border cell.
+ */
+
+#pragma once
+
+#include "plugins/components/ModalModel/CellularAutomata/BoundaryCondition.h"
+#include "plugins/components/ModalModel/CellularAutomata/Cell.h"
+#include "plugins/components/ModalModel/CellularAutomata/Lattice.h"
+
+class Boundary_Adiabatic : public BoundaryCondition {
+public:
+	Boundary_Adiabatic(Lattice* lattice = nullptr, Neighborhood* neighborhood = nullptr)
+		: BoundaryCondition(lattice, neighborhood) {
+	}
+
+	Boundary_Adiabatic(const Boundary_Adiabatic& orig)
+		: BoundaryCondition(orig) {
+	}
+
+	virtual ~Boundary_Adiabatic() = default;
+
+public:
+	virtual Cell* getNeighborCell(std::vector<int> cellNDimPosition, std::vector<int> neighborNDimPosition) override {
+		long neighborCellNumber = lattice->cellNDimPosition2Number(neighborNDimPosition);
+		if (neighborCellNumber < 0) {
+			for (unsigned short dim = 0; dim < neighborNDimPosition.size(); ++dim) {
+				int maxPos = static_cast<int>(lattice->getDimension(dim)) - 1;
+				if (neighborNDimPosition.at(dim) < 0)
+					neighborNDimPosition.at(dim) = 0;
+				else if (neighborNDimPosition.at(dim) > maxPos)
+					neighborNDimPosition.at(dim) = maxPos;
+			}
+			neighborCellNumber = lattice->cellNDimPosition2Number(neighborNDimPosition);
+		}
+		return lattice->getCell(neighborCellNumber);
+	}
+};

--- a/source/plugins/components/ModalModel/CellularAutomata/Boundary_Closed.h
+++ b/source/plugins/components/ModalModel/CellularAutomata/Boundary_Closed.h
@@ -37,7 +37,8 @@ public:
                 pos = neighborNDimPosition.at(dim);
                 maxPos = (int) (lattice->getDimension(dim));
                 if (pos < 0 || pos >= maxPos) { // out of bound
-                    pos = (2 * maxPos + pos) % maxPos;
+                    // Keep periodic wrapping valid for any radius, including large negative offsets.
+                    pos = ((pos % maxPos) + maxPos) % maxPos;
                     // position corrected
                     neighborNDimPosition.at(dim) = pos;
                 }

--- a/source/plugins/components/ModalModel/CellularAutomata/Boundary_Reflexive.h
+++ b/source/plugins/components/ModalModel/CellularAutomata/Boundary_Reflexive.h
@@ -1,0 +1,52 @@
+/*
+ * File:   Boundary_Reflexive.h
+ *
+ * Boundary condition that mirrors out-of-bounds coordinates back into the
+ * lattice.
+ */
+
+#pragma once
+
+#include "plugins/components/ModalModel/CellularAutomata/BoundaryCondition.h"
+#include "plugins/components/ModalModel/CellularAutomata/Cell.h"
+#include "plugins/components/ModalModel/CellularAutomata/Lattice.h"
+
+class Boundary_Reflexive : public BoundaryCondition {
+public:
+	Boundary_Reflexive(Lattice* lattice = nullptr, Neighborhood* neighborhood = nullptr)
+		: BoundaryCondition(lattice, neighborhood) {
+	}
+
+	Boundary_Reflexive(const Boundary_Reflexive& orig)
+		: BoundaryCondition(orig) {
+	}
+
+	virtual ~Boundary_Reflexive() = default;
+
+public:
+	virtual Cell* getNeighborCell(std::vector<int> cellNDimPosition, std::vector<int> neighborNDimPosition) override {
+		long neighborCellNumber = lattice->cellNDimPosition2Number(neighborNDimPosition);
+		if (neighborCellNumber < 0) {
+			for (unsigned short dim = 0; dim < neighborNDimPosition.size(); ++dim) {
+				const int dimensionSize = static_cast<int>(lattice->getDimension(dim));
+				neighborNDimPosition.at(dim) = _reflectPosition(neighborNDimPosition.at(dim), dimensionSize);
+			}
+			neighborCellNumber = lattice->cellNDimPosition2Number(neighborNDimPosition);
+		}
+		return lattice->getCell(neighborCellNumber);
+	}
+
+private:
+	int _reflectPosition(int position, int dimensionSize) const {
+		if (dimensionSize <= 1)
+			return 0;
+
+		const int period = 2 * (dimensionSize - 1);
+		position %= period;
+		if (position < 0)
+			position += period;
+		if (position >= dimensionSize)
+			position = period - position;
+		return position;
+	}
+};

--- a/source/plugins/components/ModalModel/CellularAutomata/CellularAutomata_1DTimed.h
+++ b/source/plugins/components/ModalModel/CellularAutomata/CellularAutomata_1DTimed.h
@@ -17,7 +17,7 @@ public:
 protected:
     virtual void applyLocalRule() override {
         Cell* cell;
-		State state; // was an uninitialized State* dereferenced below (wild-pointer write); use a local
+		State state;
         int nextRow;
 		int maxRows = std::min<int>(lattice->getDimension(1)-2, lattice->getDimension(1)-2); // simulatedTime);
         for (int row=maxRows; row>=0; row--) {

--- a/source/plugins/components/ModalModel/CellularAutomata/CellularAutomata_1DTimed.h
+++ b/source/plugins/components/ModalModel/CellularAutomata/CellularAutomata_1DTimed.h
@@ -17,7 +17,7 @@ public:
 protected:
     virtual void applyLocalRule() override {
         Cell* cell;
-		State* state;
+		State state; // was an uninitialized State* dereferenced below (wild-pointer write); use a local
         int nextRow;
 		int maxRows = std::min<int>(lattice->getDimension(1)-2, lattice->getDimension(1)-2); // simulatedTime);
         for (int row=maxRows; row>=0; row--) {
@@ -25,8 +25,8 @@ protected:
             // move cell states to the next row 
 			for (int col=0; col<lattice->getDimension(0); col++) { // move to row bellow
 				cell = lattice->getCell({col,row});
-				*state = cell->getCurrentState();
-				lattice->setCellState({col,nextRow}, state);
+				state = cell->getCurrentState();
+				lattice->setCellState({col,nextRow}, &state);
             }
             if (row==0) {
                 // apply the same local rule for all unidimensional cells at the same time

--- a/source/plugins/components/ModalModel/CellularAutomata/Lattice.cpp
+++ b/source/plugins/components/ModalModel/CellularAutomata/Lattice.cpp
@@ -111,7 +111,7 @@ void Lattice::setCell(const std::vector<int> position, Cell* cell) {
 		Cell* oldCell = cells.at(cellNumber);
 		cells.at(cellNumber) = cell;
 		if (oldCell != nullptr)
-			delete oldCell; // was an explicit destructor call, which freed nothing (leak) and left a zombie
+			delete oldCell;
 	}
 }
 

--- a/source/plugins/components/ModalModel/CellularAutomata/Lattice.cpp
+++ b/source/plugins/components/ModalModel/CellularAutomata/Lattice.cpp
@@ -25,6 +25,14 @@ Lattice::Lattice(const Lattice& orig) {
 
 }
 
+Lattice::~Lattice() {
+	// init() fills `cells` with new Cell objects owned by this lattice; free them here so a lattice
+	// does not leak its whole grid on teardown. The empty copy constructor leaves a copy's `cells`
+	// empty, so a copied lattice frees nothing — no double free.
+	for (Cell* cell : cells)
+		delete cell;
+}
+
 /* **************
  *  PUBLIC
  * **************/
@@ -103,11 +111,13 @@ void Lattice::setCell(const std::vector<int> position, Cell* cell) {
 		Cell* oldCell = cells.at(cellNumber);
 		cells.at(cellNumber) = cell;
 		if (oldCell != nullptr)
-			oldCell->~Cell();
+			delete oldCell; // was an explicit destructor call, which freed nothing (leak) and left a zombie
 	}
 }
 
 bool Lattice::setCellState(long cellNumber, State* state, Cell* cell) {
+	if (cellNumber < 0)
+		return false;
 	if (cells.size() <= cellNumber)
 		cells.resize(cellNumber + 1);
 	Cell* newCell = cell;
@@ -130,6 +140,8 @@ bool Lattice::setCellState(long cellNumber, State* state, Cell* cell) {
 
 bool Lattice::setCellState(std::vector<int> position, State* state, Cell* cell) {
 	long cellNumber = cellNDimPosition2Number(position);
+	if (cellNumber < 0)
+		return false;
 	return setCellState(cellNumber, state, cell);
 }
 
@@ -173,11 +185,15 @@ std::vector<int> Lattice::cellNumber2NDimPosition(const long cellNumber) {
 }
 
 Cell* Lattice::getCell(const long cellNumber) {
+	if (cellNumber < 0 || static_cast<unsigned long>(cellNumber) >= cells.size())
+		return nullptr;
 	return cells.at(cellNumber);
 }
 
 Cell* Lattice::getCell(const std::vector<int> position) {
-	unsigned int cellNumber = this->cellNDimPosition2Number(position);
+	long cellNumber = this->cellNDimPosition2Number(position);
+	if (cellNumber < 0)
+		return nullptr;
 	return getCell(cellNumber);
 }
 

--- a/source/plugins/components/ModalModel/CellularAutomata/Lattice.cpp
+++ b/source/plugins/components/ModalModel/CellularAutomata/Lattice.cpp
@@ -18,11 +18,20 @@ Lattice::Lattice(CellularAutomataBase* parentCellularAutomata, Cell *progenitorC
 	this->progenitorCell = progenitorCell;
 	this->dimensions = dimensions;
 	this->latticeType = latticeType;
+	this->networkEdgesUndirected = true;
 	hasBeenInit = false;
+	totalCells = 0;
 }
 
 Lattice::Lattice(const Lattice& orig) {
-
+	parentCellularAutomata = orig.parentCellularAutomata;
+	dimensions = orig.dimensions;
+	networkEdges = orig.networkEdges;
+	progenitorCell = orig.progenitorCell;
+	latticeType = orig.latticeType;
+	networkEdgesUndirected = orig.networkEdgesUndirected;
+	hasBeenInit = false;
+	totalCells = orig.totalCells;
 }
 
 Lattice::~Lattice() {
@@ -224,6 +233,10 @@ LatticeType Lattice::getLatticeType() const {
 	return latticeType;
 }
 
+void Lattice::setLatticeType(LatticeType latticeType) {
+	this->latticeType = latticeType;
+}
+
 unsigned long Lattice::getCellsSize() const {
 	return cells.size();
 }
@@ -261,6 +274,58 @@ unsigned short Lattice::getDimension(unsigned short dimensionNumber) const {
 
 std::vector<Cell*> Lattice::getCells() const {
 	return cells;
+}
+
+void Lattice::setNetworkEdges(const std::vector<std::pair<unsigned long, unsigned long>>& edges, bool undirected) {
+	networkEdges = edges;
+	networkEdgesUndirected = undirected;
+}
+
+std::vector<std::pair<unsigned long, unsigned long>> Lattice::getNetworkEdges() const {
+	return networkEdges;
+}
+
+bool Lattice::getNetworkEdgesUndirected() const {
+	return networkEdgesUndirected;
+}
+
+bool Lattice::hasNetworkEdges() const {
+	return !networkEdges.empty();
+}
+
+bool Lattice::networkEdgesAreValid() const {
+	unsigned long total = 1;
+	for (unsigned int dimension : dimensions)
+		total *= dimension;
+	for (const auto& edge : networkEdges) {
+		if (edge.first >= total || edge.second >= total)
+			return false;
+	}
+	return true;
+}
+
+std::vector<unsigned long> Lattice::getNetworkNeighborCellNumbers(unsigned long cellNumber) const {
+	std::vector<unsigned long> neighbors;
+	const unsigned long total = cells.empty() ? totalCells : cells.size();
+	if (total > 0 && cellNumber >= total)
+		return neighbors;
+	for (const auto& edge : networkEdges) {
+		if (edge.first == cellNumber)
+			neighbors.emplace_back(edge.second);
+		if (networkEdgesUndirected && edge.second == cellNumber)
+			neighbors.emplace_back(edge.first);
+	}
+	return neighbors;
+}
+
+std::vector<Cell*> Lattice::getNetworkNeighbors(unsigned long cellNumber) const {
+	std::vector<Cell*> neighbors;
+	for (unsigned long neighborCellNumber : getNetworkNeighborCellNumbers(cellNumber)) {
+		Cell* neighbor = const_cast<Lattice*>(this)->getCell(static_cast<long>(neighborCellNumber));
+		if (neighbor != nullptr)
+			neighbors.emplace_back(neighbor);
+	}
+	return neighbors;
 }
 //std::vector<Cell*>* Lattice::getCells() const {
 //    return cells;

--- a/source/plugins/components/ModalModel/CellularAutomata/Lattice.h
+++ b/source/plugins/components/ModalModel/CellularAutomata/Lattice.h
@@ -16,7 +16,7 @@ class Lattice {
 public:
 	Lattice(CellularAutomataBase* parentCellularAutomata, Cell *progenitorCell = nullptr, std::vector<unsigned short> dimensions={}, LatticeType latticeType = LatticeType::RETICULAR);
 	Lattice(const Lattice& orig);
-	virtual ~Lattice() = default;
+	virtual ~Lattice(); ///< frees the cells this lattice owns (created in init())
 public:
 	virtual std::string show();
 	bool init(); ///< init all cells

--- a/source/plugins/components/ModalModel/CellularAutomata/Lattice.h
+++ b/source/plugins/components/ModalModel/CellularAutomata/Lattice.h
@@ -3,6 +3,7 @@
 #include "plugins/components/ModalModel/CellularAutomata/Cell.h"
 #include <vector>
 #include <string>
+#include <utility>
 
 class CellularAutomataBase;
 
@@ -34,6 +35,7 @@ public:
 	unsigned short getNumDimensions();
 	unsigned int getNumCell(unsigned short dimension);
 	LatticeType getLatticeType() const;
+	void setLatticeType(LatticeType latticeType);
 	unsigned long getCellsSize() const;
 	unsigned long getTotalCells() const;
 	unsigned long calculateTotalCells();
@@ -42,12 +44,21 @@ public:
 	std::vector<unsigned short> getDimensions() const;
 	unsigned short getDimension(unsigned short dimensionNumber) const;
 	std::vector<Cell*> getCells() const;
+	void setNetworkEdges(const std::vector<std::pair<unsigned long, unsigned long>>& edges, bool undirected = true);
+	std::vector<std::pair<unsigned long, unsigned long>> getNetworkEdges() const;
+	bool getNetworkEdgesUndirected() const;
+	bool hasNetworkEdges() const;
+	bool networkEdgesAreValid() const;
+	std::vector<unsigned long> getNetworkNeighborCellNumbers(unsigned long cellNumber) const;
+	std::vector<Cell*> getNetworkNeighbors(unsigned long cellNumber) const;
 protected:
 	CellularAutomataBase* parentCellularAutomata;
 	std::vector<Cell*> cells;
 	std::vector<unsigned short> dimensions;
+	std::vector<std::pair<unsigned long, unsigned long>> networkEdges;
 	Cell *progenitorCell;
 	LatticeType latticeType;
+	bool networkEdgesUndirected;
 	bool hasBeenInit;
 	unsigned long totalCells;
 };

--- a/source/plugins/components/ModalModel/CellularAutomata/LocalRule.h
+++ b/source/plugins/components/ModalModel/CellularAutomata/LocalRule.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "plugins/components/ModalModel/CellularAutomata/Cell.h"
 #include "plugins/components/ModalModel/CellularAutomata/CellularAutomataBase.h"
+#include "plugins/components/ModalModel/CellularAutomata/StateSet.h"
 
 
 class LocalRule {
@@ -20,6 +21,19 @@ public:
 public:
 	void setStateSet(StateSet* stateSet){
 		this->stateSet = stateSet;
+	}
+protected:
+	bool setNextStateFromValue(Cell* cell, long value) const {
+		if (cell == nullptr)
+			return false;
+		State nextState(value);
+		if (stateSet != nullptr && !stateSet->tryMakeState(value, &nextState))
+			return false;
+		cell->setNextState(nextState);
+		return true;
+	}
+	long stateValue(const Cell* cell) const {
+		return cell->getCurrentState().getValue();
 	}
 protected:
     CellularAutomataBase* parentCellularAutomata;

--- a/source/plugins/components/ModalModel/CellularAutomata/LocalRule_Elementary.h
+++ b/source/plugins/components/ModalModel/CellularAutomata/LocalRule_Elementary.h
@@ -15,15 +15,17 @@ public:
     virtual ~LocalRule_Elementary()=default;
 public:
     virtual void applyRule(Cell* cell) override {
-		long number = 0;
-        int bit, power = 2;
-        for (Cell* neigh : cell->getNeighbors()) {
-			number += neigh->getCurrentState().getValue() * std::pow(2, power--);
-            if (power==1)
-				number += std::pow(2, power--)*cell->getCurrentState().getValue();
-        }
-        bit = (ruleNumber & (uint8_t)std::pow(2,number)) >> number;
-		cell->setNextState(State(bit));
+        // Wolfram index for a 1D radius-1 elementary CA = 4*left + 2*center + 1*right (left is the MSB).
+        // Computed with integer shifts; the previous version used std::pow on doubles, which is fragile.
+        // Neighbors of a centered radius-1 1D cell arrive in canonical order {left, right}.
+        const std::vector<Cell*> neighbors = cell->getNeighbors();
+        long index = static_cast<long>(stateValue(cell)) << 1; // center, weight 2
+        if (neighbors.size() >= 1)
+            index += static_cast<long>(stateValue(neighbors[0])) << 2; // left, weight 4
+        if (neighbors.size() >= 2)
+            index += static_cast<long>(stateValue(neighbors[1]));      // right, weight 1
+        const int bit = (ruleNumber >> index) & 1;
+        setNextStateFromValue(cell, bit);
     }
 public:
     uint8_t getRuleNumber() const { return ruleNumber; }

--- a/source/plugins/components/ModalModel/CellularAutomata/LocalRule_FlorestalFire.h
+++ b/source/plugins/components/ModalModel/CellularAutomata/LocalRule_FlorestalFire.h
@@ -1,9 +1,11 @@
 #pragma once
 
 #include <random>
+#include <vector>
 
 #include "plugins/components/ModalModel/CellularAutomata/LocalRule.h"
 #include "plugins/components/ModalModel/CellularAutomata/Cell.h"
+#include "plugins/components/ModalModel/CellularAutomata/StateSet_Enumerable.h"
 
 class LocalRule_FlorestalFire : public LocalRule {
 public:
@@ -18,42 +20,65 @@ public:
     virtual ~LocalRule_FlorestalFire() = default;
 public:
 
-    virtual void applyRule(Cell* cell) {
-        std::random_device r;
-        std::default_random_engine e1(r());
-        std::uniform_real_distribution<double> uniform(0.0, 1.0);
-        StateSet* set = parentCellularAutomata->getStateSet();
-        std::vector<unsigned int> sumNeighStates;
-        sumNeighStates.resize(set->getStatesSyze());
-        for (Cell* neigh : cell->getNeighbors()) {
-            sumNeighStates.at(neigh->getCurrentState()->getDoubleValue())++;
+    virtual void applyRule(Cell* cell) override {
+        if (cell == nullptr || stateSet == nullptr) {
+            return;
         }
+
+        auto* enumerableStateSet = dynamic_cast<StateSet_Enumerable*>(stateSet);
+        if (enumerableStateSet == nullptr || enumerableStateSet->getStatesSize() < 4) {
+            cell->setNextState(cell->getCurrentState());
+            return;
+        }
+
+        // Reproducible RNG: a single fixed-seed engine (member), not a fresh std::random_device-seeded
+        // engine per cell per step (which made every run different — uncomprovável — and was a heavy
+        // per-cell allocation). For a stochastic rule, a fixed seed makes results repeatable (REGRA 3).
+        std::uniform_real_distribution<double> uniform(0.0, 1.0);
+        std::vector<unsigned int> sumNeighStates(enumerableStateSet->getStatesSize(), 0);
+
+        for (Cell* neigh : cell->getNeighbors()) {
+            const long stateValue = neigh->getCurrentState().getValue();
+            if (stateValue >= 0 && static_cast<size_t>(stateValue) < sumNeighStates.size()) {
+                sumNeighStates.at(static_cast<size_t>(stateValue))++;
+            }
+        }
+
+        const long currentState = cell->getCurrentState().getValue();
         cell->setNextState(cell->getCurrentState());
-        switch ((int) cell->getCurrentState()->getDoubleValue()) {
+
+        switch (currentState) {
             case 0: // soil
-                if (uniform(e1) < pSoil2Grass+sumNeighStates.at(1)*pSoil2Grass)
-                    cell->setNextState(set->getState(1));
-                    break;
+                if (sumNeighStates.size() > 1 && uniform(engine) < pSoil2Grass + sumNeighStates.at(1) * pSoil2Grass) {
+                    cell->setNextState(*enumerableStateSet->getState(1));
+                }
+                break;
             case 1: // grass
-                if (uniform(e1) < pGrass2Tree+sumNeighStates.at(2)*pGrass2Tree)
-                    cell->setNextState(set->getState(2));
-                else if (uniform(e1) < pGrass2Fire+(sumNeighStates.at(3)>0)*pGrassPropagateFire) 
-                    cell->setNextState(set->getState(3));
-                    break;
+                if (sumNeighStates.size() > 2 && uniform(engine) < pGrass2Tree + sumNeighStates.at(2) * pGrass2Tree) {
+                    cell->setNextState(*enumerableStateSet->getState(2));
+                } else if (sumNeighStates.size() > 3 &&
+                           uniform(engine) < pGrass2Fire + (sumNeighStates.at(3) > 0 ? pGrassPropagateFire : 0.0)) {
+                    cell->setNextState(*enumerableStateSet->getState(3));
+                }
                 break;
             case 2: // tree
-                if (uniform(e1) < pTree2Fire+(sumNeighStates.at(3)>0)*pTreePropagateFire) 
-                    cell->setNextState(set->getState(3));
-                else if (uniform(e1) < pTree2Soil+sumNeighStates.at(0)*pTree2Soil)
-                    cell->setNextState(set->getState(0));
+                if (sumNeighStates.size() > 3 &&
+                    uniform(engine) < pTree2Fire + (sumNeighStates.at(3) > 0 ? pTreePropagateFire : 0.0)) {
+                    cell->setNextState(*enumerableStateSet->getState(3));
+                } else if (sumNeighStates.size() > 0 && uniform(engine) < pTree2Soil + sumNeighStates.at(0) * pTree2Soil) {
+                    cell->setNextState(*enumerableStateSet->getState(0));
+                }
                 break;
             case 3: // fire
-                cell->setNextState(set->getState(0));
+                cell->setNextState(*enumerableStateSet->getState(0));
+                break;
+            default:
                 break;
         }
     }
 protected:
 private:
+    std::default_random_engine engine{12345u}; // fixed seed -> reproducible runs (was reseeded per cell)
     double pSoil2Grass = 0.001;
     double pGrass2Tree = 0.0001;
     double pGrass2Fire = 0.00001;

--- a/source/plugins/components/ModalModel/CellularAutomata/LocalRule_FlorestalFire.h
+++ b/source/plugins/components/ModalModel/CellularAutomata/LocalRule_FlorestalFire.h
@@ -1,11 +1,9 @@
 #pragma once
 
 #include <random>
-#include <vector>
 
 #include "plugins/components/ModalModel/CellularAutomata/LocalRule.h"
 #include "plugins/components/ModalModel/CellularAutomata/Cell.h"
-#include "plugins/components/ModalModel/CellularAutomata/StateSet_Enumerable.h"
 
 class LocalRule_FlorestalFire : public LocalRule {
 public:
@@ -20,65 +18,42 @@ public:
     virtual ~LocalRule_FlorestalFire() = default;
 public:
 
-    virtual void applyRule(Cell* cell) override {
-        if (cell == nullptr || stateSet == nullptr) {
-            return;
-        }
-
-        auto* enumerableStateSet = dynamic_cast<StateSet_Enumerable*>(stateSet);
-        if (enumerableStateSet == nullptr || enumerableStateSet->getStatesSize() < 4) {
-            cell->setNextState(cell->getCurrentState());
-            return;
-        }
-
-        // Reproducible RNG: a single fixed-seed engine (member), not a fresh std::random_device-seeded
-        // engine per cell per step (which made every run different — uncomprovável — and was a heavy
-        // per-cell allocation). For a stochastic rule, a fixed seed makes results repeatable (REGRA 3).
+    virtual void applyRule(Cell* cell) {
+        std::random_device r;
+        std::default_random_engine e1(r());
         std::uniform_real_distribution<double> uniform(0.0, 1.0);
-        std::vector<unsigned int> sumNeighStates(enumerableStateSet->getStatesSize(), 0);
-
+        StateSet* set = parentCellularAutomata->getStateSet();
+        std::vector<unsigned int> sumNeighStates;
+        sumNeighStates.resize(set->getStatesSyze());
         for (Cell* neigh : cell->getNeighbors()) {
-            const long stateValue = neigh->getCurrentState().getValue();
-            if (stateValue >= 0 && static_cast<size_t>(stateValue) < sumNeighStates.size()) {
-                sumNeighStates.at(static_cast<size_t>(stateValue))++;
-            }
+            sumNeighStates.at(neigh->getCurrentState()->getDoubleValue())++;
         }
-
-        const long currentState = cell->getCurrentState().getValue();
         cell->setNextState(cell->getCurrentState());
-
-        switch (currentState) {
+        switch ((int) cell->getCurrentState()->getDoubleValue()) {
             case 0: // soil
-                if (sumNeighStates.size() > 1 && uniform(engine) < pSoil2Grass + sumNeighStates.at(1) * pSoil2Grass) {
-                    cell->setNextState(*enumerableStateSet->getState(1));
-                }
-                break;
+                if (uniform(e1) < pSoil2Grass+sumNeighStates.at(1)*pSoil2Grass)
+                    cell->setNextState(set->getState(1));
+                    break;
             case 1: // grass
-                if (sumNeighStates.size() > 2 && uniform(engine) < pGrass2Tree + sumNeighStates.at(2) * pGrass2Tree) {
-                    cell->setNextState(*enumerableStateSet->getState(2));
-                } else if (sumNeighStates.size() > 3 &&
-                           uniform(engine) < pGrass2Fire + (sumNeighStates.at(3) > 0 ? pGrassPropagateFire : 0.0)) {
-                    cell->setNextState(*enumerableStateSet->getState(3));
-                }
+                if (uniform(e1) < pGrass2Tree+sumNeighStates.at(2)*pGrass2Tree)
+                    cell->setNextState(set->getState(2));
+                else if (uniform(e1) < pGrass2Fire+(sumNeighStates.at(3)>0)*pGrassPropagateFire) 
+                    cell->setNextState(set->getState(3));
+                    break;
                 break;
             case 2: // tree
-                if (sumNeighStates.size() > 3 &&
-                    uniform(engine) < pTree2Fire + (sumNeighStates.at(3) > 0 ? pTreePropagateFire : 0.0)) {
-                    cell->setNextState(*enumerableStateSet->getState(3));
-                } else if (sumNeighStates.size() > 0 && uniform(engine) < pTree2Soil + sumNeighStates.at(0) * pTree2Soil) {
-                    cell->setNextState(*enumerableStateSet->getState(0));
-                }
+                if (uniform(e1) < pTree2Fire+(sumNeighStates.at(3)>0)*pTreePropagateFire) 
+                    cell->setNextState(set->getState(3));
+                else if (uniform(e1) < pTree2Soil+sumNeighStates.at(0)*pTree2Soil)
+                    cell->setNextState(set->getState(0));
                 break;
             case 3: // fire
-                cell->setNextState(*enumerableStateSet->getState(0));
-                break;
-            default:
+                cell->setNextState(set->getState(0));
                 break;
         }
     }
 protected:
 private:
-    std::default_random_engine engine{12345u}; // fixed seed -> reproducible runs (was reseeded per cell)
     double pSoil2Grass = 0.001;
     double pGrass2Tree = 0.0001;
     double pGrass2Fire = 0.00001;

--- a/source/plugins/components/ModalModel/CellularAutomata/LocalRule_GameOfLife.h
+++ b/source/plugins/components/ModalModel/CellularAutomata/LocalRule_GameOfLife.h
@@ -14,15 +14,15 @@ public:
     virtual void applyRule(Cell* cell) override {
         unsigned int living = 0;
         for (Cell* neigh : cell->getNeighbors()) {
-			living += neigh->getCurrentState().getValue();
+			living += stateValue(neigh);
         }
-		if (cell->getCurrentState().getValue() == 1) {
+		if (stateValue(cell) == 1) {
             if (living < 2 || living > 3)
-				cell->setNextState(State(0));
+				setNextStateFromValue(cell, 0);
             else
                 cell->setNextState(cell->getCurrentState());
         } else if (living == 3)
-			cell->setNextState(State(1));
+			setNextStateFromValue(cell, 1);
         else 
             cell->setNextState(cell->getCurrentState());
     }

--- a/source/plugins/components/ModalModel/CellularAutomata/LocalRule_Growty.h
+++ b/source/plugins/components/ModalModel/CellularAutomata/LocalRule_Growty.h
@@ -13,11 +13,11 @@ public:
     virtual void applyRule(Cell* cell) override {
         unsigned int sum = 0;
         for (Cell* neigh : cell->getNeighbors()) {
-			sum += neigh->getCurrentState().getValue();
+			sum += stateValue(neigh);
         }
         if (sum <= 3 || sum == 5)
-			cell->setNextState(State(0));
+			setNextStateFromValue(cell, 0);
         else
-			cell->setNextState(State(1));
+			setNextStateFromValue(cell, 1);
     }
 };

--- a/source/plugins/components/ModalModel/CellularAutomata/LocalRule_UserDefined.h
+++ b/source/plugins/components/ModalModel/CellularAutomata/LocalRule_UserDefined.h
@@ -1,0 +1,217 @@
+#pragma once
+
+// LocalRule_UserDefined — a cellular-automaton local rule whose transition function is supplied by
+// the user as C++ source and compiled at runtime to a shared library (via the GenESyS CppCompiler),
+// then loaded and invoked per cell.
+// This is "Linha B" of Tema 6: arbitrary local rules defined by the user, without recompiling GenESyS.
+//
+// The user writes one C-linkage function (no GenESyS headers needed). Two contracts are accepted:
+//
+//   (simple)   extern "C" long nextState(long self, const long* neighbors, int numNeighbors);
+//   (extended) extern "C" long nextStateEx(long self, const long* neighbors, int numNeighbors,
+//                                           const int* position, int numDimensions);
+//
+//   - self         : current state of the cell (a long).
+//   - neighbors    : current states of the cell's neighbors, in the neighborhood's canonical order
+//                    (for a 1D centered radius-1 neighborhood this is {left, right}).
+//   - numNeighbors : how many neighbors were provided.
+//   - position     : (extended only) the cell's n-dimensional coordinate, length numDimensions.
+//   - numDimensions: (extended only) the lattice dimensionality.
+//   - return value : the cell's next state.
+//
+// The extended contract lets a rule depend on the cell's position in the lattice (tema 6 §6: the
+// local rule may need "a posição da célula no lattice ... a dimensão do lattice"). If the compiled
+// library exports nextStateEx it is used; otherwise nextState is used. At least one must be present.
+//
+// Example (elementary rule 90, next = left XOR right):
+//     extern "C" long nextState(long self, const long* n, int) { return n[0] ^ n[1]; }
+// Example (position-dependent: a cell's next state is the parity of its first coordinate):
+//     extern "C" long nextStateEx(long, const long*, int, const int* pos, int) { return pos[0] & 1; }
+//
+// The function is pure integer arithmetic, so it compiles standalone (g++ -shared -fPIC), which keeps
+// runtime compilation fast and portable between Linux (.so) and macOS (clang also accepts -shared).
+//
+// Design mirrors the existing CppForG component (plugins/components/ExternalIntegration/CppForG.cpp),
+// which already does compile -> load -> dlsym with extern "C" symbols.
+
+#include "plugins/components/ModalModel/CellularAutomata/LocalRule.h"
+#include "plugins/components/ModalModel/CellularAutomata/Cell.h"
+#include "plugins/components/ModalModel/CellularAutomata/State.h"
+#include "plugins/data/ExternalIntegration/CppCompiler.h"
+
+#include <dlfcn.h>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+// The user-provided transition function, resolved by name "nextState" from the compiled library.
+// Declared at namespace scope with C linkage (as CppForG does), so dlsym finds the unmangled symbol.
+extern "C" typedef long (*NextStateFunction)(long self, const long* neighbors, int numNeighbors);
+// Optional extended contract: also receives the cell's n-dimensional position (length numDimensions),
+// resolved by name "nextStateEx" if the library exports it. Lets rules depend on cell coordinates.
+extern "C" typedef long (*NextStateExFunction)(long self, const long* neighbors, int numNeighbors,
+	const int* position, int numDimensions);
+
+class LocalRule_UserDefined : public LocalRule {
+public:
+	// The CppCompiler is injected (not owned): the caller controls its model, compiler command and
+	// output/temp directories. Those directories must exist and be writable before build() is called.
+	LocalRule_UserDefined(CellularAutomataBase* parentCellularAutomata, CppCompiler* compiler, StateSet* stateSet = nullptr)
+		: LocalRule(parentCellularAutomata, stateSet) {
+		this->compiler = compiler;
+	}
+	// Non-copyable: it owns a loaded dynamic library and a function pointer into it. A shallow copy
+	// would either alias one library across two owners (double unload) or, as the old default-bodied
+	// copy did, leave the copy with compiler==nullptr/ruleFunction==nullptr (a silent no-op rule).
+	LocalRule_UserDefined(const LocalRule_UserDefined&) = delete;
+	LocalRule_UserDefined& operator=(const LocalRule_UserDefined&) = delete;
+	virtual ~LocalRule_UserDefined() {
+		if (libraryLoaded && compiler != nullptr) {
+			compiler->unloadLibrary();
+		}
+	}
+
+public:
+	// Compiles `userSource` (which must define `extern "C" long nextState(long, const long*, int)`)
+	// into a shared library, loads it, and resolves the `nextState` symbol. Returns false and fills
+	// `errorMessage` on any failure (write error, compilation error, load error, missing symbol);
+	// on failure the rule stays not-ready and applyRule() leaves cells unchanged.
+	bool build(const std::string& userSource, std::string& errorMessage) {
+		if (compiler == nullptr) {
+			errorMessage += "LocalRule_UserDefined: no CppCompiler was provided.";
+			return false;
+		}
+		// Working directory for the generated source and library. Use the compiler's temp dir (the
+		// caller points it at a writable location, e.g. the component's .temp/). The output dir is
+		// cleared below so the compiled library path equals the filename we set, which the success check stats.
+		std::string workDir = compiler->getTempDir();
+		if (workDir.empty()) {
+			workDir = "./";
+		}
+		if (workDir.back() != '/') {
+			workDir += '/';
+		}
+		std::error_code dirError;
+		std::filesystem::create_directories(workDir, dirError); // best-effort; ofstream check below is authoritative
+		// Unique base name per build so dlopen never returns a stale cached mapping of an overwritten
+		// library (a real hazard when the same rule is rebuilt or several rules coexist).
+		const std::string base = "genesys_user_local_rule_" + std::to_string(buildCounter++);
+		const std::string sourceFile = workDir + base + ".cpp";
+		const std::string libraryFile = workDir + base + ".so";
+		std::ofstream out(sourceFile.c_str());
+		if (!out.good()) {
+			errorMessage += "LocalRule_UserDefined: cannot write source file '" + sourceFile +
+				"' (does the working directory exist and is it writable?).";
+			return false;
+		}
+		out << userSource;
+		out.close();
+
+		compiler->setSourceFilename(sourceFile);
+		compiler->setOutputFilename(libraryFile); // path equals what the compiler's success check stats
+		compiler->setOutputDir("");               // so the compiled path equals libraryFile exactly
+
+		// The generated .cpp/.so are only needed transiently: the compiler consumes the source, and the
+		// loaded library stays mapped after dlopen even once its file is unlinked. Remove both on every
+		// exit so they don't pile up across rebuilds (the unique names already prevent dlopen cache reuse).
+		auto removeBuildFiles = [&]() {
+			std::error_code removeError;
+			std::filesystem::remove(sourceFile, removeError);
+			std::filesystem::remove(libraryFile, removeError);
+		};
+
+		const CppCompiler::CompilationResult result = compiler->compileToDynamicLibrary();
+		if (!result.success) {
+			errorMessage += "LocalRule_UserDefined: compilation failed:\n" + result.compilationErrOutput;
+			removeBuildFiles();
+			return false;
+		}
+		if (libraryLoaded) {
+			compiler->unloadLibrary();
+			libraryLoaded = false;
+		}
+		if (!compiler->loadLibrary(errorMessage)) {
+			removeBuildFiles();
+			return false;
+		}
+		libraryLoaded = true;
+		void* handle = compiler->getDynamicLibraryHandler();
+		if (handle == nullptr) {
+			errorMessage += "LocalRule_UserDefined: dynamic library handle is null after load.";
+			removeBuildFiles();
+			return false;
+		}
+		// Prefer the extended symbol (gives the rule the cell position); fall back to the simple one.
+		// A missing optional symbol is not an error, so dlerror() is cleared between lookups; at least
+		// one of the two must resolve.
+		dlerror();
+		ruleFunctionEx = reinterpret_cast<NextStateExFunction>(dlsym(handle, "nextStateEx"));
+		dlerror();
+		ruleFunction = reinterpret_cast<NextStateFunction>(dlsym(handle, "nextState"));
+		dlerror();
+		if (ruleFunctionEx == nullptr && ruleFunction == nullptr) {
+			errorMessage += "LocalRule_UserDefined: could not resolve symbol 'nextState' or 'nextStateEx' "
+				"(the user source must define one of them).";
+			removeBuildFiles();
+			return false;
+		}
+		removeBuildFiles();
+		return true;
+	}
+
+	// Convenience: wraps a function BODY (statements that return a long) into a full compilable source
+	// exposing the required extern "C" nextState signature. Lets a user write just the rule logic,
+	// e.g. wrapBody("return neighbors[0] ^ neighbors[1];") for elementary rule 90.
+	static std::string wrapBody(const std::string& body) {
+		return std::string(
+			"extern \"C\" long nextState(long self, const long* neighbors, int numNeighbors) {\n") +
+			"\t(void) self; (void) neighbors; (void) numNeighbors;\n\t" + body + "\n}\n";
+	}
+
+	// Convenience: builds a rule given only its function BODY, wrapping it via wrapBody() into the
+	// required extern "C" nextState signature. Equivalent to build(wrapBody(body), errorMessage). Use
+	// for a simple body; for a full translation unit (helpers, includes, several functions) use build().
+	bool buildBody(const std::string& body, std::string& errorMessage) {
+		return build(wrapBody(body), errorMessage);
+	}
+
+	bool isReady() const { return ruleFunction != nullptr || ruleFunctionEx != nullptr; }
+
+public:
+	virtual void applyRule(Cell* cell) override {
+		if (ruleFunction == nullptr && ruleFunctionEx == nullptr) {
+			return; // not built yet: leave the cell unchanged
+		}
+		const std::vector<Cell*> neighbors = cell->getNeighbors();
+		// Reuse a member buffer across cells/steps instead of allocating a fresh vector per cell per
+		// step (clear() keeps the capacity), which matters on large lattices over many generations.
+		neighborStatesBuffer.clear();
+		neighborStatesBuffer.reserve(neighbors.size());
+		for (Cell* neighbor : neighbors) {
+			neighborStatesBuffer.emplace_back(neighbor->getCurrentState().getValue());
+		}
+		const long self = cell->getCurrentState().getValue();
+		const int numNeighbors = static_cast<int>(neighborStatesBuffer.size());
+		long next;
+		if (ruleFunctionEx != nullptr) {
+			// Extended contract: also hand the rule the cell's n-dimensional position so it can be
+			// position-dependent (tema 6 §6). getPosition() is populated by Lattice::init().
+			const std::vector<int> position = cell->getPosition();
+			next = ruleFunctionEx(self, neighborStatesBuffer.data(), numNeighbors,
+				position.data(), static_cast<int>(position.size()));
+		} else {
+			next = ruleFunction(self, neighborStatesBuffer.data(), numNeighbors);
+		}
+		cell->setNextState(State(next));
+	}
+
+private:
+	CppCompiler* compiler = nullptr; // injected, not owned
+	NextStateFunction ruleFunction = nullptr;     // simple contract symbol, or null if the rule uses Ex
+	NextStateExFunction ruleFunctionEx = nullptr; // extended contract symbol (preferred when present)
+	bool libraryLoaded = false;
+	std::vector<long> neighborStatesBuffer; // reused across applyRule() calls to avoid per-cell allocation
+	inline static int buildCounter = 0; // gives each compiled library a unique name
+};

--- a/source/plugins/components/ModalModel/CellularAutomata/LocalRule_UserDefined.h
+++ b/source/plugins/components/ModalModel/CellularAutomata/LocalRule_UserDefined.h
@@ -3,7 +3,7 @@
 // LocalRule_UserDefined — a cellular-automaton local rule whose transition function is supplied by
 // the user as C++ source and compiled at runtime to a shared library (via the GenESyS CppCompiler),
 // then loaded and invoked per cell.
-// This is "Linha B" of Tema 6: arbitrary local rules defined by the user, without recompiling GenESyS.
+// Arbitrary local rules defined by the user, without recompiling GenESyS.
 //
 // The user writes one C-linkage function (no GenESyS headers needed). Two contracts are accepted:
 //
@@ -19,8 +19,8 @@
 //   - numDimensions: (extended only) the lattice dimensionality.
 //   - return value : the cell's next state.
 //
-// The extended contract lets a rule depend on the cell's position in the lattice (tema 6 §6: the
-// local rule may need "a posição da célula no lattice ... a dimensão do lattice"). If the compiled
+// The extended contract lets a rule depend on the cell's position in the lattice: a rule may need
+// the cell's position and the lattice dimensionality. If the compiled
 // library exports nextStateEx it is used; otherwise nextState is used. At least one must be present.
 //
 // Example (elementary rule 90, next = left XOR right):
@@ -197,7 +197,7 @@ public:
 		long next;
 		if (ruleFunctionEx != nullptr) {
 			// Extended contract: also hand the rule the cell's n-dimensional position so it can be
-			// position-dependent (tema 6 §6). getPosition() is populated by Lattice::init().
+			// position-dependent. getPosition() is populated by Lattice::init().
 			const std::vector<int> position = cell->getPosition();
 			next = ruleFunctionEx(self, neighborStatesBuffer.data(), numNeighbors,
 				position.data(), static_cast<int>(position.size()));

--- a/source/plugins/components/ModalModel/CellularAutomata/Neighborhood.h
+++ b/source/plugins/components/ModalModel/CellularAutomata/Neighborhood.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <string>
+#include <utility>
+#include <vector>
 
 
 class Cell;

--- a/source/plugins/components/ModalModel/CellularAutomata/Neighborhood_Hexagonal.h
+++ b/source/plugins/components/ModalModel/CellularAutomata/Neighborhood_Hexagonal.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "plugins/components/ModalModel/CellularAutomata/Cell.h"
+#include "plugins/components/ModalModel/CellularAutomata/Neighborhood.h"
+
+#include <vector>
+
+class Neighborhood_Hexagonal : public Neighborhood {
+public:
+	Neighborhood_Hexagonal(CellularAutomataBase* parentCellularAutomata, unsigned short radius = 1, BoundaryCondition* boundary = nullptr)
+		: Neighborhood(parentCellularAutomata, radius, boundary) {
+		this->name = "Hexagonal";
+	}
+	Neighborhood_Hexagonal(const Neighborhood_Hexagonal& orig) : Neighborhood(orig) {}
+	virtual ~Neighborhood_Hexagonal() = default;
+
+public:
+	virtual std::string show() override {
+		return "hexagonal";
+	}
+
+	virtual std::vector<Cell*> getNeighbors(Cell* cell) override {
+		std::vector<Cell*> neighbors;
+		const std::vector<int> position = cell->getPosition();
+		const bool oddColumn = (position.at(0) % 2) != 0;
+		const std::vector<std::pair<unsigned short, int>> leftUp = oddColumn
+			? std::vector<std::pair<unsigned short, int>>{{0, -1}, {1, 1}}
+			: std::vector<std::pair<unsigned short, int>>{{0, -1}};
+		const std::vector<std::pair<unsigned short, int>> rightUp = oddColumn
+			? std::vector<std::pair<unsigned short, int>>{{0, 1}, {1, 1}}
+			: std::vector<std::pair<unsigned short, int>>{{0, 1}};
+		const std::vector<std::pair<unsigned short, int>> leftDown = oddColumn
+			? std::vector<std::pair<unsigned short, int>>{{0, -1}}
+			: std::vector<std::pair<unsigned short, int>>{{0, -1}, {1, -1}};
+		const std::vector<std::pair<unsigned short, int>> rightDown = oddColumn
+			? std::vector<std::pair<unsigned short, int>>{{0, 1}}
+			: std::vector<std::pair<unsigned short, int>>{{0, 1}, {1, -1}};
+
+		neighbors.emplace_back(getNeighborCell(position, leftUp));
+		neighbors.emplace_back(getNeighborCell(position, {{1, 1}}));
+		neighbors.emplace_back(getNeighborCell(position, rightUp));
+		neighbors.emplace_back(getNeighborCell(position, rightDown));
+		neighbors.emplace_back(getNeighborCell(position, {{1, -1}}));
+		neighbors.emplace_back(getNeighborCell(position, leftDown));
+		if (includeCellItself)
+			neighbors.emplace_back(cell);
+		return neighbors;
+	}
+};

--- a/source/plugins/components/ModalModel/CellularAutomata/Neighborhood_Moore.h
+++ b/source/plugins/components/ModalModel/CellularAutomata/Neighborhood_Moore.h
@@ -11,6 +11,8 @@
 #include "plugins/components/ModalModel/CellularAutomata/Neighborhood.h"
 #include "plugins/components/ModalModel/CellularAutomata/Cell.h"
 
+#include <vector>
+
 class Neighborhood_Moore : public Neighborhood {
 public:
     Neighborhood_Moore(CellularAutomataBase* parentCellularAutomata, unsigned short radius = 1, BoundaryCondition* boundary = nullptr)
@@ -25,39 +27,35 @@ public:
         std::vector<Cell*> neighbors;
         unsigned short numDimensions = parentCellularAutomata->getLattice()->getNumDimensions();
 		std::vector<int> cellPosition = cell->getPosition();
-        // TODO:  Redo for n-dims.
-        switch (numDimensions) {
-          case 1:
-                for (int r = 1; r <= radius; r++) {
-                    neighbors.emplace_back(getNeighborCell(cellPosition, {{0, -r}}));
-                    neighbors.emplace_back(getNeighborCell(cellPosition, {{0, -r}}));
-                }
-                break;
-            case 2:
-                for (int r = 1; r <= radius; r++) {
-                    neighbors.emplace_back(getNeighborCell(cellPosition, {{0, -r}}));
-                    neighbors.emplace_back(getNeighborCell(cellPosition, {{0, r}}));
-                    neighbors.emplace_back(getNeighborCell(cellPosition, {{1, -r}}));
-                    neighbors.emplace_back(getNeighborCell(cellPosition, {{1, r}}));
-                    neighbors.emplace_back(getNeighborCell(cellPosition, {{0,-r},{1, -r}}));
-                    neighbors.emplace_back(getNeighborCell(cellPosition, {{0,-r},{1, r}}));
-                    neighbors.emplace_back(getNeighborCell(cellPosition, {{0,r},{1, -r}}));
-                    neighbors.emplace_back(getNeighborCell(cellPosition, {{0,r},{1, r}}));
-                    // Moore with radius > 1 is not working (extra loops nedded)
-                }
-                break;
-            case 3:
-                break;
-            default:
-                break;
-        }
+
+        std::vector<int> offset(numDimensions, 0);
+        collectNeighbors(cellPosition, offset, 0, neighbors);
+
         if (includeCellItself)
             neighbors.emplace_back(cell);
-        std::cout << "Neighs from " << cell->show() <<" are: ";
-        for (Cell* n: neighbors) {
-            std::cout << n->show() << ", ";
-        }
-        std::cout << std::endl;
         return neighbors;
+    }
+private:
+    void collectNeighbors(const std::vector<int>& cellPosition, std::vector<int>& offset, unsigned short dimension, std::vector<Cell*>& neighbors) {
+        if (dimension == offset.size()) {
+            bool isZeroOffset = true;
+            std::vector<std::pair<unsigned short, int>> dimensionChanges;
+            for (unsigned short dim = 0; dim < offset.size(); ++dim) {
+                if (offset.at(dim) != 0) {
+                    isZeroOffset = false;
+                    dimensionChanges.emplace_back(dim, offset.at(dim));
+                }
+            }
+            if (!isZeroOffset) {
+                // Offsets are visited from dimension 0 to n-1.
+                neighbors.emplace_back(getNeighborCell(cellPosition, dimensionChanges));
+            }
+            return;
+        }
+
+        for (int delta = -static_cast<int>(radius); delta <= static_cast<int>(radius); ++delta) {
+            offset.at(dimension) = delta;
+            collectNeighbors(cellPosition, offset, dimension + 1, neighbors);
+        }
     }
 };

--- a/source/plugins/components/ModalModel/CellularAutomata/Neighborhood_Network.h
+++ b/source/plugins/components/ModalModel/CellularAutomata/Neighborhood_Network.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "plugins/components/ModalModel/CellularAutomata/Cell.h"
+#include "plugins/components/ModalModel/CellularAutomata/CellularAutomataBase.h"
+#include "plugins/components/ModalModel/CellularAutomata/Lattice.h"
+#include "plugins/components/ModalModel/CellularAutomata/Neighborhood.h"
+
+#include <vector>
+
+class Neighborhood_Network : public Neighborhood {
+public:
+	Neighborhood_Network(CellularAutomataBase* parentCellularAutomata, unsigned short radius = 1, BoundaryCondition* boundary = nullptr)
+		: Neighborhood(parentCellularAutomata, radius, boundary) {
+		this->name = "Network";
+	}
+	Neighborhood_Network(const Neighborhood_Network& orig) : Neighborhood(orig) {}
+	virtual ~Neighborhood_Network() = default;
+
+public:
+	virtual std::string show() override {
+		return "network";
+	}
+
+	virtual std::vector<Cell*> getNeighbors(Cell* cell) override {
+		std::vector<Cell*> neighbors = parentCellularAutomata->getLattice()->getNetworkNeighbors(static_cast<unsigned long>(cell->getCellNumber()));
+		if (includeCellItself)
+			neighbors.emplace_back(cell);
+		return neighbors;
+	}
+};

--- a/source/plugins/components/ModalModel/CellularAutomata/Neighborhood_Triangular.h
+++ b/source/plugins/components/ModalModel/CellularAutomata/Neighborhood_Triangular.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "plugins/components/ModalModel/CellularAutomata/Cell.h"
+#include "plugins/components/ModalModel/CellularAutomata/Neighborhood.h"
+
+#include <vector>
+
+class Neighborhood_Triangular : public Neighborhood {
+public:
+	Neighborhood_Triangular(CellularAutomataBase* parentCellularAutomata, unsigned short radius = 1, BoundaryCondition* boundary = nullptr)
+		: Neighborhood(parentCellularAutomata, radius, boundary) {
+		this->name = "Triangular";
+	}
+	Neighborhood_Triangular(const Neighborhood_Triangular& orig) : Neighborhood(orig) {}
+	virtual ~Neighborhood_Triangular() = default;
+
+public:
+	virtual std::string show() override {
+		return "triangular";
+	}
+
+	virtual std::vector<Cell*> getNeighbors(Cell* cell) override {
+		std::vector<Cell*> neighbors;
+		const std::vector<int> position = cell->getPosition();
+		neighbors.emplace_back(getNeighborCell(position, {{0, -1}}));
+		neighbors.emplace_back(getNeighborCell(position, {{0, 1}}));
+		const int verticalDelta = ((position.at(0) + position.at(1)) % 2 == 0) ? -1 : 1;
+		neighbors.emplace_back(getNeighborCell(position, {{1, verticalDelta}}));
+		if (includeCellItself)
+			neighbors.emplace_back(cell);
+		return neighbors;
+	}
+};

--- a/source/plugins/components/ModalModel/CellularAutomata/Neighborhood_VonNeumann.h
+++ b/source/plugins/components/ModalModel/CellularAutomata/Neighborhood_VonNeumann.h
@@ -9,6 +9,7 @@
 
 #include <string>
 #include <vector>
+#include <cstdlib>
 
 #include "plugins/components/ModalModel/CellularAutomata/Neighborhood.h"
 #include "plugins/components/ModalModel/CellularAutomata/Lattice.h"
@@ -35,30 +36,38 @@ public:
         std::vector<Cell*> neighbors;
         unsigned short numDimensions = parentCellularAutomata->getLattice()->getNumDimensions();
 		std::vector<int> cellPosition = cell->getPosition();
-        // TODO: Redo for n-dims, not switch for every case
-        switch (numDimensions) {
-            case 1:
-                for (int r = 1; r <= radius; r++) {
-                    neighbors.emplace_back(getNeighborCell(cellPosition,{{0, -r}}));
-                    neighbors.emplace_back(getNeighborCell(cellPosition,{{0, -r}}));
-                }
-                break;
-            case 2:
-                for (int r = 1; r <= radius; r++) {
-                    neighbors.emplace_back(getNeighborCell(cellPosition,{{0, -r}}));
-                    neighbors.emplace_back(getNeighborCell(cellPosition,{{0, r}}));
-                    neighbors.emplace_back(getNeighborCell(cellPosition,{{1, -r}}));
-                    neighbors.emplace_back(getNeighborCell(cellPosition,{{1, r}}));
-                    // TODO Só funcina para r=1
-                }
-                break;
-            case 3:
-                break;
-            default:
-                break;
-        }
+
+        std::vector<int> offset(numDimensions, 0);
+        collectNeighbors(cellPosition, offset, 0, neighbors);
+
         if (includeCellItself)
             neighbors.emplace_back(cell);
         return neighbors;
+    }
+private:
+    void collectNeighbors(const std::vector<int>& cellPosition, std::vector<int>& offset, unsigned short dimension, std::vector<Cell*>& neighbors) {
+        if (dimension == offset.size()) {
+            bool isZeroOffset = true;
+            unsigned int manhattanDistance = 0;
+            std::vector<std::pair<unsigned short, int>> dimensionChanges;
+            for (unsigned short dim = 0; dim < offset.size(); ++dim) {
+                int delta = offset.at(dim);
+                manhattanDistance += static_cast<unsigned int>(std::abs(delta));
+                if (delta != 0) {
+                    isZeroOffset = false;
+                    dimensionChanges.emplace_back(dim, delta);
+                }
+            }
+            if (!isZeroOffset && manhattanDistance <= radius) {
+                // Offsets are visited from dimension 0 to n-1.
+                neighbors.emplace_back(getNeighborCell(cellPosition, dimensionChanges));
+            }
+            return;
+        }
+
+        for (int delta = -static_cast<int>(radius); delta <= static_cast<int>(radius); ++delta) {
+            offset.at(dimension) = delta;
+            collectNeighbors(cellPosition, offset, dimension + 1, neighbors);
+        }
     }
 };

--- a/source/plugins/components/ModalModel/CellularAutomata/State.h
+++ b/source/plugins/components/ModalModel/CellularAutomata/State.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cmath>
+#include <limits>
 #include <string>
 
 /*
@@ -64,15 +66,20 @@ private:
 
 class State {
 public:
-	State() {}
-	State(long value) {_value=value;}
-	State(const State& orig){}
+	State() : _value(0.0) {}
+	State(int value) {_value=static_cast<double>(value);}
+	State(long value) {_value=static_cast<double>(value);}
+	State(double value) {_value=value;}
+	State(const State& orig) : _value(orig._value) {}
 	virtual ~State() = default;
 public:
-	long getValue(){return _value;}
-	void setValue(long value) {_value=value;}
-	std::string show();
+	long getValue() const {return static_cast<long>(_value);}
+	double getDoubleValue() const {return _value;}
+	void setValue(int value) {_value=static_cast<double>(value);}
+	void setValue(long value) {_value=static_cast<double>(value);}
+	void setDoubleValue(double value) {_value=value;}
+	std::string show() { return std::to_string(getValue()); }
 protected:
-	long _value;
+	double _value = 0.0;
 private:
 };

--- a/source/plugins/components/ModalModel/CellularAutomata/StateSet.cpp
+++ b/source/plugins/components/ModalModel/CellularAutomata/StateSet.cpp
@@ -18,3 +18,27 @@ StateSet::StateSet(const StateSet& orig) {
  *  PUBLIC
  * **************/
 
+bool StateSet::contains(const State& state) const {
+	return true;
+}
+
+bool StateSet::tryMakeState(long value, State* state) const {
+	return tryMakeState(static_cast<double>(value), state);
+}
+
+bool StateSet::tryMakeState(double value, State* state) const {
+	State candidate(value);
+	if (!contains(candidate))
+		return false;
+	if (state != nullptr)
+		*state = candidate;
+	return true;
+}
+
+std::string StateSet::show() const {
+	return typeName();
+}
+
+std::string StateSet::typeName() const {
+	return "generic";
+}

--- a/source/plugins/components/ModalModel/CellularAutomata/StateSet.h
+++ b/source/plugins/components/ModalModel/CellularAutomata/StateSet.h
@@ -12,6 +12,11 @@ public:
 	StateSet(const StateSet& orig);
 	virtual ~StateSet()=default;
 public:
+	virtual bool contains(const State& state) const;
+	virtual bool tryMakeState(long value, State* state) const;
+	virtual bool tryMakeState(double value, State* state) const;
+	virtual std::string show() const;
+	virtual std::string typeName() const;
 protected:
 	CellularAutomataBase* parentCellularAutomata;
 private:

--- a/source/plugins/components/ModalModel/CellularAutomata/StateSet_Bit.h
+++ b/source/plugins/components/ModalModel/CellularAutomata/StateSet_Bit.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "plugins/components/ModalModel/CellularAutomata/StateSet.h"
+
+#include <cmath>
+#include <string>
+
+class StateSet_Bit : public StateSet {
+public:
+	StateSet_Bit(CellularAutomataBase* parentCellularAutomata)
+		: StateSet(parentCellularAutomata) {
+	}
+
+	virtual bool contains(const State& state) const override {
+		const double value = state.getDoubleValue();
+		return std::isfinite(value) && (value == 0.0 || value == 1.0);
+	}
+
+	virtual std::string show() const override {
+		return "{0,1}";
+	}
+
+	virtual std::string typeName() const override {
+		return "bit";
+	}
+};

--- a/source/plugins/components/ModalModel/CellularAutomata/StateSet_Double.h
+++ b/source/plugins/components/ModalModel/CellularAutomata/StateSet_Double.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "plugins/components/ModalModel/CellularAutomata/StateSet.h"
+
+#include <cmath>
+#include <string>
+
+class StateSet_Double : public StateSet {
+public:
+	StateSet_Double(CellularAutomataBase* parentCellularAutomata)
+		: StateSet(parentCellularAutomata) {
+	}
+
+	virtual bool contains(const State& state) const override {
+		return std::isfinite(state.getDoubleValue());
+	}
+
+	virtual std::string show() const override {
+		return "finite double values";
+	}
+
+	virtual std::string typeName() const override {
+		return "double";
+	}
+};

--- a/source/plugins/components/ModalModel/CellularAutomata/StateSet_Enumerable.cpp
+++ b/source/plugins/components/ModalModel/CellularAutomata/StateSet_Enumerable.cpp
@@ -21,8 +21,41 @@ StateSet_Enumerable::StateSet_Enumerable(const StateSet_Enumerable& orig)
  *  PUBLIC
  * **************/
 
-std::string StateSet_Enumerable::show() {
-	return "-";
+bool StateSet_Enumerable::contains(const State& state) const {
+	for (State* allowedState : states) {
+		if (allowedState != nullptr && allowedState->getDoubleValue() == state.getDoubleValue())
+			return true;
+	}
+	return false;
+}
+
+bool StateSet_Enumerable::tryMakeState(long value, State* state) const {
+	return tryMakeState(static_cast<double>(value), state);
+}
+
+bool StateSet_Enumerable::tryMakeState(double value, State* state) const {
+	for (State* allowedState : states) {
+		if (allowedState != nullptr && allowedState->getDoubleValue() == value) {
+			if (state != nullptr)
+				*state = *allowedState;
+			return true;
+		}
+	}
+	return false;
+}
+
+std::string StateSet_Enumerable::show() const {
+	std::string output = "{";
+	for (unsigned int i = 0; i < states.size(); ++i) {
+		if (i > 0)
+			output += ",";
+		output += states.at(i) == nullptr ? "null" : std::to_string(states.at(i)->getDoubleValue());
+	}
+	return output + "}";
+}
+
+std::string StateSet_Enumerable::typeName() const {
+	return "enumerated";
 }
 
 unsigned int StateSet_Enumerable::size(){
@@ -47,7 +80,7 @@ State* StateSet_Enumerable::getState(unsigned int rank) {
 
 State* StateSet_Enumerable::getState(std::string name) {
 	for (State* s: states) {
-		if (std::to_string(s->getValue())==name) {
+		if (std::to_string(s->getValue())==name || std::to_string(s->getDoubleValue())==name) {
 			return s;
 		}
 	}

--- a/source/plugins/components/ModalModel/CellularAutomata/StateSet_Enumerable.h
+++ b/source/plugins/components/ModalModel/CellularAutomata/StateSet_Enumerable.h
@@ -26,8 +26,6 @@ public:
 	void setStates(std::vector<State*> states);
 	std::vector<State*> getStates() const;
 protected:
-	// parentCellularAutomata is inherited from StateSet; it used to be shadowed here (two separate
-	// fields), which was a silent maintenance hazard. Only the enumerated-specific `states` lives here.
 	std::vector<State*> states;
 private:
 };

--- a/source/plugins/components/ModalModel/CellularAutomata/StateSet_Enumerable.h
+++ b/source/plugins/components/ModalModel/CellularAutomata/StateSet_Enumerable.h
@@ -13,7 +13,11 @@ public:
 	StateSet_Enumerable(const StateSet_Enumerable& orig);
 	virtual ~StateSet_Enumerable()=default;
 public:
-	virtual std::string show();
+	virtual bool contains(const State& state) const override;
+	virtual bool tryMakeState(long value, State* state) const override;
+	virtual bool tryMakeState(double value, State* state) const override;
+	virtual std::string show() const override;
+	virtual std::string typeName() const override;
 	unsigned int size();
 	void addState(State* state);
 	unsigned int getStatesSize();
@@ -22,7 +26,8 @@ public:
 	void setStates(std::vector<State*> states);
 	std::vector<State*> getStates() const;
 protected:
-	CellularAutomataBase* parentCellularAutomata;
+	// parentCellularAutomata is inherited from StateSet; it used to be shadowed here (two separate
+	// fields), which was a silent maintenance hazard. Only the enumerated-specific `states` lives here.
 	std::vector<State*> states;
 private:
 };

--- a/source/plugins/components/ModalModel/CellularAutomata/StateSet_Integer.h
+++ b/source/plugins/components/ModalModel/CellularAutomata/StateSet_Integer.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "plugins/components/ModalModel/CellularAutomata/StateSet.h"
+
+#include <cmath>
+#include <limits>
+#include <string>
+
+class StateSet_Integer : public StateSet {
+public:
+	StateSet_Integer(CellularAutomataBase* parentCellularAutomata,
+			long minValue = std::numeric_limits<long>::min(),
+			long maxValue = std::numeric_limits<long>::max())
+		: StateSet(parentCellularAutomata), minValue(minValue), maxValue(maxValue) {
+	}
+
+	virtual bool contains(const State& state) const override {
+		const double value = state.getDoubleValue();
+		return std::isfinite(value) &&
+				std::floor(value) == value &&
+				value >= static_cast<double>(minValue) &&
+				value <= static_cast<double>(maxValue);
+	}
+
+	virtual std::string show() const override {
+		return "[" + std::to_string(minValue) + "," + std::to_string(maxValue) + "]";
+	}
+
+	virtual std::string typeName() const override {
+		return "integer";
+	}
+
+private:
+	long minValue;
+	long maxValue;
+};

--- a/source/plugins/components/ModalModel/CellularAutomataComp.cpp
+++ b/source/plugins/components/ModalModel/CellularAutomataComp.cpp
@@ -4,25 +4,41 @@
  * and open the template in the editor.
  */
 
-/* 
+/*
  * File:   CelularAutomata.cpp
  * Author: rlcancian
- * 
+ *
  * Created on 03 de Junho de 2019, 15:14
  */
 
 #include "plugins/components/ModalModel/CellularAutomataComp.h"
-#include "kernel/simulator/Model.h"
+#include "../../../kernel/simulator/Model.h"
+#include "plugins/components/ModalModel/CellularAutomata/Boundary_Adiabatic.h"
 #include "plugins/components/ModalModel/CellularAutomata/Boundary_Closed.h"
 #include "plugins/components/ModalModel/CellularAutomata/Boundary_Fixed.h"
+#include "plugins/components/ModalModel/CellularAutomata/Boundary_Reflexive.h"
 #include "plugins/components/ModalModel/CellularAutomata/CellularAutomata_Classic.h"
 #include "plugins/components/ModalModel/CellularAutomata/CellularAutomata_1DTimed.h"
 #include "plugins/components/ModalModel/CellularAutomata/LocalRule_Elementary.h"
 #include "plugins/components/ModalModel/CellularAutomata/LocalRule_GameOfLife.h"
 #include "plugins/components/ModalModel/CellularAutomata/LocalRule_Growty.h"
+#include "plugins/components/ModalModel/CellularAutomata/LocalRule_UserDefined.h"
 #include "plugins/components/ModalModel/CellularAutomata/Neighborhood_Center.h"
 #include "plugins/components/ModalModel/CellularAutomata/Neighborhood_Moore.h"
 #include "plugins/components/ModalModel/CellularAutomata/Neighborhood_VonNeumann.h"
+#include "plugins/components/ModalModel/CellularAutomata/State.h"
+#include "plugins/components/ModalModel/CellularAutomata/StateSet_Bit.h"
+#include "plugins/components/ModalModel/CellularAutomata/StateSet_Double.h"
+#include "plugins/components/ModalModel/CellularAutomata/StateSet_Enumerable.h"
+#include "plugins/components/ModalModel/CellularAutomata/StateSet_Integer.h"
+#include "plugins/data/ExternalIntegration/CppCompiler.h"
+
+#include <algorithm>
+#include <numeric>
+#include <random>
+#include <sstream>
+#include <string>
+#include <vector>
 
 #ifdef PLUGINCONNECT_DYNAMIC
 
@@ -31,11 +47,49 @@ extern "C" StaticGetPluginInformation GetPluginInformation() {
 }
 #endif
 
+namespace {
+// Lattice dimensions are persisted as a comma-separated list (e.g. "5,5") so a saved automaton
+// round-trips to a checkable configuration (Tema 6 §10.1: persist the model's structural parameters).
+std::string serializeDimensions(const std::vector<unsigned short>& dimensions) {
+	std::string out;
+	for (std::size_t i = 0; i < dimensions.size(); ++i) {
+		if (i > 0)
+			out += ',';
+		out += std::to_string(dimensions.at(i));
+	}
+	return out;
+}
+
+std::vector<unsigned short> parseDimensions(const std::string& serialized) {
+	std::vector<unsigned short> dimensions;
+	std::stringstream stream(serialized);
+	std::string item;
+	while (std::getline(stream, item, ',')) {
+		if (!item.empty())
+			dimensions.emplace_back(static_cast<unsigned short>(std::stoul(item)));
+	}
+	return dimensions;
+}
+} // namespace
+
 ModelDataDefinition* CellularAutomataComp::NewInstance(Model* model, std::string name) {
 	return new CellularAutomataComp(model, name);
 }
 
 CellularAutomataComp::CellularAutomataComp(Model* model, std::string name) : ModelComponent(model, Util::TypeOf<CellularAutomataComp>(), name) {
+}
+
+CellularAutomataComp::~CellularAutomataComp() {
+	// These sub-objects are plain classes (not ModelDataDefinition), so this component owns them and
+	// must free them. Deleting _localRule first runs the LocalRule_UserDefined destructor, which
+	// unloads its dynamic library. _ruleCompiler is a ModelDataDefinition owned by the model, so it
+	// is intentionally NOT deleted here (the model frees it).
+	delete _localRule;
+	delete _cellularAutomata;
+	delete _lattice;
+	delete _neighboorhood;
+	delete _boundary;
+	delete _stateSet;
 }
 
 std::string CellularAutomataComp::show() {
@@ -54,25 +108,154 @@ ModelComponent* CellularAutomataComp::LoadInstance(Model* model, PersistenceReco
 }
 
 void CellularAutomataComp::_onDispatchEvent(Entity* entity, unsigned int inputPortNumber) {
-	_cellularAutomata->step();
+	_stepCellularAutomataByPolicy();
 	_parentModel->sendEntityToComponent(entity, this->getConnectionManager()->getFrontConnection());
 }
 
 bool CellularAutomataComp::_loadInstance(PersistenceRecord *fields) {
 	bool res = ModelComponent::_loadInstance(fields);
 	if (res) {
-		// @TODO: not implemented yet
+		// Recreate the sub-objects from the persisted type enums. The cellular-automata type must be
+		// restored first because the lattice/neighborhood/boundary/state-set/rule reference it.
+		setCellularAutomataType(static_cast<CellularAutomataType>(
+			fields->loadField("cellularAutomataType", static_cast<int>(DEFAULT.cellularAutomataType))));
+		setLatticeType(static_cast<LatticeType>(
+			fields->loadField("latticeType", static_cast<int>(DEFAULT.latticeType))));
+		// Restore the lattice dimensions (a structural model parameter) onto the freshly built lattice.
+		const std::string serializedDimensions = fields->loadField("latticeDimensions", std::string(""));
+		if (_lattice != nullptr && !serializedDimensions.empty())
+			_lattice->setDimensions(parseDimensions(serializedDimensions));
+		setNeighboorhoodType(static_cast<NeighboorhoodType>(
+			fields->loadField("neighborhoodType", static_cast<int>(DEFAULT.neighboorhoodType))));
+		if (_neighboorhood != nullptr)
+			_neighboorhood->setRadius(static_cast<unsigned short>(fields->loadField("neighborhoodRadius", 1)));
+		setBoundaryType(static_cast<BoundaryType>(
+			fields->loadField("boundaryType", static_cast<int>(DEFAULT.boundaryType))));
+		setStateSetType(static_cast<StateSetType>(
+			fields->loadField("stateSetType", static_cast<int>(DEFAULT.stateSetType))));
+		setUpdatePolicyType(static_cast<UpdatePolicyType>(
+			fields->loadField("updatePolicyType", static_cast<int>(DEFAULT.updatePolicyType))));
+		setUpdateBlockSize(static_cast<unsigned int>(
+			fields->loadField("updateBlockSize", static_cast<int>(DEFAULT.updateBlockSize))));
+		setRandomSeed(static_cast<unsigned int>(
+			fields->loadField("randomSeed", static_cast<int>(DEFAULT.randomSeed))));
+		// Set the elementary rule number before the rule type, so an ELEMENTAR_CA rule is built with it.
+		setElementaryRuleNumber(static_cast<uint8_t>(fields->loadField("elementaryRuleNumber", 30)));
+		// Load the user source before the rule type, so a USERDEFINED rule has its source available.
+		_userDefinedRuleSource = fields->loadField("userDefinedRuleSource", DEFAULT.userDefinedRuleSource);
+		setLocalRuleType(static_cast<LocalRuleType>(
+			fields->loadField("localRuleType", static_cast<int>(DEFAULT.localRuleType))));
 	}
 	return res;
 }
 
 void CellularAutomataComp::_saveInstance(PersistenceRecord *fields, bool saveDefaultValues) {
 	ModelComponent::_saveInstance(fields, saveDefaultValues);
-	// @TODO: not implemented yet
+	fields->saveField("cellularAutomataType", static_cast<int>(_cellularAutomataType),
+		static_cast<int>(DEFAULT.cellularAutomataType), saveDefaultValues);
+	fields->saveField("latticeType", static_cast<int>(_latticeType),
+		static_cast<int>(DEFAULT.latticeType), saveDefaultValues);
+	fields->saveField("neighborhoodType", static_cast<int>(_neighboorhoodType),
+		static_cast<int>(DEFAULT.neighboorhoodType), saveDefaultValues);
+	fields->saveField("boundaryType", static_cast<int>(_boundaryType),
+		static_cast<int>(DEFAULT.boundaryType), saveDefaultValues);
+	fields->saveField("stateSetType", static_cast<int>(_stateSetType),
+		static_cast<int>(DEFAULT.stateSetType), saveDefaultValues);
+	fields->saveField("localRuleType", static_cast<int>(_localRuleType),
+		static_cast<int>(DEFAULT.localRuleType), saveDefaultValues);
+	fields->saveField("updatePolicyType", static_cast<int>(_updatePolicyType),
+		static_cast<int>(DEFAULT.updatePolicyType), saveDefaultValues);
+	fields->saveField("updateBlockSize", static_cast<int>(_updateBlockSize),
+		static_cast<int>(DEFAULT.updateBlockSize), saveDefaultValues);
+	fields->saveField("randomSeed", static_cast<int>(_randomSeed),
+		static_cast<int>(DEFAULT.randomSeed), saveDefaultValues);
+	fields->saveField("elementaryRuleNumber", static_cast<int>(_elementaryRuleNumber), 30, saveDefaultValues);
+	fields->saveField("userDefinedRuleSource", _userDefinedRuleSource,
+		DEFAULT.userDefinedRuleSource, saveDefaultValues);
+	const std::string serializedDimensions = _lattice != nullptr ? serializeDimensions(_lattice->getDimensions()) : std::string("");
+	fields->saveField("latticeDimensions", serializedDimensions, std::string(""), saveDefaultValues);
+	const int neighborhoodRadius = _neighboorhood != nullptr ? static_cast<int>(_neighboorhood->getRadius()) : 1;
+	fields->saveField("neighborhoodRadius", neighborhoodRadius, 1, saveDefaultValues);
+}
+
+bool CellularAutomataComp::_buildUserDefinedRule(std::string* errorMessage) {
+	if (_userDefinedRuleSource.empty()) {
+		*errorMessage += "USERDEFINED local rule requires source code (use setUserDefinedRuleSource). ";
+		return false;
+	}
+	if (_cellularAutomata == nullptr) {
+		*errorMessage += "USERDEFINED local rule needs a cellular automata (set its type first). ";
+		return false;
+	}
+	if (_ruleCompiler == nullptr) {
+		_ruleCompiler = new CppCompiler(_parentModel, getName() + ".LocalRuleCompiler");
+	}
+	_ruleCompiler->setOutputDir(".temp/");
+	_ruleCompiler->setTempDir(".temp/");
+	_ruleCompiler->setFlagsGeneral("-w -std=c++14");
+	if (_localRule != nullptr) {
+		delete _localRule;
+		_localRule = nullptr;
+	}
+	LocalRule_UserDefined* userRule = new LocalRule_UserDefined(_cellularAutomata, _ruleCompiler, _stateSet);
+	std::string buildError;
+	if (!userRule->build(_userDefinedRuleSource, buildError)) {
+		*errorMessage += "USERDEFINED local rule failed to compile/load: " + buildError + " ";
+		delete userRule;
+		// userRule registered itself in the automaton (LocalRule ctor); clear the now-dangling pointer.
+		_cellularAutomata->setLocalRule(nullptr);
+		return false;
+	}
+	_localRule = userRule;
+	// Don't leave the throwaway per-build temp paths in the compiler's persistent fields.
+	_ruleCompiler->setSourceFilename("");
+	_ruleCompiler->setOutputFilename("");
+	return true;
 }
 
 bool CellularAutomataComp::_check(std::string* errorMessage) {
-	*errorMessage += "";
+	// Best-of-each semantic check: Sutter's decomposed structural/rule/policy validation, plus the
+	// USERDEFINED (Linha B) rule built lazily once every structural sub-object is available.
+	if (!_checkImplementedTypes(errorMessage))
+		return false;
+	if (_cellularAutomata == nullptr) {
+		*errorMessage += "Cellular automata type is not set or is not supported. ";
+		return false;
+	}
+	if (_lattice == nullptr) {
+		*errorMessage += "Lattice type is not set. ";
+		return false;
+	}
+	if (_neighboorhood == nullptr) {
+		*errorMessage += "Neighborhood type is not set. ";
+		return false;
+	}
+	if (_boundary == nullptr) {
+		*errorMessage += "Boundary type is not set. ";
+		return false;
+	}
+	if (_stateSet == nullptr) {
+		*errorMessage += "State set type is not set. ";
+		return false;
+	}
+	// Linha B: compile and load a user-defined local rule now, when the automaton, lattice,
+	// neighborhood, boundary and state set all exist (see _buildUserDefinedRule).
+	if (_localRuleType == LocalRuleType::USERDEFINED) {
+		if (!_buildUserDefinedRule(errorMessage))
+			return false;
+	}
+	if (_localRule == nullptr) {
+		*errorMessage += "Local rule is not set (or its type is not supported yet). ";
+		return false;
+	}
+	if (!_checkLattice(errorMessage))
+		return false;
+	if (!_checkStateSet(errorMessage))
+		return false;
+	if (!_checkRuleCompatibility(errorMessage))
+		return false;
+	if (!_checkUpdatePolicy(errorMessage))
+		return false;
 	_cellularAutomata->setLattice(_lattice);
 	_cellularAutomata->setLocalRule(_localRule);
 	_cellularAutomata->setNeighborhood(_neighboorhood);
@@ -85,7 +268,103 @@ bool CellularAutomataComp::_check(std::string* errorMessage) {
 }
 
 void CellularAutomataComp::_initBetweenReplications() {
-	_cellularAutomata->init();
+	_randomStepCounter = 0;
+	if (_cellularAutomata != nullptr) // guard like _stepCellularAutomataByPolicy: never deref before _check succeeds
+		_cellularAutomata->init();
+}
+
+bool CellularAutomataComp::initializeCellularAutomata(std::string* errorMessage) {
+	std::string localErrorMessage;
+	std::string* message = errorMessage != nullptr ? errorMessage : &localErrorMessage;
+	if (!_check(message))
+		return false;
+	_randomStepCounter = 0;
+	return _cellularAutomata->init();
+}
+
+void CellularAutomataComp::stepCellularAutomata() {
+	_stepCellularAutomataByPolicy();
+}
+
+bool CellularAutomataComp::setCellState(long cellNumber, int value) {
+	return setCellState(cellNumber, static_cast<long>(value));
+}
+
+bool CellularAutomataComp::setCellState(long cellNumber, long value) {
+	return setCellState(cellNumber, static_cast<double>(value));
+}
+
+bool CellularAutomataComp::setCellState(long cellNumber, double value) {
+	if (_lattice == nullptr)
+		return false;
+	State state;
+	if (_stateSet != nullptr && !_stateSet->tryMakeState(value, &state))
+		return false;
+	else if (_stateSet == nullptr)
+		state.setDoubleValue(value);
+	return _lattice->setCellState(cellNumber, &state);
+}
+
+bool CellularAutomataComp::setCellState(const std::vector<int>& position, int value) {
+	return setCellState(position, static_cast<long>(value));
+}
+
+bool CellularAutomataComp::setCellState(const std::vector<int>& position, long value) {
+	return setCellState(position, static_cast<double>(value));
+}
+
+bool CellularAutomataComp::setCellState(const std::vector<int>& position, double value) {
+	if (_lattice == nullptr)
+		return false;
+	State state;
+	if (_stateSet != nullptr && !_stateSet->tryMakeState(value, &state))
+		return false;
+	else if (_stateSet == nullptr)
+		state.setDoubleValue(value);
+	return _lattice->setCellState(position, &state);
+}
+
+std::string CellularAutomataComp::showCellularAutomata() const {
+	if (_lattice == nullptr)
+		return "";
+	std::ostringstream output;
+	for (unsigned long cellNumber = 0; cellNumber < _lattice->getCellsSize(); ++cellNumber) {
+		output << _lattice->getCell(static_cast<long>(cellNumber))->getCurrentState().getValue();
+	}
+	return output.str();
+}
+
+void CellularAutomataComp::setElementaryRuleNumber(uint8_t ruleNumber) {
+	_elementaryRuleNumber = ruleNumber;
+	if (_localRuleType == LocalRuleType::ELEMENTAR_CA && _localRule != nullptr) {
+		if (auto* elementaryRule = dynamic_cast<LocalRule_Elementary*>(_localRule))
+			elementaryRule->setRuleNumber(ruleNumber);
+	}
+}
+
+CellularAutomataComp::UpdatePolicyType CellularAutomataComp::getUpdatePolicyType() const {
+	return _updatePolicyType;
+}
+
+void CellularAutomataComp::setUpdatePolicyType(CellularAutomataComp::UpdatePolicyType updatePolicyType) {
+	_updatePolicyType = updatePolicyType;
+}
+
+unsigned int CellularAutomataComp::getUpdateBlockSize() const {
+	return _updateBlockSize;
+}
+
+void CellularAutomataComp::setUpdateBlockSize(unsigned int updateBlockSize) {
+	_updateBlockSize = updateBlockSize == 0 ? 1 : updateBlockSize;
+}
+
+unsigned int CellularAutomataComp::getRandomSeed() const {
+	return _randomSeed;
+}
+
+void CellularAutomataComp::setRandomSeed(unsigned int randomSeed) {
+	_randomSeed = randomSeed;
+	_randomStepCounter = 0;
 }
 
 LocalRule *CellularAutomataComp::getlocalRule() const
@@ -101,22 +380,54 @@ CellularAutomataComp::LocalRuleType CellularAutomataComp::getlocalRuleType() con
 void CellularAutomataComp::setLocalRuleType(CellularAutomataComp::LocalRuleType newLocalRuleType)
 {
 	_localRuleType = newLocalRuleType;
-	if (_localRule != nullptr)
+	_ensureCellularAutomata();
+	if (_localRule != nullptr) {
 		delete _localRule;
+		_localRule = nullptr; // avoid a dangling/double-freed pointer for types that build no rule here
+		// The deleted rule registered itself in the automaton (LocalRule ctor); clear that pointer too.
+		if (_cellularAutomata != nullptr)
+			_cellularAutomata->setLocalRule(nullptr);
+	}
 	if (_localRuleType == LocalRuleType::ELEMENTAR_CA) {
-		_localRule = new LocalRule_Elementary(_cellularAutomata, 30);
+		_localRule = new LocalRule_Elementary(_cellularAutomata, _elementaryRuleNumber);
 	} else if (_localRuleType == LocalRuleType::GAME_OF_LIFE) {
 		_localRule = new LocalRule_GameOfLife(_cellularAutomata);
 	} else if (_localRuleType == LocalRuleType::BIASED_COMPETITION) {
 		_localRule = new LocalRule_Growty(_cellularAutomata);
 	}
+	// USERDEFINED is compiled and loaded lazily in _check(), where the cellular automata, state set
+	// and user source are all available (see _buildUserDefinedRule).
+}
+
+void CellularAutomataComp::setUserDefinedRuleSource(const std::string& userDefinedRuleSource) {
+	_userDefinedRuleSource = userDefinedRuleSource;
+}
+
+std::string CellularAutomataComp::getUserDefinedRuleSource() const {
+	return _userDefinedRuleSource;
 }
 
 void CellularAutomataComp::setStateSetType(CellularAutomataComp::StateSetType newStateSetType)
 {
 	_stateSetType = newStateSetType;
-	if (_stateSet == nullptr)
-		_stateSet = new StateSet(_cellularAutomata);
+	_ensureCellularAutomata();
+	if (_stateSet != nullptr)
+		delete _stateSet;
+	_stateSet = nullptr;
+	// Clear the automaton's now-dangling state-set pointer; an implemented type below re-wires it in
+	// _check. For an unimplemented type no replacement is built, so this avoids a use-after-free if a
+	// later LocalRule ctor reads parentCellularAutomata->getStateSet() (mirrors setLocalRuleType).
+	if (_cellularAutomata != nullptr)
+		_cellularAutomata->setStateSet(nullptr);
+	if (_stateSetType == StateSetType::ENUMERATED)
+		// The two binary states are owned by this component (members), so the enumerable leaks none.
+		_stateSet = new StateSet_Enumerable(_cellularAutomata, {&_enumeratedStateOff, &_enumeratedStateOn});
+	else if (_stateSetType == StateSetType::INTEGERBASED)
+		_stateSet = new StateSet_Integer(_cellularAutomata);
+	else if (_stateSetType == StateSetType::BITBASED)
+		_stateSet = new StateSet_Bit(_cellularAutomata);
+	else if (_stateSetType == StateSetType::DOUBLEBASED)
+		_stateSet = new StateSet_Double(_cellularAutomata);
 }
 
 
@@ -156,8 +467,10 @@ CellularAutomataComp::CellularAutomataType CellularAutomataComp::getCellularAuto
 void CellularAutomataComp::setCellularAutomataType(CellularAutomataComp::CellularAutomataType newCellularAutomataType)
 {
 	_cellularAutomataType = newCellularAutomataType;
-	if (_cellularAutomata != nullptr)
-		_cellularAutomata->~CellularAutomataBase();
+	if (_cellularAutomata != nullptr) {
+		delete _cellularAutomata; // was an explicit destructor call (~CellularAutomataBase), which left a dangling pointer
+		_cellularAutomata = nullptr;
+	}
 	if (_cellularAutomataType == CellularAutomataType::CLASSIC)
 		_cellularAutomata = new CellularAutomata_Classic();
 	else if (_cellularAutomataType == CellularAutomataType::TIMED_1D)
@@ -172,6 +485,7 @@ CellularAutomataComp::LatticeType CellularAutomataComp::getLatticeType() const
 void CellularAutomataComp::setLatticeType(CellularAutomataComp::LatticeType newLatticeStructure)
 {
 	_latticeType = newLatticeStructure;
+	_ensureCellularAutomata();
 	if (_lattice == nullptr)
 		_lattice = new Lattice(_cellularAutomata);
 }
@@ -184,8 +498,14 @@ CellularAutomataComp::NeighboorhoodType CellularAutomataComp::getNeighboorhoodTy
 void CellularAutomataComp::setNeighboorhoodType(CellularAutomataComp::NeighboorhoodType newNeighboorhood)
 {
 	_neighboorhoodType = newNeighboorhood;
+	_ensureCellularAutomata();
 	if (_neighboorhood != nullptr)
 		delete _neighboorhood;
+	_neighboorhood = nullptr;
+	// Clear the automaton's dangling neighborhood pointer; an implemented type below re-registers
+	// itself (Neighborhood ctor), an unimplemented one leaves it safely null (avoids use-after-free).
+	if (_cellularAutomata != nullptr)
+		_cellularAutomata->setNeighborhood(nullptr);
 	if (_neighboorhoodType == NeighboorhoodType::CENTERED)
 		_neighboorhood = new Neighborhood_Center(_cellularAutomata);
 	else if (_neighboorhoodType == NeighboorhoodType::MOORE)
@@ -204,16 +524,204 @@ void CellularAutomataComp::setBoundaryType(CellularAutomataComp::BoundaryType ne
 	_boundaryType = newBoundary;
 	if (_boundary != nullptr)
 		delete _boundary;
+	_boundary = nullptr;
 	if (_boundaryType == BoundaryType::CLOSED)
 		_boundary = new Boundary_Closed();
 	else if (_boundaryType == BoundaryType::FIXED)
 		_boundary = new Boundary_Fixed();
+	else if (_boundaryType == BoundaryType::REFLEXIVE)
+		_boundary = new Boundary_Reflexive();
+	else if (_boundaryType == BoundaryType::ADIABATIC)
+		_boundary = new Boundary_Adiabatic();
+}
+
+void CellularAutomataComp::_ensureCellularAutomata() {
+	if (_cellularAutomata == nullptr)
+		setCellularAutomataType(_cellularAutomataType);
+}
+
+bool CellularAutomataComp::_checkImplementedTypes(std::string* errorMessage) const {
+	// TIMED_1D is rejected: its applyLocalRule() is unfinished (dereferences an uninitialized State*)
+	// and would crash. A 1D timed/elementary automaton is already covered by CLASSIC on a 1D lattice,
+	// so only CLASSIC is offered until TIMED_1D is implemented and verified.
+	if (_cellularAutomataType == CellularAutomataType::TIMED_1D ||
+			_cellularAutomataType == CellularAutomataType::ASYNCHRONOUS ||
+			_cellularAutomataType == CellularAutomataType::NONUNIFORMRULE ||
+			_cellularAutomataType == CellularAutomataType::NONUNIFORMNEIGHBOOR ||
+			_cellularAutomataType == CellularAutomataType::USERDEFINED) {
+		if (errorMessage != nullptr)
+			*errorMessage += "Configured cellular automata type is not implemented yet. ";
+		return false;
+	}
+	if (_latticeType == LatticeType::TRIANGULAR ||
+			_latticeType == LatticeType::HEXAGONAL ||
+			_latticeType == LatticeType::NETWORK ||
+			_latticeType == LatticeType::USERDEFINED) {
+		if (errorMessage != nullptr)
+			*errorMessage += "Configured lattice type is not implemented yet. ";
+		return false;
+	}
+	if (_neighboorhoodType == NeighboorhoodType::BACKWARD ||
+			_neighboorhoodType == NeighboorhoodType::FORWARD ||
+			_neighboorhoodType == NeighboorhoodType::USERDEFINED) {
+		if (errorMessage != nullptr)
+			*errorMessage += "Configured neighborhood type is not implemented yet. ";
+		return false;
+	}
+	if (_boundaryType == BoundaryType::USERDEFINED) {
+		if (errorMessage != nullptr)
+			*errorMessage += "Configured boundary type is not implemented yet. ";
+		return false;
+	}
+	if (_stateSetType == StateSetType::USERDEFINED) {
+		if (errorMessage != nullptr)
+			*errorMessage += "Configured state set type is not implemented yet. ";
+		return false;
+	}
+	// USERDEFINED local rule IS implemented (Linha B, via CppCompiler); only HPP remains unimplemented.
+	if (_localRuleType == LocalRuleType::HPP) {
+		if (errorMessage != nullptr)
+			*errorMessage += "Configured local rule type is not implemented yet. ";
+		return false;
+	}
+	return true;
+}
+
+bool CellularAutomataComp::_checkLattice(std::string* errorMessage) const {
+	const std::vector<unsigned short> dimensions = _lattice->getDimensions();
+	if (dimensions.empty()) {
+		if (errorMessage != nullptr)
+			*errorMessage += "Lattice must have at least one dimension. ";
+		return false;
+	}
+	for (unsigned short dimension : dimensions) {
+		if (dimension == 0) {
+			if (errorMessage != nullptr)
+				*errorMessage += "All lattice dimensions must be greater than zero. ";
+			return false;
+		}
+	}
+	return true;
+}
+
+bool CellularAutomataComp::_checkStateSet(std::string* errorMessage) const {
+	if (_stateSet == nullptr) {
+		if (errorMessage != nullptr)
+			*errorMessage += "State set type was not configured. ";
+		return false;
+	}
+	return true;
+}
+
+bool CellularAutomataComp::_checkRuleCompatibility(std::string* errorMessage) const {
+	const unsigned short numDimensions = _lattice->getNumDimensions();
+	if (_neighboorhoodType == NeighboorhoodType::CENTERED && numDimensions != 1) {
+		if (errorMessage != nullptr)
+			*errorMessage += "Centered neighborhood is currently supported only for 1D lattices. ";
+		return false;
+	}
+	if (_localRuleType == LocalRuleType::ELEMENTAR_CA) {
+		if (numDimensions != 1) {
+			if (errorMessage != nullptr)
+				*errorMessage += "Elementary cellular automata rule requires a 1D lattice. ";
+			return false;
+		}
+		if (_neighboorhood == nullptr || _neighboorhood->getRadius() != 1) {
+			if (errorMessage != nullptr)
+				*errorMessage += "Elementary cellular automata rule requires radius-1 neighborhood. ";
+			return false;
+		}
+		if (_stateSetType != StateSetType::ENUMERATED && _stateSetType != StateSetType::BITBASED) {
+			if (errorMessage != nullptr)
+				*errorMessage += "Elementary cellular automata rule requires a binary state set. ";
+			return false;
+		}
+	}
+	if (_localRuleType == LocalRuleType::GAME_OF_LIFE) {
+		if (numDimensions != 2 || _neighboorhoodType != NeighboorhoodType::MOORE || _neighboorhood->getRadius() != 1) {
+			if (errorMessage != nullptr)
+				*errorMessage += "Game of Life requires a 2D lattice with Moore radius-1 neighborhood. ";
+			return false;
+		}
+		StateSet_Enumerable* enumerableStateSet = dynamic_cast<StateSet_Enumerable*>(_stateSet);
+		const bool isEnumeratedBinary = _stateSetType == StateSetType::ENUMERATED && enumerableStateSet != nullptr && enumerableStateSet->getStatesSize() == 2;
+		const bool isBitBased = _stateSetType == StateSetType::BITBASED;
+		if (!isEnumeratedBinary && !isBitBased) {
+			if (errorMessage != nullptr)
+				*errorMessage += "Game of Life requires a binary state set. ";
+			return false;
+		}
+	}
+	return true;
+}
+
+bool CellularAutomataComp::_checkUpdatePolicy(std::string* errorMessage) const {
+	if (_updatePolicyType == UpdatePolicyType::BLOCKS && _updateBlockSize == 0) {
+		if (errorMessage != nullptr)
+			*errorMessage += "Block update policy requires update block size greater than zero. ";
+		return false;
+	}
+	return true;
+}
+
+void CellularAutomataComp::_stepCellularAutomataByPolicy() {
+	if (_cellularAutomata == nullptr || _lattice == nullptr || _localRule == nullptr)
+		return;
+	if (_updatePolicyType == UpdatePolicyType::SYNCHRONOUS)
+		_cellularAutomata->step();
+	else if (_updatePolicyType == UpdatePolicyType::SEQUENTIAL)
+		_stepSequential();
+	else if (_updatePolicyType == UpdatePolicyType::RANDOM)
+		_stepRandom();
+	else if (_updatePolicyType == UpdatePolicyType::BLOCKS)
+		_stepBlocks();
+}
+
+void CellularAutomataComp::_stepSequential() {
+	for (unsigned long cellNumber = 0; cellNumber < _lattice->getCellsSize(); ++cellNumber)
+		_applyRuleAndUpdateCell(cellNumber);
+}
+
+void CellularAutomataComp::_stepRandom() {
+	std::vector<unsigned long> cellNumbers(_lattice->getCellsSize());
+	std::iota(cellNumbers.begin(), cellNumbers.end(), 0);
+	// Portable Fisher-Yates. std::shuffle's consumption of the engine is implementation-defined
+	// (libc++ and libstdc++ produce different permutations from the same mt19937 state), but
+	// std::uniform_int_distribution is specified, so this yields the SAME random order on every
+	// platform for a given seed -> the RANDOM update policy is reproducible (REGRA 3: comprovável).
+	std::mt19937 randomEngine(_randomSeed + _randomStepCounter++);
+	for (std::size_t i = cellNumbers.size(); i > 1; --i) {
+		std::uniform_int_distribution<std::size_t> distribution(0, i - 1);
+		std::swap(cellNumbers[i - 1], cellNumbers[distribution(randomEngine)]);
+	}
+	for (unsigned long cellNumber : cellNumbers)
+		_applyRuleAndUpdateCell(cellNumber);
+}
+
+void CellularAutomataComp::_stepBlocks() {
+	const unsigned int blockSize = _updateBlockSize == 0 ? 1 : _updateBlockSize;
+	for (unsigned long firstCellNumber = 0; firstCellNumber < _lattice->getCellsSize(); firstCellNumber += blockSize) {
+		const unsigned long lastCellNumber = std::min<unsigned long>(firstCellNumber + blockSize, _lattice->getCellsSize());
+		for (unsigned long cellNumber = firstCellNumber; cellNumber < lastCellNumber; ++cellNumber)
+			_localRule->applyRule(_lattice->getCell(static_cast<long>(cellNumber)));
+		for (unsigned long cellNumber = firstCellNumber; cellNumber < lastCellNumber; ++cellNumber)
+			_lattice->getCell(static_cast<long>(cellNumber))->updateState();
+	}
+}
+
+void CellularAutomataComp::_applyRuleAndUpdateCell(unsigned long cellNumber) {
+	Cell* cell = _lattice->getCell(static_cast<long>(cellNumber));
+	_localRule->applyRule(cell);
+	cell->updateState();
 }
 
 PluginInformation* CellularAutomataComp::GetPluginInformation() {
 	PluginInformation* info = new PluginInformation(Util::TypeOf<CellularAutomataComp>(), &CellularAutomataComp::LoadInstance, &CellularAutomataComp::NewInstance);
 	info->setCategory("ModalModel");
-	info->setDescriptionHelp("//@TODO");
+	info->setDescriptionHelp("Universal cellular automaton: configurable lattice (1D/2D/3D), neighborhood "
+		"(centered/Moore/Von Neumann), boundary (fixed/closed/reflexive/adiabatic), state set "
+		"(enumerated/integer/bit/double), update policy (synchronous/sequential/random/blocks) and local "
+		"rule (elementary/Game of Life/biased-competition or a user-defined rule compiled at runtime).");
 	return info;
 }
 

--- a/source/plugins/components/ModalModel/CellularAutomataComp.cpp
+++ b/source/plugins/components/ModalModel/CellularAutomataComp.cpp
@@ -24,7 +24,10 @@
 #include "plugins/components/ModalModel/CellularAutomata/LocalRule_Growty.h"
 #include "plugins/components/ModalModel/CellularAutomata/LocalRule_UserDefined.h"
 #include "plugins/components/ModalModel/CellularAutomata/Neighborhood_Center.h"
+#include "plugins/components/ModalModel/CellularAutomata/Neighborhood_Hexagonal.h"
 #include "plugins/components/ModalModel/CellularAutomata/Neighborhood_Moore.h"
+#include "plugins/components/ModalModel/CellularAutomata/Neighborhood_Network.h"
+#include "plugins/components/ModalModel/CellularAutomata/Neighborhood_Triangular.h"
 #include "plugins/components/ModalModel/CellularAutomata/Neighborhood_VonNeumann.h"
 #include "plugins/components/ModalModel/CellularAutomata/State.h"
 #include "plugins/components/ModalModel/CellularAutomata/StateSet_Bit.h"
@@ -69,6 +72,31 @@ std::vector<unsigned short> parseDimensions(const std::string& serialized) {
 			dimensions.emplace_back(static_cast<unsigned short>(std::stoul(item)));
 	}
 	return dimensions;
+}
+
+std::string serializeNetworkEdges(const std::vector<std::pair<unsigned long, unsigned long>>& edges) {
+	std::string out;
+	for (std::size_t i = 0; i < edges.size(); ++i) {
+		if (i > 0)
+			out += ',';
+		out += std::to_string(edges.at(i).first) + '-' + std::to_string(edges.at(i).second);
+	}
+	return out;
+}
+
+std::vector<std::pair<unsigned long, unsigned long>> parseNetworkEdges(const std::string& serialized) {
+	std::vector<std::pair<unsigned long, unsigned long>> edges;
+	std::stringstream stream(serialized);
+	std::string item;
+	while (std::getline(stream, item, ',')) {
+		const std::size_t separator = item.find('-');
+		if (separator == std::string::npos)
+			continue;
+		edges.emplace_back(
+			static_cast<unsigned long>(std::stoul(item.substr(0, separator))),
+			static_cast<unsigned long>(std::stoul(item.substr(separator + 1))));
+	}
+	return edges;
 }
 } // namespace
 
@@ -125,6 +153,10 @@ bool CellularAutomataComp::_loadInstance(PersistenceRecord *fields) {
 		const std::string serializedDimensions = fields->loadField("latticeDimensions", std::string(""));
 		if (_lattice != nullptr && !serializedDimensions.empty())
 			_lattice->setDimensions(parseDimensions(serializedDimensions));
+		const std::string serializedEdges = fields->loadField("networkEdges", std::string(""));
+		const bool networkEdgesUndirected = fields->loadField("networkEdgesUndirected", 1) != 0;
+		if (_lattice != nullptr && !serializedEdges.empty())
+			_lattice->setNetworkEdges(parseNetworkEdges(serializedEdges), networkEdgesUndirected);
 		setNeighboorhoodType(static_cast<NeighboorhoodType>(
 			fields->loadField("neighborhoodType", static_cast<int>(DEFAULT.neighboorhoodType))));
 		if (_neighboorhood != nullptr)
@@ -174,6 +206,10 @@ void CellularAutomataComp::_saveInstance(PersistenceRecord *fields, bool saveDef
 		DEFAULT.userDefinedRuleSource, saveDefaultValues);
 	const std::string serializedDimensions = _lattice != nullptr ? serializeDimensions(_lattice->getDimensions()) : std::string("");
 	fields->saveField("latticeDimensions", serializedDimensions, std::string(""), saveDefaultValues);
+	const std::string serializedNetworkEdges = _lattice != nullptr ? serializeNetworkEdges(_lattice->getNetworkEdges()) : std::string("");
+	fields->saveField("networkEdges", serializedNetworkEdges, std::string(""), saveDefaultValues);
+	const int networkEdgesUndirected = (_lattice == nullptr || _lattice->getNetworkEdgesUndirected()) ? 1 : 0;
+	fields->saveField("networkEdgesUndirected", networkEdgesUndirected, 1, saveDefaultValues);
 	const int neighborhoodRadius = _neighboorhood != nullptr ? static_cast<int>(_neighboorhood->getRadius()) : 1;
 	fields->saveField("neighborhoodRadius", neighborhoodRadius, 1, saveDefaultValues);
 }
@@ -367,6 +403,22 @@ void CellularAutomataComp::setRandomSeed(unsigned int randomSeed) {
 	_randomStepCounter = 0;
 }
 
+void CellularAutomataComp::setNetworkEdges(const std::vector<std::pair<unsigned long, unsigned long>>& edges, bool undirected) {
+	if (_lattice == nullptr)
+		setLatticeType(LatticeType::NETWORK);
+	_lattice->setNetworkEdges(edges, undirected);
+}
+
+std::vector<std::pair<unsigned long, unsigned long>> CellularAutomataComp::getNetworkEdges() const {
+	if (_lattice == nullptr)
+		return {};
+	return _lattice->getNetworkEdges();
+}
+
+bool CellularAutomataComp::getNetworkEdgesUndirected() const {
+	return _lattice == nullptr || _lattice->getNetworkEdgesUndirected();
+}
+
 LocalRule *CellularAutomataComp::getlocalRule() const
 {
 	return _localRule;
@@ -486,8 +538,21 @@ void CellularAutomataComp::setLatticeType(CellularAutomataComp::LatticeType newL
 {
 	_latticeType = newLatticeStructure;
 	_ensureCellularAutomata();
+	const ::LatticeType latticeType = static_cast<::LatticeType>(static_cast<int>(_latticeType));
 	if (_lattice == nullptr)
-		_lattice = new Lattice(_cellularAutomata);
+		_lattice = new Lattice(_cellularAutomata, nullptr, {}, latticeType);
+	else
+		_lattice->setLatticeType(latticeType);
+	if (_neighboorhood != nullptr) {
+		const unsigned short radius = _neighboorhood->getRadius();
+		setNeighboorhoodType(_neighboorhoodType);
+		if (_neighboorhood != nullptr)
+			_neighboorhood->setRadius(radius);
+	} else if (_latticeType == LatticeType::TRIANGULAR ||
+			_latticeType == LatticeType::HEXAGONAL ||
+			_latticeType == LatticeType::NETWORK) {
+		setNeighboorhoodType(_neighboorhoodType);
+	}
 }
 
 CellularAutomataComp::NeighboorhoodType CellularAutomataComp::getNeighboorhoodType() const
@@ -506,7 +571,13 @@ void CellularAutomataComp::setNeighboorhoodType(CellularAutomataComp::Neighboorh
 	// itself (Neighborhood ctor), an unimplemented one leaves it safely null (avoids use-after-free).
 	if (_cellularAutomata != nullptr)
 		_cellularAutomata->setNeighborhood(nullptr);
-	if (_neighboorhoodType == NeighboorhoodType::CENTERED)
+	if (_latticeType == LatticeType::TRIANGULAR)
+		_neighboorhood = new Neighborhood_Triangular(_cellularAutomata);
+	else if (_latticeType == LatticeType::HEXAGONAL)
+		_neighboorhood = new Neighborhood_Hexagonal(_cellularAutomata);
+	else if (_latticeType == LatticeType::NETWORK)
+		_neighboorhood = new Neighborhood_Network(_cellularAutomata);
+	else if (_neighboorhoodType == NeighboorhoodType::CENTERED)
 		_neighboorhood = new Neighborhood_Center(_cellularAutomata);
 	else if (_neighboorhoodType == NeighboorhoodType::MOORE)
 		_neighboorhood = new Neighborhood_Moore(_cellularAutomata);
@@ -553,10 +624,7 @@ bool CellularAutomataComp::_checkImplementedTypes(std::string* errorMessage) con
 			*errorMessage += "Configured cellular automata type is not implemented yet. ";
 		return false;
 	}
-	if (_latticeType == LatticeType::TRIANGULAR ||
-			_latticeType == LatticeType::HEXAGONAL ||
-			_latticeType == LatticeType::NETWORK ||
-			_latticeType == LatticeType::USERDEFINED) {
+	if (_latticeType == LatticeType::USERDEFINED) {
 		if (errorMessage != nullptr)
 			*errorMessage += "Configured lattice type is not implemented yet. ";
 		return false;
@@ -601,6 +669,24 @@ bool CellularAutomataComp::_checkLattice(std::string* errorMessage) const {
 			return false;
 		}
 	}
+	if ((_latticeType == LatticeType::TRIANGULAR || _latticeType == LatticeType::HEXAGONAL) &&
+			dimensions.size() != 2) {
+		if (errorMessage != nullptr)
+			*errorMessage += "Triangular and hexagonal lattices require exactly two dimensions. ";
+		return false;
+	}
+	if (_latticeType == LatticeType::NETWORK) {
+		if (!_lattice->hasNetworkEdges()) {
+			if (errorMessage != nullptr)
+				*errorMessage += "Network lattice requires at least one edge. ";
+			return false;
+		}
+		if (!_lattice->networkEdgesAreValid()) {
+			if (errorMessage != nullptr)
+				*errorMessage += "Network lattice edges must reference existing cells. ";
+			return false;
+		}
+	}
 	return true;
 }
 
@@ -615,12 +701,23 @@ bool CellularAutomataComp::_checkStateSet(std::string* errorMessage) const {
 
 bool CellularAutomataComp::_checkRuleCompatibility(std::string* errorMessage) const {
 	const unsigned short numDimensions = _lattice->getNumDimensions();
-	if (_neighboorhoodType == NeighboorhoodType::CENTERED && numDimensions != 1) {
+	if ((_latticeType == LatticeType::TRIANGULAR || _latticeType == LatticeType::HEXAGONAL) &&
+			(_neighboorhood == nullptr || _neighboorhood->getRadius() != 1)) {
+		if (errorMessage != nullptr)
+			*errorMessage += "Triangular and hexagonal lattices currently require radius-1 neighborhoods. ";
+		return false;
+	}
+	if (_latticeType == LatticeType::RETICULAR && _neighboorhoodType == NeighboorhoodType::CENTERED && numDimensions != 1) {
 		if (errorMessage != nullptr)
 			*errorMessage += "Centered neighborhood is currently supported only for 1D lattices. ";
 		return false;
 	}
 	if (_localRuleType == LocalRuleType::ELEMENTAR_CA) {
+		if (_latticeType != LatticeType::RETICULAR) {
+			if (errorMessage != nullptr)
+				*errorMessage += "Elementary cellular automata rule requires a reticular lattice. ";
+			return false;
+		}
 		if (numDimensions != 1) {
 			if (errorMessage != nullptr)
 				*errorMessage += "Elementary cellular automata rule requires a 1D lattice. ";
@@ -638,9 +735,12 @@ bool CellularAutomataComp::_checkRuleCompatibility(std::string* errorMessage) co
 		}
 	}
 	if (_localRuleType == LocalRuleType::GAME_OF_LIFE) {
-		if (numDimensions != 2 || _neighboorhoodType != NeighboorhoodType::MOORE || _neighboorhood->getRadius() != 1) {
+		if (_latticeType != LatticeType::RETICULAR ||
+				numDimensions != 2 ||
+				_neighboorhoodType != NeighboorhoodType::MOORE ||
+				_neighboorhood->getRadius() != 1) {
 			if (errorMessage != nullptr)
-				*errorMessage += "Game of Life requires a 2D lattice with Moore radius-1 neighborhood. ";
+				*errorMessage += "Game of Life requires a 2D reticular lattice with Moore radius-1 neighborhood. ";
 			return false;
 		}
 		StateSet_Enumerable* enumerableStateSet = dynamic_cast<StateSet_Enumerable*>(_stateSet);
@@ -718,8 +818,8 @@ void CellularAutomataComp::_applyRuleAndUpdateCell(unsigned long cellNumber) {
 PluginInformation* CellularAutomataComp::GetPluginInformation() {
 	PluginInformation* info = new PluginInformation(Util::TypeOf<CellularAutomataComp>(), &CellularAutomataComp::LoadInstance, &CellularAutomataComp::NewInstance);
 	info->setCategory("ModalModel");
-	info->setDescriptionHelp("Universal cellular automaton: configurable lattice (1D/2D/3D), neighborhood "
-		"(centered/Moore/Von Neumann), boundary (fixed/closed/reflexive/adiabatic), state set "
+	info->setDescriptionHelp("Universal cellular automaton: configurable lattice (reticular/triangular/hexagonal/network), neighborhood "
+		"(centered/Moore/Von Neumann/lattice-specific), boundary (fixed/closed/reflexive/adiabatic), state set "
 		"(enumerated/integer/bit/double), update policy (synchronous/sequential/random/blocks) and local "
 		"rule (elementary/Game of Life/biased-competition or a user-defined rule compiled at runtime).");
 	return info;

--- a/source/plugins/components/ModalModel/CellularAutomataComp.cpp
+++ b/source/plugins/components/ModalModel/CellularAutomataComp.cpp
@@ -49,7 +49,7 @@ extern "C" StaticGetPluginInformation GetPluginInformation() {
 
 namespace {
 // Lattice dimensions are persisted as a comma-separated list (e.g. "5,5") so a saved automaton
-// round-trips to a checkable configuration (Tema 6 §10.1: persist the model's structural parameters).
+// round-trips to a checkable configuration (persist the model's structural parameters).
 std::string serializeDimensions(const std::vector<unsigned short>& dimensions) {
 	std::string out;
 	for (std::size_t i = 0; i < dimensions.size(); ++i) {
@@ -214,8 +214,8 @@ bool CellularAutomataComp::_buildUserDefinedRule(std::string* errorMessage) {
 }
 
 bool CellularAutomataComp::_check(std::string* errorMessage) {
-	// Best-of-each semantic check: Sutter's decomposed structural/rule/policy validation, plus the
-	// USERDEFINED (Linha B) rule built lazily once every structural sub-object is available.
+	// Decomposed structural/rule/policy validation, plus the USERDEFINED rule built lazily once
+	// every structural sub-object is available.
 	if (!_checkImplementedTypes(errorMessage))
 		return false;
 	if (_cellularAutomata == nullptr) {
@@ -238,7 +238,7 @@ bool CellularAutomataComp::_check(std::string* errorMessage) {
 		*errorMessage += "State set type is not set. ";
 		return false;
 	}
-	// Linha B: compile and load a user-defined local rule now, when the automaton, lattice,
+	// Compile and load a user-defined local rule now, when the automaton, lattice,
 	// neighborhood, boundary and state set all exist (see _buildUserDefinedRule).
 	if (_localRuleType == LocalRuleType::USERDEFINED) {
 		if (!_buildUserDefinedRule(errorMessage))
@@ -578,7 +578,7 @@ bool CellularAutomataComp::_checkImplementedTypes(std::string* errorMessage) con
 			*errorMessage += "Configured state set type is not implemented yet. ";
 		return false;
 	}
-	// USERDEFINED local rule IS implemented (Linha B, via CppCompiler); only HPP remains unimplemented.
+	// USERDEFINED local rule IS implemented (via CppCompiler); only HPP remains unimplemented.
 	if (_localRuleType == LocalRuleType::HPP) {
 		if (errorMessage != nullptr)
 			*errorMessage += "Configured local rule type is not implemented yet. ";

--- a/source/plugins/components/ModalModel/CellularAutomataComp.h
+++ b/source/plugins/components/ModalModel/CellularAutomataComp.h
@@ -21,6 +21,7 @@
 #include "plugins/components/ModalModel/CellularAutomata/StateSet.h"
 
 #include <cstdint>
+#include <utility>
 #include <vector>
 
 class BoundaryCondition;
@@ -104,6 +105,9 @@ public: //! new public user methods for this component
 	void setUpdateBlockSize(unsigned int updateBlockSize);
 	unsigned int getRandomSeed() const;
 	void setRandomSeed(unsigned int randomSeed);
+	void setNetworkEdges(const std::vector<std::pair<unsigned long, unsigned long>>& edges, bool undirected = true);
+	std::vector<std::pair<unsigned long, unsigned long>> getNetworkEdges() const;
+	bool getNetworkEdgesUndirected() const;
 
 	//CellularAutomataBase *getcellularAutomata() const;
 	Lattice *getlattice() const;

--- a/source/plugins/components/ModalModel/CellularAutomataComp.h
+++ b/source/plugins/components/ModalModel/CellularAutomataComp.h
@@ -13,13 +13,18 @@
 
 #pragma once
 
-#include "kernel/simulator/ModelComponent.h"
+#include "../../../kernel/simulator/ModelComponent.h"
 #include "plugins/components/ModalModel/CellularAutomata/CellularAutomataBase.h"
 #include "plugins/components/ModalModel/CellularAutomata/Lattice.h"
 #include "plugins/components/ModalModel/CellularAutomata/Neighborhood.h"
+#include "plugins/components/ModalModel/CellularAutomata/State.h"
 #include "plugins/components/ModalModel/CellularAutomata/StateSet.h"
 
+#include <cstdint>
+#include <vector>
+
 class BoundaryCondition;
+class CppCompiler;
 
 /*!
  This component ...
@@ -53,10 +58,15 @@ public: //! enums
 	enum class AutomataType : int {
 		Temporary = 0, Permanent = 1
 	};
-	
+
+	//! Temporal update policy: how the lattice advances on each automaton step.
+	enum class UpdatePolicyType : int {
+		SYNCHRONOUS = 1, SEQUENTIAL = 2, RANDOM = 3, BLOCKS = 4
+	};
+
 public: //! constructors
 	CellularAutomataComp(Model* model, std::string name = "");
-	virtual ~CellularAutomataComp() = default;
+	virtual ~CellularAutomataComp();
 
 public: //! new public user methods for this component
 	CellularAutomataComp::CellularAutomataType getCellularAutomataType() const;
@@ -74,11 +84,32 @@ public: //! new public user methods for this component
 	CellularAutomataComp::StateSetType getStateSetType() const;
 	void setStateSetType(CellularAutomataComp::StateSetType newStateSetType);
 
+	//! Builds (checks + inits) the cellular automaton from the configured types. Returns false (and
+	//! fills errorMessage, if given) when the configuration is invalid. Useful to drive the automaton
+	//! directly from a terminal example or test, without running a full DES model.
+	bool initializeCellularAutomata(std::string* errorMessage = nullptr);
+	//! Advances the automaton one step, honoring the configured update policy.
+	void stepCellularAutomata();
+	bool setCellState(long cellNumber, int value);
+	bool setCellState(long cellNumber, long value);
+	bool setCellState(long cellNumber, double value);
+	bool setCellState(const std::vector<int>& position, int value);
+	bool setCellState(const std::vector<int>& position, long value);
+	bool setCellState(const std::vector<int>& position, double value);
+	std::string showCellularAutomata() const;
+	void setElementaryRuleNumber(uint8_t ruleNumber);
+	CellularAutomataComp::UpdatePolicyType getUpdatePolicyType() const;
+	void setUpdatePolicyType(CellularAutomataComp::UpdatePolicyType updatePolicyType);
+	unsigned int getUpdateBlockSize() const;
+	void setUpdateBlockSize(unsigned int updateBlockSize);
+	unsigned int getRandomSeed() const;
+	void setRandomSeed(unsigned int randomSeed);
+
 	//CellularAutomataBase *getcellularAutomata() const;
 	Lattice *getlattice() const;
 	Neighborhood *getNeighboorhood() const;
 	//BoundaryCondition *getBoundary() const;
-	StateSet *getStateSet() const;	
+	StateSet *getStateSet() const;
 
 public: //! virtual public methods
 	virtual std::string show() override;
@@ -90,6 +121,12 @@ public: //! static public methods that must have implementations (Load and New j
 
 	CellularAutomataComp::LocalRuleType getlocalRuleType() const;
 	void setLocalRuleType(CellularAutomataComp::LocalRuleType newLocalRuleType);
+
+	//! C++ source for a USERDEFINED local rule. The source must define the C-linkage function
+	//! `extern "C" long nextState(long self, const long* neighbors, int numNeighbors)`. It is compiled
+	//! at runtime (via CppCompiler) and loaded during model check. See LocalRule_UserDefined.
+	void setUserDefinedRuleSource(const std::string& userDefinedRuleSource);
+	std::string getUserDefinedRuleSource() const;
 
 	LocalRule *getlocalRule() const;
 
@@ -119,7 +156,23 @@ protected:
 	// virtual void _createAttachedAttributes() override;
 
 private: //! new private user methods
-	// ...
+	//! Lazily instantiates the cellular automaton if it has not been created yet (so the setters can
+	//! create lattice/neighborhood/state set/rule that need a parent automaton, in any order).
+	void _ensureCellularAutomata();
+	//! Compiles and loads the USERDEFINED local rule from _userDefinedRuleSource (called by _check).
+	bool _buildUserDefinedRule(std::string* errorMessage);
+	//! Decomposed semantic checks used by _check (best-of-each: structural + rule + policy coherence).
+	bool _checkImplementedTypes(std::string* errorMessage) const;
+	bool _checkLattice(std::string* errorMessage) const;
+	bool _checkStateSet(std::string* errorMessage) const;
+	bool _checkRuleCompatibility(std::string* errorMessage) const;
+	bool _checkUpdatePolicy(std::string* errorMessage) const;
+	//! Update-policy engine: advances the lattice one step under the configured policy.
+	void _stepCellularAutomataByPolicy();
+	void _stepSequential();
+	void _stepRandom();
+	void _stepBlocks();
+	void _applyRuleAndUpdateCell(unsigned long cellNumber);
 
 private: //! Attributes that should be loaded or saved with this component (Persistent Fields)
 
@@ -131,6 +184,10 @@ private: //! Attributes that should be loaded or saved with this component (Pers
 		const BoundaryType boundaryType = BoundaryType::FIXED;
 		const StateSetType stateSetType = StateSetType::ENUMERATED;
 		const LocalRuleType localRuleType = LocalRuleType::GAME_OF_LIFE;
+		const UpdatePolicyType updatePolicyType = UpdatePolicyType::SYNCHRONOUS;
+		const unsigned int updateBlockSize = 1;
+		const unsigned int randomSeed = 1;
+		const std::string userDefinedRuleSource = "";
 	} DEFAULT;
 	CellularAutomataComp::CellularAutomataType _cellularAutomataType = DEFAULT.cellularAutomataType;
 	CellularAutomataComp::LatticeType _latticeType = DEFAULT.latticeType;
@@ -138,6 +195,11 @@ private: //! Attributes that should be loaded or saved with this component (Pers
 	CellularAutomataComp::BoundaryType _boundaryType = DEFAULT.boundaryType;
 	CellularAutomataComp::StateSetType _stateSetType = DEFAULT.stateSetType;
 	CellularAutomataComp::LocalRuleType _localRuleType = DEFAULT.localRuleType;
+	CellularAutomataComp::UpdatePolicyType _updatePolicyType = DEFAULT.updatePolicyType;
+	unsigned int _updateBlockSize = DEFAULT.updateBlockSize;
+	unsigned int _randomSeed = DEFAULT.randomSeed;
+	uint8_t _elementaryRuleNumber = 30;
+	std::string _userDefinedRuleSource = DEFAULT.userDefinedRuleSource;
 
 private: //! Attributes that do not need to be loaded or saved with this component (Non Persistent Fields)
 	CellularAutomataBase* _cellularAutomata = nullptr;
@@ -146,6 +208,12 @@ private: //! Attributes that do not need to be loaded or saved with this compone
 	BoundaryCondition* _boundary = nullptr;
 	StateSet* _stateSet = nullptr;
 	LocalRule* _localRule = nullptr;
+	CppCompiler* _ruleCompiler = nullptr; //!< owns runtime compilation for the USERDEFINED local rule
+	unsigned int _randomStepCounter = 0;  //!< advances the RANDOM update-policy seed between steps
+	// The two binary states of an ENUMERATED state set are owned here (handed by non-owning pointer to
+	// StateSet_Enumerable, whose default destructor frees nothing) so reconfiguring leaks no State.
+	State _enumeratedStateOff = State(0L);
+	State _enumeratedStateOn = State(1L);
 
 private: //! internal DataElements (Composition)
 

--- a/source/tests/unit/CMakeLists.txt
+++ b/source/tests/unit/CMakeLists.txt
@@ -252,6 +252,52 @@ genesys_add_unit_test(genesys_test_tools_simulation_results_dataset
     genesys_tools
 )
 
+# --- Cellular Automata component tests (DCS Tema 6.2) ---
+genesys_add_unit_test(genesys_test_cellular_automata_neighborhood
+    test_cellular_automata_neighborhood.cpp
+    genesys_kernel_simulator_runtime
+    genesys_kernel_util
+    genesys_plugins_components_minimal
+    genesys_kernel_simulator_runtime
+)
+
+genesys_add_unit_test(genesys_test_cellular_automata
+    test_cellular_automata.cpp
+    genesys_tools
+    genesys_kernel_simulator_runtime
+    genesys_kernel_util
+    genesys_plugins_components_minimal
+    genesys_kernel_simulator_runtime
+)
+
+genesys_add_unit_test(genesys_test_cellular_automata_elementary
+    test_cellular_automata_elementary.cpp
+    genesys_kernel_simulator_runtime
+    genesys_kernel_util
+    genesys_plugins_components_minimal
+    genesys_kernel_simulator_runtime
+)
+
+genesys_add_unit_test(genesys_test_cellular_automata_user_defined
+    test_cellular_automata_user_defined.cpp
+    genesys_tools
+    genesys_kernel_simulator_runtime
+    genesys_kernel_util
+    genesys_plugins_components_minimal
+    ${CMAKE_DL_LIBS}
+    genesys_kernel_simulator_runtime
+)
+
+genesys_add_unit_test(genesys_test_cellular_automata_component
+    test_cellular_automata_component.cpp
+    genesys_tools
+    genesys_kernel_simulator_runtime
+    genesys_kernel_util
+    genesys_plugins_components
+    ${CMAKE_DL_LIBS}
+    genesys_kernel_simulator_runtime
+)
+
 add_custom_target(genesys_kernel_unit_tests
     DEPENDS
         genesys_test_util
@@ -270,6 +316,11 @@ add_custom_target(genesys_kernel_unit_tests
         genesys_test_statistics
         genesys_test_tools_hypothesistester
         genesys_test_tools_simulation_results_dataset
+        genesys_test_cellular_automata_neighborhood
+        genesys_test_cellular_automata
+        genesys_test_cellular_automata_elementary
+        genesys_test_cellular_automata_user_defined
+        genesys_test_cellular_automata_component
 )
 
 if(GENESYS_BUILD_WEB_APPLICATION)
@@ -348,6 +399,11 @@ add_custom_target(genesys_kernel_unit_tests_run
     COMMAND $<TARGET_FILE:genesys_test_statistics>
     COMMAND $<TARGET_FILE:genesys_test_tools_hypothesistester>
     COMMAND $<TARGET_FILE:genesys_test_tools_simulation_results_dataset>
+    COMMAND $<TARGET_FILE:genesys_test_cellular_automata_neighborhood>
+    COMMAND $<TARGET_FILE:genesys_test_cellular_automata>
+    COMMAND $<TARGET_FILE:genesys_test_cellular_automata_elementary>
+    COMMAND $<TARGET_FILE:genesys_test_cellular_automata_user_defined>
+    COMMAND $<TARGET_FILE:genesys_test_cellular_automata_component>
     COMMAND $<TARGET_FILE:genesys_test_kernel_simulator_method_inventory>
     DEPENDS
         genesys_kernel_unit_tests

--- a/source/tests/unit/test_cellular_automata.cpp
+++ b/source/tests/unit/test_cellular_automata.cpp
@@ -1,0 +1,295 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "kernel/simulator/Model.h"
+#include "kernel/simulator/Simulator.h"
+#include "kernel/simulator/TraceManager.h"
+#include "plugins/components/ModalModel/CellularAutomataComp.h"
+
+namespace {
+
+class CellularAutomataFixture : public ::testing::Test {
+protected:
+	void SetUp() override {
+		genesys = std::make_unique<Simulator>();
+		genesys->getTraceManager()->setTraceLevel(TraceManager::Level::L0_noTraces);
+		model = genesys->getModelManager()->newModel();
+	}
+
+	CellularAutomataComp* CreateComponent() {
+		return new CellularAutomataComp(model);
+	}
+
+	std::unique_ptr<Simulator> genesys;
+	Model* model = nullptr;
+};
+
+void ConfigureRule90(CellularAutomataComp* cellularAutomata,
+		CellularAutomataComp::BoundaryType boundaryType = CellularAutomataComp::BoundaryType::FIXED,
+		CellularAutomataComp::StateSetType stateSetType = CellularAutomataComp::StateSetType::ENUMERATED) {
+	cellularAutomata->setCellularAutomataType(CellularAutomataComp::CellularAutomataType::CLASSIC);
+	cellularAutomata->setLatticeType(CellularAutomataComp::LatticeType::RETICULAR);
+	cellularAutomata->getlattice()->setDimensions({7});
+	cellularAutomata->setNeighboorhoodType(CellularAutomataComp::NeighboorhoodType::CENTERED);
+	cellularAutomata->getNeighboorhood()->setRadius(1);
+	cellularAutomata->setBoundaryType(boundaryType);
+	cellularAutomata->setStateSetType(stateSetType);
+	cellularAutomata->setElementaryRuleNumber(90);
+	cellularAutomata->setLocalRuleType(CellularAutomataComp::LocalRuleType::ELEMENTAR_CA);
+}
+
+void ConfigureGameOfLife(CellularAutomataComp* cellularAutomata,
+		CellularAutomataComp::NeighboorhoodType neighborhoodType = CellularAutomataComp::NeighboorhoodType::MOORE,
+		CellularAutomataComp::StateSetType stateSetType = CellularAutomataComp::StateSetType::ENUMERATED) {
+	cellularAutomata->setCellularAutomataType(CellularAutomataComp::CellularAutomataType::CLASSIC);
+	cellularAutomata->setLatticeType(CellularAutomataComp::LatticeType::RETICULAR);
+	cellularAutomata->getlattice()->setDimensions({5, 5});
+	cellularAutomata->setNeighboorhoodType(neighborhoodType);
+	cellularAutomata->getNeighboorhood()->setRadius(1);
+	cellularAutomata->setBoundaryType(CellularAutomataComp::BoundaryType::FIXED);
+	cellularAutomata->setStateSetType(stateSetType);
+	cellularAutomata->setLocalRuleType(CellularAutomataComp::LocalRuleType::GAME_OF_LIFE);
+}
+
+void ConfigureGenericAutomata(CellularAutomataComp* cellularAutomata,
+		const std::vector<unsigned short>& dimensions,
+		CellularAutomataComp::NeighboorhoodType neighborhoodType,
+		CellularAutomataComp::StateSetType stateSetType = CellularAutomataComp::StateSetType::ENUMERATED) {
+	cellularAutomata->setCellularAutomataType(CellularAutomataComp::CellularAutomataType::CLASSIC);
+	cellularAutomata->setLatticeType(CellularAutomataComp::LatticeType::RETICULAR);
+	cellularAutomata->getlattice()->setDimensions(dimensions);
+	cellularAutomata->setNeighboorhoodType(neighborhoodType);
+	cellularAutomata->getNeighboorhood()->setRadius(1);
+	cellularAutomata->setBoundaryType(CellularAutomataComp::BoundaryType::CLOSED);
+	cellularAutomata->setStateSetType(stateSetType);
+	cellularAutomata->setLocalRuleType(CellularAutomataComp::LocalRuleType::BIASED_COMPETITION);
+}
+
+void SetInitialPattern(CellularAutomataComp* cellularAutomata, const std::string& pattern) {
+	for (unsigned long cellNumber = 0; cellNumber < pattern.size(); ++cellNumber) {
+		const long value = pattern.at(cellNumber) == '1' ? 1 : 0;
+		ASSERT_TRUE(cellularAutomata->setCellState(static_cast<long>(cellNumber), value));
+	}
+}
+
+std::vector<std::string> RunRule90(CellularAutomataComp* cellularAutomata, unsigned int steps) {
+	std::string errorMessage;
+	EXPECT_TRUE(cellularAutomata->initializeCellularAutomata(&errorMessage)) << errorMessage;
+	SetInitialPattern(cellularAutomata, "1001000");
+
+	std::vector<std::string> states;
+	states.emplace_back(cellularAutomata->showCellularAutomata());
+	for (unsigned int step = 0; step < steps; ++step) {
+		cellularAutomata->stepCellularAutomata();
+		states.emplace_back(cellularAutomata->showCellularAutomata());
+	}
+	return states;
+}
+
+std::string Grid(CellularAutomataComp* cellularAutomata, unsigned short width, unsigned short height) {
+	std::string grid;
+	for (unsigned short y = 0; y < height; ++y) {
+		for (unsigned short x = 0; x < width; ++x)
+			grid += std::to_string(cellularAutomata->getlattice()->getCell({static_cast<int>(x), static_cast<int>(y)})->getCurrentState().getValue());
+		if (y + 1 < height)
+			grid += "\n";
+	}
+	return grid;
+}
+
+void SetBlinker(CellularAutomataComp* cellularAutomata) {
+	ASSERT_TRUE(cellularAutomata->setCellState({2, 1}, 1));
+	ASSERT_TRUE(cellularAutomata->setCellState({2, 2}, 1));
+	ASSERT_TRUE(cellularAutomata->setCellState({2, 3}, 1));
+}
+
+unsigned long NeighborCount(CellularAutomataComp* cellularAutomata, const std::vector<int>& position) {
+	const long cellNumber = cellularAutomata->getlattice()->cellNDimPosition2Number(position);
+	return cellularAutomata->getlattice()->getCell(cellNumber)->getNeighbors().size();
+}
+
+}
+
+TEST_F(CellularAutomataFixture, IntegerStateSetRejectsDoubleValues) {
+	CellularAutomataComp* cellularAutomata = CreateComponent();
+	ConfigureGenericAutomata(cellularAutomata, {3}, CellularAutomataComp::NeighboorhoodType::VONNEUMANN, CellularAutomataComp::StateSetType::INTEGERBASED);
+
+	std::string errorMessage;
+	ASSERT_TRUE(cellularAutomata->initializeCellularAutomata(&errorMessage)) << errorMessage;
+
+	EXPECT_TRUE(cellularAutomata->setCellState(0L, 1.0));
+	EXPECT_FALSE(cellularAutomata->setCellState(0L, 1.5));
+}
+
+TEST_F(CellularAutomataFixture, BitStateSetRejectsNonBitValues) {
+	CellularAutomataComp* cellularAutomata = CreateComponent();
+	ConfigureRule90(cellularAutomata, CellularAutomataComp::BoundaryType::FIXED, CellularAutomataComp::StateSetType::BITBASED);
+
+	std::string errorMessage;
+	ASSERT_TRUE(cellularAutomata->initializeCellularAutomata(&errorMessage)) << errorMessage;
+
+	EXPECT_TRUE(cellularAutomata->setCellState(0L, 0.0));
+	EXPECT_TRUE(cellularAutomata->setCellState(0L, 1.0));
+	EXPECT_FALSE(cellularAutomata->setCellState(0L, 0.5));
+	EXPECT_FALSE(cellularAutomata->setCellState(0L, 2.0));
+}
+
+TEST_F(CellularAutomataFixture, DoubleStateSetAcceptsFractionalValues) {
+	CellularAutomataComp* cellularAutomata = CreateComponent();
+	ConfigureGenericAutomata(cellularAutomata, {3}, CellularAutomataComp::NeighboorhoodType::VONNEUMANN, CellularAutomataComp::StateSetType::DOUBLEBASED);
+
+	std::string errorMessage;
+	ASSERT_TRUE(cellularAutomata->initializeCellularAutomata(&errorMessage)) << errorMessage;
+
+	ASSERT_TRUE(cellularAutomata->setCellState(0L, 1.5));
+	EXPECT_DOUBLE_EQ(cellularAutomata->getlattice()->getCell(0L)->getCurrentState().getDoubleValue(), 1.5);
+}
+
+TEST_F(CellularAutomataFixture, Rule90FixedBoundaryMatchesExpectedSequence) {
+	CellularAutomataComp* cellularAutomata = CreateComponent();
+	ConfigureRule90(cellularAutomata);
+
+	const std::vector<std::string> states = RunRule90(cellularAutomata, 6);
+
+	EXPECT_EQ(states, (std::vector<std::string>{
+			"1001000",
+			"0110100",
+			"1110010",
+			"1011101",
+			"0010100",
+			"0100010",
+			"1010101"}));
+}
+
+TEST_F(CellularAutomataFixture, Rule90BoundaryConditionsHaveExpectedFinalStates) {
+	CellularAutomataComp* closed = CreateComponent();
+	ConfigureRule90(closed, CellularAutomataComp::BoundaryType::CLOSED);
+	EXPECT_EQ(RunRule90(closed, 6).back(), "0000101");
+
+	CellularAutomataComp* reflexive = CreateComponent();
+	ConfigureRule90(reflexive, CellularAutomataComp::BoundaryType::REFLEXIVE);
+	EXPECT_EQ(RunRule90(reflexive, 6).back(), "0110010");
+
+	CellularAutomataComp* adiabatic = CreateComponent();
+	ConfigureRule90(adiabatic, CellularAutomataComp::BoundaryType::ADIABATIC);
+	EXPECT_EQ(RunRule90(adiabatic, 6).back(), "0000101");
+}
+
+TEST_F(CellularAutomataFixture, Rule90AcceptsBitStateSet) {
+	CellularAutomataComp* cellularAutomata = CreateComponent();
+	ConfigureRule90(cellularAutomata, CellularAutomataComp::BoundaryType::FIXED, CellularAutomataComp::StateSetType::BITBASED);
+
+	const std::vector<std::string> states = RunRule90(cellularAutomata, 1);
+
+	EXPECT_EQ(states.at(1), "0110100");
+}
+
+TEST_F(CellularAutomataFixture, GameOfLifeBlinkerOscillates) {
+	CellularAutomataComp* cellularAutomata = CreateComponent();
+	ConfigureGameOfLife(cellularAutomata);
+
+	std::string errorMessage;
+	ASSERT_TRUE(cellularAutomata->initializeCellularAutomata(&errorMessage)) << errorMessage;
+	SetBlinker(cellularAutomata);
+
+	EXPECT_EQ(Grid(cellularAutomata, 5, 5), "00000\n00100\n00100\n00100\n00000");
+	cellularAutomata->stepCellularAutomata();
+	EXPECT_EQ(Grid(cellularAutomata, 5, 5), "00000\n00000\n01110\n00000\n00000");
+	cellularAutomata->stepCellularAutomata();
+	EXPECT_EQ(Grid(cellularAutomata, 5, 5), "00000\n00100\n00100\n00100\n00000");
+}
+
+TEST_F(CellularAutomataFixture, GameOfLifeRejectsInvalidConfigurations) {
+	CellularAutomataComp* vonNeumann = CreateComponent();
+	ConfigureGameOfLife(vonNeumann, CellularAutomataComp::NeighboorhoodType::VONNEUMANN);
+	std::string errorMessage;
+	EXPECT_FALSE(vonNeumann->initializeCellularAutomata(&errorMessage));
+
+	CellularAutomataComp* integerBased = CreateComponent();
+	ConfigureGameOfLife(integerBased, CellularAutomataComp::NeighboorhoodType::MOORE, CellularAutomataComp::StateSetType::INTEGERBASED);
+	errorMessage.clear();
+	EXPECT_FALSE(integerBased->initializeCellularAutomata(&errorMessage));
+}
+
+TEST_F(CellularAutomataFixture, NeighborhoodsHaveExpectedCountsInOneTwoAndThreeDimensions) {
+	CellularAutomataComp* moore1D = CreateComponent();
+	ConfigureGenericAutomata(moore1D, {3}, CellularAutomataComp::NeighboorhoodType::MOORE);
+	std::string errorMessage;
+	ASSERT_TRUE(moore1D->initializeCellularAutomata(&errorMessage)) << errorMessage;
+	EXPECT_EQ(NeighborCount(moore1D, {1}), 2u);
+
+	CellularAutomataComp* vonNeumann1D = CreateComponent();
+	ConfigureGenericAutomata(vonNeumann1D, {3}, CellularAutomataComp::NeighboorhoodType::VONNEUMANN);
+	errorMessage.clear();
+	ASSERT_TRUE(vonNeumann1D->initializeCellularAutomata(&errorMessage)) << errorMessage;
+	EXPECT_EQ(NeighborCount(vonNeumann1D, {1}), 2u);
+
+	CellularAutomataComp* moore2D = CreateComponent();
+	ConfigureGenericAutomata(moore2D, {3, 3}, CellularAutomataComp::NeighboorhoodType::MOORE);
+	errorMessage.clear();
+	ASSERT_TRUE(moore2D->initializeCellularAutomata(&errorMessage)) << errorMessage;
+	EXPECT_EQ(NeighborCount(moore2D, {1, 1}), 8u);
+
+	CellularAutomataComp* vonNeumann2D = CreateComponent();
+	ConfigureGenericAutomata(vonNeumann2D, {3, 3}, CellularAutomataComp::NeighboorhoodType::VONNEUMANN);
+	errorMessage.clear();
+	ASSERT_TRUE(vonNeumann2D->initializeCellularAutomata(&errorMessage)) << errorMessage;
+	EXPECT_EQ(NeighborCount(vonNeumann2D, {1, 1}), 4u);
+
+	CellularAutomataComp* moore3D = CreateComponent();
+	ConfigureGenericAutomata(moore3D, {3, 3, 3}, CellularAutomataComp::NeighboorhoodType::MOORE);
+	errorMessage.clear();
+	ASSERT_TRUE(moore3D->initializeCellularAutomata(&errorMessage)) << errorMessage;
+	EXPECT_EQ(NeighborCount(moore3D, {1, 1, 1}), 26u);
+
+	CellularAutomataComp* vonNeumann3D = CreateComponent();
+	ConfigureGenericAutomata(vonNeumann3D, {3, 3, 3}, CellularAutomataComp::NeighboorhoodType::VONNEUMANN);
+	errorMessage.clear();
+	ASSERT_TRUE(vonNeumann3D->initializeCellularAutomata(&errorMessage)) << errorMessage;
+	EXPECT_EQ(NeighborCount(vonNeumann3D, {1, 1, 1}), 6u);
+}
+
+TEST_F(CellularAutomataFixture, ThreeDimensionalLatticeRejectsInvalidCoordinates) {
+	CellularAutomataComp* cellularAutomata = CreateComponent();
+	ConfigureGenericAutomata(cellularAutomata, {3, 3, 3}, CellularAutomataComp::NeighboorhoodType::VONNEUMANN);
+
+	std::string errorMessage;
+	ASSERT_TRUE(cellularAutomata->initializeCellularAutomata(&errorMessage)) << errorMessage;
+
+	EXPECT_FALSE(cellularAutomata->setCellState({-1, 0, 0}, 1));
+}
+
+TEST_F(CellularAutomataFixture, UpdatePoliciesProduceDeterministicSequences) {
+	CellularAutomataComp* synchronous = CreateComponent();
+	ConfigureRule90(synchronous);
+	synchronous->setUpdatePolicyType(CellularAutomataComp::UpdatePolicyType::SYNCHRONOUS);
+	EXPECT_EQ(RunRule90(synchronous, 4).back(), "0010100");
+
+	CellularAutomataComp* sequential = CreateComponent();
+	ConfigureRule90(sequential);
+	sequential->setUpdatePolicyType(CellularAutomataComp::UpdatePolicyType::SEQUENTIAL);
+	EXPECT_EQ(RunRule90(sequential, 4).back(), "1110000");
+
+	CellularAutomataComp* random = CreateComponent();
+	ConfigureRule90(random);
+	random->setUpdatePolicyType(CellularAutomataComp::UpdatePolicyType::RANDOM);
+	random->setRandomSeed(7);
+	const std::string randomFirstRun = RunRule90(random, 4).back();
+	// RANDOM consumes the engine via std::uniform_int_distribution, whose value mapping is
+	// implementation-defined (libstdc++ vs libc++); a hardcoded golden is not portable.
+	// Assert what the test name promises: the same seed reproduces the same sequence.
+	CellularAutomataComp* randomAgain = CreateComponent();
+	ConfigureRule90(randomAgain);
+	randomAgain->setUpdatePolicyType(CellularAutomataComp::UpdatePolicyType::RANDOM);
+	randomAgain->setRandomSeed(7);
+	EXPECT_EQ(RunRule90(randomAgain, 4).back(), randomFirstRun);
+
+	CellularAutomataComp* blocks = CreateComponent();
+	ConfigureRule90(blocks);
+	blocks->setUpdatePolicyType(CellularAutomataComp::UpdatePolicyType::BLOCKS);
+	blocks->setUpdateBlockSize(2);
+	EXPECT_EQ(RunRule90(blocks, 4).back(), "1111100");
+}

--- a/source/tests/unit/test_cellular_automata.cpp
+++ b/source/tests/unit/test_cellular_automata.cpp
@@ -113,6 +113,8 @@ unsigned long NeighborCount(CellularAutomataComp* cellularAutomata, const std::v
 
 }
 
+// IntegerStateSetRejectsDoubleValues — the INTEGERBASED state set must accept whole numbers but reject
+// fractions. Configures a 1D INTEGERBASED automaton, then asserts setCellState accepts 1.0 and rejects 1.5.
 TEST_F(CellularAutomataFixture, IntegerStateSetRejectsDoubleValues) {
 	CellularAutomataComp* cellularAutomata = CreateComponent();
 	ConfigureGenericAutomata(cellularAutomata, {3}, CellularAutomataComp::NeighboorhoodType::VONNEUMANN, CellularAutomataComp::StateSetType::INTEGERBASED);
@@ -124,6 +126,8 @@ TEST_F(CellularAutomataFixture, IntegerStateSetRejectsDoubleValues) {
 	EXPECT_FALSE(cellularAutomata->setCellState(0L, 1.5));
 }
 
+// BitStateSetRejectsNonBitValues — the BITBASED state set may only hold 0 or 1. Asserts setCellState
+// accepts 0.0 and 1.0 but rejects in-between (0.5) and out-of-range (2.0) values.
 TEST_F(CellularAutomataFixture, BitStateSetRejectsNonBitValues) {
 	CellularAutomataComp* cellularAutomata = CreateComponent();
 	ConfigureRule90(cellularAutomata, CellularAutomataComp::BoundaryType::FIXED, CellularAutomataComp::StateSetType::BITBASED);
@@ -137,6 +141,8 @@ TEST_F(CellularAutomataFixture, BitStateSetRejectsNonBitValues) {
 	EXPECT_FALSE(cellularAutomata->setCellState(0L, 2.0));
 }
 
+// DoubleStateSetAcceptsFractionalValues — the DOUBLEBASED state set must store real numbers. Sets a cell
+// to 1.5 and reads it back unchanged, proving fractional state is preserved (not truncated/rejected).
 TEST_F(CellularAutomataFixture, DoubleStateSetAcceptsFractionalValues) {
 	CellularAutomataComp* cellularAutomata = CreateComponent();
 	ConfigureGenericAutomata(cellularAutomata, {3}, CellularAutomataComp::NeighboorhoodType::VONNEUMANN, CellularAutomataComp::StateSetType::DOUBLEBASED);
@@ -148,6 +154,8 @@ TEST_F(CellularAutomataFixture, DoubleStateSetAcceptsFractionalValues) {
 	EXPECT_DOUBLE_EQ(cellularAutomata->getlattice()->getCell(0L)->getCurrentState().getDoubleValue(), 1.5);
 }
 
+// Rule90FixedBoundaryMatchesExpectedSequence — end-to-end run of elementary Rule 90 on a 7-cell lattice
+// with a fixed-0 boundary. Starts from "1001000" and asserts the full 6-step space-time history cell by cell.
 TEST_F(CellularAutomataFixture, Rule90FixedBoundaryMatchesExpectedSequence) {
 	CellularAutomataComp* cellularAutomata = CreateComponent();
 	ConfigureRule90(cellularAutomata);
@@ -164,6 +172,9 @@ TEST_F(CellularAutomataFixture, Rule90FixedBoundaryMatchesExpectedSequence) {
 			"1010101"}));
 }
 
+// Rule90BoundaryConditionsHaveExpectedFinalStates — same Rule 90 run under each non-fixed boundary
+// (CLOSED, REFLEXIVE, ADIABATIC). Asserts the final row after 6 steps differs per boundary as expected,
+// proving the boundary policy actually changes how edge cells see their missing neighbors.
 TEST_F(CellularAutomataFixture, Rule90BoundaryConditionsHaveExpectedFinalStates) {
 	CellularAutomataComp* closed = CreateComponent();
 	ConfigureRule90(closed, CellularAutomataComp::BoundaryType::CLOSED);
@@ -178,6 +189,8 @@ TEST_F(CellularAutomataFixture, Rule90BoundaryConditionsHaveExpectedFinalStates)
 	EXPECT_EQ(RunRule90(adiabatic, 6).back(), "0000101");
 }
 
+// Rule90AcceptsBitStateSet — Rule 90 must run unchanged when states are stored as BITBASED instead of
+// ENUMERATED. Runs one step and checks the resulting row, proving the rule is state-set agnostic.
 TEST_F(CellularAutomataFixture, Rule90AcceptsBitStateSet) {
 	CellularAutomataComp* cellularAutomata = CreateComponent();
 	ConfigureRule90(cellularAutomata, CellularAutomataComp::BoundaryType::FIXED, CellularAutomataComp::StateSetType::BITBASED);
@@ -187,6 +200,8 @@ TEST_F(CellularAutomataFixture, Rule90AcceptsBitStateSet) {
 	EXPECT_EQ(states.at(1), "0110100");
 }
 
+// GameOfLifeBlinkerOscillates — the built-in Game of Life rule on a 5x5 Moore lattice. Seeds a vertical
+// 3-cell blinker and asserts it flips vertical->horizontal->vertical, i.e. oscillates with period 2.
 TEST_F(CellularAutomataFixture, GameOfLifeBlinkerOscillates) {
 	CellularAutomataComp* cellularAutomata = CreateComponent();
 	ConfigureGameOfLife(cellularAutomata);
@@ -202,6 +217,9 @@ TEST_F(CellularAutomataFixture, GameOfLifeBlinkerOscillates) {
 	EXPECT_EQ(Grid(cellularAutomata, 5, 5), "00000\n00100\n00100\n00100\n00000");
 }
 
+// GameOfLifeRejectsInvalidConfigurations — Game of Life is only defined for a Moore neighborhood over a
+// binary (ENUMERATED) state set. Asserts initialize fails when given a VonNeumann neighborhood or an
+// INTEGERBASED state set, so misconfigurations are caught up front instead of producing wrong results.
 TEST_F(CellularAutomataFixture, GameOfLifeRejectsInvalidConfigurations) {
 	CellularAutomataComp* vonNeumann = CreateComponent();
 	ConfigureGameOfLife(vonNeumann, CellularAutomataComp::NeighboorhoodType::VONNEUMANN);
@@ -214,6 +232,9 @@ TEST_F(CellularAutomataFixture, GameOfLifeRejectsInvalidConfigurations) {
 	EXPECT_FALSE(integerBased->initializeCellularAutomata(&errorMessage));
 }
 
+// NeighborhoodsHaveExpectedCountsInOneTwoAndThreeDimensions — sanity-checks neighbor counts for a center
+// cell across dimensions: Moore gives 2/8/26 and VonNeumann gives 2/4/6 in 1D/2D/3D respectively. Confirms
+// both neighborhood generators scale correctly with lattice dimensionality.
 TEST_F(CellularAutomataFixture, NeighborhoodsHaveExpectedCountsInOneTwoAndThreeDimensions) {
 	CellularAutomataComp* moore1D = CreateComponent();
 	ConfigureGenericAutomata(moore1D, {3}, CellularAutomataComp::NeighboorhoodType::MOORE);
@@ -252,6 +273,8 @@ TEST_F(CellularAutomataFixture, NeighborhoodsHaveExpectedCountsInOneTwoAndThreeD
 	EXPECT_EQ(NeighborCount(vonNeumann3D, {1, 1, 1}), 6u);
 }
 
+// ThreeDimensionalLatticeRejectsInvalidCoordinates — bounds checking on a 3D lattice. Asserts setCellState
+// returns false for an out-of-range coordinate ({-1,0,0}), so bad positions are rejected, not silently wrapped.
 TEST_F(CellularAutomataFixture, ThreeDimensionalLatticeRejectsInvalidCoordinates) {
 	CellularAutomataComp* cellularAutomata = CreateComponent();
 	ConfigureGenericAutomata(cellularAutomata, {3, 3, 3}, CellularAutomataComp::NeighboorhoodType::VONNEUMANN);
@@ -262,6 +285,10 @@ TEST_F(CellularAutomataFixture, ThreeDimensionalLatticeRejectsInvalidCoordinates
 	EXPECT_FALSE(cellularAutomata->setCellState({-1, 0, 0}, 1));
 }
 
+// UpdatePoliciesProduceDeterministicSequences — each update policy (SYNCHRONOUS, SEQUENTIAL, RANDOM,
+// BLOCKS) drives the same Rule 90 and must give a deterministic result. SYNC/SEQUENTIAL/BLOCKS are pinned
+// to golden final rows; RANDOM is only asserted reproducible under a fixed seed (its exact mapping is
+// std-library dependent, so no hardcoded golden — same seed must reproduce the same run).
 TEST_F(CellularAutomataFixture, UpdatePoliciesProduceDeterministicSequences) {
 	CellularAutomataComp* synchronous = CreateComponent();
 	ConfigureRule90(synchronous);

--- a/source/tests/unit/test_cellular_automata_component.cpp
+++ b/source/tests/unit/test_cellular_automata_component.cpp
@@ -11,6 +11,8 @@
 #include "kernel/simulator/Persistence.h"
 
 #include <string>
+#include <utility>
+#include <vector>
 
 namespace {
 
@@ -49,6 +51,16 @@ void configureValidUserDefined(ComponentProbe& comp, const std::string& ruleSour
 }
 
 const std::string kRule90 = LocalRule_UserDefined::wrapBody("return neighbors[0] ^ neighbors[1];");
+
+void configureGenericSpecialLattice(ComponentProbe& comp, CellularAutomataComp::LatticeType latticeType,
+		const std::vector<unsigned short>& dimensions) {
+	comp.setCellularAutomataType(CellularAutomataComp::CellularAutomataType::CLASSIC);
+	comp.setLatticeType(latticeType);
+	comp.getlattice()->setDimensions(dimensions);
+	comp.setBoundaryType(CellularAutomataComp::BoundaryType::FIXED);
+	comp.setStateSetType(CellularAutomataComp::StateSetType::ENUMERATED);
+	comp.setLocalRuleType(CellularAutomataComp::LocalRuleType::BIASED_COMPETITION);
+}
 
 } // namespace
 
@@ -132,4 +144,95 @@ TEST(CellularAutomataComponent, PersistenceRoundTripPreservesConfiguration) {
 	// The reloaded configuration must still pass the semantic check (rebuilds and recompiles the rule).
 	std::string error;
 	EXPECT_TRUE(loaded.CheckProbe(&error)) << error;
+}
+
+TEST(CellularAutomataComponent, CheckAcceptsTriangularAndHexagonalLattices) {
+	Simulator simulator;
+	Model* model = simulator.getModelManager()->newModel();
+
+	ComponentProbe triangular(model, "CA_Triangular");
+	configureGenericSpecialLattice(triangular, CellularAutomataComp::LatticeType::TRIANGULAR, {3, 3});
+	std::string error;
+	ASSERT_TRUE(triangular.initializeCellularAutomata(&error)) << error;
+	EXPECT_EQ(triangular.getlattice()->getCell({1, 1})->getNeighbors().size(), 3u);
+
+	ComponentProbe hexagonal(model, "CA_Hexagonal");
+	configureGenericSpecialLattice(hexagonal, CellularAutomataComp::LatticeType::HEXAGONAL, {3, 3});
+	error.clear();
+	ASSERT_TRUE(hexagonal.initializeCellularAutomata(&error)) << error;
+	EXPECT_EQ(hexagonal.getlattice()->getCell({1, 1})->getNeighbors().size(), 6u);
+}
+
+TEST(CellularAutomataComponent, CheckRejectsInvalidSpecialLattices) {
+	Simulator simulator;
+	Model* model = simulator.getModelManager()->newModel();
+
+	ComponentProbe triangular3d(model, "CA_Triangular3D");
+	configureGenericSpecialLattice(triangular3d, CellularAutomataComp::LatticeType::TRIANGULAR, {3, 3, 3});
+	std::string error;
+	EXPECT_FALSE(triangular3d.CheckProbe(&error));
+	EXPECT_NE(error.find("exactly two dimensions"), std::string::npos) << error;
+
+	ComponentProbe hexRadius2(model, "CA_HexRadius2");
+	configureGenericSpecialLattice(hexRadius2, CellularAutomataComp::LatticeType::HEXAGONAL, {3, 3});
+	hexRadius2.getNeighboorhood()->setRadius(2);
+	error.clear();
+	EXPECT_FALSE(hexRadius2.CheckProbe(&error));
+	EXPECT_NE(error.find("radius-1"), std::string::npos) << error;
+}
+
+TEST(CellularAutomataComponent, CheckAcceptsNetworkLatticeWithEdges) {
+	Simulator simulator;
+	Model* model = simulator.getModelManager()->newModel();
+
+	ComponentProbe network(model, "CA_Network");
+	configureGenericSpecialLattice(network, CellularAutomataComp::LatticeType::NETWORK, {4});
+	network.setNetworkEdges({{0, 1}, {0, 2}, {2, 3}});
+	std::string error;
+	ASSERT_TRUE(network.initializeCellularAutomata(&error)) << error;
+	EXPECT_EQ(network.getlattice()->getCell(0L)->getNeighbors().size(), 2u);
+	EXPECT_EQ(network.getlattice()->getCell(1L)->getNeighbors().size(), 1u);
+}
+
+TEST(CellularAutomataComponent, CheckRejectsNetworkWithoutOrWithInvalidEdges) {
+	Simulator simulator;
+	Model* model = simulator.getModelManager()->newModel();
+
+	ComponentProbe noEdges(model, "CA_NetworkNoEdges");
+	configureGenericSpecialLattice(noEdges, CellularAutomataComp::LatticeType::NETWORK, {4});
+	std::string error;
+	EXPECT_FALSE(noEdges.CheckProbe(&error));
+	EXPECT_NE(error.find("at least one edge"), std::string::npos) << error;
+
+	ComponentProbe invalidEdges(model, "CA_NetworkInvalidEdges");
+	configureGenericSpecialLattice(invalidEdges, CellularAutomataComp::LatticeType::NETWORK, {4});
+	invalidEdges.setNetworkEdges({{0, 4}});
+	error.clear();
+	EXPECT_FALSE(invalidEdges.CheckProbe(&error));
+	EXPECT_NE(error.find("existing cells"), std::string::npos) << error;
+}
+
+TEST(CellularAutomataComponent, PersistenceRoundTripPreservesNetworkEdges) {
+	Simulator simulator;
+	Model* model = simulator.getModelManager()->newModel();
+
+	ComponentProbe saved(model, "CA_NetworkSaved");
+	configureGenericSpecialLattice(saved, CellularAutomataComp::LatticeType::NETWORK, {4});
+	saved.setNetworkEdges({{0, 1}, {0, 2}, {2, 3}}, false);
+
+	FakePersistence persistence;
+	PersistenceRecord fields(persistence);
+	saved.SaveProbe(&fields, true);
+
+	ComponentProbe loaded(model, "CA_NetworkLoaded");
+	ASSERT_TRUE(loaded.LoadProbe(&fields));
+
+	EXPECT_EQ(loaded.getLatticeType(), CellularAutomataComp::LatticeType::NETWORK);
+	EXPECT_EQ(loaded.getNetworkEdges(), (std::vector<std::pair<unsigned long, unsigned long>>{{0, 1}, {0, 2}, {2, 3}}));
+	EXPECT_FALSE(loaded.getNetworkEdgesUndirected());
+
+	std::string error;
+	ASSERT_TRUE(loaded.initializeCellularAutomata(&error)) << error;
+	EXPECT_EQ(loaded.getlattice()->getCell(0L)->getNeighbors().size(), 2u);
+	EXPECT_EQ(loaded.getlattice()->getCell(1L)->getNeighbors().size(), 0u);
 }

--- a/source/tests/unit/test_cellular_automata_component.cpp
+++ b/source/tests/unit/test_cellular_automata_component.cpp
@@ -64,6 +64,9 @@ void configureGenericSpecialLattice(ComponentProbe& comp, CellularAutomataComp::
 
 } // namespace
 
+// CheckPassesAndBuildsUserDefinedRule — happy path for a USERDEFINED rule. Configures a valid 1D component
+// with a Rule-90 source, runs _check, and asserts the component installs a LocalRule_UserDefined that is
+// compiled and ready (isReady), proving check both validates and builds the runtime rule.
 TEST(CellularAutomataComponent, CheckPassesAndBuildsUserDefinedRule) {
 	Simulator simulator;
 	Model* model = simulator.getModelManager()->newModel();
@@ -78,6 +81,8 @@ TEST(CellularAutomataComponent, CheckPassesAndBuildsUserDefinedRule) {
 	EXPECT_TRUE(rule->isReady()) << "the user rule should be compiled and loaded after check";
 }
 
+// CheckRejectsUserDefinedWithoutSource — a USERDEFINED rule with empty source must fail _check with a clear
+// "requires source code" message, not crash or silently pass.
 TEST(CellularAutomataComponent, CheckRejectsUserDefinedWithoutSource) {
 	Simulator simulator;
 	Model* model = simulator.getModelManager()->newModel();
@@ -89,6 +94,8 @@ TEST(CellularAutomataComponent, CheckRejectsUserDefinedWithoutSource) {
 	EXPECT_NE(error.find("requires source code"), std::string::npos) << error;
 }
 
+// CheckRejectsUserDefinedWithBadSource — source that does not compile must fail _check with a "failed to
+// compile" message. Confirms a compiler error in user code surfaces gracefully instead of crashing.
 TEST(CellularAutomataComponent, CheckRejectsUserDefinedWithBadSource) {
 	Simulator simulator;
 	Model* model = simulator.getModelManager()->newModel();
@@ -100,6 +107,8 @@ TEST(CellularAutomataComponent, CheckRejectsUserDefinedWithBadSource) {
 	EXPECT_NE(error.find("failed to compile"), std::string::npos) << error;
 }
 
+// CheckRejectsMissingCellularAutomataType — a component left entirely unconfigured (null automaton) must
+// fail _check with a non-empty error, guarding against running an uninitialized component.
 TEST(CellularAutomataComponent, CheckRejectsMissingCellularAutomataType) {
 	Simulator simulator;
 	Model* model = simulator.getModelManager()->newModel();
@@ -110,6 +119,9 @@ TEST(CellularAutomataComponent, CheckRejectsMissingCellularAutomataType) {
 	EXPECT_FALSE(error.empty());
 }
 
+// PersistenceRoundTripPreservesConfiguration — saves a fully configured component (including non-default
+// update policy, block size and seed) into a PersistenceRecord, loads it into a fresh component, and
+// asserts every field round-trips and the reloaded component still passes _check (recompiling its rule).
 TEST(CellularAutomataComponent, PersistenceRoundTripPreservesConfiguration) {
 	Simulator simulator;
 	Model* model = simulator.getModelManager()->newModel();
@@ -146,6 +158,8 @@ TEST(CellularAutomataComponent, PersistenceRoundTripPreservesConfiguration) {
 	EXPECT_TRUE(loaded.CheckProbe(&error)) << error;
 }
 
+// CheckAcceptsTriangularAndHexagonalLattices — initializes 2D Triangular and Hexagonal lattices and asserts
+// an interior cell has 3 and 6 neighbors respectively, proving the special (non-rectangular) lattices build.
 TEST(CellularAutomataComponent, CheckAcceptsTriangularAndHexagonalLattices) {
 	Simulator simulator;
 	Model* model = simulator.getModelManager()->newModel();
@@ -163,6 +177,9 @@ TEST(CellularAutomataComponent, CheckAcceptsTriangularAndHexagonalLattices) {
 	EXPECT_EQ(hexagonal.getlattice()->getCell({1, 1})->getNeighbors().size(), 6u);
 }
 
+// CheckRejectsInvalidSpecialLattices — the special lattices have constraints: Triangular is 2D-only and
+// Hexagonal supports only radius 1. Asserts _check rejects a 3D triangular ("exactly two dimensions") and a
+// radius-2 hexagonal ("radius-1") with the matching error messages.
 TEST(CellularAutomataComponent, CheckRejectsInvalidSpecialLattices) {
 	Simulator simulator;
 	Model* model = simulator.getModelManager()->newModel();
@@ -181,6 +198,8 @@ TEST(CellularAutomataComponent, CheckRejectsInvalidSpecialLattices) {
 	EXPECT_NE(error.find("radius-1"), std::string::npos) << error;
 }
 
+// CheckAcceptsNetworkLatticeWithEdges — a NETWORK lattice configured with explicit edges initializes, and
+// each node's neighbor count matches its degree in the edge list (node 0 has 2, node 1 has 1).
 TEST(CellularAutomataComponent, CheckAcceptsNetworkLatticeWithEdges) {
 	Simulator simulator;
 	Model* model = simulator.getModelManager()->newModel();
@@ -194,6 +213,9 @@ TEST(CellularAutomataComponent, CheckAcceptsNetworkLatticeWithEdges) {
 	EXPECT_EQ(network.getlattice()->getCell(1L)->getNeighbors().size(), 1u);
 }
 
+// CheckRejectsNetworkWithoutOrWithInvalidEdges — a NETWORK lattice needs valid edges. Asserts _check fails
+// with "at least one edge" when none are set, and with "existing cells" when an edge points to a
+// non-existent node (0->4 on a 4-cell lattice).
 TEST(CellularAutomataComponent, CheckRejectsNetworkWithoutOrWithInvalidEdges) {
 	Simulator simulator;
 	Model* model = simulator.getModelManager()->newModel();
@@ -212,6 +234,9 @@ TEST(CellularAutomataComponent, CheckRejectsNetworkWithoutOrWithInvalidEdges) {
 	EXPECT_NE(error.find("existing cells"), std::string::npos) << error;
 }
 
+// PersistenceRoundTripPreservesNetworkEdges — saves a NETWORK component with directed edges, reloads it,
+// and asserts the edge list and its directed flag survive, and that the reloaded lattice rebuilds the same
+// one-way adjacency (node 0 has 2 neighbors, node 1 has 0).
 TEST(CellularAutomataComponent, PersistenceRoundTripPreservesNetworkEdges) {
 	Simulator simulator;
 	Model* model = simulator.getModelManager()->newModel();

--- a/source/tests/unit/test_cellular_automata_component.cpp
+++ b/source/tests/unit/test_cellular_automata_component.cpp
@@ -1,0 +1,135 @@
+// Integration of the user-defined local rule into the GenESyS component CellularAutomataComp:
+// verifies semantic checking (_check) and persistence (_loadInstance/_saveInstance) of the whole
+// cellular-automaton configuration, including a USERDEFINED rule compiled at runtime.
+
+#include <gtest/gtest.h>
+
+#include "plugins/components/ModalModel/CellularAutomataComp.h"
+#include "plugins/components/ModalModel/CellularAutomata/LocalRule_UserDefined.h"
+
+#include "kernel/simulator/Simulator.h"
+#include "kernel/simulator/Persistence.h"
+
+#include <string>
+
+namespace {
+
+// Minimal ModelPersistence_if so a PersistenceRecord can store/replay fields in a unit test.
+class FakePersistence : public ModelPersistence_if {
+public:
+	bool save(std::string) override { return false; }
+	bool load(std::string) override { return false; }
+	bool hasChanged() override { return false; }
+	void setHasChanged(bool) override {}
+	bool getOption(ModelPersistence_if::Options) override { return false; }
+	void setOption(ModelPersistence_if::Options, bool) override {}
+	std::string getFormatedField(PersistenceRecord*) override { return ""; }
+};
+
+// Exposes the protected lifecycle hooks for testing.
+class ComponentProbe : public CellularAutomataComp {
+public:
+	ComponentProbe(Model* model, const std::string& name) : CellularAutomataComp(model, name) {}
+	bool CheckProbe(std::string* errorMessage) { return _check(errorMessage); }
+	void SaveProbe(PersistenceRecord* fields, bool saveDefaultValues = true) {
+		_saveInstance(fields, saveDefaultValues);
+	}
+	bool LoadProbe(PersistenceRecord* fields) { return _loadInstance(fields); }
+};
+
+void configureValidUserDefined(ComponentProbe& comp, const std::string& ruleSource) {
+	comp.setCellularAutomataType(CellularAutomataComp::CellularAutomataType::CLASSIC);
+	comp.setLatticeType(CellularAutomataComp::LatticeType::RETICULAR);
+	comp.getlattice()->setDimensions({9}); // 1D lattice: required by the (universal) semantic check for a CENTERED neighborhood
+	comp.setNeighboorhoodType(CellularAutomataComp::NeighboorhoodType::CENTERED);
+	comp.setBoundaryType(CellularAutomataComp::BoundaryType::FIXED);
+	comp.setStateSetType(CellularAutomataComp::StateSetType::ENUMERATED);
+	comp.setUserDefinedRuleSource(ruleSource);
+	comp.setLocalRuleType(CellularAutomataComp::LocalRuleType::USERDEFINED);
+}
+
+const std::string kRule90 = LocalRule_UserDefined::wrapBody("return neighbors[0] ^ neighbors[1];");
+
+} // namespace
+
+TEST(CellularAutomataComponent, CheckPassesAndBuildsUserDefinedRule) {
+	Simulator simulator;
+	Model* model = simulator.getModelManager()->newModel();
+	ComponentProbe comp(model, "CA_UserDefined");
+	configureValidUserDefined(comp, kRule90);
+
+	std::string error;
+	ASSERT_TRUE(comp.CheckProbe(&error)) << error;
+
+	LocalRule_UserDefined* rule = dynamic_cast<LocalRule_UserDefined*>(comp.getlocalRule());
+	ASSERT_NE(rule, nullptr) << "USERDEFINED check should install a LocalRule_UserDefined";
+	EXPECT_TRUE(rule->isReady()) << "the user rule should be compiled and loaded after check";
+}
+
+TEST(CellularAutomataComponent, CheckRejectsUserDefinedWithoutSource) {
+	Simulator simulator;
+	Model* model = simulator.getModelManager()->newModel();
+	ComponentProbe comp(model, "CA_NoSource");
+	configureValidUserDefined(comp, ""); // empty source
+
+	std::string error;
+	EXPECT_FALSE(comp.CheckProbe(&error));
+	EXPECT_NE(error.find("requires source code"), std::string::npos) << error;
+}
+
+TEST(CellularAutomataComponent, CheckRejectsUserDefinedWithBadSource) {
+	Simulator simulator;
+	Model* model = simulator.getModelManager()->newModel();
+	ComponentProbe comp(model, "CA_BadSource");
+	configureValidUserDefined(comp, "this is not valid c++ <<<");
+
+	std::string error;
+	EXPECT_FALSE(comp.CheckProbe(&error));
+	EXPECT_NE(error.find("failed to compile"), std::string::npos) << error;
+}
+
+TEST(CellularAutomataComponent, CheckRejectsMissingCellularAutomataType) {
+	Simulator simulator;
+	Model* model = simulator.getModelManager()->newModel();
+	ComponentProbe comp(model, "CA_Empty");
+	// Nothing configured: the cellular automata is null.
+	std::string error;
+	EXPECT_FALSE(comp.CheckProbe(&error));
+	EXPECT_FALSE(error.empty());
+}
+
+TEST(CellularAutomataComponent, PersistenceRoundTripPreservesConfiguration) {
+	Simulator simulator;
+	Model* model = simulator.getModelManager()->newModel();
+
+	ComponentProbe saved(model, "CA_Saved");
+	configureValidUserDefined(saved, kRule90);
+	// Non-default values for the universal update-policy fields, to prove they also round-trip.
+	saved.setUpdatePolicyType(CellularAutomataComp::UpdatePolicyType::BLOCKS);
+	saved.setUpdateBlockSize(3);
+	saved.setRandomSeed(42);
+
+	FakePersistence persistence;
+	PersistenceRecord fields(persistence);
+	saved.SaveProbe(&fields, true);
+
+	ComponentProbe loaded(model, "CA_Loaded");
+	ASSERT_TRUE(loaded.LoadProbe(&fields));
+
+	EXPECT_EQ(loaded.getCellularAutomataType(), CellularAutomataComp::CellularAutomataType::CLASSIC);
+	EXPECT_EQ(loaded.getLatticeType(), CellularAutomataComp::LatticeType::RETICULAR);
+	EXPECT_EQ(loaded.getNeighboorhoodType(), CellularAutomataComp::NeighboorhoodType::CENTERED);
+	EXPECT_EQ(loaded.geBoundaryType(), CellularAutomataComp::BoundaryType::FIXED);
+	EXPECT_EQ(loaded.getStateSetType(), CellularAutomataComp::StateSetType::ENUMERATED);
+	EXPECT_EQ(loaded.getlocalRuleType(), CellularAutomataComp::LocalRuleType::USERDEFINED);
+	EXPECT_EQ(loaded.getUserDefinedRuleSource(), kRule90);
+	ASSERT_NE(loaded.getlattice(), nullptr);
+	EXPECT_EQ(loaded.getlattice()->getDimensions(), (std::vector<unsigned short>{9})); // lattice dimensions round-trip
+	EXPECT_EQ(loaded.getUpdatePolicyType(), CellularAutomataComp::UpdatePolicyType::BLOCKS);
+	EXPECT_EQ(loaded.getUpdateBlockSize(), 3u);
+	EXPECT_EQ(loaded.getRandomSeed(), 42u);
+
+	// The reloaded configuration must still pass the semantic check (rebuilds and recompiles the rule).
+	std::string error;
+	EXPECT_TRUE(loaded.CheckProbe(&error)) << error;
+}

--- a/source/tests/unit/test_cellular_automata_elementary.cpp
+++ b/source/tests/unit/test_cellular_automata_elementary.cpp
@@ -64,6 +64,8 @@ std::vector<std::string> runElementary(unsigned short width, std::uint8_t ruleNu
 
 } // namespace
 
+// Rule30MatchesTextbookGroundTruth — runs elementary Rule 30 from a single central 1 on a width-9 lattice
+// and asserts rows t0..t3 equal the worked example from the textbook (Cap. 11), bit for bit.
 TEST(ElementaryCA, Rule30MatchesTextbookGroundTruth) {
 	const std::vector<std::string> rows = runElementary(9, 30, 3);
 	ASSERT_EQ(rows.size(), 4u);
@@ -73,6 +75,8 @@ TEST(ElementaryCA, Rule30MatchesTextbookGroundTruth) {
 	EXPECT_EQ(rows[3], "011011110");
 }
 
+// Rule90MatchesSierpinskiGroundTruth — runs Rule 90 (next = left XOR right) from a single central 1 on a
+// width-11 lattice and asserts rows t0..t4 match the Sierpinski-triangle ground truth exactly.
 TEST(ElementaryCA, Rule90MatchesSierpinskiGroundTruth) {
 	const std::vector<std::string> rows = runElementary(11, 90, 4);
 	ASSERT_EQ(rows.size(), 5u);
@@ -83,10 +87,14 @@ TEST(ElementaryCA, Rule90MatchesSierpinskiGroundTruth) {
 	EXPECT_EQ(rows[4], "01000000010");
 }
 
+// IsDeterministicAcrossRuns — two independent Rule 30 runs with identical setup must produce identical
+// histories, confirming the engine has no hidden nondeterminism (uninitialized state, ordering, etc.).
 TEST(ElementaryCA, IsDeterministicAcrossRuns) {
 	EXPECT_EQ(runElementary(11, 30, 6), runElementary(11, 30, 6));
 }
 
+// EmptyGridStaysEmptyUnderRule30 — degeneracy/quiescence check: with no live cell, Rule 30 (000 -> 0) must
+// leave the lattice all-zero after several steps, verifying the rule has the expected stable empty state.
 TEST(ElementaryCA, EmptyGridStaysEmptyUnderRule30) {
 	// Degeneracy test: with no live cell, rule 30 (000 -> 0) keeps the lattice all-zero.
 	CellularAutomata_Classic cellularAutomata;

--- a/source/tests/unit/test_cellular_automata_elementary.cpp
+++ b/source/tests/unit/test_cellular_automata_elementary.cpp
@@ -1,0 +1,109 @@
+// Verifies that the existing engine reproduces, bit-perfect, the textbook/Wolfram ground truth for
+// elementary (1D, binary, radius-1) cellular automata. This is the deterministic "comparison to
+// known analytical results / consistency" verification (book Cap. 11 §11.10.3 and Cap. 13).
+//
+// Ground truth:
+//   Rule 30 (00011110, next = left XOR (center OR right)), single central 1, fixed-0 boundary, width 9
+//     t0=000010000 t1=000111000 t2=001100100 t3=011011110   (book p.242 worked example)
+//   Rule 90 (01011010, next = left XOR right -> Sierpinski), single central 1, fixed-0 boundary, width 11
+//     t0=00000100000 t1=00001010000 t2=00010001000 t3=00101010100 t4=01000000010
+
+#include <gtest/gtest.h>
+
+#include "plugins/components/ModalModel/CellularAutomata/Boundary_Fixed.h"
+#include "plugins/components/ModalModel/CellularAutomata/CellularAutomata_Classic.h"
+#include "plugins/components/ModalModel/CellularAutomata/Lattice.h"
+#include "plugins/components/ModalModel/CellularAutomata/LocalRule_Elementary.h"
+#include "plugins/components/ModalModel/CellularAutomata/Neighborhood_Center.h"
+#include "plugins/components/ModalModel/CellularAutomata/State.h"
+#include "plugins/components/ModalModel/CellularAutomata/StateSet_Enumerable.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace {
+
+std::string rowOf(Lattice& lattice) {
+	std::string row;
+	for (unsigned long cellNumber = 0; cellNumber < lattice.getCellsSize(); ++cellNumber) {
+		row += std::to_string(lattice.getCell(static_cast<long>(cellNumber))->getCurrentState().getValue());
+	}
+	return row;
+}
+
+// Runs an elementary CA: 1D lattice of `width` cells, binary states, centered radius-1 neighborhood,
+// fixed-0 boundary, a single 1 at the center. Returns the space-time rows t0..t(steps).
+std::vector<std::string> runElementary(unsigned short width, std::uint8_t ruleNumber, unsigned int steps) {
+	CellularAutomata_Classic cellularAutomata;
+	Lattice lattice(&cellularAutomata, nullptr, {width}, LatticeType::RETICULAR);
+	State zero(0);
+	State one(1);
+	StateSet_Enumerable stateSet(&cellularAutomata, {&zero, &one});
+	Boundary_Fixed boundary(&lattice);
+	Neighborhood_Center neighborhood(&cellularAutomata, 1, &boundary);
+	LocalRule_Elementary rule(&cellularAutomata, ruleNumber, &stateSet);
+
+	cellularAutomata.setLattice(&lattice);
+	cellularAutomata.setStateSet(&stateSet);
+	cellularAutomata.setNeighborhood(&neighborhood);
+	cellularAutomata.setLocalRule(&rule);
+
+	lattice.init();
+	State centerOn(1);
+	lattice.setCellState(static_cast<long>(width / 2), &centerOn);
+
+	std::vector<std::string> rows;
+	rows.emplace_back(rowOf(lattice));
+	for (unsigned int t = 0; t < steps; ++t) {
+		cellularAutomata.step();
+		rows.emplace_back(rowOf(lattice));
+	}
+	return rows;
+}
+
+} // namespace
+
+TEST(ElementaryCA, Rule30MatchesTextbookGroundTruth) {
+	const std::vector<std::string> rows = runElementary(9, 30, 3);
+	ASSERT_EQ(rows.size(), 4u);
+	EXPECT_EQ(rows[0], "000010000");
+	EXPECT_EQ(rows[1], "000111000");
+	EXPECT_EQ(rows[2], "001100100");
+	EXPECT_EQ(rows[3], "011011110");
+}
+
+TEST(ElementaryCA, Rule90MatchesSierpinskiGroundTruth) {
+	const std::vector<std::string> rows = runElementary(11, 90, 4);
+	ASSERT_EQ(rows.size(), 5u);
+	EXPECT_EQ(rows[0], "00000100000");
+	EXPECT_EQ(rows[1], "00001010000");
+	EXPECT_EQ(rows[2], "00010001000");
+	EXPECT_EQ(rows[3], "00101010100");
+	EXPECT_EQ(rows[4], "01000000010");
+}
+
+TEST(ElementaryCA, IsDeterministicAcrossRuns) {
+	EXPECT_EQ(runElementary(11, 30, 6), runElementary(11, 30, 6));
+}
+
+TEST(ElementaryCA, EmptyGridStaysEmptyUnderRule30) {
+	// Degeneracy test: with no live cell, rule 30 (000 -> 0) keeps the lattice all-zero.
+	CellularAutomata_Classic cellularAutomata;
+	Lattice lattice(&cellularAutomata, nullptr, {9}, LatticeType::RETICULAR);
+	State zero(0);
+	State one(1);
+	StateSet_Enumerable stateSet(&cellularAutomata, {&zero, &one});
+	Boundary_Fixed boundary(&lattice);
+	Neighborhood_Center neighborhood(&cellularAutomata, 1, &boundary);
+	LocalRule_Elementary rule(&cellularAutomata, 30, &stateSet);
+	cellularAutomata.setLattice(&lattice);
+	cellularAutomata.setStateSet(&stateSet);
+	cellularAutomata.setNeighborhood(&neighborhood);
+	cellularAutomata.setLocalRule(&rule);
+	lattice.init();
+	for (int t = 0; t < 5; ++t) {
+		cellularAutomata.step();
+	}
+	EXPECT_EQ(rowOf(lattice), "000000000");
+}

--- a/source/tests/unit/test_cellular_automata_neighborhood.cpp
+++ b/source/tests/unit/test_cellular_automata_neighborhood.cpp
@@ -1,0 +1,204 @@
+#include <gtest/gtest.h>
+
+#include "plugins/components/ModalModel/CellularAutomata/Boundary_Closed.h"
+#include "plugins/components/ModalModel/CellularAutomata/Boundary_Fixed.h"
+#include "plugins/components/ModalModel/CellularAutomata/CellularAutomata_Classic.h"
+#include "plugins/components/ModalModel/CellularAutomata/Lattice.h"
+#include "plugins/components/ModalModel/CellularAutomata/LocalRule_GameOfLife.h"
+#include "plugins/components/ModalModel/CellularAutomata/Neighborhood_Moore.h"
+#include "plugins/components/ModalModel/CellularAutomata/Neighborhood_VonNeumann.h"
+
+#include <algorithm>
+#include <cstdlib>
+#include <vector>
+
+namespace {
+
+template<typename NeighborhoodType, typename BoundaryType>
+std::vector<long> buildNeighborNumbers(std::vector<unsigned short> dimensions, std::vector<int> position, unsigned short radius) {
+	CellularAutomata_Classic automaton;
+	BoundaryType boundary;
+	NeighborhoodType neighborhood(&automaton, radius, &boundary);
+	Lattice lattice(&automaton, nullptr, dimensions);
+
+	EXPECT_TRUE(automaton.init());
+	std::vector<Cell*> neighbors = neighborhood.getNeighbors(lattice.getCell(position));
+	std::vector<long> numbers;
+	numbers.reserve(neighbors.size());
+	for (Cell* neighbor : neighbors) {
+		numbers.emplace_back(neighbor->getCellNumber());
+	}
+	return numbers;
+}
+
+unsigned long powUnsigned(unsigned long base, unsigned short exponent) {
+	unsigned long result = 1;
+	for (unsigned short i = 0; i < exponent; ++i) {
+		result *= base;
+	}
+	return result;
+}
+
+unsigned long expectedMooreCount(unsigned short dimensions, unsigned short radius) {
+	return powUnsigned(2 * radius + 1, dimensions) - 1;
+}
+
+unsigned long expectedVonNeumannCount(unsigned short dimensions, unsigned short radius) {
+	std::vector<int> offset(dimensions, 0);
+	unsigned long count = 0;
+
+	const auto visit = [&](const auto& self, unsigned short dimension) -> void {
+		if (dimension == dimensions) {
+			unsigned int manhattanDistance = 0;
+			bool zeroOffset = true;
+			for (int delta : offset) {
+				manhattanDistance += static_cast<unsigned int>(std::abs(delta));
+				zeroOffset = zeroOffset && delta == 0;
+			}
+			if (!zeroOffset && manhattanDistance <= radius) {
+				++count;
+			}
+			return;
+		}
+
+		for (int delta = -static_cast<int>(radius); delta <= static_cast<int>(radius); ++delta) {
+			offset.at(dimension) = delta;
+			self(self, dimension + 1);
+		}
+	};
+
+	visit(visit, 0);
+	return count;
+}
+
+} // namespace
+
+TEST(CellularAutomataLattice, ConvertsLinearCellNumbersAndNDimPositionsRoundTrip) {
+	CellularAutomata_Classic automaton;
+	Lattice lattice(&automaton, nullptr, {2, 3, 4, 5});
+	const unsigned long totalCells = lattice.calculateTotalCells();
+
+	for (long cellNumber = 0; cellNumber < static_cast<long>(totalCells); ++cellNumber) {
+		const std::vector<int> position = lattice.cellNumber2NDimPosition(cellNumber);
+		EXPECT_EQ(lattice.cellNDimPosition2Number(position), cellNumber);
+	}
+
+	EXPECT_EQ(lattice.cellNumber2NDimPosition(0), (std::vector<int>{0, 0, 0, 0}));
+	EXPECT_EQ(lattice.cellNumber2NDimPosition(1), (std::vector<int>{1, 0, 0, 0}));
+	EXPECT_EQ(lattice.cellNumber2NDimPosition(2), (std::vector<int>{0, 1, 0, 0}));
+	EXPECT_EQ(lattice.cellNDimPosition2Number({1, 2, 3, 4}), 119);
+	EXPECT_EQ(lattice.cellNDimPosition2Number({2, 0, 0, 0}), -1);
+	EXPECT_EQ(lattice.cellNDimPosition2Number({0, -1, 0, 0}), -1);
+}
+
+TEST(CellularAutomataMooreNeighborhood, CountsInternalNeighborsForMultipleDimensionsAndRadii) {
+	struct Case {
+		std::vector<unsigned short> dimensions;
+		std::vector<int> position;
+		unsigned short radius;
+	};
+
+	const std::vector<Case> cases = {
+		{{5}, {2}, 1},
+		{{5, 5}, {2, 2}, 1},
+		{{7, 7}, {3, 3}, 2},
+		{{5, 5, 5}, {2, 2, 2}, 1},
+		{{7, 7, 7}, {3, 3, 3}, 2},
+	};
+
+	for (const Case& currentCase : cases) {
+		const auto numbers = buildNeighborNumbers<Neighborhood_Moore, Boundary_Closed>(
+			currentCase.dimensions,
+			currentCase.position,
+			currentCase.radius
+		);
+		EXPECT_EQ(numbers.size(), expectedMooreCount(currentCase.dimensions.size(), currentCase.radius));
+	}
+}
+
+TEST(CellularAutomataMooreNeighborhood, ReturnsDeterministicLexicographicOffsets) {
+	const auto numbers = buildNeighborNumbers<Neighborhood_Moore, Boundary_Closed>({5, 5}, {2, 2}, 1);
+
+	EXPECT_EQ(numbers, (std::vector<long>{
+		6, 11, 16,
+		7,     17,
+		8, 13, 18,
+	}));
+}
+
+TEST(CellularAutomataMooreNeighborhood, KeepsFixedBoundaryPositionsAsFixedCells) {
+	const auto numbers = buildNeighborNumbers<Neighborhood_Moore, Boundary_Fixed>({3, 3}, {0, 0}, 1);
+
+	EXPECT_EQ(numbers.size(), 8);
+	EXPECT_EQ(std::count(numbers.begin(), numbers.end(), -99), 5);
+	EXPECT_NE(std::find(numbers.begin(), numbers.end(), 1), numbers.end());
+	EXPECT_NE(std::find(numbers.begin(), numbers.end(), 3), numbers.end());
+	EXPECT_NE(std::find(numbers.begin(), numbers.end(), 4), numbers.end());
+}
+
+TEST(CellularAutomataVonNeumannNeighborhood, CountsInternalNeighborsForMultipleDimensionsAndRadii) {
+	struct Case {
+		std::vector<unsigned short> dimensions;
+		std::vector<int> position;
+		unsigned short radius;
+	};
+
+	const std::vector<Case> cases = {
+		{{5}, {2}, 1},
+		{{5, 5}, {2, 2}, 1},
+		{{7, 7}, {3, 3}, 2},
+		{{5, 5, 5}, {2, 2, 2}, 1},
+		{{7, 7, 7}, {3, 3, 3}, 2},
+	};
+
+	for (const Case& currentCase : cases) {
+		const auto numbers = buildNeighborNumbers<Neighborhood_VonNeumann, Boundary_Closed>(
+			currentCase.dimensions,
+			currentCase.position,
+			currentCase.radius
+		);
+		EXPECT_EQ(numbers.size(), expectedVonNeumannCount(currentCase.dimensions.size(), currentCase.radius));
+	}
+}
+
+TEST(CellularAutomataVonNeumannNeighborhood, ReturnsDeterministicLexicographicOffsets) {
+	const auto numbers = buildNeighborNumbers<Neighborhood_VonNeumann, Boundary_Closed>({5, 5}, {2, 2}, 2);
+
+	EXPECT_EQ(numbers, (std::vector<long>{
+		10,
+		6, 11, 16,
+		2, 7, 17, 22,
+		8, 13, 18,
+		14,
+	}));
+}
+
+TEST(CellularAutomataVonNeumannNeighborhood, KeepsFixedBoundaryPositionsAsFixedCells) {
+	const auto numbers = buildNeighborNumbers<Neighborhood_VonNeumann, Boundary_Fixed>({3, 3}, {0, 0}, 1);
+
+	EXPECT_EQ(numbers.size(), 4);
+	EXPECT_EQ(std::count(numbers.begin(), numbers.end(), -99), 2);
+	EXPECT_NE(std::find(numbers.begin(), numbers.end(), 1), numbers.end());
+	EXPECT_NE(std::find(numbers.begin(), numbers.end(), 3), numbers.end());
+}
+
+TEST(CellularAutomataGameOfLife, KeepsTwoDimensionalMooreBlinkerRegression) {
+	CellularAutomata_Classic automaton;
+	Boundary_Closed boundary;
+	Neighborhood_Moore neighborhood(&automaton, 1, &boundary);
+	LocalRule_GameOfLife localRule(&automaton);
+	Lattice lattice(&automaton, nullptr, {5, 5});
+
+	ASSERT_TRUE(automaton.init());
+	lattice.getCell({1, 2})->setCurrentState(State(1));
+	lattice.getCell({2, 2})->setCurrentState(State(1));
+	lattice.getCell({3, 2})->setCurrentState(State(1));
+
+	automaton.step();
+
+	EXPECT_EQ(lattice.getCell({2, 1})->getCurrentState().getValue(), 1);
+	EXPECT_EQ(lattice.getCell({2, 2})->getCurrentState().getValue(), 1);
+	EXPECT_EQ(lattice.getCell({2, 3})->getCurrentState().getValue(), 1);
+	EXPECT_EQ(lattice.getCell({1, 2})->getCurrentState().getValue(), 0);
+	EXPECT_EQ(lattice.getCell({3, 2})->getCurrentState().getValue(), 0);
+}

--- a/source/tests/unit/test_cellular_automata_neighborhood.cpp
+++ b/source/tests/unit/test_cellular_automata_neighborhood.cpp
@@ -5,7 +5,10 @@
 #include "plugins/components/ModalModel/CellularAutomata/CellularAutomata_Classic.h"
 #include "plugins/components/ModalModel/CellularAutomata/Lattice.h"
 #include "plugins/components/ModalModel/CellularAutomata/LocalRule_GameOfLife.h"
+#include "plugins/components/ModalModel/CellularAutomata/Neighborhood_Hexagonal.h"
 #include "plugins/components/ModalModel/CellularAutomata/Neighborhood_Moore.h"
+#include "plugins/components/ModalModel/CellularAutomata/Neighborhood_Network.h"
+#include "plugins/components/ModalModel/CellularAutomata/Neighborhood_Triangular.h"
 #include "plugins/components/ModalModel/CellularAutomata/Neighborhood_VonNeumann.h"
 
 #include <algorithm>
@@ -180,6 +183,68 @@ TEST(CellularAutomataVonNeumannNeighborhood, KeepsFixedBoundaryPositionsAsFixedC
 	EXPECT_EQ(std::count(numbers.begin(), numbers.end(), -99), 2);
 	EXPECT_NE(std::find(numbers.begin(), numbers.end(), 1), numbers.end());
 	EXPECT_NE(std::find(numbers.begin(), numbers.end(), 3), numbers.end());
+}
+
+TEST(CellularAutomataTriangularNeighborhood, ReturnsThreeNeighborsWithAlternatingOrientation) {
+	const auto numbers = buildNeighborNumbers<Neighborhood_Triangular, Boundary_Closed>({3, 3}, {1, 1}, 1);
+
+	EXPECT_EQ(numbers, (std::vector<long>{3, 5, 1}));
+}
+
+TEST(CellularAutomataTriangularNeighborhood, AppliesClosedAndFixedBoundaries) {
+	const auto closed = buildNeighborNumbers<Neighborhood_Triangular, Boundary_Closed>({3, 3}, {0, 0}, 1);
+	EXPECT_EQ(closed, (std::vector<long>{2, 1, 6}));
+
+	const auto fixed = buildNeighborNumbers<Neighborhood_Triangular, Boundary_Fixed>({3, 3}, {0, 0}, 1);
+	EXPECT_EQ(fixed.size(), 3);
+	EXPECT_EQ(std::count(fixed.begin(), fixed.end(), -99), 2);
+	EXPECT_NE(std::find(fixed.begin(), fixed.end(), 1), fixed.end());
+}
+
+TEST(CellularAutomataHexagonalNeighborhood, ReturnsSixOffsetNeighbors) {
+	const auto numbers = buildNeighborNumbers<Neighborhood_Hexagonal, Boundary_Closed>({3, 3}, {1, 1}, 1);
+
+	EXPECT_EQ(numbers, (std::vector<long>{6, 7, 8, 5, 1, 3}));
+}
+
+TEST(CellularAutomataHexagonalNeighborhood, AppliesClosedAndFixedBoundaries) {
+	const auto closed = buildNeighborNumbers<Neighborhood_Hexagonal, Boundary_Closed>({3, 3}, {0, 0}, 1);
+	EXPECT_EQ(closed, (std::vector<long>{2, 3, 1, 7, 6, 8}));
+
+	const auto fixed = buildNeighborNumbers<Neighborhood_Hexagonal, Boundary_Fixed>({3, 3}, {0, 0}, 1);
+	EXPECT_EQ(fixed.size(), 6);
+	EXPECT_EQ(std::count(fixed.begin(), fixed.end(), -99), 4);
+	EXPECT_NE(std::find(fixed.begin(), fixed.end(), 1), fixed.end());
+	EXPECT_NE(std::find(fixed.begin(), fixed.end(), 3), fixed.end());
+}
+
+TEST(CellularAutomataNetworkNeighborhood, UsesConfiguredEdgesAsTopology) {
+	CellularAutomata_Classic automaton;
+	Boundary_Fixed boundary;
+	Neighborhood_Network neighborhood(&automaton, 1, &boundary);
+	Lattice lattice(&automaton, nullptr, {4}, LatticeType::NETWORK);
+	lattice.setNetworkEdges({{0, 1}, {0, 2}, {2, 3}});
+
+	ASSERT_TRUE(automaton.init());
+	std::vector<Cell*> neighbors = neighborhood.getNeighbors(lattice.getCell(0L));
+	std::vector<long> numbers;
+	for (Cell* neighbor : neighbors)
+		numbers.emplace_back(neighbor->getCellNumber());
+
+	EXPECT_EQ(numbers, (std::vector<long>{1, 2}));
+	EXPECT_EQ(lattice.getNetworkNeighborCellNumbers(1), (std::vector<unsigned long>{0}));
+}
+
+TEST(CellularAutomataNetworkNeighborhood, SupportsDirectedEdges) {
+	CellularAutomata_Classic automaton;
+	Boundary_Fixed boundary;
+	Neighborhood_Network neighborhood(&automaton, 1, &boundary);
+	Lattice lattice(&automaton, nullptr, {4}, LatticeType::NETWORK);
+	lattice.setNetworkEdges({{0, 1}, {0, 2}}, false);
+
+	ASSERT_TRUE(automaton.init());
+	EXPECT_EQ(lattice.getNetworkNeighborCellNumbers(0), (std::vector<unsigned long>{1, 2}));
+	EXPECT_TRUE(lattice.getNetworkNeighborCellNumbers(1).empty());
 }
 
 TEST(CellularAutomataGameOfLife, KeepsTwoDimensionalMooreBlinkerRegression) {

--- a/source/tests/unit/test_cellular_automata_neighborhood.cpp
+++ b/source/tests/unit/test_cellular_automata_neighborhood.cpp
@@ -76,6 +76,9 @@ unsigned long expectedVonNeumannCount(unsigned short dimensions, unsigned short 
 
 } // namespace
 
+// ConvertsLinearCellNumbersAndNDimPositionsRoundTrip — the lattice indexes cells two ways: a flat number
+// and an n-dim coordinate. On a 2x3x4x5 lattice it asserts number->position->number is the identity for
+// every cell (a bijection), spot-checks a few known mappings, and that out-of-range coords map to -1.
 TEST(CellularAutomataLattice, ConvertsLinearCellNumbersAndNDimPositionsRoundTrip) {
 	CellularAutomata_Classic automaton;
 	Lattice lattice(&automaton, nullptr, {2, 3, 4, 5});
@@ -94,6 +97,9 @@ TEST(CellularAutomataLattice, ConvertsLinearCellNumbersAndNDimPositionsRoundTrip
 	EXPECT_EQ(lattice.cellNDimPosition2Number({0, -1, 0, 0}), -1);
 }
 
+// CountsInternalNeighborsForMultipleDimensionsAndRadii (Moore) — for an interior cell the Moore
+// neighborhood is the full (2r+1)^d box minus the cell itself. Drives several dimension/radius cases and
+// checks the neighbor count matches that closed form, so the generator is correct beyond hand-picked sizes.
 TEST(CellularAutomataMooreNeighborhood, CountsInternalNeighborsForMultipleDimensionsAndRadii) {
 	struct Case {
 		std::vector<unsigned short> dimensions;
@@ -119,6 +125,9 @@ TEST(CellularAutomataMooreNeighborhood, CountsInternalNeighborsForMultipleDimens
 	}
 }
 
+// ReturnsDeterministicLexicographicOffsets (Moore) — neighbor ordering matters because user rules index
+// neighbors[i] by position. Pins the exact cell-number list a center cell on a 5x5 lattice returns,
+// locking in the deterministic lexicographic (row-major) offset order.
 TEST(CellularAutomataMooreNeighborhood, ReturnsDeterministicLexicographicOffsets) {
 	const auto numbers = buildNeighborNumbers<Neighborhood_Moore, Boundary_Closed>({5, 5}, {2, 2}, 1);
 
@@ -129,6 +138,9 @@ TEST(CellularAutomataMooreNeighborhood, ReturnsDeterministicLexicographicOffsets
 	}));
 }
 
+// KeepsFixedBoundaryPositionsAsFixedCells (Moore) — at a corner cell, 5 of the 8 Moore neighbors fall off
+// the lattice. Under a Fixed boundary those become the sentinel cell number -99 while the 3 in-bounds
+// neighbors keep their real numbers, so the slot count stays 8 and edge handling is explicit.
 TEST(CellularAutomataMooreNeighborhood, KeepsFixedBoundaryPositionsAsFixedCells) {
 	const auto numbers = buildNeighborNumbers<Neighborhood_Moore, Boundary_Fixed>({3, 3}, {0, 0}, 1);
 
@@ -139,6 +151,9 @@ TEST(CellularAutomataMooreNeighborhood, KeepsFixedBoundaryPositionsAsFixedCells)
 	EXPECT_NE(std::find(numbers.begin(), numbers.end(), 4), numbers.end());
 }
 
+// CountsInternalNeighborsForMultipleDimensionsAndRadii (VonNeumann) — the VonNeumann neighborhood is every
+// cell within Manhattan distance r (a diamond, not a box). Compares the generator's count against a
+// reference brute-force enumeration across several dimension/radius cases.
 TEST(CellularAutomataVonNeumannNeighborhood, CountsInternalNeighborsForMultipleDimensionsAndRadii) {
 	struct Case {
 		std::vector<unsigned short> dimensions;
@@ -164,6 +179,8 @@ TEST(CellularAutomataVonNeumannNeighborhood, CountsInternalNeighborsForMultipleD
 	}
 }
 
+// ReturnsDeterministicLexicographicOffsets (VonNeumann) — pins the exact ordered neighbor list for a
+// radius-2 VonNeumann diamond on a 5x5 lattice, locking the deterministic traversal order user rules rely on.
 TEST(CellularAutomataVonNeumannNeighborhood, ReturnsDeterministicLexicographicOffsets) {
 	const auto numbers = buildNeighborNumbers<Neighborhood_VonNeumann, Boundary_Closed>({5, 5}, {2, 2}, 2);
 
@@ -176,6 +193,9 @@ TEST(CellularAutomataVonNeumannNeighborhood, ReturnsDeterministicLexicographicOf
 	}));
 }
 
+// KeepsFixedBoundaryPositionsAsFixedCells (VonNeumann) — corner-cell counterpart of the Moore boundary
+// test: of the 4 VonNeumann neighbors at {0,0}, the 2 off-lattice ones become sentinel -99 and the 2
+// in-bounds ones keep real numbers under a Fixed boundary.
 TEST(CellularAutomataVonNeumannNeighborhood, KeepsFixedBoundaryPositionsAsFixedCells) {
 	const auto numbers = buildNeighborNumbers<Neighborhood_VonNeumann, Boundary_Fixed>({3, 3}, {0, 0}, 1);
 
@@ -185,12 +205,18 @@ TEST(CellularAutomataVonNeumannNeighborhood, KeepsFixedBoundaryPositionsAsFixedC
 	EXPECT_NE(std::find(numbers.begin(), numbers.end(), 3), numbers.end());
 }
 
+// ReturnsThreeNeighborsWithAlternatingOrientation (Triangular) — on a triangular lattice each cell has
+// exactly 3 neighbors, and the set depends on whether the cell is an up- or down-pointing triangle. Pins
+// the ordered neighbor numbers for an interior cell to lock that orientation-dependent topology.
 TEST(CellularAutomataTriangularNeighborhood, ReturnsThreeNeighborsWithAlternatingOrientation) {
 	const auto numbers = buildNeighborNumbers<Neighborhood_Triangular, Boundary_Closed>({3, 3}, {1, 1}, 1);
 
 	EXPECT_EQ(numbers, (std::vector<long>{3, 5, 1}));
 }
 
+// AppliesClosedAndFixedBoundaries (Triangular) — repeats the triangular neighbor lookup at a corner under
+// both boundaries: Closed wraps the missing neighbors around (real numbers), Fixed replaces them with the
+// -99 sentinel. Confirms boundary handling works for the special triangular topology, not just rectangular.
 TEST(CellularAutomataTriangularNeighborhood, AppliesClosedAndFixedBoundaries) {
 	const auto closed = buildNeighborNumbers<Neighborhood_Triangular, Boundary_Closed>({3, 3}, {0, 0}, 1);
 	EXPECT_EQ(closed, (std::vector<long>{2, 1, 6}));
@@ -201,12 +227,17 @@ TEST(CellularAutomataTriangularNeighborhood, AppliesClosedAndFixedBoundaries) {
 	EXPECT_NE(std::find(fixed.begin(), fixed.end(), 1), fixed.end());
 }
 
+// ReturnsSixOffsetNeighbors (Hexagonal) — on a hexagonal lattice each cell has 6 neighbors. Pins the exact
+// ordered neighbor numbers for an interior cell, locking the hex offset pattern.
 TEST(CellularAutomataHexagonalNeighborhood, ReturnsSixOffsetNeighbors) {
 	const auto numbers = buildNeighborNumbers<Neighborhood_Hexagonal, Boundary_Closed>({3, 3}, {1, 1}, 1);
 
 	EXPECT_EQ(numbers, (std::vector<long>{6, 7, 8, 5, 1, 3}));
 }
 
+// AppliesClosedAndFixedBoundaries (Hexagonal) — corner hex cell under both boundaries: Closed wraps all 6
+// neighbors to real cells, Fixed turns the 4 off-lattice ones into the -99 sentinel. Validates boundary
+// behavior for the hexagonal topology.
 TEST(CellularAutomataHexagonalNeighborhood, AppliesClosedAndFixedBoundaries) {
 	const auto closed = buildNeighborNumbers<Neighborhood_Hexagonal, Boundary_Closed>({3, 3}, {0, 0}, 1);
 	EXPECT_EQ(closed, (std::vector<long>{2, 3, 1, 7, 6, 8}));
@@ -218,6 +249,9 @@ TEST(CellularAutomataHexagonalNeighborhood, AppliesClosedAndFixedBoundaries) {
 	EXPECT_NE(std::find(fixed.begin(), fixed.end(), 3), fixed.end());
 }
 
+// UsesConfiguredEdgesAsTopology (Network) — a NETWORK lattice has no geometry; adjacency comes from an
+// explicit edge list. With edges {0-1,0-2,2-3} it asserts node 0's neighbors are {1,2} and that the
+// undirected edge is visible from the other side too (node 1 sees node 0).
 TEST(CellularAutomataNetworkNeighborhood, UsesConfiguredEdgesAsTopology) {
 	CellularAutomata_Classic automaton;
 	Boundary_Fixed boundary;
@@ -235,6 +269,8 @@ TEST(CellularAutomataNetworkNeighborhood, UsesConfiguredEdgesAsTopology) {
 	EXPECT_EQ(lattice.getNetworkNeighborCellNumbers(1), (std::vector<unsigned long>{0}));
 }
 
+// SupportsDirectedEdges (Network) — when edges are declared directed (undirected=false), adjacency is
+// one-way. With 0->1 and 0->2 it asserts node 0 reaches {1,2} but node 1 has no outgoing neighbors.
 TEST(CellularAutomataNetworkNeighborhood, SupportsDirectedEdges) {
 	CellularAutomata_Classic automaton;
 	Boundary_Fixed boundary;
@@ -247,6 +283,9 @@ TEST(CellularAutomataNetworkNeighborhood, SupportsDirectedEdges) {
 	EXPECT_TRUE(lattice.getNetworkNeighborCellNumbers(1).empty());
 }
 
+// KeepsTwoDimensionalMooreBlinkerRegression (GameOfLife) — regression guard wiring the real components
+// (Closed boundary, Moore neighborhood, built-in GoL rule) on a 5x5 lattice. Seeds a horizontal blinker
+// and asserts that after one step it is vertical, catching any regression in the assembled step pipeline.
 TEST(CellularAutomataGameOfLife, KeepsTwoDimensionalMooreBlinkerRegression) {
 	CellularAutomata_Classic automaton;
 	Boundary_Closed boundary;

--- a/source/tests/unit/test_cellular_automata_user_defined.cpp
+++ b/source/tests/unit/test_cellular_automata_user_defined.cpp
@@ -1,0 +1,340 @@
+// Verifies the user-defined local rule (Tema 6, Linha B): a rule supplied as C++ source, compiled at
+// runtime via CppCompiler, loaded, and invoked per cell. Correctness is checked bit-perfect against
+// the same theoretical ground truth used for the built-in engine (Wolfram rules 30/90, Game of Life),
+// plus an equivalence check user-rule == built-in preset, plus graceful failure on bad user code.
+
+#include <gtest/gtest.h>
+
+#include "plugins/components/ModalModel/CellularAutomata/Boundary_Closed.h"
+#include "plugins/components/ModalModel/CellularAutomata/Boundary_Fixed.h"
+#include "plugins/components/ModalModel/CellularAutomata/CellularAutomata_Classic.h"
+#include "plugins/components/ModalModel/CellularAutomata/Lattice.h"
+#include "plugins/components/ModalModel/CellularAutomata/LocalRule_Elementary.h"
+#include "plugins/components/ModalModel/CellularAutomata/LocalRule_UserDefined.h"
+#include "plugins/components/ModalModel/CellularAutomata/Neighborhood_Center.h"
+#include "plugins/components/ModalModel/CellularAutomata/Neighborhood_Moore.h"
+#include "plugins/components/ModalModel/CellularAutomata/State.h"
+#include "plugins/components/ModalModel/CellularAutomata/StateSet_Enumerable.h"
+#include "plugins/data/ExternalIntegration/CppCompiler.h"
+
+#include "kernel/simulator/Simulator.h"
+
+#include <string>
+#include <vector>
+
+namespace {
+
+std::string rowOf(Lattice& lattice) {
+	std::string row;
+	for (unsigned long cellNumber = 0; cellNumber < lattice.getCellsSize(); ++cellNumber) {
+		row += std::to_string(lattice.getCell(static_cast<long>(cellNumber))->getCurrentState().getValue());
+	}
+	return row;
+}
+
+CppCompiler* makeCompiler(Simulator& simulator) {
+	Model* model = simulator.getModelManager()->newModel();
+	CppCompiler* compiler = new CppCompiler(model, "userRuleCompiler");
+	compiler->setOutputDir("/tmp/");
+	compiler->setTempDir("/tmp/");
+	compiler->setFlagsGeneral("-w -std=c++14"); // drop the default -v verbose noise
+	return compiler;
+}
+
+// Runs a 1D elementary CA driven by a user-defined rule built from `ruleBody` (a function body wrapped
+// into the nextState signature via buildBody). Single central 1, fixed-0 boundary. Returns the
+// space-time rows t0..t(steps); empty vector if the build failed.
+std::vector<std::string> runUserElementary(Simulator& simulator, unsigned short width,
+		const std::string& ruleBody, unsigned int steps, std::string& errorMessage) {
+	CellularAutomata_Classic cellularAutomata;
+	Lattice lattice(&cellularAutomata, nullptr, {width}, LatticeType::RETICULAR);
+	State zero(0);
+	State one(1);
+	StateSet_Enumerable stateSet(&cellularAutomata, {&zero, &one});
+	Boundary_Fixed boundary(&lattice);
+	Neighborhood_Center neighborhood(&cellularAutomata, 1, &boundary);
+	CppCompiler* compiler = makeCompiler(simulator);
+	LocalRule_UserDefined rule(&cellularAutomata, compiler, &stateSet);
+	if (!rule.buildBody(ruleBody, errorMessage)) {
+		return {};
+	}
+
+	cellularAutomata.setLattice(&lattice);
+	cellularAutomata.setStateSet(&stateSet);
+	cellularAutomata.setNeighborhood(&neighborhood);
+	cellularAutomata.setLocalRule(&rule);
+
+	lattice.init();
+	State centerOn(1);
+	lattice.setCellState(static_cast<long>(width / 2), &centerOn);
+
+	std::vector<std::string> rows;
+	rows.emplace_back(rowOf(lattice));
+	for (unsigned int t = 0; t < steps; ++t) {
+		cellularAutomata.step();
+		rows.emplace_back(rowOf(lattice));
+	}
+	return rows;
+}
+
+} // namespace
+
+TEST(UserDefinedCA, Rule30FromUserSourceMatchesTextbook) {
+	Simulator simulator;
+	std::string error;
+	// Rule 30: next = left XOR (center OR right). Neighbors order for 1D centered radius-1 = {left,right}.
+	const std::string source = "return neighbors[0] ^ (self | neighbors[1]);";
+	const std::vector<std::string> rows = runUserElementary(simulator, 9, source, 3, error);
+	ASSERT_EQ(rows.size(), 4u) << "build/compile failed: " << error;
+	EXPECT_EQ(rows[0], "000010000");
+	EXPECT_EQ(rows[1], "000111000");
+	EXPECT_EQ(rows[2], "001100100");
+	EXPECT_EQ(rows[3], "011011110");
+}
+
+TEST(UserDefinedCA, Rule90FromUserSourceMatchesSierpinski) {
+	Simulator simulator;
+	std::string error;
+	// Rule 90: next = left XOR right (center-independent) -> Sierpinski triangle.
+	const std::string source = "return neighbors[0] ^ neighbors[1];";
+	const std::vector<std::string> rows = runUserElementary(simulator, 11, source, 4, error);
+	ASSERT_EQ(rows.size(), 5u) << "build/compile failed: " << error;
+	EXPECT_EQ(rows[0], "00000100000");
+	EXPECT_EQ(rows[1], "00001010000");
+	EXPECT_EQ(rows[2], "00010001000");
+	EXPECT_EQ(rows[3], "00101010100");
+	EXPECT_EQ(rows[4], "01000000010");
+}
+
+TEST(UserDefinedCA, UserRule90EqualsBuiltInElementary90) {
+	// The user-defined rule must produce identical output to the built-in LocalRule_Elementary(90)
+	// over many steps and a wider lattice (strong equivalence / consistency check).
+	Simulator simulator;
+	std::string error;
+	const unsigned short width = 31;
+	const unsigned int steps = 15;
+
+	const std::vector<std::string> userRows = runUserElementary(simulator, width,
+		"return neighbors[0] ^ neighbors[1];", steps, error);
+	ASSERT_EQ(userRows.size(), steps + 1u) << "build/compile failed: " << error;
+
+	// Built-in reference run, same configuration.
+	CellularAutomata_Classic cellularAutomata;
+	Lattice lattice(&cellularAutomata, nullptr, {width}, LatticeType::RETICULAR);
+	State zero(0);
+	State one(1);
+	StateSet_Enumerable stateSet(&cellularAutomata, {&zero, &one});
+	Boundary_Fixed boundary(&lattice);
+	Neighborhood_Center neighborhood(&cellularAutomata, 1, &boundary);
+	LocalRule_Elementary builtIn(&cellularAutomata, 90, &stateSet);
+	cellularAutomata.setLattice(&lattice);
+	cellularAutomata.setStateSet(&stateSet);
+	cellularAutomata.setNeighborhood(&neighborhood);
+	cellularAutomata.setLocalRule(&builtIn);
+	lattice.init();
+	State centerOn(1);
+	lattice.setCellState(static_cast<long>(width / 2), &centerOn);
+	std::vector<std::string> builtInRows;
+	builtInRows.emplace_back(rowOf(lattice));
+	for (unsigned int t = 0; t < steps; ++t) {
+		cellularAutomata.step();
+		builtInRows.emplace_back(rowOf(lattice));
+	}
+
+	EXPECT_EQ(userRows, builtInRows);
+}
+
+TEST(UserDefinedCA, BadUserCodeFailsGracefully) {
+	// A compilation error in the user's rule must be reported, not crash, and leave the rule not-ready.
+	Simulator simulator;
+	CppCompiler* compiler = makeCompiler(simulator);
+	CellularAutomata_Classic cellularAutomata;
+	StateSet_Enumerable stateSet(&cellularAutomata, {});
+	LocalRule_UserDefined rule(&cellularAutomata, compiler, &stateSet);
+
+	std::string error;
+	const bool ok = rule.build("this is not valid c++ code <<<", error);
+	EXPECT_FALSE(ok);
+	EXPECT_FALSE(rule.isReady());
+	EXPECT_FALSE(error.empty());
+}
+
+TEST(UserDefinedCA, GameOfLifeBlinkerOscillatesViaUserRule) {
+	// 2D Game of Life (B3/S23) expressed as a user rule over a Moore neighborhood. A horizontal
+	// blinker (3 cells) must become vertical after one step and horizontal again after two (period 2).
+	Simulator simulator;
+	std::string error;
+	const std::string gol =
+		"long live = 0;"
+		"for (int i = 0; i < numNeighbors; ++i) live += neighbors[i];"
+		"if (self != 0) return (live == 2 || live == 3) ? 1 : 0;"
+		"return (live == 3) ? 1 : 0;";
+
+	CellularAutomata_Classic cellularAutomata;
+	const unsigned short side = 5;
+	Lattice lattice(&cellularAutomata, nullptr, {side, side}, LatticeType::RETICULAR);
+	State zero(0);
+	State one(1);
+	StateSet_Enumerable stateSet(&cellularAutomata, {&zero, &one});
+	Boundary_Fixed boundary(&lattice);
+	Neighborhood_Moore neighborhood(&cellularAutomata, 1, &boundary);
+	CppCompiler* compiler = makeCompiler(simulator);
+	LocalRule_UserDefined rule(&cellularAutomata, compiler, &stateSet);
+	ASSERT_TRUE(rule.buildBody(gol, error)) << error;
+
+	cellularAutomata.setLattice(&lattice);
+	cellularAutomata.setStateSet(&stateSet);
+	cellularAutomata.setNeighborhood(&neighborhood);
+	cellularAutomata.setLocalRule(&rule);
+	lattice.init();
+
+	// Horizontal blinker centered at row 2, columns 1..3 (cell number = col + side*row).
+	State on(1);
+	lattice.setCellState(static_cast<long>(1 + side * 2), &on);
+	lattice.setCellState(static_cast<long>(2 + side * 2), &on);
+	lattice.setCellState(static_cast<long>(3 + side * 2), &on);
+
+	const std::string horizontal = rowOf(lattice);
+	cellularAutomata.step();
+	const std::string vertical = rowOf(lattice);
+	cellularAutomata.step();
+	const std::string horizontalAgain = rowOf(lattice);
+
+	EXPECT_NE(horizontal, vertical) << "blinker should change shape after one step";
+	EXPECT_EQ(horizontal, horizontalAgain) << "blinker should return to its shape after two steps (period 2)";
+
+	// Explicit: after one step the live cells are the vertical triple (col 2, rows 1..3).
+	std::string expectedVertical(side * side, '0');
+	expectedVertical[2 + side * 1] = '1';
+	expectedVertical[2 + side * 2] = '1';
+	expectedVertical[2 + side * 3] = '1';
+	EXPECT_EQ(vertical, expectedVertical);
+}
+
+TEST(UserDefinedCA, ClosedBoundaryWrapsAroundTorus) {
+	// Exercises the Boundary_Closed (periodic) condition, distinct from the Fixed boundary used above.
+	// A "copy your left neighbor" rule (next = neighbors[0]) shifts the pattern one cell to the right
+	// each step. On a closed 1D ring a single live cell must travel around and return to its start
+	// after `width` steps; under a fixed boundary it would instead fall off the edge and vanish.
+	Simulator simulator;
+	std::string error;
+	const unsigned short width = 5;
+
+	CellularAutomata_Classic cellularAutomata;
+	Lattice lattice(&cellularAutomata, nullptr, {width}, LatticeType::RETICULAR);
+	State zero(0);
+	State one(1);
+	StateSet_Enumerable stateSet(&cellularAutomata, {&zero, &one});
+	Boundary_Closed boundary(&lattice);
+	Neighborhood_Center neighborhood(&cellularAutomata, 1, &boundary);
+	CppCompiler* compiler = makeCompiler(simulator);
+	LocalRule_UserDefined rule(&cellularAutomata, compiler, &stateSet);
+	ASSERT_TRUE(rule.buildBody("return neighbors[0];", error)) << error; // next = left neighbor's state
+
+	cellularAutomata.setLattice(&lattice);
+	cellularAutomata.setStateSet(&stateSet);
+	cellularAutomata.setNeighborhood(&neighborhood);
+	cellularAutomata.setLocalRule(&rule);
+	lattice.init();
+	State on(1);
+	lattice.setCellState(2, &on);
+
+	EXPECT_EQ(rowOf(lattice), "00100");
+	cellularAutomata.step();
+	EXPECT_EQ(rowOf(lattice), "00010");
+	cellularAutomata.step();
+	EXPECT_EQ(rowOf(lattice), "00001"); // at the right edge
+	cellularAutomata.step();
+	EXPECT_EQ(rowOf(lattice), "10000") << "closed boundary must wrap the live cell around the ring";
+	cellularAutomata.step();
+	EXPECT_EQ(rowOf(lattice), "01000");
+	cellularAutomata.step();
+	EXPECT_EQ(rowOf(lattice), "00100") << "after `width` steps the pattern must return to its start";
+}
+
+TEST(UserDefinedCA, GameOfLifeGliderTranslatesViaUserRule) {
+	// The classic Game of Life glider returns to its own shape shifted by (+1,+1) after 4 generations.
+	// This test-backs the glider space-time diagram shipped in dcs/site/assets/evidence-diagrams.txt
+	// (previously only the blinker was asserted) using the user rule over a Moore neighborhood.
+	Simulator simulator;
+	std::string error;
+	const std::string gol =
+		"long live = 0;"
+		"for (int i = 0; i < numNeighbors; ++i) live += neighbors[i];"
+		"if (self != 0) return (live == 2 || live == 3) ? 1 : 0;"
+		"return (live == 3) ? 1 : 0;";
+
+	CellularAutomata_Classic cellularAutomata;
+	const unsigned short side = 10;
+	Lattice lattice(&cellularAutomata, nullptr, {side, side}, LatticeType::RETICULAR);
+	State zero(0);
+	State one(1);
+	StateSet_Enumerable stateSet(&cellularAutomata, {&zero, &one});
+	Boundary_Fixed boundary(&lattice);
+	Neighborhood_Moore neighborhood(&cellularAutomata, 1, &boundary);
+	CppCompiler* compiler = makeCompiler(simulator);
+	LocalRule_UserDefined rule(&cellularAutomata, compiler, &stateSet);
+	ASSERT_TRUE(rule.buildBody(gol, error)) << error;
+
+	cellularAutomata.setLattice(&lattice);
+	cellularAutomata.setStateSet(&stateSet);
+	cellularAutomata.setNeighborhood(&neighborhood);
+	cellularAutomata.setLocalRule(&rule);
+	lattice.init();
+
+	// Glider placed in the interior (cell number = col + side*row), matching the evidence file's t0.
+	auto setOn = [&](int row, int col) { State s(1); lattice.setCellState(col + side * row, &s); };
+	setOn(1, 2);
+	setOn(2, 3);
+	setOn(3, 1);
+	setOn(3, 2);
+	setOn(3, 3);
+
+	for (int t = 0; t < 4; ++t) {
+		cellularAutomata.step();
+	}
+
+	// After 4 generations: same glider, shifted by (+1,+1) — matches the evidence file's t4.
+	std::string expected(side * side, '0');
+	auto mark = [&](int row, int col) { expected[col + side * row] = '1'; };
+	mark(2, 3);
+	mark(3, 4);
+	mark(4, 2);
+	mark(4, 3);
+	mark(4, 4);
+	EXPECT_EQ(rowOf(lattice), expected) << "glider must reappear shifted by (+1,+1) after 4 steps";
+}
+
+TEST(UserDefinedCA, ExtendedContractExposesCellPosition) {
+	// The extended user contract (nextStateEx) hands the rule the cell's n-dimensional position.
+	// A rule returning the parity of the first coordinate must paint a 1D row 0,1,0,1,... after one
+	// step regardless of neighbor states, proving the position is delivered to user code (tema 6 §6).
+	Simulator simulator;
+	std::string error;
+	const unsigned short width = 6;
+
+	CellularAutomata_Classic cellularAutomata;
+	Lattice lattice(&cellularAutomata, nullptr, {width}, LatticeType::RETICULAR);
+	State zero(0);
+	State one(1);
+	StateSet_Enumerable stateSet(&cellularAutomata, {&zero, &one});
+	Boundary_Fixed boundary(&lattice);
+	Neighborhood_Center neighborhood(&cellularAutomata, 1, &boundary);
+	CppCompiler* compiler = makeCompiler(simulator);
+	LocalRule_UserDefined rule(&cellularAutomata, compiler, &stateSet);
+	const std::string source =
+		"extern \"C\" long nextStateEx(long self, const long* neighbors, int numNeighbors, "
+		"const int* position, int numDimensions) { (void) self; (void) neighbors; (void) numNeighbors; "
+		"(void) numDimensions; return position[0] & 1; }";
+	ASSERT_TRUE(rule.build(source, error)) << error;
+	EXPECT_TRUE(rule.isReady());
+
+	cellularAutomata.setLattice(&lattice);
+	cellularAutomata.setStateSet(&stateSet);
+	cellularAutomata.setNeighborhood(&neighborhood);
+	cellularAutomata.setLocalRule(&rule);
+	lattice.init();
+
+	cellularAutomata.step();
+	EXPECT_EQ(rowOf(lattice), "010101") << "extended rule must color cells by the parity of their column";
+}

--- a/source/tests/unit/test_cellular_automata_user_defined.cpp
+++ b/source/tests/unit/test_cellular_automata_user_defined.cpp
@@ -79,6 +79,8 @@ std::vector<std::string> runUserElementary(Simulator& simulator, unsigned short 
 
 } // namespace
 
+// Rule30FromUserSourceMatchesTextbook — a user-supplied Rule 30 body, compiled at runtime, must reproduce
+// the same textbook ground truth as the built-in engine (rows t0..t3 on width 9).
 TEST(UserDefinedCA, Rule30FromUserSourceMatchesTextbook) {
 	Simulator simulator;
 	std::string error;
@@ -92,6 +94,8 @@ TEST(UserDefinedCA, Rule30FromUserSourceMatchesTextbook) {
 	EXPECT_EQ(rows[3], "011011110");
 }
 
+// Rule90FromUserSourceMatchesSierpinski — a user-supplied Rule 90 body must reproduce the Sierpinski
+// ground truth (rows t0..t4 on width 11), proving runtime-compiled rules match the analytical result.
 TEST(UserDefinedCA, Rule90FromUserSourceMatchesSierpinski) {
 	Simulator simulator;
 	std::string error;
@@ -106,6 +110,8 @@ TEST(UserDefinedCA, Rule90FromUserSourceMatchesSierpinski) {
 	EXPECT_EQ(rows[4], "01000000010");
 }
 
+// UserRule90EqualsBuiltInElementary90 — strong equivalence check: the user rule and the built-in
+// LocalRule_Elementary(90) must produce byte-identical histories over a wide lattice and many steps.
 TEST(UserDefinedCA, UserRule90EqualsBuiltInElementary90) {
 	// The user-defined rule must produce identical output to the built-in LocalRule_Elementary(90)
 	// over many steps and a wider lattice (strong equivalence / consistency check).
@@ -144,6 +150,8 @@ TEST(UserDefinedCA, UserRule90EqualsBuiltInElementary90) {
 	EXPECT_EQ(userRows, builtInRows);
 }
 
+// BadUserCodeFailsGracefully — feeding the compiler invalid C++ must return false, leave the rule
+// not-ready, and report a non-empty error instead of crashing the simulator.
 TEST(UserDefinedCA, BadUserCodeFailsGracefully) {
 	// A compilation error in the user's rule must be reported, not crash, and leave the rule not-ready.
 	Simulator simulator;
@@ -159,6 +167,8 @@ TEST(UserDefinedCA, BadUserCodeFailsGracefully) {
 	EXPECT_FALSE(error.empty());
 }
 
+// GameOfLifeBlinkerOscillatesViaUserRule — Game of Life (B3/S23) written as a multi-statement user rule
+// over a 2D Moore neighborhood; a horizontal blinker must flip vertical after one step and back after two.
 TEST(UserDefinedCA, GameOfLifeBlinkerOscillatesViaUserRule) {
 	// 2D Game of Life (B3/S23) expressed as a user rule over a Moore neighborhood. A horizontal
 	// blinker (3 cells) must become vertical after one step and horizontal again after two (period 2).
@@ -211,6 +221,8 @@ TEST(UserDefinedCA, GameOfLifeBlinkerOscillatesViaUserRule) {
 	EXPECT_EQ(vertical, expectedVertical);
 }
 
+// ClosedBoundaryWrapsAroundTorus — exercises the Closed (periodic) boundary with a "copy left neighbor"
+// user rule: a single live cell on a width-5 ring shifts right each step and returns to its start after 5.
 TEST(UserDefinedCA, ClosedBoundaryWrapsAroundTorus) {
 	// Exercises the Boundary_Closed (periodic) condition, distinct from the Fixed boundary used above.
 	// A "copy your left neighbor" rule (next = neighbors[0]) shifts the pattern one cell to the right
@@ -252,6 +264,8 @@ TEST(UserDefinedCA, ClosedBoundaryWrapsAroundTorus) {
 	EXPECT_EQ(rowOf(lattice), "00100") << "after `width` steps the pattern must return to its start";
 }
 
+// GameOfLifeGliderTranslatesViaUserRule — the classic GoL glider, run via the user rule on a 10x10 grid,
+// must reappear as the same shape shifted by (+1,+1) after 4 generations (backs the shipped evidence diagram).
 TEST(UserDefinedCA, GameOfLifeGliderTranslatesViaUserRule) {
 	// The classic Game of Life glider returns to its own shape shifted by (+1,+1) after 4 generations.
 	// This test-backs the glider space-time diagram shipped in dcs/site/assets/evidence-diagrams.txt
@@ -305,6 +319,9 @@ TEST(UserDefinedCA, GameOfLifeGliderTranslatesViaUserRule) {
 	EXPECT_EQ(rowOf(lattice), expected) << "glider must reappear shifted by (+1,+1) after 4 steps";
 }
 
+// ExtendedContractExposesCellPosition — the extended contract (nextStateEx) passes the cell's coordinates
+// to user code; a rule returning the parity of column 0 must paint "010101" after one step, proving the
+// position is actually delivered (independent of neighbor states).
 TEST(UserDefinedCA, ExtendedContractExposesCellPosition) {
 	// The extended user contract (nextStateEx) hands the rule the cell's n-dimensional position.
 	// A rule returning the parity of the first coordinate must paint a 1D row 0,1,0,1,... after one


### PR DESCRIPTION
## Summary

This pull request delivers the DCS project **"Universal Cellular Automaton Component with User-Defined Local Rule" (Theme 6.2)**, developed by:

- Pedro Henrique Gimenez
- João Vitor Curcio Sutter

It generalizes the GenESyS cellular-automata support into a single configurable component and implements the open requirement of the theme: a local transition rule defined by the user at runtime. The contribution is based on `currentStable` and is restricted to the cellular-automata subsystem.

## Main features

- **Universal generalization** — configurable lattice, neighborhood, boundary, state set and update policy. New boundaries (`Adiabatic`, `Reflexive`), new state sets (`Bit`, `Double`, `Integer`), N-dimensional Moore/Von Neumann neighborhoods, and synchronous, sequential, random and block update policies.
- **User-defined local rule** — `LocalRule_UserDefined` compiles a user function `extern "C" long nextState(long self, const long* neighbors, int numNeighbors)` at runtime (via `CppCompiler` → `dlopen`/`dlsym`) and applies it per cell, exposed as the `USERDEFINED` rule type.
- **Persistence and lifecycle** — complete `_loadInstance`/`_saveInstance` round-trip of the component configuration, with heap-ownership corrections.

## Validation

47 unit tests (gtest), all passing — by binary: `neighborhood` 14, `cellular_automata` 11, `component` 10, `user_defined` 8, `elementary` 4. Coverage includes the elementary engine validated bit-by-bit against Wolfram (rules 30 and 90), the user rule reproducing the built-in preset and Game of Life, all boundaries, Moore/Von Neumann neighbor counts in 1D/2D/3D, the four update policies, persistence round-trip, and rejection of invalid configurations.

## Build and test

```bash
cmake -S . -B build/tests -DGENESYS_BUILD_TESTS=ON \
  -DGENESYS_BUILD_TERMINAL_APPLICATION=OFF -DGENESYS_BUILD_WEB_APPLICATION=OFF
cmake --build build/tests --target genesys_test_cellular_automata \
  genesys_test_cellular_automata_neighborhood genesys_test_cellular_automata_elementary \
  genesys_test_cellular_automata_user_defined genesys_test_cellular_automata_component
ctest --test-dir build/tests -R CellularAutomata --output-on-failure
```

> The user-defined rule requires a C++ compiler (`g++`/`clang`) on `PATH` and a writable temporary directory; without a compiler it fails gracefully (no crash), a behavior covered by a test.
