### PR TITLE
Draft: port DCS ODE/PDE tools core to WorkInProgress

### DIFF
--- a/docs/ai_assistants/dcs_ode_pde_workinprogress_integration.md
+++ b/docs/ai_assistants/dcs_ode_pde_workinprogress_integration.md
@@ -1,0 +1,211 @@
+# DCS ODE/PDE Integration into WorkInProgress
+
+- Date: 2026-07-05
+- Source branch: `2026-1`
+- Target branch: `WorkInProgress`
+- Temporary branch: `integration-dcs-ode-pde-to-workinprogress-20260705`
+- Status: diagnostic and handoff only; no source files were ported in this branch because the GitHub-connector-only analysis found path and architecture divergence that makes blind copying unsafe.
+
+## Objective
+
+Prepare a selective integration path for accepted DCS Tema 8.1 and Tema 8.2 contributions that are already merged in `2026-1`, without importing rejected academic artifacts or overwriting unrelated `WorkInProgress` changes.
+
+## Repository state confirmed through GitHub connector
+
+`2026-1` and `WorkInProgress` both exist as usable refs. A GitHub compare from `WorkInProgress` to `2026-1` reported a diverged history: `2026-1` is 41 commits ahead of `WorkInProgress` and 133 commits behind it. The merge base was `b6bddc5ca3def48606833e9dbc3df23da2424213`; the current `WorkInProgress` tip inspected was `28ebf10a68f80426fbb2fa80f3b98be456f6541e`.
+
+The ahead-side file list contains the accepted ODE/PDE payload, but also unrelated or unsuitable files such as `.github/workflows/genesys-ci.yml`, `__temporary_check`, `source/tools/Optimization/OptimizerDefaultImpl1.*`, and historical `documentation/` entries. These must not be copied blindly into `WorkInProgress`.
+
+## PRs analyzed
+
+### PR #437 — Tema 8.1 — EDOs
+
+- Title: `Tema 8.1 - EDOs`.
+- Base: `2026-1`.
+- Current GitHub state: closed and merged.
+- Merge commit: `5cb8cdd81d3831f45e66db36409a611db78d5dc1`.
+- Changed files reported by GitHub:
+  - `documentation/continuous-system-ode-solver-validation-2026-06-30.md`
+  - `models/TestContinuousSystem.gen`
+  - `models/test_harmonic_oscillator.gen`
+  - `source/plugins/PluginConnectorDummyImpl1.cpp`
+  - `source/plugins/components/Continuous/ContinuousSystemComponent.cpp`
+  - `source/plugins/components/Continuous/ContinuousSystemComponent.h`
+  - `source/plugins/components/Continuous/DiffEquations.cpp`
+  - `source/plugins/components/Continuous/DiffEquations.h`
+  - `source/plugins/components/Continuous/LSODE.cpp`
+  - `source/plugins/components/Continuous/LSODE.h`
+  - `source/plugins/data/Continuous/ODESolver.cpp`
+  - `source/plugins/data/Continuous/ODESolver.h`
+  - `source/tests/demo_continuous_trace.cpp`
+  - `source/tests/smoke/CMakeLists.txt`
+  - `source/tests/test_continuous_system.cpp`
+  - `source/tests/test_lsode.cpp`
+  - `source/tests/test_ode_solver_numerical_validation.cpp`
+  - `source/tools/RungeKutta4OdeSolver.h`
+
+Current `2026-1` versions must be treated as authoritative over older evaluation notes and ZIP material, because the PR is now merged. In particular, current `source/plugins/data/Continuous/ODESolver.h` includes `kernel/simulator/model/ModelDataDefinition.h`, not the older invalid `kernel/simulator/ModelDataDefinition.h` path from the earlier evaluation.
+
+### PR #425 — Tema 8.2 — EDOs e EDPs
+
+- Title: `8.2: Solver de EDO por Factory + Dormand-Prince 5(4) e plugin de difusao N-D`.
+- Base: `2026-1`.
+- Current GitHub state: closed and merged.
+- Merge commit: `7066c4f5f76a675da28f34d9e8c4d1c931e32372`.
+- Changed files reported by GitHub:
+  - `source/plugins/components/Continuous/DiffusionSimulate.cpp`
+  - `source/plugins/components/Continuous/DiffusionSimulate.h`
+  - `source/plugins/data/Continuous/DiffusionField.cpp`
+  - `source/plugins/data/Continuous/DiffusionField.h`
+  - `source/tests/CMakeLists.txt`
+  - `source/tests/diffusion_demo.cpp`
+  - `source/tests/unit/CMakeLists.txt`
+  - `source/tests/unit/test_plugins_continuous_diffusion.cpp`
+  - `source/tests/unit/test_tools_diffusion_mol.cpp`
+  - `source/tests/unit/test_tools_ode_solver_factory.cpp`
+  - `source/tools/DiffusionMethodOfLinesSystem.h`
+  - `source/tools/DormandPrince54OdeSolver.h`
+  - `source/tools/OdeSolverFactory.h`
+
+The accepted PR no longer consists of the original rejected academic artifact set. The current accepted file list does not include root `README.md`, `relatorio.pdf`, `video_entrega.mp4`, or direct `BioNetwork.*` changes, which matches the intended cleanup policy.
+
+### PR #439 — Tema 8.1 controlled evaluation
+
+- Title: `DCS T8.1 controlled evaluation`.
+- Base: `2026-1`.
+- Current GitHub state: open and not merged.
+- Head: `t81ctrl2`.
+- This PR is still useful as historical/evaluation context, but it is not the integration source because PR #437 is now merged into `2026-1`.
+
+## Uploaded reports and ZIP material analyzed
+
+The uploaded Tema 8.1 evaluation report described the old state where PR #437 had been technically rejected and PR #439 was open but not merged. That information is now superseded by GitHub for integration purposes, because #437 is currently closed and merged.
+
+The uploaded Tema 8.2 evaluation report identified the numerically valuable core files (`OdeSolverFactory`, `DormandPrince54OdeSolver`, `DiffusionMethodOfLinesSystem`, and tests), while rejecting root README replacement, PDF/video artifacts, and domain-specific `BioNetwork.*`/`DiffusionField.*` modifications as they existed at that time. GitHub now shows #425 closed and merged with a cleaner accepted file set under `source/plugins/components/Continuous`, `source/plugins/data/Continuous`, `source/tools`, and `source/tests`.
+
+The uploaded ZIP was inspected. It contains:
+
+- Tema 8.1 files under a submission folder, including `ContinuousSystemComponent`, `ODESolver`, `DiffEquations`, `LSODE`, tests, models, and a PDF.
+- Tema 8.2 files including solver/factory headers, diffusion MOL tests, a nested repository ZIP, `relatorio.pdf`, `video_entrega.mp4`, and academic README material.
+
+For integration, the ZIP is historical context only. Use current `2026-1` files as source of truth.
+
+## Critical WorkInProgress divergence
+
+`WorkInProgress` has already reorganized tools into subdirectories. Confirmed examples:
+
+- `source/tools/Continuous/OdeSolver_if.h` exists in `WorkInProgress`.
+- `source/tools/Continuous/OdeSystem_if.h` exists in `WorkInProgress`.
+- `source/tools/Continuous/RungeKutta4OdeSolver.h` exists in `WorkInProgress`.
+- `source/tools/CMakeLists.txt` in `WorkInProgress` references `Continuous/SolverDefaultImpl1.cpp`, `Statistics/*`, `Optimization/*`, `AIAssistant/*`, and `FactorialDesign/*`.
+
+By contrast, the accepted DCS files in `2026-1` are under root `source/tools/` paths, for example:
+
+- `source/tools/OdeSolverFactory.h`
+- `source/tools/DormandPrince54OdeSolver.h`
+- `source/tools/DiffusionMethodOfLinesSystem.h`
+
+Therefore, a literal copy from `2026-1` to `WorkInProgress` would partially reintroduce the older layout and duplicate or bypass the current `source/tools/Continuous/` organization. The next implementation step should adapt the accepted solver/factory headers into `source/tools/Continuous/` or deliberately add compatibility wrapper headers after an explicit architectural decision.
+
+## Recommended selective port
+
+### Tema 8.1 — recommended files to port from current `2026-1`
+
+Port after adapting includes to the current `WorkInProgress` layout:
+
+- `source/plugins/data/Continuous/ODESolver.h`
+- `source/plugins/data/Continuous/ODESolver.cpp`
+- `source/plugins/components/Continuous/ContinuousSystemComponent.h`
+- `source/plugins/components/Continuous/ContinuousSystemComponent.cpp`
+- selected changes in `source/plugins/components/Continuous/LSODE.h`
+- selected changes in `source/plugins/components/Continuous/LSODE.cpp`
+- selected changes in `source/plugins/components/Continuous/DiffEquations.h`
+- selected changes in `source/plugins/components/Continuous/DiffEquations.cpp`
+- registration additions in `source/plugins/PluginConnectorDummyImpl1.cpp`, merged manually into the current `WorkInProgress` file so that AI, WCM, Python, biochemical, and other newer entries are preserved.
+
+Do not port from old ZIP if it conflicts with current `2026-1`.
+
+### Tema 8.2 — recommended files to port from current `2026-1`
+
+Port after adapting the tools layout:
+
+- `source/tools/DiffusionMethodOfLinesSystem.h` -> likely `source/tools/Continuous/DiffusionMethodOfLinesSystem.h`
+- `source/tools/DormandPrince54OdeSolver.h` -> likely `source/tools/Continuous/DormandPrince54OdeSolver.h`
+- `source/tools/OdeSolverFactory.h` -> likely `source/tools/Continuous/OdeSolverFactory.h`
+- `source/plugins/data/Continuous/DiffusionField.h`
+- `source/plugins/data/Continuous/DiffusionField.cpp`
+- `source/plugins/components/Continuous/DiffusionSimulate.h`
+- `source/plugins/components/Continuous/DiffusionSimulate.cpp`
+- `source/tests/unit/test_tools_ode_solver_factory.cpp`
+- `source/tests/unit/test_tools_diffusion_mol.cpp`
+- `source/tests/unit/test_plugins_continuous_diffusion.cpp`, only if the plugin registration and data/component files are ported together.
+- CMake registrations in `source/tests/unit/CMakeLists.txt`, merged manually with the current `WorkInProgress` file.
+
+## Explicitly rejected for this integration
+
+Do not bring:
+
+- root `README.md` replacements from academic submissions;
+- `relatorio.pdf`;
+- `video_entrega.mp4`;
+- ZIP files or Moodle submission artifacts;
+- `__temporary_check`;
+- unrelated optimization files from the same `2026-1` ahead-set;
+- broad `.github/workflows/genesys-ci.yml` changes unless CI policy is intentionally being synchronized;
+- historical `documentation/` paths as-is; if technical handoff is still valuable, consolidate into `docs/ai_assistants/`.
+
+## Implementation recommendation
+
+Because the current target branch has a newer architecture, do not use a mechanical branch-level cherry-pick or a blind file-copy operation. Use one of two approaches:
+
+1. Local implementation preferred:
+   - checkout `WorkInProgress`;
+   - create a topic branch;
+   - copy current accepted files from `2026-1`;
+   - move/adapt `source/tools/*Ode*` headers into `source/tools/Continuous/`;
+   - update includes in plugins and tests;
+   - manually merge `PluginConnectorDummyImpl1.cpp` additions;
+   - manually merge `source/tests/unit/CMakeLists.txt` additions;
+   - run CMake/Ninja/CTest locally before opening PR.
+
+2. GitHub-connector-only implementation:
+   - create branch from `WorkInProgress`;
+   - apply only small, manually reviewed files per commit;
+   - avoid large source-file replacement when it risks dropping newer `WorkInProgress` changes;
+   - open PR as draft and rely on GitHub Actions for CI.
+
+This diagnostic branch followed approach 2 only up to documentation because applying large code files safely through the connector would require manual adaptation of multiple large files and CMake merge points without local build feedback.
+
+## Validation performed
+
+Validated by GitHub connector inspection only:
+
+- repository metadata;
+- existence and usability of refs `2026-1` and `WorkInProgress` through file fetch and compare;
+- current merged state of PR #425 and PR #437;
+- current open/non-merged state of PR #439;
+- current `WorkInProgress` AI-assistant documentation;
+- current `WorkInProgress` tool layout under `source/tools/Continuous`;
+- current `WorkInProgress` unit-test CMake structure;
+- current `2026-1` ODE/PDE file presence through compare and file fetch.
+
+No local build was run. No CMake/Ninja/CTest execution was possible from the ChatGPT Web/GitHub connector environment.
+
+## Risks remaning
+
+- Solver/factory headers from `2026-1` must be adapted to the `WorkInProgress` `source/tools/Continuous/` layout.
+- `PluginConnectorDummyImpl1.cpp` must be merged manually; replacing the file with the `2026-1` version would drop WCM, AI, Python, biochemical, and other newer registrations present in `WorkInProgress`.
+- `source/tests/unit/CMakeLists.txt` must be merged manually; replacing it with the `2026-1` version would regress GUI path updates, worker application changes, WCM tests, generated method inventory tests, and other WorkInProgress-only test structure.
+- Continuous-time semantics still need review: both DCS themes touch hybrid discrete/continuous simulation, and the current documentation requires explicit tests for time-step and event-calendar interaction.
+- The accepted GitHub state has priority over older evaluation reports, but the older reports still identify conceptual risks that remain valid until tested.
+
+## Next steps
+
+1. Decide whether `OdeSolverFactory`, `DormandPrince54OdeSolver`, and `DiffusionMethodOfLinesSystem` should live under `source/tools/Continuous/` in `WorkInProgress`.
+2. Port the three Tema 8.2 header-only numerical files first, adapting includes.
+3. Add and register `test_tools_ode_solver_factory.cpp` and `test_tools_diffusion_mol.cpp` in `source/tests/unit/CMakeLists.txt`.
+4. Validate the tools-only tests in CI or local CMake/Ninja.
+5. Port `DiffusionField` and `DiffusionSimulate` next, then add plugin-level tests.
+6. Port Tema 8.1 `ODESolver` and `ContinuousSystemComponent` after the tools layout is stable.
+7. Manually merge plugin registrations into `PluginConnectorDummyImpl1.cpp` without dropping newer `WorkInProgress` entries.
+8. Run full `tests-unit` and targeted continuous/hybrid tests before merging into `WorkInProgress`.

--- a/docs/ai_assistants/dcs_ode_pde_workinprogress_integration.md
+++ b/docs/ai_assistants/dcs_ode_pde_workinprogress_integration.md
@@ -4,17 +4,16 @@
 - Source branch: `2026-1`
 - Target branch: `WorkInProgress`
 - Temporary branch: `integration-dcs-ode-pde-to-workinprogress-20260705`
-- Status: diagnostic and handoff only; no source files were ported in this branch because the GitHub-connector-only analysis found path and architecture divergence that makes blind copying unsafe.
+- PR: #460, draft
+- Status: first implementation slice in progress. The tools-only Tema 8.2 numerical core was ported to the current `WorkInProgress` layout under `source/tools/Continuous/`, with focused unit tests registered in `source/tests/unit/CMakeLists.txt`. Plugin/data/component integration is still pending.
 
 ## Objective
 
-Prepare a selective integration path for accepted DCS Tema 8.1 and Tema 8.2 contributions that are already merged in `2026-1`, without importing rejected academic artifacts or overwriting unrelated `WorkInProgress` changes.
+Prepare a selective integration path for accepted DCS Tema 8.1 and Tema 8.2 contributions already merged in `2026-1`, without importing rejected academic artifacts or overwriting unrelated `WorkInProgress` changes.
 
 ## Repository state confirmed through GitHub connector
 
-`2026-1` and `WorkInProgress` both exist as usable refs. A GitHub compare from `WorkInProgress` to `2026-1` reported a diverged history: `2026-1` is 41 commits ahead of `WorkInProgress` and 133 commits behind it. The merge base was `b6bddc5ca3def48606833e9dbc3df23da2424213`; the current `WorkInProgress` tip inspected was `28ebf10a68f80426fbb2fa80f3b98be456f6541e`.
-
-The ahead-side file list contains the accepted ODE/PDE payload, but also unrelated or unsuitable files such as `.github/workflows/genesys-ci.yml`, `__temporary_check`, `source/tools/Optimization/OptimizerDefaultImpl1.*`, and historical `documentation/` entries. These must not be copied blindly into `WorkInProgress`.
+`2026-1` and `WorkInProgress` both exist as usable refs. A GitHub compare from `WorkInProgress` to `2026-1` reported a diverged history: `2026-1` was 41 commits ahead of `WorkInProgress` and 133 commits behind it. The ahead-side file list contained accepted ODE/PDE payload plus unrelated or unsuitable files such as `.github/workflows/genesys-ci.yml`, `__temporary_check`, `source/tools/Optimization/OptimizerDefaultImpl1.*`, and historical `documentation/` entries. Those unrelated files were not ported.
 
 ## PRs analyzed
 
@@ -24,27 +23,22 @@ The ahead-side file list contains the accepted ODE/PDE payload, but also unrelat
 - Base: `2026-1`.
 - Current GitHub state: closed and merged.
 - Merge commit: `5cb8cdd81d3831f45e66db36409a611db78d5dc1`.
-- Changed files reported by GitHub:
-  - `documentation/continuous-system-ode-solver-validation-2026-06-30.md`
-  - `models/TestContinuousSystem.gen`
-  - `models/test_harmonic_oscillator.gen`
-  - `source/plugins/PluginConnectorDummyImpl1.cpp`
-  - `source/plugins/components/Continuous/ContinuousSystemComponent.cpp`
-  - `source/plugins/components/Continuous/ContinuousSystemComponent.h`
-  - `source/plugins/components/Continuous/DiffEquations.cpp`
-  - `source/plugins/components/Continuous/DiffEquations.h`
-  - `source/plugins/components/Continuous/LSODE.cpp`
-  - `source/plugins/components/Continuous/LSODE.h`
-  - `source/plugins/data/Continuous/ODESolver.cpp`
-  - `source/plugins/data/Continuous/ODESolver.h`
-  - `source/tests/demo_continuous_trace.cpp`
-  - `source/tests/smoke/CMakeLists.txt`
-  - `source/tests/test_continuous_system.cpp`
-  - `source/tests/test_lsode.cpp`
-  - `source/tests/test_ode_solver_numerical_validation.cpp`
-  - `source/tools/RungeKutta4OdeSolver.h`
+- Integration source status: accepted in `2026-1`, but not yet ported in this implementation slice.
 
-Current `2026-1` versions must be treated as authoritative over older evaluation notes and ZIP material, because the PR is now merged. In particular, current `source/plugins/data/Continuous/ODESolver.h` includes `kernel/simulator/model/ModelDataDefinition.h`, not the older invalid `kernel/simulator/ModelDataDefinition.h` path from the earlier evaluation.
+Relevant files in #437:
+
+- `source/plugins/data/Continuous/ODESolver.h`
+- `source/plugins/data/Continuous/ODESolver.cpp`
+- `source/plugins/components/Continuous/ContinuousSystemComponent.h`
+- `source/plugins/components/Continuous/ContinuousSystemComponent.cpp`
+- `source/plugins/components/Continuous/LSODE.h`
+- `source/plugins/components/Continuous/LSODE.cpp`
+- `source/plugins/components/Continuous/DiffEquations.h`
+- `source/plugins/components/Continuous/DiffEquations.cpp`
+- `source/plugins/PluginConnectorDummyImpl1.cpp`
+- smoke tests and demonstration models.
+
+Current `2026-1` versions must be treated as authoritative over older evaluation notes and ZIP material. In particular, current `source/plugins/data/Continuous/ODESolver.h` uses `kernel/simulator/model/ModelDataDefinition.h`, not the older invalid include path from the earlier evaluation.
 
 ### PR #425 — Tema 8.2 — EDOs e EDPs
 
@@ -52,22 +46,20 @@ Current `2026-1` versions must be treated as authoritative over older evaluation
 - Base: `2026-1`.
 - Current GitHub state: closed and merged.
 - Merge commit: `7066c4f5f76a675da28f34d9e8c4d1c931e32372`.
-- Changed files reported by GitHub:
-  - `source/plugins/components/Continuous/DiffusionSimulate.cpp`
-  - `source/plugins/components/Continuous/DiffusionSimulate.h`
-  - `source/plugins/data/Continuous/DiffusionField.cpp`
-  - `source/plugins/data/Continuous/DiffusionField.h`
-  - `source/tests/CMakeLists.txt`
-  - `source/tests/diffusion_demo.cpp`
-  - `source/tests/unit/CMakeLists.txt`
-  - `source/tests/unit/test_plugins_continuous_diffusion.cpp`
-  - `source/tests/unit/test_tools_diffusion_mol.cpp`
-  - `source/tests/unit/test_tools_ode_solver_factory.cpp`
-  - `source/tools/DiffusionMethodOfLinesSystem.h`
-  - `source/tools/DormandPrince54OdeSolver.h`
-  - `source/tools/OdeSolverFactory.h`
+- Integration source status: accepted in `2026-1`; the tools-only subset was ported/adapted in this branch.
 
-The accepted PR no longer consists of the original rejected academic artifact set. The current accepted file list does not include root `README.md`, `relatorio.pdf`, `video_entrega.mp4`, or direct `BioNetwork.*` changes, which matches the intended cleanup policy.
+Relevant files in #425:
+
+- `source/tools/OdeSolverFactory.h`
+- `source/tools/DormandPrince54OdeSolver.h`
+- `source/tools/DiffusionMethodOfLinesSystem.h`
+- `source/tests/unit/test_tools_ode_solver_factory.cpp`
+- `source/tests/unit/test_tools_diffusion_mol.cpp`
+- `source/plugins/data/Continuous/DiffusionField.*`
+- `source/plugins/components/Continuous/DiffusionSimulate.*`
+- `source/tests/unit/test_plugins_continuous_diffusion.cpp`
+
+The accepted PR no longer contains the original rejected academic artifact set. The current accepted GitHub file list does not include root `README.md`, `relatorio.pdf`, `video_entrega.mp4`, or direct `BioNetwork.*` changes.
 
 ### PR #439 — Tema 8.1 controlled evaluation
 
@@ -75,71 +67,77 @@ The accepted PR no longer consists of the original rejected academic artifact se
 - Base: `2026-1`.
 - Current GitHub state: open and not merged.
 - Head: `t81ctrl2`.
-- This PR is still useful as historical/evaluation context, but it is not the integration source because PR #437 is now merged into `2026-1`.
+- Use only as historical/evaluation context. The integration source for Tema 8.1 is the current merged state of #437 in `2026-1`.
 
 ## Uploaded reports and ZIP material analyzed
 
-The uploaded Tema 8.1 evaluation report described the old state where PR #437 had been technically rejected and PR #439 was open but not merged. That information is now superseded by GitHub for integration purposes, because #437 is currently closed and merged.
+The uploaded Tema 8.1 evaluation report described an earlier state where PR #437 had been technically rejected and PR #439 was open but not merged. That information is now superseded by GitHub for integration purposes because #437 is currently closed and merged.
 
 The uploaded Tema 8.2 evaluation report identified the numerically valuable core files (`OdeSolverFactory`, `DormandPrince54OdeSolver`, `DiffusionMethodOfLinesSystem`, and tests), while rejecting root README replacement, PDF/video artifacts, and domain-specific `BioNetwork.*`/`DiffusionField.*` modifications as they existed at that time. GitHub now shows #425 closed and merged with a cleaner accepted file set under `source/plugins/components/Continuous`, `source/plugins/data/Continuous`, `source/tools`, and `source/tests`.
 
-The uploaded ZIP was inspected. It contains:
-
-- Tema 8.1 files under a submission folder, including `ContinuousSystemComponent`, `ODESolver`, `DiffEquations`, `LSODE`, tests, models, and a PDF.
-- Tema 8.2 files including solver/factory headers, diffusion MOL tests, a nested repository ZIP, `relatorio.pdf`, `video_entrega.mp4`, and academic README material.
-
-For integration, the ZIP is historical context only. Use current `2026-1` files as source of truth.
+The uploaded ZIP was inspected as historical context only. Use current `2026-1` files as source of truth.
 
 ## Critical WorkInProgress divergence
 
-`WorkInProgress` has already reorganized tools into subdirectories. Confirmed examples:
+`WorkInProgress` already reorganized tools into subdirectories. Confirmed examples:
 
-- `source/tools/Continuous/OdeSolver_if.h` exists in `WorkInProgress`.
-- `source/tools/Continuous/OdeSystem_if.h` exists in `WorkInProgress`.
-- `source/tools/Continuous/RungeKutta4OdeSolver.h` exists in `WorkInProgress`.
-- `source/tools/CMakeLists.txt` in `WorkInProgress` references `Continuous/SolverDefaultImpl1.cpp`, `Statistics/*`, `Optimization/*`, `AIAssistant/*`, and `FactorialDesign/*`.
+- `source/tools/Continuous/OdeSolver_if.h`
+- `source/tools/Continuous/OdeSystem_if.h`
+- `source/tools/Continuous/RungeKutta4OdeSolver.h`
+- `source/tools/CMakeLists.txt` referencing `Continuous/SolverDefaultImpl1.cpp`, `Statistics/*`, `Optimization/*`, `AIAssistant/*`, and `FactorialDesign/*`.
 
-By contrast, the accepted DCS files in `2026-1` are under root `source/tools/` paths, for example:
+The accepted Tema 8.2 files in `2026-1` were under root `source/tools/`. This branch intentionally ports them to `source/tools/Continuous/` instead of reintroducing root-level tool headers.
 
-- `source/tools/OdeSolverFactory.h`
-- `source/tools/DormandPrince54OdeSolver.h`
-- `source/tools/DiffusionMethodOfLinesSystem.h`
+## Implemented in this branch
 
-Therefore, a literal copy from `2026-1` to `WorkInProgress` would partially reintroduce the older layout and duplicate or bypass the current `source/tools/Continuous/` organization. The next implementation step should adapt the accepted solver/factory headers into `source/tools/Continuous/` or deliberately add compatibility wrapper headers after an explicit architectural decision.
+### Tema 8.2 tools-only numerical core
 
-## Recommended selective port
+Created/adapted:
 
-### Tema 8.1 — recommended files to port from current `2026-1`
+- `source/tools/Continuous/OdeSolverFactory.h`
+- `source/tools/Continuous/DormandPrince54OdeSolver.h`
+- `source/tools/Continuous/DiffusionMethodOfLinesSystem.h`
 
-Port after adapting includes to the current `WorkInProgress` layout:
+Adaptation decisions:
 
-- `source/plugins/data/Continuous/ODESolver.h`
-- `source/plugins/data/Continuous/ODESolver.cpp`
-- `source/plugins/components/Continuous/ContinuousSystemComponent.h`
-- `source/plugins/components/Continuous/ContinuousSystemComponent.cpp`
-- selected changes in `source/plugins/components/Continuous/LSODE.h`
-- selected changes in `source/plugins/components/Continuous/LSODE.cpp`
-- selected changes in `source/plugins/components/Continuous/DiffEquations.h`
-- selected changes in `source/plugins/components/Continuous/DiffEquations.cpp`
-- registration additions in `source/plugins/PluginConnectorDummyImpl1.cpp`, merged manually into the current `WorkInProgress` file so that AI, WCM, Python, biochemical, and other newer entries are preserved.
+- Preserve the existing `WorkInProgress` layout.
+- Include `OdeSolver_if.h`, `OdeSystem_if.h`, and `RungeKutta4OdeSolver.h` from the same `source/tools/Continuous/` directory.
+- Keep the implementation header-only, matching the accepted `2026-1` contribution.
 
-Do not port from old ZIP if it conflicts with current `2026-1`.
+### Unit tests
 
-### Tema 8.2 — recommended files to port from current `2026-1`
+Created/adapted:
 
-Port after adapting the tools layout:
-
-- `source/tools/DiffusionMethodOfLinesSystem.h` -> likely `source/tools/Continuous/DiffusionMethodOfLinesSystem.h`
-- `source/tools/DormandPrince54OdeSolver.h` -> likely `source/tools/Continuous/DormandPrince54OdeSolver.h`
-- `source/tools/OdeSolverFactory.h` -> likely `source/tools/Continuous/OdeSolverFactory.h`
-- `source/plugins/data/Continuous/DiffusionField.h`
-- `source/plugins/data/Continuous/DiffusionField.cpp`
-- `source/plugins/components/Continuous/DiffusionSimulate.h`
-- `source/plugins/components/Continuous/DiffusionSimulate.cpp`
 - `source/tests/unit/test_tools_ode_solver_factory.cpp`
 - `source/tests/unit/test_tools_diffusion_mol.cpp`
-- `source/tests/unit/test_plugins_continuous_diffusion.cpp`, only if the plugin registration and data/component files are ported together.
-- CMake registrations in `source/tests/unit/CMakeLists.txt`, merged manually with the current `WorkInProgress` file.
+
+CMake updated:
+
+- `source/tests/unit/CMakeLists.txt`
+
+Registered targets:
+
+- `genesys_test_tools_ode_solver_factory`
+- `genesys_test_tools_diffusion_mol`
+
+Both targets are added to `genesys_kernel_unit_tests` and `genesys_kernel_unit_tests_run`.
+
+The diffusion MOL test is currently a reduced smoke subset because the GitHub connector blocked creation of the full large test file in a single write operation. It still checks a 1D Dirichlet sine-mode decay, Neumann mass conservation, invalid configuration rejection, and row-major indexing round-trip.
+
+## Explicitly not implemented yet
+
+Not yet ported:
+
+- `source/plugins/data/Continuous/DiffusionField.*`
+- `source/plugins/components/Continuous/DiffusionSimulate.*`
+- `source/tests/unit/test_plugins_continuous_diffusion.cpp`
+- `source/plugins/data/Continuous/ODESolver.*`
+- `source/plugins/components/Continuous/ContinuousSystemComponent.*`
+- selected `LSODE.*` changes
+- selected `DiffEquations.*` changes
+- `PluginConnectorDummyImpl1.cpp` registrations
+
+Do not copy `PluginConnectorDummyImpl1.cpp` from `2026-1` wholesale. It must be manually merged to preserve newer WCM, AI, Python, biochemical, and other registrations present in `WorkInProgress`.
 
 ## Explicitly rejected for this integration
 
@@ -151,61 +149,39 @@ Do not bring:
 - ZIP files or Moodle submission artifacts;
 - `__temporary_check`;
 - unrelated optimization files from the same `2026-1` ahead-set;
-- broad `.github/workflows/genesys-ci.yml` changes unless CI policy is intentionally being synchronized;
-- historical `documentation/` paths as-is; if technical handoff is still valuable, consolidate into `docs/ai_assistants/`.
-
-## Implementation recommendation
-
-Because the current target branch has a newer architecture, do not use a mechanical branch-level cherry-pick or a blind file-copy operation. Use one of two approaches:
-
-1. Local implementation preferred:
-   - checkout `WorkInProgress`;
-   - create a topic branch;
-   - copy current accepted files from `2026-1`;
-   - move/adapt `source/tools/*Ode*` headers into `source/tools/Continuous/`;
-   - update includes in plugins and tests;
-   - manually merge `PluginConnectorDummyImpl1.cpp` additions;
-   - manually merge `source/tests/unit/CMakeLists.txt` additions;
-   - run CMake/Ninja/CTest locally before opening PR.
-
-2. GitHub-connector-only implementation:
-   - create branch from `WorkInProgress`;
-   - apply only small, manually reviewed files per commit;
-   - avoid large source-file replacement when it risks dropping newer `WorkInProgress` changes;
-   - open PR as draft and rely on GitHub Actions for CI.
-
-This diagnostic branch followed approach 2 only up to documentation because applying large code files safely through the connector would require manual adaptation of multiple large files and CMake merge points without local build feedback.
+- broad `.github/workflows/genesys-ci.yml` changes unless CI policy is intentionally synchronized;
+- historical `documentation/` paths as-is; consolidate useful material into `docs/ai_assistants/`.
 
 ## Validation performed
 
-Validated by GitHub connector inspection only:
+Validated by GitHub connector inspection and remote file operations only:
 
 - repository metadata;
-- existence and usability of refs `2026-1` and `WorkInProgress` through file fetch and compare;
-- current merged state of PR #425 and PR #437;
-- current open/non-merged state of PR #439;
-- current `WorkInProgress` AI-assistant documentation;
-- current `WorkInProgress` tool layout under `source/tools/Continuous`;
-- current `WorkInProgress` unit-test CMake structure;
-- current `2026-1` ODE/PDE file presence through compare and file fetch.
+- PR state for #425, #437, and #439;
+- branch comparison;
+- `WorkInProgress` AI-assistant documentation;
+- `WorkInProgress` tools layout;
+- `WorkInProgress` unit-test CMake structure;
+- source file creation and CMake registration in the integration branch.
 
-No local build was run. No CMake/Ninja/CTest execution was possible from the ChatGPT Web/GitHub connector environment.
+No local build was run. No CMake/Ninja/CTest execution was possible from ChatGPT Web with GitHub connector.
 
-## Risks remaning
+## Risks remaining
 
-- Solver/factory headers from `2026-1` must be adapted to the `WorkInProgress` `source/tools/Continuous/` layout.
-- `PluginConnectorDummyImpl1.cpp` must be merged manually; replacing the file with the `2026-1` version would drop WCM, AI, Python, biochemical, and other newer registrations present in `WorkInProgress`.
-- `source/tests/unit/CMakeLists.txt` must be merged manually; replacing it with the `2026-1` version would regress GUI path updates, worker application changes, WCM tests, generated method inventory tests, and other WorkInProgress-only test structure.
+- The new header-only tools need actual CMake/Ninja/CTest validation.
+- The reduced diffusion test should later be expanded back toward the full accepted #425 test coverage.
+- Plugin/data/component integration is still pending.
 - Continuous-time semantics still need review: both DCS themes touch hybrid discrete/continuous simulation, and the current documentation requires explicit tests for time-step and event-calendar interaction.
-- The accepted GitHub state has priority over older evaluation reports, but the older reports still identify conceptual risks that remain valid until tested.
+- `PluginConnectorDummyImpl1.cpp` and `source/tests/unit/CMakeLists.txt` are high-conflict files and must remain manually merged.
 
 ## Next steps
 
-1. Decide whether `OdeSolverFactory`, `DormandPrince54OdeSolver`, and `DiffusionMethodOfLinesSystem` should live under `source/tools/Continuous/` in `WorkInProgress`.
-2. Port the three Tema 8.2 header-only numerical files first, adapting includes.
-3. Add and register `test_tools_ode_solver_factory.cpp` and `test_tools_diffusion_mol.cpp` in `source/tests/unit/CMakeLists.txt`.
-4. Validate the tools-only tests in CI or local CMake/Ninja.
-5. Port `DiffusionField` and `DiffusionSimulate` next, then add plugin-level tests.
-6. Port Tema 8.1 `ODESolver` and `ContinuousSystemComponent` after the tools layout is stable.
-7. Manually merge plugin registrations into `PluginConnectorDummyImpl1.cpp` without dropping newer `WorkInProgress` entries.
-8. Run full `tests-unit` and targeted continuous/hybrid tests before merging into `WorkInProgress`.
+1. Wait for CI on PR #460 or run locally:
+   - `cmake --preset tests-unit`
+   - `cmake --build --preset tests-unit`
+   - `ctest --preset tests-unit --output-on-failure`
+2. If the tools-only slice passes, port `DiffusionField.*` and `DiffusionSimulate.*`.
+3. Add `test_plugins_continuous_diffusion.cpp` only after plugin registration is ported.
+4. Port Tema 8.1 `ODESolver` and `ContinuousSystemComponent` after the tools layout is stable.
+5. Manually merge plugin registrations into `PluginConnectorDummyImpl1.cpp` without dropping newer `WorkInProgress` entries.
+6. Run full `tests-unit` and targeted continuous/hybrid tests before merging into `WorkInProgress`.

--- a/source/tests/unit/CMakeLists.txt
+++ b/source/tests/unit/CMakeLists.txt
@@ -179,8 +179,8 @@ if(DEFINED GENESYS_QT_TEST_PACKAGE)
         "${CMAKE_SOURCE_DIR}/source/applications/gui/genesys/*.cpp"
     )
     list(FILTER GENESYS_QT_GUI_TEST_SOURCES EXCLUDE REGEX "/build/")
-    list(FILTER GENESYS_QT_GUI_TEST_SOURCES EXCLUDE REGEX "/main\\.cpp$")
-    list(FILTER GENESYS_QT_GUI_TEST_SOURCES EXCLUDE REGEX "/qcustomplot\\.cpp$")
+    list(FILTER GENESYS_QT_GUI_TEST_SOURCES EXCLUDE REGEX "/main\.cpp$")
+    list(FILTER GENESYS_QT_GUI_TEST_SOURCES EXCLUDE REGEX "/qcustomplot\.cpp$")
 
     if(NOT TARGET genesys_tools)
         add_subdirectory(${CMAKE_SOURCE_DIR}/source/tools ${CMAKE_BINARY_DIR}/source/tools-for-gui-tests)
@@ -280,6 +280,16 @@ genesys_add_unit_test(genesys_test_tools_simulation_results_dataset
     genesys_tools
 )
 
+genesys_add_unit_test(genesys_test_tools_ode_solver_factory
+    test_tools_ode_solver_factory.cpp
+    genesys_tools
+)
+
+genesys_add_unit_test(genesys_test_tools_diffusion_mol
+    test_tools_diffusion_mol.cpp
+    genesys_tools
+)
+
 add_custom_target(genesys_kernel_unit_tests
     DEPENDS
         genesys_test_util
@@ -299,6 +309,8 @@ add_custom_target(genesys_kernel_unit_tests
         genesys_test_statistics
         genesys_test_tools_hypothesistester
         genesys_test_tools_simulation_results_dataset
+        genesys_test_tools_ode_solver_factory
+        genesys_test_tools_diffusion_mol
         genesys_test_wcm_plugins
 )
 
@@ -379,6 +391,8 @@ add_custom_target(genesys_kernel_unit_tests_run
     COMMAND $<TARGET_FILE:genesys_test_statistics>
     COMMAND $<TARGET_FILE:genesys_test_tools_hypothesistester>
     COMMAND $<TARGET_FILE:genesys_test_tools_simulation_results_dataset>
+    COMMAND $<TARGET_FILE:genesys_test_tools_ode_solver_factory>
+    COMMAND $<TARGET_FILE:genesys_test_tools_diffusion_mol>
     COMMAND $<TARGET_FILE:genesys_test_wcm_plugins>
     COMMAND $<TARGET_FILE:genesys_test_kernel_simulator_method_inventory>
     DEPENDS

--- a/source/tests/unit/test_tools_diffusion_mol.cpp
+++ b/source/tests/unit/test_tools_diffusion_mol.cpp
@@ -1,0 +1,66 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <vector>
+
+#include "tools/Continuous/DiffusionMethodOfLinesSystem.h"
+#include "tools/Continuous/OdeSolverFactory.h"
+
+namespace {
+using DMS = DiffusionMethodOfLinesSystem;
+
+bool integrateOnce(const DMS& sys, std::vector<double>& field, double dt) {
+	auto solver = OdeSolverFactory::create("DormandPrince54");
+	std::vector<double> next(field.size(), 0.0);
+	if (!solver->advance(sys, 0.0, dt, field.data(), next.data())) {
+		return false;
+	}
+	field = next;
+	return true;
+}
+
+} // namespace
+
+TEST(DiffusionMolTest, OneDimensionalSineModeDecaysAtDiscreteRate) {
+	DMS sys({41}, {0.05}, 0.2, DMS::Boundary::Dirichlet);
+	ASSERT_TRUE(sys.isValid());
+	std::vector<double> y(sys.totalNodes());
+	sys.fillSineModes({2}, 1.0, y.data());
+	const std::vector<double> y0 = y;
+	const double lambda = sys.sineModeDecayRate({2});
+	ASSERT_TRUE(integrateOnce(sys, y, 0.5));
+	const double factor = std::exp(-lambda * 0.5);
+	double maxError = 0.0;
+	for (std::size_t i = 0; i < y.size(); ++i) {
+		maxError = std::max(maxError, std::fabs(y[i] - y0[i] * factor));
+	}
+	EXPECT_LT(maxError, 1e-7);
+}
+
+TEST(DiffusionMolTest, NeumannConservesMass) {
+	DMS sys({31, 31}, {0.1, 0.1}, 0.3, DMS::Boundary::Neumann);
+	ASSERT_TRUE(sys.isValid());
+	std::vector<double> y(sys.totalNodes());
+	sys.fillGaussian(1.0, 0.3, y.data());
+	const double initialMass = sys.totalMass(y.data());
+	ASSERT_TRUE(integrateOnce(sys, y, 0.5));
+	EXPECT_NEAR(sys.totalMass(y.data()), initialMass, 1e-9);
+	EXPECT_LT(sys.maxValue(y.data()), 1.0);
+}
+
+TEST(DiffusionMolTest, RejectsInvalidConfiguration) {
+	EXPECT_FALSE(DMS({2}, {0.1}, 0.1, DMS::Boundary::Dirichlet).isValid());
+	EXPECT_FALSE(DMS({10}, {0.1, 0.1}, 0.1, DMS::Boundary::Dirichlet).isValid());
+	EXPECT_FALSE(DMS({10}, {-0.1}, 0.1, DMS::Boundary::Dirichlet).isValid());
+	EXPECT_EQ(DMS({2}, {0.1}, 0.1, DMS::Boundary::Dirichlet).dimension(), 0u);
+}
+
+TEST(DiffusionMolTest, RowMajorIndexingRoundTrips) {
+	DMS sys({4, 5, 6}, {0.1, 0.1, 0.1}, 0.1, DMS::Boundary::Dirichlet);
+	ASSERT_TRUE(sys.isValid());
+	const std::vector<unsigned int> multiIndex = {2, 3, 4};
+	const unsigned int node = sys.nodeIndex(multiIndex);
+	EXPECT_EQ(sys.coordinate(node, 0), 2u);
+	EXPECT_EQ(sys.coordinate(node, 1), 3u);
+	EXPECT_EQ(sys.coordinate(node, 2), 4u);
+}

--- a/source/tests/unit/test_tools_ode_solver_factory.cpp
+++ b/source/tests/unit/test_tools_ode_solver_factory.cpp
@@ -1,0 +1,192 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <memory>
+#include <vector>
+
+#include "tools/Continuous/DormandPrince54OdeSolver.h"
+#include "tools/Continuous/OdeSolverFactory.h"
+#include "tools/Continuous/OdeSystem_if.h"
+#include "tools/Continuous/RungeKutta4OdeSolver.h"
+
+namespace {
+
+class ExponentialDecay : public OdeSystem_if {
+public:
+	explicit ExponentialDecay(double k) : _k(k) {}
+	unsigned int dimension() const override { return 1; }
+	void evaluate(double, const double* y, double* dydt) const override { dydt[0] = -_k * y[0]; }
+private:
+	double _k;
+};
+
+class HarmonicOscillator : public OdeSystem_if {
+public:
+	explicit HarmonicOscillator(double w) : _w(w) {}
+	unsigned int dimension() const override { return 2; }
+	void evaluate(double, const double* y, double* dydt) const override {
+		dydt[0] = y[1];
+		dydt[1] = -_w * _w * y[0];
+	}
+private:
+	double _w;
+};
+
+bool integrateTo(const OdeSolver_if& solver, const OdeSystem_if& system,
+                 double T, unsigned int steps, std::vector<double>& state) {
+	const double dt = T / static_cast<double>(steps);
+	std::vector<double> next(state.size(), 0.0);
+	double t = 0.0;
+	for (unsigned int s = 0; s < steps; ++s) {
+		if (!solver.advance(system, t, dt, state.data(), next.data())) {
+			return false;
+		}
+		state = next;
+		t += dt;
+	}
+	return true;
+}
+
+} // namespace
+
+TEST(OdeSolverFactoryTest, RegistersBothBuiltInSolvers) {
+	EXPECT_TRUE(OdeSolverFactory::isRegistered("RungeKutta4"));
+	EXPECT_TRUE(OdeSolverFactory::isRegistered("DormandPrince54"));
+	EXPECT_FALSE(OdeSolverFactory::isRegistered("Nonexistent"));
+	EXPECT_GE(OdeSolverFactory::availableKeys().size(), 2u);
+}
+
+TEST(OdeSolverFactoryTest, CreatesNonNullSolversFromEnum) {
+	auto rk = OdeSolverFactory::create(OdeSolverType::RungeKutta4);
+	auto dp = OdeSolverFactory::create(OdeSolverType::DormandPrince54);
+	ASSERT_NE(rk, nullptr);
+	ASSERT_NE(dp, nullptr);
+	EXPECT_NE(dynamic_cast<RungeKutta4OdeSolver*>(rk.get()), nullptr);
+	EXPECT_NE(dynamic_cast<DormandPrince54OdeSolver*>(dp.get()), nullptr);
+}
+
+TEST(OdeSolverFactoryTest, CreatesSolversFromStringKey) {
+	auto rk = OdeSolverFactory::create(std::string("RungeKutta4"));
+	auto dp = OdeSolverFactory::create(std::string("DormandPrince54"));
+	ASSERT_NE(rk, nullptr);
+	ASSERT_NE(dp, nullptr);
+	EXPECT_NE(dynamic_cast<RungeKutta4OdeSolver*>(rk.get()), nullptr);
+	EXPECT_NE(dynamic_cast<DormandPrince54OdeSolver*>(dp.get()), nullptr);
+}
+
+TEST(OdeSolverFactoryTest, UnknownKeyFallsBackToRungeKutta4) {
+	auto solver = OdeSolverFactory::create(std::string("DoesNotExist"));
+	ASSERT_NE(solver, nullptr);
+	EXPECT_NE(dynamic_cast<RungeKutta4OdeSolver*>(solver.get()), nullptr);
+}
+
+TEST(OdeSolverFactoryTest, KeyEnumRoundTrip) {
+	OdeSolverType type;
+	EXPECT_TRUE(OdeSolverFactory::fromKey("RungeKutta4", type));
+	EXPECT_EQ(type, OdeSolverType::RungeKutta4);
+	EXPECT_TRUE(OdeSolverFactory::fromKey("DormandPrince54", type));
+	EXPECT_EQ(type, OdeSolverType::DormandPrince54);
+	EXPECT_FALSE(OdeSolverFactory::fromKey("bogus", type));
+	EXPECT_EQ(OdeSolverFactory::toKey(OdeSolverType::RungeKutta4), "RungeKutta4");
+	EXPECT_EQ(OdeSolverFactory::toKey(OdeSolverType::DormandPrince54), "DormandPrince54");
+}
+
+TEST(OdeSolverFactoryTest, RegisterCreatorIsOpenForExtension) {
+	const std::string key = "CustomRk4Alias_UT";
+	EXPECT_FALSE(OdeSolverFactory::isRegistered(key));
+	const bool added = OdeSolverFactory::registerCreator(
+			key, [] { return std::make_unique<RungeKutta4OdeSolver>(); });
+	EXPECT_TRUE(added);
+	EXPECT_TRUE(OdeSolverFactory::isRegistered(key));
+	const bool addedAgain = OdeSolverFactory::registerCreator(
+			key, [] { return std::make_unique<RungeKutta4OdeSolver>(); });
+	EXPECT_FALSE(addedAgain);
+	auto solver = OdeSolverFactory::create(key);
+	ASSERT_NE(solver, nullptr);
+}
+
+TEST(DormandPrince54Test, MatchesExponentialDecayAnalyticalSolution) {
+	ExponentialDecay decay(0.7);
+	DormandPrince54OdeSolver dp;
+	const double y0 = 5.0, T = 3.0;
+	std::vector<double> state{y0};
+	ASSERT_TRUE(integrateTo(dp, decay, T, 30, state));
+	EXPECT_NEAR(state[0], y0 * std::exp(-0.7 * T), 1e-6);
+}
+
+TEST(DormandPrince54Test, MatchesHarmonicOscillatorAnalyticalSolution) {
+	HarmonicOscillator osc(2.0);
+	DormandPrince54OdeSolver dp;
+	const double T = 2.5;
+	std::vector<double> state{1.0, 0.0};
+	ASSERT_TRUE(integrateTo(dp, osc, T, 50, state));
+	EXPECT_NEAR(state[0], std::cos(2.0 * T), 1e-6);
+	EXPECT_NEAR(state[1], -2.0 * std::sin(2.0 * T), 1e-6);
+}
+
+TEST(DormandPrince54Test, IsAtLeastAsAccurateAsRk4OnSameMacroGrid) {
+	ExponentialDecay decay(1.0);
+	const double y0 = 1.0, T = 4.0, exact = y0 * std::exp(-T);
+	RungeKutta4OdeSolver rk;
+	DormandPrince54OdeSolver dp(1e-8, 1e-11);
+	std::vector<double> sRk{y0}, sDp{y0};
+	ASSERT_TRUE(integrateTo(rk, decay, T, 20, sRk));
+	ASSERT_TRUE(integrateTo(dp, decay, T, 20, sDp));
+	EXPECT_LT(std::fabs(sDp[0] - exact), std::fabs(sRk[0] - exact));
+}
+
+TEST(DormandPrince54Test, ToleranceTighteningReducesError) {
+	ExponentialDecay decay(1.3);
+	const double y0 = 2.0, T = 5.0, exact = y0 * std::exp(-1.3 * T);
+	DormandPrince54OdeSolver loose(1e-3, 1e-6);
+	DormandPrince54OdeSolver tight(1e-9, 1e-12);
+	std::vector<double> sLoose{y0}, sTight{y0};
+	ASSERT_TRUE(integrateTo(loose, decay, T, 1, sLoose));
+	ASSERT_TRUE(integrateTo(tight, decay, T, 1, sTight));
+	EXPECT_LT(std::fabs(sTight[0] - exact), std::fabs(sLoose[0] - exact));
+}
+
+TEST(RungeKutta4Test, ExhibitsFourthOrderConvergence) {
+	ExponentialDecay decay(1.0);
+	const double y0 = 1.0, T = 2.0, exact = std::exp(-T);
+	auto rk = OdeSolverFactory::create(OdeSolverType::RungeKutta4);
+	std::vector<double> s1{y0}, s2{y0};
+	ASSERT_TRUE(integrateTo(*rk, decay, T, 20, s1));
+	ASSERT_TRUE(integrateTo(*rk, decay, T, 40, s2));
+	const double e1 = std::fabs(s1[0] - exact);
+	const double e2 = std::fabs(s2[0] - exact);
+	const double order = std::log2(e1 / e2);
+	EXPECT_GT(order, 3.7);
+}
+
+TEST(OdeSolverContractTest, RejectInvalidArguments) {
+	ExponentialDecay decay(1.0);
+	DormandPrince54OdeSolver dp;
+	RungeKutta4OdeSolver rk;
+	double in[] = {3.0};
+	double out[] = {-1.0};
+	EXPECT_FALSE(dp.advance(decay, 0.0, -1.0, in, out));
+	EXPECT_FALSE(rk.advance(decay, 0.0, -1.0, in, out));
+	EXPECT_FALSE(dp.advance(decay, 0.0, 1.0, nullptr, out));
+	EXPECT_FALSE(dp.advance(decay, 0.0, 1.0, in, nullptr));
+}
+
+TEST(OdeSolverContractTest, ZeroStepCopiesStateUnchanged) {
+	ExponentialDecay decay(1.0);
+	DormandPrince54OdeSolver dp;
+	double in[] = {3.0};
+	double out[] = {-1.0};
+	ASSERT_TRUE(dp.advance(decay, 0.0, 0.0, in, out));
+	EXPECT_DOUBLE_EQ(out[0], 3.0);
+}
+
+TEST(OdeSolverContractTest, ZeroDimensionSystemIsRejected) {
+	struct ZeroDim : OdeSystem_if {
+		unsigned int dimension() const override { return 0; }
+		void evaluate(double, const double*, double*) const override {}
+	} zero;
+	DormandPrince54OdeSolver dp;
+	double in[] = {1.0};
+	double out[] = {0.0};
+	EXPECT_FALSE(dp.advance(zero, 0.0, 1.0, in, out));
+}

--- a/source/tools/Continuous/DiffusionMethodOfLinesSystem.h
+++ b/source/tools/Continuous/DiffusionMethodOfLinesSystem.h
@@ -1,0 +1,220 @@
+#ifndef DIFFUSIONMETHODOFLINESSYSTEM_H
+#define DIFFUSIONMETHODOFLINESSYSTEM_H
+
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <vector>
+
+#include "OdeSystem_if.h"
+
+class DiffusionMethodOfLinesSystem : public OdeSystem_if {
+public:
+	static constexpr double kPi = 3.14159265358979323846;
+
+	enum class Boundary {
+		Dirichlet,
+		Neumann
+	};
+
+	DiffusionMethodOfLinesSystem() = default;
+
+	DiffusionMethodOfLinesSystem(std::vector<unsigned int> shape,
+	                             std::vector<double> spacing,
+	                             double diffusionCoefficient,
+	                             Boundary boundary)
+		: _shape(std::move(shape)),
+		  _spacing(std::move(spacing)),
+		  _D(diffusionCoefficient),
+		  _boundary(boundary) {
+		rebuild();
+	}
+
+	unsigned int dimension() const override { return _totalNodes; }
+
+	void evaluate(double, const double* y, double* dydt) const override {
+		if (!_valid || y == nullptr || dydt == nullptr) {
+			return;
+		}
+		const unsigned int N = static_cast<unsigned int>(_shape.size());
+		for (unsigned int node = 0; node < _totalNodes; ++node) {
+			if (_boundary == Boundary::Dirichlet && isBoundaryNode(node)) {
+				dydt[node] = 0.0;
+				continue;
+			}
+			double laplacian = 0.0;
+			for (unsigned int d = 0; d < N; ++d) {
+				const unsigned int m = coordinate(node, d);
+				const unsigned int last = _shape[d] - 1u;
+				const std::size_t s = _stride[d];
+				double secondDifference;
+				if (m == 0u) {
+					secondDifference = 2.0 * (y[node + s] - y[node]);
+				} else if (m == last) {
+					secondDifference = 2.0 * (y[node - s] - y[node]);
+				} else {
+					secondDifference = y[node + s] - 2.0 * y[node] + y[node - s];
+				}
+				laplacian += secondDifference * _invH2[d];
+			}
+			dydt[node] = _D * laplacian;
+		}
+	}
+
+	bool isValid() const { return _valid; }
+	unsigned int totalNodes() const { return _totalNodes; }
+	const std::vector<unsigned int>& shape() const { return _shape; }
+	const std::vector<double>& spacing() const { return _spacing; }
+	double diffusionCoefficient() const { return _D; }
+	Boundary boundary() const { return _boundary; }
+
+	unsigned int coordinate(unsigned int node, unsigned int d) const {
+		return static_cast<unsigned int>((node / _stride[d]) % _shape[d]);
+	}
+
+	unsigned int nodeIndex(const std::vector<unsigned int>& multiIndex) const {
+		std::size_t idx = 0;
+		for (std::size_t d = 0; d < _shape.size(); ++d) {
+			idx += static_cast<std::size_t>(multiIndex[d]) * _stride[d];
+		}
+		return static_cast<unsigned int>(idx);
+	}
+
+	bool isBoundaryNode(unsigned int node) const {
+		for (unsigned int d = 0; d < _shape.size(); ++d) {
+			const unsigned int m = coordinate(node, d);
+			if (m == 0u || m == _shape[d] - 1u) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	void fillSineModes(const std::vector<unsigned int>& modes, double amplitude, double* y) const {
+		const unsigned int N = static_cast<unsigned int>(_shape.size());
+		for (unsigned int node = 0; node < _totalNodes; ++node) {
+			double value = amplitude;
+			for (unsigned int d = 0; d < N; ++d) {
+				const unsigned int m = coordinate(node, d);
+				const double L = (_shape[d] - 1u) * _spacing[d];
+				const double x = m * _spacing[d];
+				value *= std::sin(modes[d] * kPi * x / L);
+			}
+			y[node] = value;
+		}
+	}
+
+	void fillGaussian(double amplitude, double sigma, double* y) const {
+		const unsigned int N = static_cast<unsigned int>(_shape.size());
+		const double twoSigma2 = 2.0 * sigma * sigma;
+		for (unsigned int node = 0; node < _totalNodes; ++node) {
+			double r2 = 0.0;
+			for (unsigned int d = 0; d < N; ++d) {
+				const unsigned int m = coordinate(node, d);
+				const double L = (_shape[d] - 1u) * _spacing[d];
+				const double x = m * _spacing[d];
+				const double dx = x - 0.5 * L;
+				r2 += dx * dx;
+			}
+			y[node] = amplitude * std::exp(-r2 / twoSigma2);
+		}
+	}
+
+	double sineModeDecayRate(const std::vector<unsigned int>& modes) const {
+		double lambda = 0.0;
+		for (std::size_t d = 0; d < _shape.size(); ++d) {
+			const double s = std::sin(modes[d] * kPi / (2.0 * (_shape[d] - 1u)));
+			lambda += (4.0 / (_spacing[d] * _spacing[d])) * s * s;
+		}
+		return _D * lambda;
+	}
+
+	double totalMass(const double* y) const {
+		double mass = 0.0;
+		double cellVolume = 1.0;
+		for (double h : _spacing) {
+			cellVolume *= h;
+		}
+		const unsigned int N = static_cast<unsigned int>(_shape.size());
+		for (unsigned int node = 0; node < _totalNodes; ++node) {
+			double weight = 1.0;
+			for (unsigned int d = 0; d < N; ++d) {
+				const unsigned int m = coordinate(node, d);
+				if (m == 0u || m == _shape[d] - 1u) {
+					weight *= 0.5;
+				}
+			}
+			mass += weight * y[node];
+		}
+		return mass * cellVolume;
+	}
+
+	double l2Norm(const double* y) const {
+		double sum = 0.0;
+		for (unsigned int i = 0; i < _totalNodes; ++i) {
+			sum += y[i] * y[i];
+		}
+		return std::sqrt(sum);
+	}
+
+	double maxValue(const double* y) const {
+		double mx = -std::numeric_limits<double>::infinity();
+		for (unsigned int i = 0; i < _totalNodes; ++i) {
+			if (y[i] > mx) {
+				mx = y[i];
+			}
+		}
+		return mx;
+	}
+
+private:
+	void rebuild() {
+		_valid = false;
+		_totalNodes = 0;
+		_stride.clear();
+		_invH2.clear();
+		const std::size_t N = _shape.size();
+		if (N == 0 || _spacing.size() != N || _D < 0.0) {
+			return;
+		}
+		for (std::size_t d = 0; d < N; ++d) {
+			if (_shape[d] < 3u || _spacing[d] <= 0.0) {
+				return;
+			}
+		}
+
+		_stride.assign(N, 1);
+		for (std::size_t d = N - 1; d-- > 0;) {
+			_stride[d] = _stride[d + 1] * _shape[d + 1];
+		}
+		std::size_t total = 1;
+		for (unsigned int n : _shape) {
+			if (total > std::numeric_limits<std::size_t>::max() / n) {
+				return;
+			}
+			total *= n;
+		}
+		if (total > std::numeric_limits<unsigned int>::max()) {
+			return;
+		}
+		_totalNodes = static_cast<unsigned int>(total);
+
+		_invH2.assign(N, 0.0);
+		for (std::size_t d = 0; d < N; ++d) {
+			_invH2[d] = 1.0 / (_spacing[d] * _spacing[d]);
+		}
+		_valid = true;
+	}
+
+private:
+	std::vector<unsigned int> _shape;
+	std::vector<double> _spacing;
+	double _D = 0.0;
+	Boundary _boundary = Boundary::Dirichlet;
+	bool _valid = false;
+	unsigned int _totalNodes = 0;
+	std::vector<std::size_t> _stride;
+	std::vector<double> _invH2;
+};
+
+#endif /* DIFFUSIONMETHODOFLINESSYSTEM_H */

--- a/source/tools/Continuous/DormandPrince54OdeSolver.h
+++ b/source/tools/Continuous/DormandPrince54OdeSolver.h
@@ -1,0 +1,168 @@
+#ifndef DORMANDPRINCE54ODESOLVER_H
+#define DORMANDPRINCE54ODESOLVER_H
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <vector>
+
+#include "OdeSolver_if.h"
+
+class DormandPrince54OdeSolver : public OdeSolver_if {
+public:
+	explicit DormandPrince54OdeSolver(double relativeTolerance = 1e-6,
+	                                  double absoluteTolerance = 1e-9,
+	                                  double safetyFactor = 0.9,
+	                                  double minScale = 0.2,
+	                                  double maxScale = 10.0,
+	                                  unsigned int maxSubsteps = 100000u)
+		: _rtol(relativeTolerance),
+		  _atol(absoluteTolerance),
+		  _safety(safetyFactor),
+		  _minScale(minScale),
+		  _maxScale(maxScale),
+		  _maxSubsteps(maxSubsteps) {}
+
+	double getRelativeTolerance() const { return _rtol; }
+	double getAbsoluteTolerance() const { return _atol; }
+
+	bool advance(const OdeSystem_if& system, double t0, double dt,
+	             const double* y0, double* y1) const override {
+		const unsigned int n = system.dimension();
+		if (n == 0 || y0 == nullptr || y1 == nullptr || dt < 0.0) {
+			return false;
+		}
+		for (unsigned int i = 0; i < n; ++i) {
+			y1[i] = y0[i];
+		}
+		if (dt == 0.0) {
+			return true;
+		}
+
+		std::vector<double> y(y0, y0 + n), yNext(n, 0.0), yErr(n, 0.0), tmp(n, 0.0);
+		std::vector<double> k1(n, 0.0), k2(n, 0.0), k3(n, 0.0), k4(n, 0.0);
+		std::vector<double> k5(n, 0.0), k6(n, 0.0), k7(n, 0.0);
+		double t = t0;
+		const double tEnd = t0 + dt;
+		double h = dt;
+		system.evaluate(t, y.data(), k1.data());
+		bool firstSameAsLast = false;
+
+		unsigned int steps = 0;
+		while (t < tEnd) {
+			if (++steps > _maxSubsteps) {
+				return false;
+			}
+			const double remaining = tEnd - t;
+			if (remaining <= stepFloor(t)) {
+				break;
+			}
+			if (h > remaining) {
+				h = remaining;
+			}
+			if (firstSameAsLast) {
+				k1 = k7;
+			}
+
+			for (unsigned int i = 0; i < n; ++i) tmp[i] = y[i] + h * A21 * k1[i];
+			system.evaluate(t + C2 * h, tmp.data(), k2.data());
+			for (unsigned int i = 0; i < n; ++i) tmp[i] = y[i] + h * (A31 * k1[i] + A32 * k2[i]);
+			system.evaluate(t + C3 * h, tmp.data(), k3.data());
+			for (unsigned int i = 0; i < n; ++i) tmp[i] = y[i] + h * (A41 * k1[i] + A42 * k2[i] + A43 * k3[i]);
+			system.evaluate(t + C4 * h, tmp.data(), k4.data());
+			for (unsigned int i = 0; i < n; ++i) tmp[i] = y[i] + h * (A51 * k1[i] + A52 * k2[i] + A53 * k3[i] + A54 * k4[i]);
+			system.evaluate(t + C5 * h, tmp.data(), k5.data());
+			for (unsigned int i = 0; i < n; ++i) tmp[i] = y[i] + h * (A61 * k1[i] + A62 * k2[i] + A63 * k3[i] + A64 * k4[i] + A65 * k5[i]);
+			system.evaluate(t + C6 * h, tmp.data(), k6.data());
+			for (unsigned int i = 0; i < n; ++i) yNext[i] = y[i] + h * (B5_1 * k1[i] + B5_3 * k3[i] + B5_4 * k4[i] + B5_5 * k5[i] + B5_6 * k6[i]);
+			system.evaluate(t + h, yNext.data(), k7.data());
+
+			for (unsigned int i = 0; i < n; ++i) {
+				yErr[i] = h * (E1 * k1[i] + E3 * k3[i] + E4 * k4[i] + E5 * k5[i] + E6 * k6[i] + E7 * k7[i]);
+			}
+
+			double errNorm = 0.0;
+			for (unsigned int i = 0; i < n; ++i) {
+				if (!std::isfinite(yNext[i]) || !std::isfinite(yErr[i])) {
+					return false;
+				}
+				const double sc = _atol + _rtol * std::max(std::fabs(y[i]), std::fabs(yNext[i]));
+				const double ratio = (sc > 0.0) ? (yErr[i] / sc) : 0.0;
+				errNorm += ratio * ratio;
+			}
+			errNorm = std::sqrt(errNorm / static_cast<double>(n));
+
+			if (errNorm <= 1.0) {
+				t += h;
+				y = yNext;
+				firstSameAsLast = true;
+				h *= scaleFactor(errNorm);
+			} else {
+				h *= scaleFactor(errNorm);
+				firstSameAsLast = false;
+				if (h < stepFloor(t)) {
+					return false;
+				}
+			}
+		}
+
+		for (unsigned int i = 0; i < n; ++i) {
+			y1[i] = y[i];
+		}
+		return true;
+	}
+
+private:
+	double scaleFactor(double errNorm) const {
+		if (errNorm == 0.0) {
+			return _maxScale;
+		}
+		return std::min(_maxScale, std::max(_minScale, _safety * std::pow(errNorm, -0.2)));
+	}
+
+	static double stepFloor(double t) {
+		return 16.0 * std::numeric_limits<double>::epsilon() * (std::fabs(t) + 1.0);
+	}
+
+private:
+	double _rtol;
+	double _atol;
+	double _safety;
+	double _minScale;
+	double _maxScale;
+	unsigned int _maxSubsteps;
+
+	static constexpr double C2 = 1.0 / 5.0;
+	static constexpr double C3 = 3.0 / 10.0;
+	static constexpr double C4 = 4.0 / 5.0;
+	static constexpr double C5 = 8.0 / 9.0;
+	static constexpr double C6 = 1.0;
+	static constexpr double A21 = 1.0 / 5.0;
+	static constexpr double A31 = 3.0 / 40.0;
+	static constexpr double A32 = 9.0 / 40.0;
+	static constexpr double A41 = 44.0 / 45.0;
+	static constexpr double A42 = -56.0 / 15.0;
+	static constexpr double A43 = 32.0 / 9.0;
+	static constexpr double A51 = 19372.0 / 6561.0;
+	static constexpr double A52 = -25360.0 / 2187.0;
+	static constexpr double A53 = 64448.0 / 6561.0;
+	static constexpr double A54 = -212.0 / 729.0;
+	static constexpr double A61 = 9017.0 / 3168.0;
+	static constexpr double A62 = -355.0 / 33.0;
+	static constexpr double A63 = 46732.0 / 5247.0;
+	static constexpr double A64 = 49.0 / 176.0;
+	static constexpr double A65 = -5103.0 / 18656.0;
+	static constexpr double B5_1 = 35.0 / 384.0;
+	static constexpr double B5_3 = 500.0 / 1113.0;
+	static constexpr double B5_4 = 125.0 / 192.0;
+	static constexpr double B5_5 = -2187.0 / 6784.0;
+	static constexpr double B5_6 = 11.0 / 84.0;
+	static constexpr double E1 = 35.0 / 384.0 - 5179.0 / 57600.0;
+	static constexpr double E3 = 500.0 / 1113.0 - 7571.0 / 16695.0;
+	static constexpr double E4 = 125.0 / 192.0 - 393.0 / 640.0;
+	static constexpr double E5 = -2187.0 / 6784.0 - (-92097.0 / 339200.0);
+	static constexpr double E6 = 11.0 / 84.0 - 187.0 / 2100.0;
+	static constexpr double E7 = -1.0 / 40.0;
+};
+
+#endif /* DORMANDPRINCE54ODESOLVER_H */

--- a/source/tools/Continuous/OdeSolverFactory.h
+++ b/source/tools/Continuous/OdeSolverFactory.h
@@ -1,0 +1,109 @@
+#ifndef ODESOLVERFACTORY_H
+#define ODESOLVERFACTORY_H
+
+#include <functional>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "DormandPrince54OdeSolver.h"
+#include "OdeSolver_if.h"
+#include "RungeKutta4OdeSolver.h"
+
+enum class OdeSolverType {
+	RungeKutta4,
+	DormandPrince54
+};
+
+class OdeSolverFactory {
+public:
+	using Creator = std::function<std::unique_ptr<OdeSolver_if>()>;
+
+	static const std::string& keyRungeKutta4() {
+		static const std::string k = "RungeKutta4";
+		return k;
+	}
+
+	static const std::string& keyDormandPrince54() {
+		static const std::string k = "DormandPrince54";
+		return k;
+	}
+
+	static const std::string& defaultKey() {
+		return keyRungeKutta4();
+	}
+
+	static std::unique_ptr<OdeSolver_if> create(OdeSolverType type) {
+		switch (type) {
+			case OdeSolverType::DormandPrince54:
+				return std::make_unique<DormandPrince54OdeSolver>();
+			case OdeSolverType::RungeKutta4:
+			default:
+				return std::make_unique<RungeKutta4OdeSolver>();
+		}
+	}
+
+	static std::unique_ptr<OdeSolver_if> create(const std::string& key) {
+		auto& reg = registry();
+		auto it = reg.find(key);
+		if (it != reg.end()) {
+			return it->second();
+		}
+		return std::make_unique<RungeKutta4OdeSolver>();
+	}
+
+	static bool isRegistered(const std::string& key) {
+		return registry().find(key) != registry().end();
+	}
+
+	static std::vector<std::string> availableKeys() {
+		std::vector<std::string> keys;
+		keys.reserve(registry().size());
+		for (const auto& entry : registry()) {
+			keys.push_back(entry.first);
+		}
+		return keys;
+	}
+
+	static bool registerCreator(const std::string& key, Creator creator) {
+		return registry().emplace(key, std::move(creator)).second;
+	}
+
+	static std::string toKey(OdeSolverType type) {
+		switch (type) {
+			case OdeSolverType::DormandPrince54:
+				return keyDormandPrince54();
+			case OdeSolverType::RungeKutta4:
+			default:
+				return keyRungeKutta4();
+		}
+	}
+
+	static bool fromKey(const std::string& key, OdeSolverType& out) {
+		if (key == keyDormandPrince54()) {
+			out = OdeSolverType::DormandPrince54;
+			return true;
+		}
+		if (key == keyRungeKutta4()) {
+			out = OdeSolverType::RungeKutta4;
+			return true;
+		}
+		return false;
+	}
+
+private:
+	static std::map<std::string, Creator>& registry() {
+		static std::map<std::string, Creator> reg = [] {
+			std::map<std::string, Creator> initial;
+			initial.emplace(keyRungeKutta4(),
+			                [] { return std::make_unique<RungeKutta4OdeSolver>(); });
+			initial.emplace(keyDormandPrince54(),
+			                [] { return std::make_unique<DormandPrince54OdeSolver>(); });
+			return initial;
+		}();
+		return reg;
+	}
+};
+
+#endif /* ODESOLVERFACTORY_H */


### PR DESCRIPTION
## Summary

This draft PR now contains the first implementation slice for the DCS Tema 8.2 ODE/PDE integration from `2026-1` into `WorkInProgress`.

The port is intentionally limited to the tools-only numerical core, adapted to the current `WorkInProgress` layout under `source/tools/Continuous/`. It does not yet port plugin data/components or plugin registrations.

## Implemented

- Added `source/tools/Continuous/OdeSolverFactory.h`.
- Added `source/tools/Continuous/DormandPrince54OdeSolver.h`.
- Added `source/tools/Continuous/DiffusionMethodOfLinesSystem.h`.
- Added `source/tests/unit/test_tools_ode_solver_factory.cpp`.
- Added `source/tests/unit/test_tools_diffusion_mol.cpp` as a reduced smoke subset; the connector blocked the full large test file write.
- Updated `source/tests/unit/CMakeLists.txt` to register:
  - `genesys_test_tools_ode_solver_factory`;
  - `genesys_test_tools_diffusion_mol`.
- Updated `docs/ai_assistants/dcs_ode_pde_workinprogress_integration.md`.

## Not yet implemented

- `DiffusionField.*`.
- `DiffusionSimulate.*`.
- `test_plugins_continuous_diffusion.cpp`.
- Tema 8.1 `ODESolver.*` and `ContinuousSystemComponent.*`.
- `LSODE.*` / `DiffEquations.*` selected changes.
- `PluginConnectorDummyImpl1.cpp` registrations.

## Validation

GitHub connector inspection and remote file operations only. No local CMake/Ninja/CTest execution was possible in ChatGPT Web.

Expected validation when CI/local build is available:

```bash
cmake --preset tests-unit
cmake --build --preset tests-unit
ctest --preset tests-unit --output-on-failure
```

## Risk controls

- No root README, PDF, MP4, ZIP, or academic artifact imported.
- No branch-level cherry-pick.
- No wholesale replacement of `PluginConnectorDummyImpl1.cpp`.
- No plugin/data/component integration yet.
- Tools were moved into `source/tools/Continuous/` instead of reintroducing old root `source/tools/` headers.