### PR TITLE
ci: align renamed semester and Debian triggers

### DIFF
--- a/.github/workflows/genesys-ci.yml
+++ b/.github/workflows/genesys-ci.yml
@@ -5,7 +5,7 @@ run-name: GenESyS CI | ${{ github.event_name }} | ref=${{ github.ref_name }} | s
 on:
   pull_request:
     branches:
-      - 2026-1
+      - 20261
       - WorkInProgress
       - WiP20261
       - currentStable

--- a/.github/workflows/genesys-debian-package.yml
+++ b/.github/workflows/genesys-debian-package.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - WiP20261
     paths:
-      - '../../packaging/debian/**'
+      - 'debian/**'
       - 'packaging/linux/**'
       - 'source/**/CMakeLists.txt'
       - 'CMakeLists.txt'
@@ -16,9 +16,9 @@ on:
   pull_request:
     branches:
       - WiP20261
-      - 2026-1
+      - 20261
     paths:
-      - '../../packaging/debian/**'
+      - 'debian/**'
       - 'packaging/linux/**'
       - 'source/**/CMakeLists.txt'
       - 'CMakeLists.txt'


### PR DESCRIPTION
## Scope

Correct active GitHub Actions trigger filters after the semester branch was renamed from `2026-1` to `20261`, and align the Debian packaging path filter with the repository's actual `debian/` directory.

## Changes

### Ordinary CI

In `.github/workflows/genesys-ci.yml`:

```yaml
pull_request:
  branches:
    - 20261
```

The obsolete `2026-1` filter is removed.

### Debian package workflow

In `.github/workflows/genesys-debian-package.yml`:

- replace PR branch `2026-1` with `20261`;
- replace the non-matching path `../../packaging/debian/**` with the current repository path `debian/**` for both push and pull-request triggers.

## Evidence

- repository ref `20261` resolves and is the renamed former `2026-1` branch;
- `debian/rules` exists at the repository root and is directly executed by the package workflow;
- `../../packaging/debian/**` does not represent the active root-level Debian packaging tree.

## Base

- Base branch: `WorkInProgress`
- Head branch: `ci/fix-20261-trigger-20260720`
- Commits:
  - `797a9a6f49b6171e26a4be3aa36df440e0c6fea3` — ordinary CI branch filter;
  - `4dfeca8723ce2f2170c0d304768f0c95aa00857e` — Debian branch/path filters.

## Non-changes

- no build command changed;
- no dependency changed;
- no job, permission, timeout, preset, test, package command, or artifact behavior changed;
- future `20262` triggers are intentionally not added now;
- this PR does not add `WorkInProgress` to the Debian workflow's target-branch filter.

## Validation

The PR targets `WorkInProgress`, so the ordinary GenESyS `tests-unit` and GUI GMDD workflow is expected to run and validate that the trigger-only edits do not affect the build/test baseline.

The Debian package workflow is **not expected to run on this PR**, because its current pull-request target branches are `WiP20261` and the corrected `20261`, not `WorkInProgress`. Its branch/path corrections therefore require one of the following later validation paths:

1. manual `workflow_dispatch` on the PR branch;
2. a future packaging change targeting an eligible branch;
3. a separate policy decision to include `WorkInProgress` in the Debian packaging PR filter.

The PR remains draft until the ordinary CI jobs complete successfully.

## Risk

Low and limited to workflow activation. The corrected filters may cause workflows to run in cases that were previously missed; that is the intended behavior.
