### PR TITLE
tests: include AI plugins in unit baseline

### DIFF
--- a/source/tests/CMakeLists.txt
+++ b/source/tests/CMakeLists.txt
@@ -7,10 +7,12 @@ if(TARGET genesys_kernel_unit_tests AND TARGET genesys_test_ai_plugins)
 endif()
 
 if(TARGET genesys_kernel_unit_tests_run AND TARGET genesys_test_ai_plugins)
-    add_custom_command(TARGET genesys_kernel_unit_tests_run
-        POST_BUILD
+    add_custom_target(genesys_test_ai_plugins_run
         COMMAND $<TARGET_FILE:genesys_test_ai_plugins>
+        DEPENDS genesys_test_ai_plugins
+        USES_TERMINAL
     )
+    add_dependencies(genesys_kernel_unit_tests_run genesys_test_ai_plugins_run)
 endif()
 
 option(GENESYS_BUILD_SMOKE_TESTS "Build smoke tests under source/tests/smoke" ON)

--- a/source/tests/CMakeLists.txt
+++ b/source/tests/CMakeLists.txt
@@ -1,5 +1,18 @@
 add_subdirectory(unit)
 
+# The AI plugin tests use only local fakes/dummy connectors and must participate
+# in both the ordinary aggregate build and the direct kernel unit-test runner.
+if(TARGET genesys_kernel_unit_tests AND TARGET genesys_test_ai_plugins)
+    add_dependencies(genesys_kernel_unit_tests genesys_test_ai_plugins)
+endif()
+
+if(TARGET genesys_kernel_unit_tests_run AND TARGET genesys_test_ai_plugins)
+    add_custom_command(TARGET genesys_kernel_unit_tests_run
+        POST_BUILD
+        COMMAND $<TARGET_FILE:genesys_test_ai_plugins>
+    )
+endif()
+
 option(GENESYS_BUILD_SMOKE_TESTS "Build smoke tests under source/tests/smoke" ON)
 
 if(GENESYS_BUILD_SMOKE_TESTS)


### PR DESCRIPTION
## Scope

Ensure the existing offline AI plugin tests participate in both GenESyS unit-test aggregation paths.

## Confirmed defect

`source/tests/unit/CMakeLists.txt` creates and registers `genesys_test_ai_plugins`, but the target was absent from:

- the dependencies of `genesys_kernel_unit_tests`, used by the ordinary `tests-unit` build preset;
- the commands executed by `genesys_kernel_unit_tests_run`, used by the kernel-focused build preset.

Consequently, a green aggregate baseline could omit `test_ai_plugins.cpp` entirely.

## Change

`source/tests/CMakeLists.txt`, after entering the unit-test subdirectory, now:

- adds `genesys_test_ai_plugins` as a dependency of `genesys_kernel_unit_tests`;
- creates `genesys_test_ai_plugins_run`, which executes the test binary and depends on it;
- adds that run target as a dependency of `genesys_kernel_unit_tests_run`.

This keeps all cross-directory orchestration in the parent tests CMake file without modifying production sources.

## CI diagnostic and correction

The first implementation attempted to attach a `POST_BUILD` command directly to `genesys_kernel_unit_tests_run` from its parent CMake directory. CI correctly rejected that at configuration time because the `add_custom_command(TARGET ...)` form may only modify a target created in the same CMake directory.

That attempt was replaced by a dedicated custom run target plus `add_dependencies(...)`, which is valid across the parent/child target graph.

Commits:

- `499019613d395f1122100fb13c41d847a6fab0a0` — initial aggregation attempt;
- `5783c7166f9623aa3c42a92a6ef2bdcc0bdce436` — correct cross-directory runner integration.

## Safety evidence

The test source is offline and deterministic:

- uses a local `FakeProviderClient`;
- uses `PluginConnectorDummyImpl1`;
- creates local simulator/model objects;
- performs no HTTP/API request;
- requires no API key or external credential.

The existing test cases cover:

1. bounded independent conversation histories;
2. AI plugin metadata through the dummy connector;
3. prompt-template expression evaluation and literal-brace escaping.

## Base

- Base branch: `WorkInProgress`
- Head branch: `tests/include-ai-plugins-baseline-20260720`
- Current head: `5783c7166f9623aa3c42a92a6ef2bdcc0bdce436`

## Non-changes

- no AI provider implementation changed;
- no network behavior changed;
- no test assertion changed;
- no plugin metadata changed;
- no production source changed;
- no CTest labels changed.

## Validation

The first run failed during CMake configuration and did not compile or execute tests; that failure is fully explained by the invalid cross-directory `add_custom_command` form.

The current head must now pass:

- CMake configure with `tests-unit`;
- aggregate build including `genesys_test_ai_plugins`;
- CTest execution including the discovered AI plugin tests;
- focused GUI GMDD diagnostics.

A later explicit `tests-kernel-unit` execution should confirm the direct runner path separately.

## Risk

Low. The expected effect is increased test coverage. A test failure after successful configuration would indicate a previously hidden defect rather than a production behavior change.
