### PR TITLE
ci: add Phase 0 kernel and smoke validation

### DIFF
--- a/.github/workflows/genesys-phase0-validation.yml
+++ b/.github/workflows/genesys-phase0-validation.yml
@@ -1,0 +1,130 @@
+name: GenESyS Phase 0 Validation
+
+run-name: GenESyS Phase 0 | ${{ github.event_name }} | ref=${{ github.ref_name }} | sha=${{ github.sha }}
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - WorkInProgress
+    paths:
+      - CMakeLists.txt
+      - CMakePresets.json
+      - source/**
+      - .github/workflows/genesys-phase0-validation.yml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: genesys-phase0-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  QT_QPA_PLATFORM: offscreen
+  CTEST_OUTPUT_ON_FAILURE: "1"
+
+jobs:
+  baseline:
+    name: Validate ${{ matrix.preset }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+
+    strategy:
+      fail-fast: false
+      matrix:
+        preset:
+          - tests-kernel-unit
+          - tests-smoke
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Show validation metadata
+        run: |
+          set -Eeuo pipefail
+          echo "event_name=${{ github.event_name }}"
+          echo "repository=${{ github.repository }}"
+          echo "ref=${GITHUB_REF}"
+          echo "sha=${GITHUB_SHA}"
+          echo "preset=${{ matrix.preset }}"
+
+      - name: Install build dependencies
+        run: |
+          set -Eeuo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential \
+            cmake \
+            ninja-build \
+            python3 \
+            python3-dev \
+            libsbml5-dev \
+            ngspice \
+            r-base \
+            octave \
+            qt6-base-dev \
+            qt6-tools-dev \
+            qt6-tools-dev-tools \
+            libgl1-mesa-dev
+
+      - name: Show toolchain baseline
+        run: |
+          set -Eeuo pipefail
+          cmake --version
+          ninja --version
+          g++ --version
+          python3 --version
+
+      - name: Configure preset
+        run: |
+          set -Eeuo pipefail
+          cmake --list-presets=all
+          cmake --preset "${{ matrix.preset }}"
+
+      - name: Build preset
+        run: |
+          set -Eeuo pipefail
+          cmake --build --preset "${{ matrix.preset }}" --parallel "$(nproc)"
+
+      - name: Capture CTest inventory
+        run: |
+          set -Eeuo pipefail
+          mkdir -p "phase0-evidence/${{ matrix.preset }}"
+          ctest --preset "${{ matrix.preset }}" -N \
+            | tee "phase0-evidence/${{ matrix.preset }}/ctest-inventory.log"
+
+      - name: Run CTest preset
+        run: |
+          set -Eeuo pipefail
+          ctest --preset "${{ matrix.preset }}" --output-on-failure \
+            | tee "phase0-evidence/${{ matrix.preset }}/ctest-run.log"
+
+      - name: Collect diagnostics
+        if: always()
+        run: |
+          set +e
+          evidence="phase0-evidence/${{ matrix.preset }}"
+          mkdir -p "${evidence}"
+          git rev-parse HEAD > "${evidence}/head-sha.txt"
+          cmake --version > "${evidence}/cmake-version.txt" 2>&1
+          ninja --version > "${evidence}/ninja-version.txt" 2>&1
+          g++ --version > "${evidence}/gxx-version.txt" 2>&1
+          find build -type f \( \
+              -name CMakeOutput.log \
+              -o -name CMakeError.log \
+              -o -name LastTest.log \
+            \) -exec cp --parents {} "${evidence}" \; 2>/dev/null || true
+
+      - name: Upload Phase 0 evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: genesys-phase0-${{ matrix.preset }}
+          path: phase0-evidence/${{ matrix.preset }}/
+          if-no-files-found: error


### PR DESCRIPTION
## Scope

Add a dedicated, reusable Phase 0 workflow for:

- `tests-kernel-unit`;
- `tests-smoke`;
- exact CTest inventory capture;
- per-preset evidence artifacts.

## Design

`.github/workflows/genesys-phase0-validation.yml`:

- is available through `workflow_dispatch`;
- runs on relevant pull requests against `WorkInProgress`;
- leaves ordinary GenESyS CI unchanged;
- uses isolated Ubuntu 24.04 matrix jobs;
- configures, builds, captures `ctest -N`, executes CTest, and uploads diagnostics.

## Executed evidence

Phase 0 workflow:

- run: `29780136722`, run number 1;
- tested merge commit: `0d5f32b48510f6c1776ccfb1572f51fb452a6538`;
- conclusion: success.

Ordinary CI:

- run: `29780136801`, run number 121;
- `tests-unit`: configure/build/CTest passed;
- GUI GMDD diagnostics passed.

### tests-kernel-unit

- configure: passed;
- build and direct runner: passed;
- CTest inventory: 1,696 registered tests;
- CTest: 1,692 executed and passed;
- disabled: 4;
- failed: 0;
- total CTest time: 26.90 seconds.

Disabled tests:

1. `SimulatorRuntimeTest.SearchQueueFindsEntityInRangeSavesRankAndRoutesToFoundPort`;
2. `SimulatorRuntimeTest.SearchQueueNotFoundRoutesToPortZeroAndSavesZeroRank`;
3. `SimulatorRuntimeTest.RemoveEqualStartAndEndRankRemovesExactlyOneAndRoutesCorrectly`;
4. `SimulatorRuntimeTest.RemoveRangeRemovesOnlyEntitiesInsideConfiguredInterval`.

AI plugin tests explicitly present and passing:

- #495 `AIConversationServiceTest.KeepsIndependentBoundedHistories`;
- #496 `AIPluginTest.BuiltInConnectorExposesSupportAndComponentMetadata`;
- #497 `AIPluginTest.PromptTemplateEvaluatesExpressionsAndEscapesLiteralBraces`.

Artifact:

- name: `genesys-phase0-tests-kernel-unit`;
- ID: `8476435822`;
- digest: `sha256:bf803a8432328e0bb7555d61c4c01d72e6cafe20391b57380099a8db440bc673`.

### tests-smoke

- configure/build/CTest: passed;
- registered/executed: 3;
- passed: 3;
- failed: 0;
- total time: 0.68 seconds.

Tests:

1. `smoke_simulator_start`;
2. `test_continuous_system`;
3. `test_lsode`.

Artifact:

- name: `genesys-phase0-tests-smoke`;
- ID: `8476325130`;
- digest: `sha256:3d0f40bb68d05ec0c738c8a34d92d2f4380cf743323015220c25706157871776`.

## Toolchain captured

- Ubuntu 24.04;
- CMake 3.31.6;
- Ninja 1.13.2;
- G++ 13.3.0;
- Qt6 dependencies installed by the workflow.

## Non-changes

- no C++ source changed;
- no CMake preset/target changed;
- no assertion changed;
- no production or package behavior changed;
- ordinary CI and branch protection policy remain unchanged.

## Base synchronization

PR #469 was merged while these jobs were running, leaving this branch behind by documentation-only commits. GitHub reports the PR mergeable; the only changed file remains the new workflow.

## Result

The three primary Phase 0 baseline presets are now executable and green in GitHub Actions:

- `tests-unit`;
- `tests-kernel-unit`;
- `tests-smoke`.

Remaining validation concerns are application startup, Debian package lifecycle, sanitizers, profiling, network/security behavior, and scientific reference correctness.