### PR TITLE
docs: record complete Phase 0 baseline evidence

### DIFF
--- a/docs/ai_assistants/build_ci_tests.md
+++ b/docs/ai_assistants/build_ci_tests.md
@@ -2,73 +2,49 @@
 
 ## 1. Purpose
 
-This document is the stable AI-assistant reference for current GenESyS build, CI, and automated-test workflows.
+Stable reference for the current GenESyS build, CI, and test workflows. Historical files and older `current_plans.md` sections must be checked against current CMake and the latest execution evidence.
 
-Historical recommendations under `docs/ai_assistants/oldies/` and older sections of `current_plans.md` must be revalidated against the current CMake files and the latest dated execution-evidence document before they are treated as current facts.
+Also read:
 
-For the current consolidation checkpoint, also read:
-
-- `genesys_2026_test_matrix.md`;
 - `genesys_2026_phase0_ci_evidence_20260720.md`;
+- `genesys_2026_test_matrix.md`;
 - `genesys_2026_consolidation_handoff.md`.
 
-## 2. Current confirmed build baseline
+## 2. Confirmed build baseline
 
-### 2.1 Toolchain and build system
+- Ubuntu 24.04 primary CI baseline;
+- minimum CMake 3.24;
+- Ninja generator;
+- C++23 required;
+- compiler extensions disabled;
+- Qt6-only project policy;
+- Google Test system package when compatible, bundled fallback otherwise.
 
-Confirmed in `CMakeLists.txt` and `CMakePresets.json`:
+Executed Phase 0 toolchain:
 
-- minimum CMake: 3.24;
-- preset schema: version 6;
-- generator: Ninja;
-- C++ standard: C++23;
-- C++ standard required: yes;
-- compiler extensions: disabled;
-- kernel, parser, and plugins enabled in the base preset;
-- GUI, worker, shell, model-specific applications, tests, and smoke tests controlled by dedicated options/presets.
+- CMake 3.31.6;
+- Ninja 1.13.2;
+- G++ 13.3.0.
 
-Qt policy:
+Qt5 fallback code may still exist but is not part of the intended supported-platform contract.
 
-- project policy is Qt6-only;
-- current source/CMake may still contain Qt5 fallback paths;
-- those fallbacks are legacy implementation debt and must not be interpreted as a supported-platform requirement.
+## 3. Primary validation presets
 
-## 3. Current configure/build/test presets
-
-### 3.1 Unit baseline
-
-Run from the repository root:
+### 3.1 Ordinary unit baseline
 
 ```bash
-cmake --list-presets=all
 cmake --preset tests-unit
 cmake --build --preset tests-unit --parallel "$(nproc)"
 ctest --preset tests-unit --output-on-failure
 ```
 
-Confirmed preset behavior:
+- directory: `build/tests-unit`;
+- target: `genesys_kernel_unit_tests`;
+- CTest label: `unit`;
+- worker support enabled for worker tests;
+- smoke and shell disabled.
 
-- build directory: `build/tests-unit`;
-- tests enabled;
-- worker application support enabled because worker tests depend on it;
-- smoke tests disabled;
-- terminal examples disabled;
-- shell application disabled;
-- build target: `genesys_kernel_unit_tests`;
-- CTest preset filters by the `unit` label.
-
-Executed evidence:
-
-- PR #469 head: `a60ca65aae4147a7d9b14bdadd9e8d39958bcaaf`;
-- GitHub Actions run: `29771060564`;
-- Ubuntu runner: 24.04.4 LTS;
-- configure: passed;
-- build: passed;
-- CTest: passed.
-
-Scope limitation:
-
-A green `tests-unit` run proves only the targets registered and executed by that preset. It does not prove that every declared test executable is included. In particular, the current aggregation status of `genesys_test_ai_plugins` must still be verified explicitly.
+Status: `validated` in current GitHub Actions checkpoints.
 
 ### 3.2 Kernel-focused baseline
 
@@ -78,17 +54,20 @@ cmake --build --preset tests-kernel-unit --parallel "$(nproc)"
 ctest --preset tests-kernel-unit --output-on-failure
 ```
 
-Confirmed preset behavior:
+- directory: `build/tests-kernel-unit`;
+- target: `genesys_kernel_unit_tests_run`;
+- build target executes the direct test-runner graph;
+- CTest then executes the registered unit inventory.
 
-- build directory: `build/tests-kernel-unit`;
-- configure preset inherits from `tests-unit`;
-- build target: `genesys_kernel_unit_tests_run`.
+Current evidence:
 
-Current validation status:
+- 1,696 registered;
+- 1,692 passed;
+- 4 disabled;
+- 0 failed;
+- AI plugin tests #495–#497 passed.
 
-- preset and target confirmed by repository inspection;
-- not executed by the recorded Phase 0 GitHub Actions run;
-- status: `needs-local-validation` or additional CI validation.
+Status: `validated` for Phase 0 run `29780136722`.
 
 ### 3.3 Smoke baseline
 
@@ -98,23 +77,16 @@ cmake --build --preset tests-smoke --parallel "$(nproc)"
 ctest --preset tests-smoke --output-on-failure
 ```
 
-Confirmed preset behavior:
+Current evidence:
 
-- build directory: `build/tests-smoke`;
-- tests enabled;
-- worker support enabled;
-- smoke tests enabled;
-- shell application disabled.
+- 3 registered/executed/passed;
+- simulator start;
+- continuous system;
+- LSODE.
 
-Current validation status:
+Status: `validated` for Phase 0 run `29780136722`.
 
-- preset and smoke targets confirmed by repository inspection;
-- not executed by the recorded Phase 0 GitHub Actions run;
-- status: `needs-local-validation` or additional CI validation.
-
-### 3.4 Test inventory commands
-
-Every baseline run should also capture the registered tests:
+### 3.4 Inventory commands
 
 ```bash
 ctest --preset tests-unit -N
@@ -122,168 +94,122 @@ ctest --preset tests-kernel-unit -N
 ctest --preset tests-smoke -N
 ```
 
-Do not reuse a historical test count as the current count. Record the exact count from the current commit and environment.
+Never reuse a historical count as a current count.
 
-## 4. Current application presets
+## 4. GitHub Actions workflows
 
-### 4.1 Shell and model-specific applications
+### 4.1 Ordinary CI
 
-Current presets include:
-
-- `genesys_shell` — builds target `genesys_shell`;
-- `terminal-smart` — builds a selected smart example through `GENESYS_TERMINAL_EXAMPLE`;
-- `terminal-model-specific` — builds a selected model-specific source;
-- `genesys_modelspecific_app` — builds target `genesys_modelspecific_app`;
-- `terminal-smart-hold-search-remove` — selected smart example;
-- `terminal-smart-ai-assistant` — selected AI-assistant smart example.
-
-`terminal-app` remains a hidden compatibility/configuration preset. Prefer the explicit public preset `genesys_shell` for the standalone shell.
-
-### 4.2 Worker
-
-Current presets:
-
-- `worker-app`;
-- `genesys_worker_app`.
-
-Both build the worker application target `genesys_worker_app` through the current `source/applications/worker/` tree.
-
-Do not refer to the current application as the active `web-app` tree unless discussing historical names or compatibility aliases.
-
-### 4.3 GUI applications
-
-Current GUI presets include:
-
-- `gui-app` — main GUI target `genesys_gui`;
-- `gui-httpworker` — target `genesys_httpworker_gui_application`;
-- `gui-dataanalyser` — standalone Data Analyser GUI;
-- `gui-optimizer` — standalone Optimizer GUI;
-- `gui-ai-assistant` — standalone AI Assistant GUI.
-
-Use Qt6 dependencies. For headless CI or test execution, use `QT_QPA_PLATFORM=offscreen` where appropriate.
-
-A successful focused GUI unit executable is not equivalent to a standalone GUI configure/build/startup validation.
-
-## 5. Current GitHub Actions ordinary CI
-
-Workflow:
+File:
 
 ```text
 .github/workflows/genesys-ci.yml
 ```
 
-Current job structure:
+Jobs:
 
-1. `Configure, build and test tests-unit`;
-2. `Diagnose GUI GMDD tests`.
+1. configure/build/CTest `tests-unit`;
+2. build/run three focused GUI GMDD tests and upload diagnostics.
 
-The ordinary job:
+Current PR target branches include `20261`, `WorkInProgress`, `WiP20261`, `currentStable`, and `master`.
 
-- runs on Ubuntu 24.04;
-- installs CMake, Ninja, GCC/build-essential, Python development files, Qt6, libSBML, ngspice, R, Octave, and OpenGL dependencies;
-- configures `tests-unit`;
-- builds the `tests-unit` preset;
-- runs CTest with `tests-unit`.
+The old `2026-1` filter was corrected through PR #470.
 
-The GUI diagnostic job:
+### 4.2 Phase 0 validation
 
-- configures `tests-unit`;
-- builds only `genesys_test_gui_gmdd_layout`;
-- executes three focused GMDD tests;
-- uploads an artifact regardless of success/failure.
+File:
 
-Current execution evidence:
+```text
+.github/workflows/genesys-phase0-validation.yml
+```
 
-- workflow run `29771060564` completed successfully;
-- ordinary unit job passed;
-- all three GUI GMDD tests passed;
-- diagnostic artifact ID: `8472919224`.
+Purpose:
 
-Older documentation that calls those three tests currently failing is superseded by `genesys_2026_phase0_ci_evidence_20260720.md` for the validated head.
+- execute `tests-kernel-unit` and `tests-smoke` in isolated matrix jobs;
+- capture CTest inventory;
+- execute CTest;
+- capture toolchain/HEAD/diagnostics;
+- upload per-preset artifacts.
 
-## 6. Branch-trigger policy
+Triggers:
 
-Current branch names include:
+- `workflow_dispatch`;
+- relevant PR changes against `WorkInProgress`.
 
-- `20261` — renamed former `2026-1` semester-stable branch;
-- `WorkInProgress` — active development line;
-- `WiP20261` — maintainer working branch;
-- `currentStable`;
-- `master`.
+This workflow complements ordinary CI; it does not replace it.
 
-At the time of this documentation update, the `WorkInProgress` version of `.github/workflows/genesys-ci.yml` still contains the obsolete target filter `2026-1`.
+### 4.3 Debian package workflow
 
-A separate bounded PR corrects active workflow filters:
-
-- PR #470: `ci: align renamed semester and Debian triggers`;
-- ordinary CI filter: `2026-1` -> `20261`;
-- Debian PR filter: `2026-1` -> `20261`;
-- Debian path filter: `../../packaging/debian/**` -> `debian/**`.
-
-Do not document those trigger corrections as integrated until PR #470 is merged.
-
-`20262` must not be added casually. Its promotion and workflow policy will be decided near the end of the second semester of 2026.
-
-## 7. Debian package workflow
-
-Workflow:
+File:
 
 ```text
 .github/workflows/genesys-debian-package.yml
 ```
 
-The active Debian packaging tree is at repository-root `debian/`, including `debian/rules`.
+The active package tree is root-level `debian/`. PR #470 corrected the branch name and path filter. The package lifecycle still requires a new execution after that correction.
 
-The package workflow:
+## 5. Current applications and presets
 
-- builds binary packages with `dpkg-buildpackage`;
-- validates AppStream metadata;
-- runs lintian diagnostically;
-- uploads package and diagnostic artifacts;
-- fails if no `.deb` is produced.
+### Shell/model-specific
 
-Current validation status:
+- `genesys_shell`;
+- `terminal-smart`;
+- `terminal-model-specific`;
+- `genesys_modelspecific_app`;
+- `terminal-smart-hold-search-remove`;
+- `terminal-smart-ai-assistant`.
 
-- prior package artifacts exist in project history;
-- the trigger-only corrections in PR #470 are not yet validated by a Debian run;
-- PR #470 targets `WorkInProgress`, while the Debian workflow currently filters PR bases to `WiP20261` and `20261`;
-- validate through manual dispatch, a future eligible packaging PR, or a separate decision to include `WorkInProgress`.
+### Worker
 
-Packaging validation remains separate from ordinary unit CI.
+- `worker-app`;
+- `genesys_worker_app`.
 
-## 8. Safe validation order
+Current source tree: `source/applications/worker/`. Do not use the historical `web-app` name as current architecture.
 
-For a build-system or cross-cutting code change:
+### GUI
 
-1. record branch and commit;
-2. list presets;
-3. configure/build/test `tests-unit`;
-4. capture `ctest --preset tests-unit -N`;
-5. configure/build/test `tests-kernel-unit` when kernel/tool/plugin code is affected;
-6. configure/build/test `tests-smoke` when runtime behavior is affected;
-7. build the affected shell, worker, GUI, or model-specific preset independently;
-8. run focused regression tests before and after the patch;
-9. run sanitizers for ownership, lifetime, UB, or numerical-memory concerns;
-10. validate Debian packaging separately when build/install/package behavior changes.
+- `gui-app`;
+- `gui-httpworker`;
+- `gui-dataanalyser`;
+- `gui-optimizer`;
+- `gui-ai-assistant`.
 
-## 9. Interpretation rules
+Use Qt6. Focused GUI unit success is not equivalent to standalone application startup validation.
 
-- A successful configure does not prove build success.
-- A successful build does not prove test success.
-- A green aggregate does not prove every declared executable was included.
-- A passing numerical unit test does not establish scientific correctness without a defined oracle and tolerance.
-- A focused GUI test does not prove GUI startup or user workflow behavior.
-- Historical CI results apply only to their recorded branch, commit, toolchain, dependencies, and test registration.
-- Later dated execution evidence supersedes older current-status claims.
+## 6. Current disabled tests
 
-## 10. Open follow-up tasks
+The kernel inventory contains four disabled simulator runtime tests concerning SearchQueue and Remove behavior. These are explicit coverage gaps and should be addressed in a separate bounded PR.
 
-- execute and record `tests-kernel-unit`;
-- execute and record `tests-smoke`;
-- verify the exact test count and intended target inclusion;
-- ensure `genesys_test_ai_plugins` is part of the ordinary baseline;
-- add or restore opt-in ASan/LSan/UBSan presets after the ordinary baseline is complete;
-- validate representative application presets independently;
-- validate PR #470 ordinary CI and later validate its Debian workflow trigger corrections;
-- determine whether the separate GUI GMDD diagnostic job remains useful now that the focused tests pass;
-- keep Debian/PPA validation separate until its dependencies, duration, and branch policy are deliberate.
+## 7. Safe validation order
+
+For cross-cutting code changes:
+
+1. record branch/commit/toolchain;
+2. run ordinary `tests-unit`;
+3. run focused tests for the changed area;
+4. run `tests-kernel-unit` when kernel/parser/plugin/tool behavior is affected;
+5. run `tests-smoke` when runtime/continuous behavior is affected;
+6. build/start the affected application preset;
+7. run sanitizers for ownership/UB/memory changes;
+8. validate packaging separately when build/install/package behavior changes.
+
+## 8. Interpretation rules
+
+- Configure success does not prove build success.
+- Build success does not prove test success.
+- A green CTest inventory does not prove unregistered code paths.
+- Generated method inventory is structural, not behavioral coverage.
+- Numerical/statistical passing tests require a defined oracle before they support scientific claims.
+- Focused GUI tests do not prove application startup or user workflow.
+- Later dated evidence supersedes older current-status claims.
+
+## 9. Open follow-up work
+
+- investigate the four disabled runtime tests;
+- validate shell, worker, main GUI, independent GUIs, and representative model-specific applications;
+- execute Debian package build/install/start/uninstall;
+- add opt-in ASan/LSan/UBSan paths;
+- characterize `SolverDefaultImpl1` with focused failing tests;
+- map overlapping full/minimal plugin targets;
+- remove Qt5 fallback in a dedicated PR;
+- validate worker authentication/security separately.

--- a/docs/ai_assistants/genesys_2026_consolidation_handoff.md
+++ b/docs/ai_assistants/genesys_2026_consolidation_handoff.md
@@ -2,245 +2,204 @@
 
 ## 1. Final task state
 
-- Overall status: `partially-validated`.
 - Repository: `rlcancian/Genesys-Simulator`.
-- Consolidation base branch: `WorkInProgress`.
-- Original inspected base commit: `b25a4d2ec31abe27f1bf3597a5135fa4828fbc35`.
-- Documentation branch: `audit/genesys-2026-consolidation-plan-20260720`.
-- Documentation pull request: PR #469, targeting `WorkInProgress`.
-- PR #469 remains documentation-only.
-- PR #470 was merged into `WorkInProgress` at `5b24c1e4f31f1b001cd0bd6910fb2c134108fc77`.
-- PR #471 was merged into `WorkInProgress` at `1fca8763cb7a6449cab719950ff74fb59e149b1e`.
-- Ordinary `tests-unit` CI is green for the documentation, workflow-trigger, and AI-test-aggregation checkpoints.
-- `tests-kernel-unit` and `tests-smoke` are still not explicitly executed in the available checkpoints.
-- Release readiness and scientific correctness are not established.
+- Active development branch: `WorkInProgress`.
+- Current integrated checkpoint: `802b8aec7ac129559692bd574e70fd9991aaec1d`.
+- Core Phase 0 baseline: `validated` for the recorded GitHub Actions commits and toolchain.
+- Consolidation documentation: merged through PR #469 as `9c52b61532b847668adc3be92c780966301bcf7c`.
+- Workflow-trigger corrections: merged through PR #470 as `5b24c1e4f31f1b001cd0bd6910fb2c134108fc77`.
+- AI-test aggregation correction: merged through PR #471 as `1fca8763cb7a6449cab719950ff74fb59e149b1e`.
+- Reusable Phase 0 kernel/smoke workflow: merged through PR #472 as `802b8aec7ac129559692bd574e70fd9991aaec1d`.
+- Release readiness: not established.
+- Numerical, statistical, biochemical, and biological validity: not established by ordinary test success.
 
 ## 2. What was done
 
 - Read the root `README.md` and mandatory `docs/ai_assistants/README.md`.
-- Inspected the CMake/Ninja/C++23 graph, presets, applications, plugins, tools, tests, CI, and selected high-risk sources.
-- Created the consolidation plan, module inventory, test matrix, human-decision records, future research plans, Phase 0 evidence, and this handoff.
-- Corrected the root README and stable build/CI guidance to use current targets, paths, options, and presets.
-- Verified that `20261` is the renamed former `2026-1` branch.
-- Recorded that promotion to `20262` is an end-of-semester activity, not a current release gate.
-- Verified current green ordinary CI and focused GUI GMDD tests.
-- Opened, validated, and integrated PR #470 for active workflow trigger corrections.
-- Opened, diagnosed, corrected, validated, and integrated PR #471 so offline AI plugin tests participate in the ordinary aggregate and kernel direct-runner graph.
+- Mapped CMake/Ninja/C++23, Qt6, applications, plugins, tools, tests, CI, packaging, and high-risk source areas.
+- Created the 2026 consolidation plan, module inventory, test matrix, decision records, research-direction documents, Phase 0 evidence, and this handoff.
+- Corrected stale build/application documentation.
+- Corrected active workflow filters after `2026-1` was renamed to `20261`.
+- Corrected the Debian workflow path filter to the root-level `debian/` tree.
+- Added the existing offline AI plugin tests to the ordinary aggregate and kernel direct runner.
+- Added `.github/workflows/genesys-phase0-validation.yml` for reusable kernel/smoke validation and evidence artifacts.
+- Executed all three primary baseline presets through GitHub Actions.
 
 ## 3. Relevant technical comments
 
-- [Build] Canonical build: CMake 3.24+, Ninja, C++23, extensions disabled.
-- [Qt] Qt6-only is the intended baseline; remaining Qt5 fallbacks are implementation debt.
-- [CI] Historical reports of 16/1657 failures and three GUI GMDD failures were not reproduced by current successful runs.
-- [CI] PR #470 changed only activation filters; no build command, dependency, job, preset, or test behavior changed.
-- [Tests] `genesys_test_ai_plugins` uses local fakes/dummy connectors and requires no network or credential.
-- [Tests] PR #471 now builds and discovers the AI tests in ordinary `tests-unit`; the explicit `tests-kernel-unit` execution remains pending.
-- [Plugins] Current runtime is still statically aggregated; future independent dynamic plugins require a stable C ABI with opaque handles and versioned function tables.
-- [Numerics] Green unit tests do not invalidate the confirmed defects in `SolverDefaultImpl1`.
-- [Statistics] Scientific validity requires authoritative references, explicit parameterizations, and independent test vectors.
-- [Worker] Intended profile is a controlled academic intranet after authentication and secret/token hardening.
-- [Optimizer] Current backend remains an internal scaffold, not a complete optimization capability.
-- [Whole-cell] Current implementation must not overclaim predictive biological validity.
+- [Build] Canonical baseline: Ubuntu 24.04, CMake 3.24+, Ninja, C++23, compiler extensions disabled.
+- [Executed toolchain] CMake 3.31.6, Ninja 1.13.2, G++ 13.3.0.
+- [Qt] Qt6-only is the intended support policy; Qt5 fallback code remains technical debt.
+- [CI] Historical records of 16/1657 failures and three failing GUI GMDD tests were not reproduced.
+- [Tests] Kernel inventory contains 1,696 registered tests: 1,692 passed and 4 were disabled.
+- [Tests] Smoke inventory contains 3 tests; all passed.
+- [AI] The three offline AI plugin tests are present as tests #495–#497 and passed.
+- [Plugins] Current runtime remains statically aggregated; dynamic migration is deferred until target overlap and lifecycle contracts are mapped.
+- [Numerics] Green tests do not invalidate the confirmed defects in `SolverDefaultImpl1`.
+- [Worker] Controlled academic intranet is the intended deployment profile after security hardening.
+- [Optimizer] The current backend remains a scaffold and must not be presented as a mature optimizer.
 
 ## 4. Problems encountered
 
-### 4.1 No local execution environment
+### 4.1 Historical documentation drift
 
-- No local compiler, Qt runtime, package manager, sanitizer, or Git worktree was available.
-- GitHub Actions was used for the executable checkpoints available through the connector.
-- Status: `needs-local-validation` for paths not present in CI.
+Old documents reported failures no longer reproduced and used obsolete branch, target, path, and application names. Stable guides and the root README were corrected. Historical files remain historical evidence rather than current status.
 
-### 4.2 Partial Phase 0 coverage
+### 4.2 AI-test aggregation omission
 
-Validated:
+`genesys_test_ai_plugins` existed but was missing from aggregate/direct-runner orchestration. The first cross-directory `add_custom_command(TARGET ...)` attempt failed during CMake configuration. The final solution uses a dedicated run target and valid dependency edges. Both ordinary and kernel paths passed.
 
-- `tests-unit` configure/build/CTest;
-- focused GUI GMDD executable and three selected tests;
-- ordinary aggregate after AI plugin inclusion.
+### 4.3 Incomplete Phase 0 CI coverage
 
-Still missing:
+The ordinary workflow covered only `tests-unit` and GUI GMDD. PR #472 added a separate reusable matrix workflow for `tests-kernel-unit` and `tests-smoke`, exact inventory, logs, versions, and artifacts.
 
-- `tests-kernel-unit`;
-- `tests-smoke`;
-- exact `ctest -N` inventory;
-- application startup matrix;
-- sanitizers;
-- package lifecycle.
+### 4.4 Remaining disabled tests
 
-### 4.3 AI test aggregation defect
+Four simulator runtime tests are registered but disabled:
 
-- Confirmed defect: `genesys_test_ai_plugins` existed but was omitted from aggregate/direct-runner orchestration.
-- First correction attempt failed because `add_custom_command(TARGET ...)` cannot modify a target created in another CMake directory.
-- Final correction: dedicated `genesys_test_ai_plugins_run` target plus cross-directory dependencies.
-- Ordinary CI result: success.
-- Status: `implemented-and-validated` for `tests-unit`; direct runner still needs the explicit kernel preset run.
+1. `SimulatorRuntimeTest.SearchQueueFindsEntityInRangeSavesRankAndRoutesToFoundPort`;
+2. `SimulatorRuntimeTest.SearchQueueNotFoundRoutesToPortZeroAndSavesZeroRank`;
+3. `SimulatorRuntimeTest.RemoveEqualStartAndEndRankRemovesExactlyOneAndRoutesCorrectly`;
+4. `SimulatorRuntimeTest.RemoveRangeRemovesOnlyEntitiesInsideConfiguredInterval`.
 
-### 4.4 Workflow activation drift
+These are explicit coverage gaps, not failures.
 
-- Ordinary CI filtered the obsolete branch name `2026-1` instead of `20261`.
-- Debian workflow used the non-matching path `../../packaging/debian/**` instead of `debian/**`.
-- PR #470 corrected both and passed ordinary CI.
-- Debian package execution itself remains unvalidated.
+### 4.5 Scientific/numerical blockers
 
-### 4.5 Numerical correctness blocker
-
-- `SolverDefaultImpl1` has confirmed undefined-behavior/correctness concerns.
-- Statistical hypothesis code depends on this legacy integrator.
-- Status: `blocked` for scientific validity until focused regression tests exist.
-
-### 4.6 Plugin target overlap
-
-- Full and minimal static plugin targets compile overlapping recursive component sources.
-- Status: mapping required before target restructuring or dynamic-plugin work.
-
-### 4.7 Security-sensitive implementation
-
-- Worker tokens use a non-cryptographic PRNG.
-- AI secret storage composes a secret-bearing shell command.
-- Status: blocks approved deployment until hardened and tested.
+`SolverDefaultImpl1`, statistical reference validation, plugin target overlap, worker security, optimizer ownership/maturity, and whole-cell scientific claims remain unresolved.
 
 ## 5. Corrections and adjustments made
 
-Integrated functional/build-governance corrections:
+Integrated changes:
 
-- PR #470:
-  - `.github/workflows/genesys-ci.yml`: `2026-1` → `20261`;
-  - `.github/workflows/genesys-debian-package.yml`: `2026-1` → `20261`;
-  - Debian trigger path: `../../packaging/debian/**` → `debian/**`.
-- PR #471:
-  - adds `genesys_test_ai_plugins` to `genesys_kernel_unit_tests` dependencies;
-  - creates a dedicated offline AI-test run target;
-  - adds it to `genesys_kernel_unit_tests_run` dependencies.
+- `.github/workflows/genesys-ci.yml`: active branch filter uses `20261`.
+- `.github/workflows/genesys-debian-package.yml`: active branch filter uses `20261`; Debian path filter uses `debian/**`.
+- `source/tests/CMakeLists.txt`: AI plugin tests included in ordinary and direct-runner graphs.
+- `.github/workflows/genesys-phase0-validation.yml`: kernel/smoke matrix validation with inventory and artifacts.
+- root and AI-assistant documentation aligned with current architecture and evidence.
 
-Documentation corrections in PR #469 include:
-
-- current README build/application instructions;
-- current branch names and promotion policy;
-- current CI evidence;
-- current GUI GMDD status;
-- current test aggregation status;
-- explicit distinction between software validation and scientific validity.
+No numerical algorithm, plugin ABI, application behavior, package recipe, worker security behavior, or scientific model was modified in this consolidation round.
 
 ## 6. Files created or changed
 
-Principal documentation artifacts:
+Principal consolidated documentation:
 
+- `README.md`;
+- `docs/ai_assistants/README.md`;
+- `docs/ai_assistants/build_ci_tests.md`;
+- `docs/ai_assistants/branch_workflow.md`;
+- `docs/ai_assistants/applications_development.md`;
+- `docs/ai_assistants/plugins_development.md`;
+- `docs/ai_assistants/tools_and_statistics.md`;
+- `docs/ai_assistants/whole_cell_and_sbml.md`;
 - `docs/ai_assistants/genesys_2026_consolidation_plan.md`;
-- `docs/ai_assistants/genesys_2026_test_matrix.md`;
 - `docs/ai_assistants/genesys_2026_module_inventory.md`;
-- `docs/ai_assistants/genesys_2026_consolidation_handoff.md`;
+- `docs/ai_assistants/genesys_2026_test_matrix.md`;
 - `docs/ai_assistants/genesys_2026_phase0_ci_evidence_20260720.md`;
-- `docs/ai_assistants/genesys_2026_human_decisions.md`;
-- `docs/ai_assistants/genesys_2026_decisions_addendum_20260720.md`;
-- `docs/ai_assistants/genesys_numerical_statistical_references_plan.md`;
-- `docs/ai_assistants/genesys_multiobjective_optimizer_future_plan.md`;
-- `docs/ai_assistants/genesys_ai_virtual_cell_research_direction.md`.
+- this handoff and associated decision/research plans.
 
-Integrated codebase files outside PR #469:
+Integrated non-document files:
 
 - `.github/workflows/genesys-ci.yml`;
 - `.github/workflows/genesys-debian-package.yml`;
+- `.github/workflows/genesys-phase0-validation.yml`;
 - `source/tests/CMakeLists.txt`.
 
 ## 7. Validation performed
 
-### 7.1 Documentation checkpoint
+### 7.1 Ordinary unit and GUI checkpoint
 
-- PR #469 workflow run `29772903692`, run 115.
-- Merge commit tested: `bf8bfd93a2b002c2098811cc339900eef516942d`.
-- Configure `tests-unit`: passed.
-- Build `tests-unit`: passed.
-- CTest `tests-unit`: passed.
-- GUI GMDD diagnostic job: passed.
+- PR #472 ordinary CI run: `29780136801`, run 121.
+- `tests-unit` configure/build/CTest: passed.
+- Focused GUI GMDD job: passed.
 
-### 7.2 Workflow-trigger correction
+### 7.2 Kernel-focused checkpoint
 
-- PR #470 workflow run `29772492281`, run 113.
-- Tested merge commit: `c30139e8ff06111f91d95b7f69a863aaf203d219`.
+- Phase 0 run: `29780136722`, run 1.
+- Tested PR merge commit: `0d5f32b48510f6c1776ccfb1572f51fb452a6538`.
+- Configure: passed.
+- Build and direct runner: passed.
+- CTest inventory: 1,696.
+- Executed/passed: 1,692.
+- Disabled: 4.
+- Failed: 0.
+- Real CTest time: 26.90 seconds.
+- Artifact: `genesys-phase0-tests-kernel-unit`, ID `8476435822`.
+- Digest: `sha256:bf803a8432328e0bb7555d61c4c01d72e6cafe20391b57380099a8db440bc673`.
+
+AI tests confirmed and passed:
+
+- #495 `AIConversationServiceTest.KeepsIndependentBoundedHistories`;
+- #496 `AIPluginTest.BuiltInConnectorExposesSupportAndComponentMetadata`;
+- #497 `AIPluginTest.PromptTemplateEvaluatesExpressionsAndEscapesLiteralBraces`.
+
+### 7.3 Smoke checkpoint
+
 - Configure/build/CTest: passed.
-- GUI GMDD job: passed.
-- Merged as `5b24c1e4f31f1b001cd0bd6910fb2c134108fc77`.
-
-### 7.3 AI test aggregation correction
-
-- PR #471 workflow run `29773299985`, run 117.
-- Tested merge commit: `7ee8eeb73490da5fb1aae3cb256a9339f2da7f59`.
-- Configure/build/CTest: passed after the CMake-scope correction.
-- Aggregate build included `genesys_test_ai_plugins`.
-- GUI GMDD job: passed.
-- Merged as `1fca8763cb7a6449cab719950ff74fb59e149b1e`.
+- Inventory/executed/passed: 3/3/3.
+- Tests: `smoke_simulator_start`, `test_continuous_system`, `test_lsode`.
+- Real time: 0.68 seconds.
+- Artifact: `genesys-phase0-tests-smoke`, ID `8476325130`.
+- Digest: `sha256:3d0f40bb68d05ec0c738c8a34d92d2f4380cf743323015220c25706157871776`.
 
 ## 8. State of the consolidation plan
 
-- Phase 0: `partially-validated`.
-  - ordinary `tests-unit`: validated;
-  - focused GUI GMDD tests: validated;
-  - active CI branch filters: corrected and integrated;
-  - ordinary AI plugin test aggregation: corrected and integrated;
-  - `tests-kernel-unit`: pending;
-  - `tests-smoke`: pending;
-  - exact test inventory: pending;
-  - application/package/sanitizer matrix: pending.
-- Phase 1 functional stabilization: not started as a consolidated implementation phase.
-- Dynamic plugin implementation: deferred pending source/target and lifecycle mapping.
-- Qt5 removal: policy decided; bounded implementation PR pending.
-- Numerical/statistical references: acquisition plan recorded; implementation validation pending.
+- Phase 0 core baseline: `validated`.
+  - `tests-unit`: validated;
+  - focused GUI GMDD: validated;
+  - `tests-kernel-unit`: validated;
+  - `tests-smoke`: validated;
+  - kernel and smoke inventories: captured;
+  - AI ordinary/direct-runner inclusion: validated.
+- Phase 0 broader release evidence: incomplete.
+  - applications, package lifecycle, sanitizers, profiling, network/security, and scientific references remain pending.
+- Phase 1 numerical/build stabilization: ready to begin with focused failing regression tests.
+- Dynamic plugins: deferred.
+- Qt5 removal: bounded implementation pending.
 
 ## 9. Pending work
 
-### 9.1 Immediate validation
+Immediate:
 
-1. Run `tests-kernel-unit`.
-2. Run `tests-smoke`.
-3. Capture `ctest -N` for all baseline presets.
-4. Confirm direct execution of `genesys_test_ai_plugins_run` through the kernel preset.
-5. Build representative application presets.
-6. Execute the Debian package workflow and package lifecycle.
+1. Investigate and enable or formally retire the four disabled Search/Remove runtime tests.
+2. Validate representative shell, worker, main GUI, and independent GUI presets.
+3. Execute Debian package build/install/start/uninstall validation.
+4. Add opt-in ASan/LSan/UBSan validation for high-risk suites.
 
-### 9.2 Priority technical work
+Priority technical work:
 
-- add failing regression tests for `SolverDefaultImpl1`;
-- apply the minimum solver correction or quarantine invalid overloads;
-- map and remove unjustified plugin target overlap;
-- remove Qt5 fallback in a dedicated PR;
-- replace worker token randomness and secret-command handling;
+- add regression tests for every defective `SolverDefaultImpl1` path;
+- apply the minimum numerical correction only after those tests fail for the expected reasons;
+- generate the plugin source-to-target/link map;
+- remove Qt5 fallback in a separate PR;
+- harden worker tokens and secret handling;
 - close optimizer ownership/copy hazards;
 - verify the temporary `Model` lifetime finding;
 - decide parser `FunctionRegistry` disposition.
 
 ## 10. Recommended next actions
 
-1. Revalidate PR #469 against the new `WorkInProgress` base containing merges #470 and #471.
-2. Merge PR #469 only after the new documentation head is green.
-3. Add explicit CI/manual-dispatch paths for `tests-kernel-unit` and `tests-smoke`, or run them locally and attach logs.
-4. Open a dedicated Qt6-only cleanup PR.
-5. Open a dedicated regression-test PR for `SolverDefaultImpl1` before changing numerical code.
-6. Keep plugin architecture, worker security, optimizer development, and scientific reference work in separate reviewable changes.
+1. Merge the documentation evidence update after ordinary CI passes.
+2. Open a focused test-only PR for `SolverDefaultImpl1`.
+3. Keep the first solver PR limited to regression tests and characterization; do not repair the implementation in the same first commit.
+4. Address the four disabled runtime tests in a separate bounded PR unless directly required by the solver work.
+5. Keep Qt6 cleanup, plugin architecture, worker security, and optimizer work isolated.
 
 ## 11. Guidance for the next AI assistant
 
-First read:
+First read `docs/ai_assistants/README.md`, then the Phase 0 evidence, test matrix, consolidation plan, module inventory, decisions addendum, and this handoff.
 
-1. `docs/ai_assistants/README.md`;
-2. `genesys_2026_decisions_addendum_20260720.md`;
-3. `genesys_2026_phase0_ci_evidence_20260720.md`;
-4. `genesys_2026_consolidation_plan.md`;
-5. `genesys_2026_test_matrix.md`;
-6. `genesys_2026_module_inventory.md`;
-7. this handoff.
-
-Use `20261`, not `2026-1`, except when quoting historical identifiers. Do not claim Phase 0 complete until kernel/smoke and exact inventory are captured. Do not infer scientific correctness from green unit tests. Add regression tests before changing numerical algorithms. Do not start dynamic plugin migration before the current static graph and ownership/lifecycle contracts are mapped.
+Use `20261`, not `2026-1`, except for historical quotations. Treat the core baseline as green only for the recorded commits/toolchain. Do not infer scientific correctness from the test count. Do not alter `SolverDefaultImpl1` before adding focused failing tests. Do not begin dynamic plugin migration before mapping current source overlap and lifecycle/ownership boundaries.
 
 ## 12. Limitations and uncertainties
 
-- No local compiler/runtime was available.
-- Exact CTest counts were not extracted.
-- `tests-kernel-unit` and `tests-smoke` were not executed.
-- Debian package generation was not executed after the trigger correction.
-- Application startup, network behavior, sanitizers, and profiling remain unvalidated.
-- Numerical, statistical, biochemical, and biological correctness requires independent references and domain review.
-- PR #469 must receive a new CI result after this update.
+- Validation used GitHub-hosted Ubuntu runners, not the maintainer's local machine.
+- Four tests remain disabled.
+- Application startup and user workflows were not executed.
+- Debian package lifecycle was not revalidated after trigger correction.
+- Sanitizers, Valgrind, profiling, worker networking, and authentication were not executed.
+- Scientific correctness still requires independent references and domain review.
 
 ## 13. Operational result
 
-Result: workflow activation and AI plugin test aggregation defects were corrected, validated, and merged into `WorkInProgress`; the consolidation documentation was updated to reflect those integrations. Phase 0 remains partially validated because kernel-focused, smoke, exact inventory, application, sanitizer, and package checkpoints are still pending.
+Result: the GenESyS core Phase 0 baseline is green and reproducible through integrated GitHub Actions workflows. The repository now has validated ordinary, kernel-focused, smoke, GUI GMDD, and AI plugin test paths. The next safe implementation phase is focused regression testing for `SolverDefaultImpl1`, while application, packaging, sanitizer, security, plugin-architecture, and scientific validation remain separate workstreams.

--- a/docs/ai_assistants/genesys_2026_phase0_ci_evidence_20260720.md
+++ b/docs/ai_assistants/genesys_2026_phase0_ci_evidence_20260720.md
@@ -2,126 +2,148 @@
 
 ## 1. Purpose
 
-Record the executed Phase 0 evidence available through GitHub Actions and the first two bounded corrections integrated into `WorkInProgress`.
+Record the complete executed evidence for the three primary GenESyS Phase 0 presets and the bounded corrections integrated during consolidation.
 
-This document supersedes older statements that treated the three GUI GMDD tests as currently failing, the ordinary pull-request CI as unknown, or the AI plugin test omission as unresolved.
+This evidence establishes a reproducible software baseline. It does not establish release readiness, security readiness, package lifecycle correctness, application usability, or scientific validity.
 
-It does not establish release readiness or scientific correctness.
-
-## 2. Repository and branch identity
+## 2. Integrated checkpoint
 
 - Repository: `rlcancian/Genesys-Simulator`.
-- Consolidation PR: #469.
-- Consolidation branch: `audit/genesys-2026-consolidation-plan-20260720`.
-- Base branch: `WorkInProgress`.
-- Original inspected base: `b25a4d2ec31abe27f1bf3597a5135fa4828fbc35`.
+- Branch: `WorkInProgress`.
+- Consolidation documentation merge: `9c52b61532b847668adc3be92c780966301bcf7c`.
+- Phase 0 workflow merge: `802b8aec7ac129559692bd574e70fd9991aaec1d`.
 - Semester branch: `20261`, renamed from historical `2026-1`.
-- Future stable branch: `20262`, intended for end-of-semester promotion only.
+- Future stable branch: `20262`, reserved for end-of-semester promotion.
 
-## 3. Executed checkpoints
+## 3. Ordinary baseline
 
-### 3.1 Consolidation documentation
+PR #472 ordinary CI:
 
-- PR: #469.
-- Workflow run: `29772903692`, run 115.
-- Tested merge commit: `bf8bfd93a2b002c2098811cc339900eef516942d`.
-- Configure preset `tests-unit`: passed.
-- Build preset `tests-unit`: passed.
-- CTest preset `tests-unit`: passed.
-- Focused GUI GMDD job: passed.
+- workflow run: `29780136801`, run 121;
+- tested merge commit: `0d5f32b48510f6c1776ccfb1572f51fb452a6538`;
+- `tests-unit` configure: passed;
+- `tests-unit` build: passed;
+- `tests-unit` CTest: passed;
+- focused GUI GMDD job: passed.
 
-### 3.2 Workflow trigger correction
+The three focused GUI tests remain green; older failing records are historical snapshots unless reproduced on a newer identified commit.
 
-- PR: #470.
-- Head: `4dfeca8723ce2f2170c0d304768f0c95aa00857e`.
-- Workflow run: `29772492281`, run 113.
-- Tested merge commit: `c30139e8ff06111f91d95b7f69a863aaf203d219`.
-- Configure/build/CTest `tests-unit`: passed.
-- Focused GUI GMDD job: passed.
-- Integrated into `WorkInProgress` as `5b24c1e4f31f1b001cd0bd6910fb2c134108fc77`.
+## 4. Kernel-focused baseline
 
-Integrated corrections:
+Phase 0 workflow:
 
-- ordinary CI PR target `2026-1` → `20261`;
-- Debian workflow PR target `2026-1` → `20261`;
-- Debian path filter `../../packaging/debian/**` → `debian/**`.
+- run: `29780136722`, run 1;
+- job: `Validate tests-kernel-unit`;
+- configure: passed;
+- build preset and direct runner: passed;
+- CTest inventory: 1,696 registered tests;
+- CTest execution: 1,692 passed, 0 failed, 4 disabled;
+- total CTest time: 26.90 seconds.
 
-The Debian package job itself was not executed by this PR because the PR base was `WorkInProgress`, which is not an eligible Debian workflow PR target.
+Artifact:
 
-### 3.3 AI plugin test aggregation
+- name: `genesys-phase0-tests-kernel-unit`;
+- ID: `8476435822`;
+- digest: `sha256:bf803a8432328e0bb7555d61c4c01d72e6cafe20391b57380099a8db440bc673`;
+- expiration: 2026-10-18.
 
-- PR: #471.
-- Final head: `5783c7166f9623aa3c42a92a6ef2bdcc0bdce436`.
-- Workflow run: `29773299985`, run 117.
-- Tested merge commit: `7ee8eeb73490da5fb1aae3cb256a9339f2da7f59`.
-- Configure/build/CTest `tests-unit`: passed.
-- Focused GUI GMDD job: passed.
-- Integrated into `WorkInProgress` as `1fca8763cb7a6449cab719950ff74fb59e149b1e`.
+Toolchain captured:
 
-The correction:
+- Ubuntu 24.04;
+- CMake 3.31.6;
+- Ninja 1.13.2;
+- G++ 13.3.0.
 
-- adds `genesys_test_ai_plugins` to the ordinary aggregate dependencies;
-- creates `genesys_test_ai_plugins_run` for the direct runner path;
-- adds that run target to `genesys_kernel_unit_tests_run` dependencies.
+AI plugin tests explicitly registered and passed:
 
-The test source uses a local fake provider and dummy connector; it performs no network call and uses no credential.
+- #495 `AIConversationServiceTest.KeepsIndependentBoundedHistories`;
+- #496 `AIPluginTest.BuiltInConnectorExposesSupportAndComponentMetadata`;
+- #497 `AIPluginTest.PromptTemplateEvaluatesExpressionsAndEscapesLiteralBraces`.
 
-## 4. GUI GMDD status
+Disabled tests:
 
-The current focused job executes:
+- #225 `SimulatorRuntimeTest.SearchQueueFindsEntityInRangeSavesRankAndRoutesToFoundPort`;
+- #226 `SimulatorRuntimeTest.SearchQueueNotFoundRoutesToPortZeroAndSavesZeroRank`;
+- #229 `SimulatorRuntimeTest.RemoveEqualStartAndEndRankRemovesExactlyOneAndRoutesCorrectly`;
+- #230 `SimulatorRuntimeTest.RemoveRangeRemovesOnlyEntitiesInsideConfiguredInterval`.
 
-1. `GuiGmddLayout.SeizeEditableReferencesStayAboveAndLowerDefinitionsUseTwoRows`;
-2. `GuiGmddLayout.SerializerRoundTripRestoresComponentColorAndDataDefinitionPosition`;
-3. `GuiGmddLayout.SerializerRoundTripRestoresViewStateGeometriesAndGroups`.
+## 5. Smoke baseline
 
-All three passed in the current successful checkpoints. Older failure reports are historical snapshots unless reproduced on a specified newer commit.
+Phase 0 workflow job `Validate tests-smoke`:
 
-## 5. Status changes justified
+- configure: passed;
+- build: passed;
+- CTest inventory: 3;
+- executed/passed: 3/3;
+- failed: 0;
+- total time: 0.68 seconds.
 
-| Concern | Current status | Evidence |
-|---|---|---|
-| Ordinary `tests-unit` | `validated` for identified runs | configure/build/CTest passed |
-| Focused GUI GMDD | `validated` for identified runs | 3/3 tests passed |
-| Active branch trigger `20261` | `implemented-and-validated` | PR #470 merged |
-| Debian root path filter | `implemented`; package execution pending | PR #470 merged |
-| AI plugin inclusion in ordinary aggregate | `implemented-and-validated` | PR #471 merged and CTest passed |
-| AI plugin direct kernel runner | `implemented`; explicit preset execution pending | target graph corrected |
-| Full Phase 0 | `partially-validated` | kernel/smoke/inventory/application/package paths missing |
-| Historical 16/1657 failures | `not-reproduced-in-current-tests-unit` | current ordinary runs passed |
+Tests:
 
-## 6. Validation not yet performed
+1. `smoke_simulator_start`;
+2. `test_continuous_system`;
+3. `test_lsode`.
 
-- `tests-kernel-unit` configure/build/CTest;
-- `tests-smoke` configure/build/CTest;
-- exact `ctest -N` counts and complete target inventory;
-- shell/worker/GUI application startup;
-- independent GUI application presets;
-- model-specific application sweep;
-- ASan/LSan/UBSan/Valgrind;
+Artifact:
+
+- name: `genesys-phase0-tests-smoke`;
+- ID: `8476325130`;
+- digest: `sha256:3d0f40bb68d05ec0c738c8a34d92d2f4380cf743323015220c25706157871776`;
+- expiration: 2026-10-18.
+
+## 6. Integrated bounded corrections
+
+PR #470, merge `5b24c1e4f31f1b001cd0bd6910fb2c134108fc77`:
+
+- ordinary CI target branch corrected to `20261`;
+- Debian workflow target branch corrected to `20261`;
+- Debian path filter corrected to `debian/**`.
+
+PR #471, merge `1fca8763cb7a6449cab719950ff74fb59e149b1e`:
+
+- AI plugin tests added to ordinary aggregate;
+- dedicated AI direct-runner target added to kernel runner graph;
+- ordinary and kernel executions passed.
+
+PR #472, merge `802b8aec7ac129559692bd574e70fd9991aaec1d`:
+
+- added reusable `genesys-phase0-validation.yml`;
+- captures kernel/smoke inventories, executions, versions, diagnostics, and artifacts.
+
+## 7. Status justified by the evidence
+
+| Concern | Status |
+|---|---|
+| `tests-unit` | `validated` for recorded commits |
+| focused GUI GMDD | `validated` |
+| `tests-kernel-unit` configure/build/direct runner/CTest | `validated` |
+| `tests-smoke` configure/build/CTest | `validated` |
+| ordinary and kernel AI plugin test inclusion | `validated` |
+| exact kernel inventory | `validated`: 1,696 registered |
+| exact smoke inventory | `validated`: 3 registered |
+| core Phase 0 baseline | `validated` |
+| four disabled runtime tests | explicit coverage gap |
+| application/package/sanitizer/security/scientific validation | pending |
+
+## 8. Validation not performed
+
+- standalone shell, worker, main GUI, and independent GUI startup/workflows;
+- representative model-specific application sweep;
 - Debian package build/install/start/uninstall after trigger correction;
+- ASan, LSan, UBSan, Valgrind, and profiling;
+- worker networking/authentication/security controls;
 - Qt5 fallback removal;
-- worker authentication, CSPRNG, resource controls, and secret handling;
-- numerical/statistical authoritative-reference validation;
-- whole-cell/biochemical benchmark validity;
-- future dynamic plugin ABI implementation.
+- dynamic plugin ABI/lifecycle implementation;
+- authoritative numerical/statistical reference validation;
+- biochemical/whole-cell benchmark validation.
 
-## 7. Remaining Phase 0 actions
+## 9. Next safe technical step
 
-1. Execute `tests-kernel-unit` on Ubuntu 24.04/Qt6.
-2. Execute `tests-smoke` on the same baseline.
-3. Capture `ctest -N` and exact execution counts for all three presets.
-4. Confirm `genesys_test_ai_plugins_run` through the explicit kernel preset.
-5. Execute the Debian packaging workflow and package lifecycle.
-6. Build representative application presets independently.
-7. Preserve all branch, commit, run, job, dependency-mode, and artifact identifiers.
+Open a test-only PR for `SolverDefaultImpl1` that:
 
-## 8. Next safe technical steps
+1. adds direct regression tests for each overload and precondition;
+2. demonstrates the uninitialized-step/RK4/Simpson/unimplemented-path defects;
+3. records analytical or independently generated expected values;
+4. does not modify the implementation until the failures are isolated.
 
-After the missing baseline presets:
-
-- open a focused regression-test PR for `SolverDefaultImpl1` before changing it;
-- create the exact static plugin source-to-target/link map;
-- remove Qt5 fallback in a dedicated PR;
-- harden worker tokens and secret handling in separate security PRs.
-
-No broad plugin, namespace, ownership, optimizer, or scientific-model refactoring is authorized by these green ordinary CI results.
+The disabled Search/Remove tests, Qt6-only cleanup, plugin target mapping, worker security, and application/package validation should remain separate bounded workstreams.

--- a/docs/ai_assistants/genesys_2026_test_matrix.md
+++ b/docs/ai_assistants/genesys_2026_test_matrix.md
@@ -2,106 +2,114 @@
 
 ## 1. Purpose
 
-Record executed validation, missing coverage, and acceptance criteria for the 2026 consolidation. A green software test does not by itself establish numerical, statistical, biochemical, or biological validity.
+Record executed software validation, remaining coverage, and acceptance criteria. Passing tests do not by themselves establish numerical, statistical, biochemical, or biological validity.
 
-## 2. Current executed evidence
+## 2. Current executed checkpoints
 
 | Checkpoint | Run | Result | Integrated state |
 |---|---:|---|---|
-| PR #469 documentation baseline | `29772903692` | `tests-unit` and GUI GMDD passed | documentation PR still open |
-| PR #470 workflow triggers | `29772492281` | `tests-unit` and GUI GMDD passed | merged as `5b24c1e4...` |
-| PR #471 AI test aggregation | `29773299985` | aggregate build, CTest, and GUI GMDD passed | merged as `1fca8763...` |
+| Consolidation documentation | `29779857979` | `tests-unit` and GUI GMDD passed | PR #469 merged as `9c52b615...` |
+| Workflow triggers | `29772492281` | `tests-unit` and GUI GMDD passed | PR #470 merged as `5b24c1e4...` |
+| AI test aggregation | `29773299985` | aggregate/CTest/GUI passed | PR #471 merged as `1fca8763...` |
+| Phase 0 kernel/smoke | `29780136722` | both matrix jobs passed | PR #472 merged as `802b8aec...` |
+| PR #472 ordinary CI | `29780136801` | `tests-unit` and GUI passed | workflow addition validated |
 
-## 3. Baseline matrix
+## 3. Core baseline matrix
 
-| Validation path | Current evidence | Status | Remaining gap |
+| Validation path | Executed evidence | Status | Remaining gap |
 |---|---|---|---|
-| `tests-unit` configure/build/CTest | multiple current successful PR runs | `validated` for executed commits | exact test count and complete inventory |
-| Three focused GUI GMDD tests | 3/3 passed in current runs | `validated` | standalone GUI startup |
-| AI plugin tests in ordinary aggregate | PR #471 merged; CTest passed | `validated` | none for ordinary path |
-| AI plugin tests in direct kernel runner | run target and dependency merged | `partially-validated` | execute `tests-kernel-unit` explicitly |
-| `tests-kernel-unit` | preset/graph confirmed | `needs-local-validation` | configure/build/CTest result |
-| `tests-smoke` | preset/sources confirmed | `needs-local-validation` | configure/build/CTest result |
-| Debian trigger/path filters | PR #470 merged | `implemented` | package workflow execution/lifecycle |
-| Application presets | presets/targets confirmed | `needs-local-validation` | independent build/startup |
-| Sanitizers | no current executed presets | `not-started` | ASan/LSan/UBSan/Valgrind |
+| `tests-unit` | configure/build/CTest passed | `validated` | preserve on future code changes |
+| Focused GUI GMDD | 3/3 passed | `validated` | standalone GUI startup/workflow |
+| `tests-kernel-unit` | configure/build/direct runner/CTest passed | `validated` | 4 disabled runtime tests |
+| Kernel CTest inventory | 1,696 registered; 1,692 passed; 4 disabled | `validated` | investigate disabled tests |
+| AI tests ordinary/direct paths | tests #495–#497 passed | `validated` | provider transport/security coverage |
+| `tests-smoke` | 3 registered/executed/passed | `validated` | broader application smoke matrix |
+| Debian trigger/path filters | integrated | `implemented` | package lifecycle execution |
+| Application presets | targets/presets confirmed | `needs-local-validation` | independent build/startup/workflows |
+| Sanitizers/profiling | not executed | `not-started` | ASan/LSan/UBSan/Valgrind/profiling |
 
-## 4. Detailed module matrix
+## 4. Exact Phase 0 inventory
+
+### 4.1 Kernel
+
+- registered: 1,696;
+- executed/passed: 1,692;
+- failed: 0;
+- disabled: 4;
+- CTest real time: 26.90 seconds.
+
+AI tests:
+
+- #495 `AIConversationServiceTest.KeepsIndependentBoundedHistories`;
+- #496 `AIPluginTest.BuiltInConnectorExposesSupportAndComponentMetadata`;
+- #497 `AIPluginTest.PromptTemplateEvaluatesExpressionsAndEscapesLiteralBraces`.
+
+Disabled runtime tests:
+
+- #225 SearchQueue found/rank/found-port path;
+- #226 SearchQueue not-found/zero-rank path;
+- #229 Remove single-rank interval path;
+- #230 Remove range path.
+
+### 4.2 Smoke
+
+- registered/executed/passed: 3/3/3;
+- failed: 0;
+- real time: 0.68 seconds;
+- tests: simulator start, continuous system, LSODE.
+
+## 5. Detailed module matrix
 
 | Module / concern | Current evidence | Missing coverage | Priority | Acceptance criterion | Status |
 |---|---|---|---|---|---|
-| Utilities | ordinary baseline green | edge cases and sanitizer coverage | P2 | deterministic edge behavior, no sanitizer findings | `partially-validated` |
-| Simulator support/runtime | ordinary baseline green | repeated lifecycle, exception paths, leak/UB checks | P0/P1 | repeatable create/destroy with no leak/UB | `partially-validated` |
-| Persistence | current tests green | cross-plugin round trip and compatibility fixtures | P1 | supported fields round-trip; unsupported fields diagnosed | `partially-validated` |
-| PluginManager | current tests green | ownership injection, duplicate insertion, load/unload, future ABI mismatch | P1 | deterministic lifecycle and diagnostics | `partially-validated` |
-| Parser expressions | current tests green | unknown-function and old-model compatibility | P1 | deterministic errors and `.gen` compatibility | `partially-validated` |
-| FunctionRegistry | historical PR only | current disposition/design | P1 | explicit decision plus compatibility tests | `not-started` |
-| Kernel statistics | ordinary baseline green | authoritative references and degenerate inputs | P0/P1 | results agree with declared references/tolerances | `partially-validated` |
-| Hypothesis testing | no current failure | legacy integrator dependency and missing reference vectors | P0 | authoritative p-values/intervals and invalid-domain handling | `blocked` scientifically |
-| `SolverDefaultImpl1` | source defects confirmed | dedicated tests for every overload/precondition | P0 | failing regressions first, then minimum correction | `blocked` |
-| ODE solver factory | analytical/convergence tests exist | stiffness, long-time, event-boundary, NaN/Inf | P1 | documented contract and analytical convergence | `partially-validated` |
-| Diffusion/continuous integration | current aggregate green | conservation, mesh convergence, target overlap, hybrid time | P0/P1 | reference solutions and no ODR/link overlap | `blocked` architecturally |
-| Cellular automata | neighborhood target green | historical full inventory reconciliation | P1 | current and historical test scope reconciled | `partially-validated` |
-| Whole-cell plugins | no failure in current ordinary run | explicit inclusion evidence, GLPK/fallback, reproducibility | P0/P1 | deterministic fixtures pass in supported modes | `partially-validated` |
-| SBML/biochemical | sources/dependency exist | support matrix, round trip, diagnostics | P1 | no silent loss and explicit unsupported constructs | `not-started` |
-| Modal/hybrid | domain sources exist | deterministic state/time fixtures | P1 | explicit time/state contracts pass | `not-started` |
-| AI plugins | offline tests now aggregated and green | explicit kernel preset runner execution | P1 | ordinary and direct-runner paths both pass | `partially-validated` |
-| AI provider clients | provider code compiles | fake transport, timeout, parsing, redaction | P1 | deterministic offline tests, no real API requirement | `needs-local-validation` |
-| AI secret storage | source risk identified | process/Secret Service boundary tests | P1 | secret absent from argv/logs; safe failure | `not-started` |
-| Worker API/token service | partial router tests; token source inspected | auth, quotas, timeout, CSPRNG, expiry/rotation | P1 | secure controlled-intranet contract | `not-started` security hardening |
-| Optimizer | scaffold source exists | algorithm, ranking, constraints, ownership | P1 | Level 3 contract and benchmark suite | `partially-implemented` |
-| Data Analyser | related tests/targets exist | reference fits and import/export | P1 | reference-backed analysis workflow | `partially-implemented` |
-| Do Experiments | backend fragments; GUI absent | DOE specification, backend tests, workflow | P1/P2 | known designs/analysis match references | `partially-implemented` |
-| Shell | target/preset confirmed | scripted startup/model/exit | P1 | minimal command/model completes and exits cleanly | `needs-local-validation` |
-| Main GUI | focused GMDD tests green | standalone configure/build/startup/model interaction | P1 | target starts and focused tests remain green | `partially-validated` |
-| Independent GUIs | targets/presets confirmed | startup and minimal workflows | P1 | each starts independently and completes a basic flow | `needs-local-validation` |
-| Packaging | workflow/assets exist; trigger corrected | build/install/start/uninstall/version | P2 | packages generated and lifecycle passes | `needs-ci-validation` |
-| Qt6-only cleanup | policy decided | remove Qt5 fallback across GUI/tests/scripts | P1/P2 | Qt6 build/tests pass; no Qt5 discovery remains | `not-started` |
-| Dynamic plugins | future ABI direction recorded | non-overlapping targets, lifecycle, ABI tests | P1/P2 | pilot plugin loads/unloads with version checks | `deferred` |
+| Utilities | baseline green | edge cases and sanitizers | P2 | deterministic edge behavior; no findings | `partially-validated` |
+| Simulator support/runtime | baseline green | disabled Search/Remove tests; lifecycle/leak paths | P0/P1 | all intended runtime tests enabled and green; no UB/leak | `partially-validated` |
+| Persistence | baseline green | cross-plugin and compatibility fixtures | P1 | supported fields round-trip; unsupported diagnosed | `partially-validated` |
+| PluginManager | baseline green | ownership, duplicate insertion, future ABI/load/unload | P1 | deterministic lifecycle and diagnostics | `partially-validated` |
+| Parser expressions | baseline green | unknown functions and historical compatibility | P1 | deterministic errors and `.gen` compatibility | `partially-validated` |
+| FunctionRegistry | historical PR only | current disposition/design | P1 | explicit decision and compatibility tests | `not-started` |
+| Kernel statistics | baseline green | authoritative references and degenerate inputs | P0/P1 | declared methods match references/tolerances | `partially-validated` |
+| Hypothesis testing | current tests green | suspect integrator and missing references | P0 | reference-backed p-values/intervals | `blocked` scientifically |
+| `SolverDefaultImpl1` | source defects confirmed | dedicated characterization/regression tests | P0 | failing tests isolate every defect before repair | `blocked` |
+| ODE factory | analytical/convergence tests green | stiffness, long-time, NaN/Inf, event boundaries | P1 | explicit solver contract and reference convergence | `partially-validated` |
+| Diffusion/continuous | aggregate and smoke green | conservation, mesh convergence, target overlap, hybrid time | P0/P1 | reference solution and no ODR/link overlap | `blocked` architecturally |
+| Cellular automata | current neighborhood tests green | historical full inventory reconciliation | P1 | current/historical scope reconciled | `partially-validated` |
+| Whole-cell | current registered suite green | GLPK/fallback, persistence, stochastic reproducibility | P0/P1 | deterministic fixtures in supported modes | `partially-validated` |
+| SBML/biochemical | sources/dependency exist | support matrix, round trip, diagnostics | P1 | no silent loss; unsupported constructs explicit | `not-started` |
+| Modal/hybrid | domain sources exist | state/time contract fixtures | P1 | deterministic event-boundary behavior | `not-started` |
+| AI plugins | ordinary and direct paths green | transport and error/security cases | P1 | offline deterministic coverage and redaction | `partially-validated` |
+| AI secret storage | source risk identified | process/Secret Service tests | P1 | secret absent from argv/logs | `not-started` |
+| Worker API/tokens | partial tests | auth, quotas, CSPRNG, expiry/rotation | P1 | controlled-intranet security contract | `not-started` hardening |
+| Optimizer | scaffold | algorithm/ranking/constraints/ownership | P1 | Level 3 contract and benchmark suite | `partially-implemented` |
+| Data Analyser | related tests exist | reference fits/import/export | P1 | reference-backed workflow | `partially-implemented` |
+| Do Experiments | backend fragments; GUI absent | DOE specification/tests/workflow | P1/P2 | known designs and analyses match references | `partially-implemented` |
+| Shell | preset confirmed | scripted startup/model/exit | P1 | minimal model completes cleanly | `needs-local-validation` |
+| Main GUI | focused tests green | standalone startup/model interaction | P1 | target starts; workflow smoke passes | `partially-validated` |
+| Independent GUIs | presets confirmed | basic startup/workflows | P1 | each application starts independently | `needs-local-validation` |
+| Packaging | triggers corrected | build/install/start/uninstall/version | P2 | packages complete lifecycle | `needs-ci-validation` |
+| Qt6-only cleanup | policy decided | remove Qt5 fallback across CMake/tests/scripts | P1/P2 | Qt6 baseline remains green; no fallback discovery | `not-started` |
+| Dynamic plugins | ABI direction recorded | target/lifecycle map and pilot | P1/P2 | versioned pilot loads/unloads safely | `deferred` |
 
-## 5. Current aggregation findings
+## 6. Aggregation findings
 
 Resolved:
 
-- `genesys_test_ai_plugins` now participates in the ordinary aggregate.
-- `genesys_test_ai_plugins_run` is attached to the kernel direct-runner graph.
+- AI plugin executable is part of the ordinary aggregate;
+- AI direct-runner target executes through `tests-kernel-unit`;
+- exact kernel and smoke inventories are captured.
 
 Still open:
 
-1. capture exact `ctest -N` counts;
-2. execute `tests-kernel-unit` to prove the direct runner;
-3. investigate repeated runtime libraries in some link lists;
-4. map full/minimal plugin source overlap;
-5. avoid treating generated method inventory as behavioral coverage.
+1. four disabled Search/Remove tests;
+2. repeated runtime libraries in selected link lists;
+3. full/minimal plugin source overlap;
+4. GUI test source aggregation/build cost;
+5. generated method inventory is structural inventory, not behavioral proof.
 
-## 6. Numerical and scientific evidence policy
+## 7. Numerical and scientific evidence policy
 
-For correctness-sensitive algorithms, record:
+Every correctness-sensitive method must define its mathematics, parameterization, domain, units, oracle/reference, tolerances, degenerate behavior, deterministic seeds, dependency mode, and exact/approximate/heuristic classification.
 
-- mathematical definition and parameterization;
-- valid domain, units, and preconditions;
-- analytical invariant or independent comparator;
-- authoritative reference;
-- absolute/relative tolerances and rationale;
-- empty, small, degenerate, repeated, and non-finite cases;
-- deterministic seeds and stochastic replication policy;
-- optional dependency mode;
-- exact/asymptotic/approximate/heuristic classification.
+## 8. Next bounded execution
 
-## 7. Next bounded execution
-
-```bash
-cmake --preset tests-kernel-unit
-cmake --build --preset tests-kernel-unit --parallel "$(nproc)"
-ctest --preset tests-kernel-unit --output-on-failure
-
-cmake --preset tests-smoke
-cmake --build --preset tests-smoke --parallel "$(nproc)"
-ctest --preset tests-smoke --output-on-failure
-
-ctest --preset tests-unit -N
-ctest --preset tests-kernel-unit -N
-ctest --preset tests-smoke -N
-```
-
-Do not begin broad refactoring merely because the current ordinary checkpoint is green.
+The next code PR should add focused regression tests for `SolverDefaultImpl1` without changing its implementation. Application, package, sanitizer, Qt6 cleanup, plugin architecture, and worker security validation remain separate workstreams.


### PR DESCRIPTION
## Scope

Update the canonical consolidation/build/test documents after the successful integration and execution of PR #472.

## Files

- `docs/ai_assistants/genesys_2026_consolidation_handoff.md`
- `docs/ai_assistants/genesys_2026_phase0_ci_evidence_20260720.md`
- `docs/ai_assistants/genesys_2026_test_matrix.md`
- `docs/ai_assistants/build_ci_tests.md`

## Executed evidence recorded

Phase 0 workflow:

- run `29780136722`, run number 1;
- tested merge commit `0d5f32b48510f6c1776ccfb1572f51fb452a6538`;
- conclusion: success.

Kernel baseline:

- 1,696 registered;
- 1,692 passed;
- 4 disabled;
- 0 failed;
- CTest time 26.90 seconds;
- AI plugin tests #495–#497 passed;
- artifact ID `8476435822`;
- digest `sha256:bf803a8432328e0bb7555d61c4c01d72e6cafe20391b57380099a8db440bc673`.

Smoke baseline:

- 3 registered/executed/passed;
- 0 failed;
- CTest time 0.68 seconds;
- artifact ID `8476325130`;
- digest `sha256:3d0f40bb68d05ec0c738c8a34d92d2f4380cf743323015220c25706157871776`.

Ordinary CI:

- run `29780136801`, run number 121;
- `tests-unit` configure/build/CTest passed;
- GUI GMDD diagnostics passed.

## Status change

The **core Phase 0 baseline** is changed from `partially-validated` to `validated` for the recorded commits/toolchain:

- `tests-unit`;
- `tests-kernel-unit`;
- `tests-smoke`;
- GUI GMDD focused tests;
- ordinary/direct AI plugin test paths.

This does **not** mark release readiness, application workflows, Debian package lifecycle, sanitizers, security, profiling, or scientific correctness as validated.

## Explicit remaining gaps

- four disabled SearchQueue/Remove runtime tests;
- application startup and representative workflows;
- package build/install/start/uninstall;
- ASan/LSan/UBSan/Valgrind/profiling;
- worker security/network behavior;
- Qt5 fallback removal;
- plugin target overlap/dynamic ABI work;
- authoritative numerical/statistical/biological validation.

## Non-changes

Documentation only. No source, CMake, test, workflow, package, or runtime behavior changes.

The PR remains draft until ordinary CI passes.