### PR TITLE
fix: stabilize legacy solver quadrature contract

### DIFF
--- a/source/tests/CMakeLists.txt
+++ b/source/tests/CMakeLists.txt
@@ -15,6 +15,47 @@ if(TARGET genesys_kernel_unit_tests_run AND TARGET genesys_test_ai_plugins)
     add_dependencies(genesys_kernel_unit_tests_run genesys_test_ai_plugins_run)
 endif()
 
+# Characterize the legacy SolverDefaultImpl1 contracts independently of the
+# broader tools library. This target intentionally links the implementation
+# directly so failures can be attributed to the legacy solver itself.
+include(GoogleTest)
+add_executable(genesys_test_tools_legacy_solver_regression
+    unit/test_tools_legacy_solver_regression.cpp
+    ${CMAKE_SOURCE_DIR}/source/tools/Continuous/SolverDefaultImpl1.cpp
+)
+
+target_include_directories(genesys_test_tools_legacy_solver_regression
+    PRIVATE
+        ${CMAKE_SOURCE_DIR}/source
+)
+
+target_link_libraries(genesys_test_tools_legacy_solver_regression
+    PRIVATE
+        GTest::gtest_main
+)
+
+target_compile_features(genesys_test_tools_legacy_solver_regression PRIVATE cxx_std_23)
+
+set_property(TARGET genesys_test_tools_legacy_solver_regression PROPERTY FOLDER tests/unit)
+
+gtest_discover_tests(genesys_test_tools_legacy_solver_regression
+    PROPERTIES
+        LABELS "unit;numerical;legacy-solver"
+)
+
+if(TARGET genesys_kernel_unit_tests)
+    add_dependencies(genesys_kernel_unit_tests genesys_test_tools_legacy_solver_regression)
+endif()
+
+if(TARGET genesys_kernel_unit_tests_run)
+    add_custom_target(genesys_test_tools_legacy_solver_regression_run
+        COMMAND $<TARGET_FILE:genesys_test_tools_legacy_solver_regression>
+        DEPENDS genesys_test_tools_legacy_solver_regression
+        USES_TERMINAL
+    )
+    add_dependencies(genesys_kernel_unit_tests_run genesys_test_tools_legacy_solver_regression_run)
+endif()
+
 option(GENESYS_BUILD_SMOKE_TESTS "Build smoke tests under source/tests/smoke" ON)
 
 if(GENESYS_BUILD_SMOKE_TESTS)

--- a/source/tests/unit/test_tools_legacy_solver_regression.cpp
+++ b/source/tests/unit/test_tools_legacy_solver_regression.cpp
@@ -2,6 +2,8 @@
 
 #include "tools/Continuous/SolverDefaultImpl1.h"
 
+#include <stdexcept>
+
 namespace {
 
 double quadratic2(double x, double) {
@@ -90,26 +92,34 @@ TEST(LegacySolverQuadratureRegression, OddStepCountPreservesSimpsonContractForFi
                 kTolerance);
 }
 
-TEST(LegacySolverDerivativeRegression, ZeroDerivativePreservesInitialValueForTwoArgumentFunction) {
+TEST(LegacySolverDerivativeRegression, RejectsUndefinedTwoArgumentDerivativeContract) {
     SolverDefaultImpl1 solver;
 
-    EXPECT_DOUBLE_EQ(solver.derivate(0.0, 42.0, zeroDerivative2, 7.0), 42.0);
+    EXPECT_THROW(
+        solver.derivate(0.0, 42.0, zeroDerivative2, 7.0),
+        std::logic_error);
 }
 
-TEST(LegacySolverDerivativeRegression, ZeroDerivativePreservesInitialValueForThreeArgumentFunction) {
+TEST(LegacySolverDerivativeRegression, RejectsUndefinedThreeArgumentDerivativeContract) {
     SolverDefaultImpl1 solver;
 
-    EXPECT_DOUBLE_EQ(solver.derivate(0.0, 42.0, zeroDerivative3, 7.0, 11.0), 42.0);
+    EXPECT_THROW(
+        solver.derivate(0.0, 42.0, zeroDerivative3, 7.0, 11.0),
+        std::logic_error);
 }
 
-TEST(LegacySolverDerivativeRegression, ZeroDerivativePreservesInitialValueForFourArgumentFunction) {
+TEST(LegacySolverDerivativeRegression, RejectsUndefinedFourArgumentDerivativeContract) {
     SolverDefaultImpl1 solver;
 
-    EXPECT_DOUBLE_EQ(solver.derivate(0.0, 42.0, zeroDerivative4, 7.0, 11.0, 13.0), 42.0);
+    EXPECT_THROW(
+        solver.derivate(0.0, 42.0, zeroDerivative4, 7.0, 11.0, 13.0),
+        std::logic_error);
 }
 
-TEST(LegacySolverDerivativeRegression, ZeroDerivativePreservesInitialValueForFiveArgumentFunction) {
+TEST(LegacySolverDerivativeRegression, RejectsUndefinedFiveArgumentDerivativeContract) {
     SolverDefaultImpl1 solver;
 
-    EXPECT_DOUBLE_EQ(solver.derivate(0.0, 42.0, zeroDerivative5, 7.0, 11.0, 13.0, 17.0), 42.0);
+    EXPECT_THROW(
+        solver.derivate(0.0, 42.0, zeroDerivative5, 7.0, 11.0, 13.0, 17.0),
+        std::logic_error);
 }

--- a/source/tests/unit/test_tools_legacy_solver_regression.cpp
+++ b/source/tests/unit/test_tools_legacy_solver_regression.cpp
@@ -1,0 +1,115 @@
+#include <gtest/gtest.h>
+
+#include "tools/Continuous/SolverDefaultImpl1.h"
+
+namespace {
+
+double quadratic2(double x, double) {
+    return x * x;
+}
+
+double quadratic3(double x, double, double) {
+    return x * x;
+}
+
+double quadratic4(double x, double, double, double) {
+    return x * x;
+}
+
+double quadratic5(double x, double, double, double, double) {
+    return x * x;
+}
+
+double zeroDerivative2(double, double) {
+    return 0.0;
+}
+
+double zeroDerivative3(double, double, double) {
+    return 0.0;
+}
+
+double zeroDerivative4(double, double, double, double) {
+    return 0.0;
+}
+
+double zeroDerivative5(double, double, double, double, double) {
+    return 0.0;
+}
+
+constexpr double kIntegralOfXSquaredFromZeroToOne = 1.0 / 3.0;
+constexpr double kTolerance = 1.0e-12;
+
+} // namespace
+
+TEST(LegacySolverQuadratureRegression, EvenStepCountIntegratesQuadraticForEveryOverload) {
+    SolverDefaultImpl1 solver(kTolerance, 4u);
+
+    EXPECT_NEAR(solver.integrate(0.0, 1.0, quadratic2, 0.0),
+                kIntegralOfXSquaredFromZeroToOne,
+                kTolerance);
+    EXPECT_NEAR(solver.integrate(0.0, 1.0, quadratic3, 0.0, 0.0),
+                kIntegralOfXSquaredFromZeroToOne,
+                kTolerance);
+    EXPECT_NEAR(solver.integrate(0.0, 1.0, quadratic4, 0.0, 0.0, 0.0),
+                kIntegralOfXSquaredFromZeroToOne,
+                kTolerance);
+    EXPECT_NEAR(solver.integrate(0.0, 1.0, quadratic5, 0.0, 0.0, 0.0, 0.0),
+                kIntegralOfXSquaredFromZeroToOne,
+                kTolerance);
+}
+
+TEST(LegacySolverQuadratureRegression, OddStepCountPreservesSimpsonContractForTwoArgumentFunction) {
+    SolverDefaultImpl1 solver(kTolerance, 3u);
+
+    EXPECT_NEAR(solver.integrate(0.0, 1.0, quadratic2, 0.0),
+                kIntegralOfXSquaredFromZeroToOne,
+                kTolerance);
+}
+
+TEST(LegacySolverQuadratureRegression, OddStepCountPreservesSimpsonContractForThreeArgumentFunction) {
+    SolverDefaultImpl1 solver(kTolerance, 3u);
+
+    EXPECT_NEAR(solver.integrate(0.0, 1.0, quadratic3, 0.0, 0.0),
+                kIntegralOfXSquaredFromZeroToOne,
+                kTolerance);
+}
+
+TEST(LegacySolverQuadratureRegression, OddStepCountPreservesSimpsonContractForFourArgumentFunction) {
+    SolverDefaultImpl1 solver(kTolerance, 3u);
+
+    EXPECT_NEAR(solver.integrate(0.0, 1.0, quadratic4, 0.0, 0.0, 0.0),
+                kIntegralOfXSquaredFromZeroToOne,
+                kTolerance);
+}
+
+TEST(LegacySolverQuadratureRegression, OddStepCountPreservesSimpsonContractForFiveArgumentFunction) {
+    SolverDefaultImpl1 solver(kTolerance, 3u);
+
+    EXPECT_NEAR(solver.integrate(0.0, 1.0, quadratic5, 0.0, 0.0, 0.0, 0.0),
+                kIntegralOfXSquaredFromZeroToOne,
+                kTolerance);
+}
+
+TEST(LegacySolverDerivativeRegression, ZeroDerivativePreservesInitialValueForTwoArgumentFunction) {
+    SolverDefaultImpl1 solver;
+
+    EXPECT_DOUBLE_EQ(solver.derivate(0.0, 42.0, zeroDerivative2, 7.0), 42.0);
+}
+
+TEST(LegacySolverDerivativeRegression, ZeroDerivativePreservesInitialValueForThreeArgumentFunction) {
+    SolverDefaultImpl1 solver;
+
+    EXPECT_DOUBLE_EQ(solver.derivate(0.0, 42.0, zeroDerivative3, 7.0, 11.0), 42.0);
+}
+
+TEST(LegacySolverDerivativeRegression, ZeroDerivativePreservesInitialValueForFourArgumentFunction) {
+    SolverDefaultImpl1 solver;
+
+    EXPECT_DOUBLE_EQ(solver.derivate(0.0, 42.0, zeroDerivative4, 7.0, 11.0, 13.0), 42.0);
+}
+
+TEST(LegacySolverDerivativeRegression, ZeroDerivativePreservesInitialValueForFiveArgumentFunction) {
+    SolverDefaultImpl1 solver;
+
+    EXPECT_DOUBLE_EQ(solver.derivate(0.0, 42.0, zeroDerivative5, 7.0, 11.0, 13.0, 17.0), 42.0);
+}

--- a/source/tools/Continuous/SolverDefaultImpl1.cpp
+++ b/source/tools/Continuous/SolverDefaultImpl1.cpp
@@ -3,168 +3,204 @@
  * Click nbfs://nbhost/SystemFileSystem/Templates/cppFiles/class.cc to edit this template
  */
 
-/* 
+/*
  * File:   IntegratorDefaultImpl1.cpp
  * Author: rlcancian
- * 
+ *
  * Created on 23 de novembro de 2021, 18:36
  */
 
 #include "SolverDefaultImpl1.h"
-#include <math.h>
 
-SolverDefaultImpl1::SolverDefaultImpl1(double precision, unsigned int steps) {
-	_precision = precision;
-	_numSteps = steps;
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <stdexcept>
+
+namespace {
+
+unsigned int normalizedSimpsonStepCount(double min,
+                                        double max,
+                                        unsigned int configuredSteps,
+                                        double precision) {
+    unsigned int steps = std::max(2u, configuredSteps);
+    const double intervalLength = std::abs(max - min);
+
+    // Preserve the legacy direction of the precision adjustment: when the
+    // configured spacing is finer than the requested precision, reduce the
+    // number of subintervals. The result is then normalized for Simpson 1/3.
+    if (intervalLength > 0.0 && precision > 0.0) {
+        const double configuredSpacing = intervalLength / static_cast<double>(steps);
+        if (configuredSpacing < precision) {
+            const double requestedSteps = std::ceil(intervalLength / precision);
+            if (requestedSteps < static_cast<double>(std::numeric_limits<unsigned int>::max())) {
+                steps = std::max(2u, static_cast<unsigned int>(requestedSteps));
+            }
+        }
+    }
+
+    // Composite Simpson 1/3 requires a positive even number of subintervals.
+    if ((steps % 2u) != 0u) {
+        if (steps == std::numeric_limits<unsigned int>::max()) {
+            --steps;
+        } else {
+            ++steps;
+        }
+    }
+
+    return steps;
+}
+
+template<typename Function>
+double integrateByCompositeSimpson(double min,
+                                   double max,
+                                   unsigned int configuredSteps,
+                                   double precision,
+                                   Function&& evaluate) {
+    if (min == max) {
+        return 0.0;
+    }
+
+    const unsigned int steps = normalizedSimpsonStepCount(
+        min, max, configuredSteps, precision);
+    const double h = (max - min) / static_cast<double>(steps);
+
+    double sum = evaluate(min) + evaluate(max);
+    for (unsigned int i = 1; i < steps; ++i) {
+        const double x = min + static_cast<double>(i) * h;
+        sum += ((i % 2u) == 0u ? 2.0 : 4.0) * evaluate(x);
+    }
+
+    return (h / 3.0) * sum;
+}
+
+[[noreturn]] void throwUnsupportedLegacyDerivative() {
+    throw std::logic_error(
+        "SolverDefaultImpl1::derivate has no defined step-size contract; "
+        "use an explicit ODE solver instead");
+}
+
+} // namespace
+
+SolverDefaultImpl1::SolverDefaultImpl1(double precision, unsigned int steps)
+    : _precision(precision),
+      _numSteps(steps),
+      _stepSize(0.0) {
 }
 
 void SolverDefaultImpl1::setPrecision(double precision) {
-	_precision = precision;
+    _precision = precision;
 }
 
 double SolverDefaultImpl1::getPrecision() {
-	return _precision;
+    return _precision;
 }
 
 void SolverDefaultImpl1::setMaxSteps(double steps) {
-	_numSteps = steps;
+    _numSteps = steps;
 }
 
 double SolverDefaultImpl1::getMaxSteps() {
-	return _numSteps;
+    return _numSteps;
 }
 
-double SolverDefaultImpl1::integrate(double min, double max, double (*f)(double, double), double p2) {
-	// Simpson's 1/3 rule
-	double steps = _numSteps;
-	double h = (max - min) / steps; // distance between points
-	if (h < _precision) {
-		steps = (max - min) / _precision;
-		h = (max - min) / steps;
-	}
-	double x, c; // x is the point being evaluated, c is the weight
-	double sum = 0.0;
-	for (int i = 0; i <= steps; i++) {
-		if (i == 0 || i == steps)
-			c = 1;
-		else if (i % 2 == 0)
-			c = 2;
-		else
-			c = 4;
-		x = min + i*h;
-		sum += c * f(x, p2);
-	}
-	return (h / 3)*sum;
+double SolverDefaultImpl1::integrate(double min,
+                                     double max,
+                                     double (*f)(double, double),
+                                     double p2) {
+    return integrateByCompositeSimpson(
+        min, max, _numSteps, _precision,
+        [f, p2](double x) { return f(x, p2); });
 }
 
-double SolverDefaultImpl1::integrate(double min, double max, double (*f)(double, double, double), double p2, double p3) {
-	// Simpson's 1/3 rule
-
-	unsigned int steps = _numSteps;
-	double h = (max - min) / steps; // distance between points
-	if (h < _precision) {
-		steps = ceil((max - min) / _precision);
-		h = (max - min) / steps;
-	}
-	double x, c; // x is the point being evaluated, c is the weight
-	double sum = 0.0;
-	for (unsigned int i = 0; i <= steps; i++) {
-		if (i == 0 || i == steps)
-			c = 1;
-		else if (i % 2 == 0)
-			c = 2;
-		else
-			c = 4;
-		x = min + i*h;
-		sum += c * f(x, p2, p3);
-	}
-	return (h / 3)*sum;
+double SolverDefaultImpl1::integrate(double min,
+                                     double max,
+                                     double (*f)(double, double, double),
+                                     double p2,
+                                     double p3) {
+    return integrateByCompositeSimpson(
+        min, max, _numSteps, _precision,
+        [f, p2, p3](double x) { return f(x, p2, p3); });
 }
 
-double SolverDefaultImpl1::integrate(double min, double max, double (*f)(double, double, double, double), double p2, double p3, double p4) {
-	// Simpson's 1/3 rule
-	double steps = _numSteps;
-	double h = (max - min) / steps; // distance between points
-	if (h < _precision) {
-		steps = (max - min) / _precision;
-		h = (max - min) / steps;
-	}
-	double x, c; // x is the point being evaluated, c is the weight
-	double sum = 0.0;
-	for (int i = 0; i <= steps; i++) {
-		if (i == 0 || i == steps)
-			c = 1;
-		else if (i % 2 == 0)
-			c = 2;
-		else
-			c = 4;
-		x = min + i*h;
-		sum += c * f(x, p2, p3, p4);
-	}
-	return (h / 3)*sum;
+double SolverDefaultImpl1::integrate(double min,
+                                     double max,
+                                     double (*f)(double, double, double, double),
+                                     double p2,
+                                     double p3,
+                                     double p4) {
+    return integrateByCompositeSimpson(
+        min, max, _numSteps, _precision,
+        [f, p2, p3, p4](double x) { return f(x, p2, p3, p4); });
 }
 
-double SolverDefaultImpl1::integrate(double min, double max, double (*f)(double, double, double, double, double), double p2, double p3, double p4, double p5) {
-	// Simpson's 1/3 rule
-	double steps = _numSteps;
-	double h = (max - min) / steps; // distance between points
-	if (h < _precision) {
-		steps = (max - min) / _precision;
-		h = (max - min) / steps;
-	}
-	double x, c; // x is the point being evaluated, c is the weight
-	double sum = 0.0;
-	for (int i = 0; i <= steps; i++) {
-		if (i == 0 || i == steps)
-			c = 1;
-		else if (i % 2 == 0)
-			c = 2;
-		else
-			c = 4;
-		x = min + i*h;
-		sum += c * f(x, p2, p3, p4, p5);
-	}
-	return (h / 3)*sum;
+double SolverDefaultImpl1::integrate(
+    double min,
+    double max,
+    double (*f)(double, double, double, double, double),
+    double p2,
+    double p3,
+    double p4,
+    double p5) {
+    return integrateByCompositeSimpson(
+        min, max, _numSteps, _precision,
+        [f, p2, p3, p4, p5](double x) { return f(x, p2, p3, p4, p5); });
 }
 
-double SolverDefaultImpl1::derivate(double initPoint, double initValue, double (*f)(double, double), double p2) {
-	double time, halfStep;
-	unsigned int i, numEqs = 1;
-	double k1[numEqs], k2[numEqs], k3[numEqs], k4[numEqs], result[numEqs];
-	time = initPoint;
-	halfStep = _stepSize * 0.5;
-	for (i = 0; i < numEqs; i++) {
-		k1[i] = f(time, p2);
-	}
-	time += halfStep;
-	for (i = 0; i < numEqs; i++) {
-		k2[i] = f(time, p2 + k1[i] * halfStep);
-	}
-	for (i = 0; i < numEqs; i++) {
-		k3[i] = f(time, p2 + k2[i] * halfStep);
-	}
-	for (i = 0; i < numEqs; i++) {
-		k4[i] = f(time, p2 + k3[i] * halfStep);
-	}
-	for (i = 0; i < numEqs; i++) {
-		result[i] = p2 + (_stepSize / 6) * (k1[i] + 2 * (k2[i] + k3[i]) + k4[i]);
-	}
-	time = initPoint + _stepSize; // OR  time += halfStep;
-	return result[0];
-
+double SolverDefaultImpl1::derivate(double initPoint,
+                                    double initValue,
+                                    double (*f)(double, double),
+                                    double p2) {
+    (void)initPoint;
+    (void)initValue;
+    (void)f;
+    (void)p2;
+    throwUnsupportedLegacyDerivative();
 }
 
-double SolverDefaultImpl1::derivate(double initPoint, double initValue, double (*f)(double, double, double), double p2, double p3) {
-	/*  @TODO: +-: not implemented yet */
-	return 0.0;
+double SolverDefaultImpl1::derivate(double initPoint,
+                                    double initValue,
+                                    double (*f)(double, double, double),
+                                    double p2,
+                                    double p3) {
+    (void)initPoint;
+    (void)initValue;
+    (void)f;
+    (void)p2;
+    (void)p3;
+    throwUnsupportedLegacyDerivative();
 }
 
-double SolverDefaultImpl1::derivate(double initPoint, double initValue, double (*f)(double, double, double, double), double p2, double p3, double p4) {
-	/*  @TODO: +-: not implemented yet */
-	return 0.0;
+double SolverDefaultImpl1::derivate(
+    double initPoint,
+    double initValue,
+    double (*f)(double, double, double, double),
+    double p2,
+    double p3,
+    double p4) {
+    (void)initPoint;
+    (void)initValue;
+    (void)f;
+    (void)p2;
+    (void)p3;
+    (void)p4;
+    throwUnsupportedLegacyDerivative();
 }
 
-double SolverDefaultImpl1::derivate(double initPoint, double initValue, double (*f)(double, double, double, double, double), double p2, double p3, double p4, double p5) {
-	/*  @TODO: +-: not implemented yet */
-	return 0.0;
+double SolverDefaultImpl1::derivate(
+    double initPoint,
+    double initValue,
+    double (*f)(double, double, double, double, double),
+    double p2,
+    double p3,
+    double p4,
+    double p5) {
+    (void)initPoint;
+    (void)initValue;
+    (void)f;
+    (void)p2;
+    (void)p3;
+    (void)p4;
+    (void)p5;
+    throwUnsupportedLegacyDerivative();
 }

--- a/source/tools/Continuous/SolverDefaultImpl1.h
+++ b/source/tools/Continuous/SolverDefaultImpl1.h
@@ -18,36 +18,40 @@
 /**
  * @brief Legacy default implementation of Solver_if.
  *
- * Implementation status:
- * - Current quadrature implementation is based on Simpson 1/3 rule.
- * - Derivation/advancement methods exist but are only partially consolidated as
- *   a broader ODE-solving strategy.
+ * Supported behavior:
+ * - Numerical quadrature through composite Simpson 1/3 with a positive even
+ *   number of subintervals.
+ *
+ * Unsupported behavior:
+ * - The historical derivate() signatures do not expose a defined step-size
+ *   contract and are not used by current repository clients. They fail
+ *   explicitly instead of returning silent or undefined numerical results.
  *
  * Planned evolution:
- * - Candidate to be conceptually split between quadrature and ODE-focused
- *   implementations.
+ * - Split the historical interface into focused quadrature and ODE abstractions
+ *   while preserving compatibility where a valid contract exists.
  */
 class SolverDefaultImpl1 : public Solver_if {
 public:
-	SolverDefaultImpl1(double precision = 1e-6, unsigned int steps = 1e3);
-	virtual ~SolverDefaultImpl1() = default;
+    SolverDefaultImpl1(double precision = 1e-6, unsigned int steps = 1e3);
+    virtual ~SolverDefaultImpl1() = default;
 public:
-	virtual void setPrecision(double e) override;
-	virtual double getPrecision() override;
-	virtual void setMaxSteps(double steps) override;
-	virtual double getMaxSteps() override;
-	virtual double integrate(double min, double max, double (*f)(double, double), double p2) override;
-	virtual double integrate(double min, double max, double (*f)(double, double, double), double p2, double p3) override;
-	virtual double integrate(double min, double max, double (*f)(double, double, double, double), double p2, double p3, double p4) override;
-	virtual double integrate(double min, double max, double (*f)(double, double, double, double, double), double p2, double p3, double p4, double p5) override;
-	virtual double derivate(double initPoint, double initValue, double (*f)(double, double), double p2) override;
-	virtual double derivate(double initPoint, double initValue, double (*f)(double, double, double), double p2, double p3) override;
-	virtual double derivate(double initPoint, double initValue, double (*f)(double, double, double, double), double p2, double p3, double p4) override;
-	virtual double derivate(double initPoint, double initValue, double (*f)(double, double, double, double, double), double p2, double p3, double p4, double p5) override;
+    virtual void setPrecision(double e) override;
+    virtual double getPrecision() override;
+    virtual void setMaxSteps(double steps) override;
+    virtual double getMaxSteps() override;
+    virtual double integrate(double min, double max, double (*f)(double, double), double p2) override;
+    virtual double integrate(double min, double max, double (*f)(double, double, double), double p2, double p3) override;
+    virtual double integrate(double min, double max, double (*f)(double, double, double, double), double p2, double p3, double p4) override;
+    virtual double integrate(double min, double max, double (*f)(double, double, double, double, double), double p2, double p3, double p4, double p5) override;
+    virtual double derivate(double initPoint, double initValue, double (*f)(double, double), double p2) override;
+    virtual double derivate(double initPoint, double initValue, double (*f)(double, double, double), double p2, double p3) override;
+    virtual double derivate(double initPoint, double initValue, double (*f)(double, double, double, double), double p2, double p3, double p4) override;
+    virtual double derivate(double initPoint, double initValue, double (*f)(double, double, double, double, double), double p2, double p3, double p4, double p5) override;
 private:
-	double _precision;
-	unsigned int _numSteps;
-	double _stepSize;
+    double _precision;
+    unsigned int _numSteps;
+    double _stepSize;
 };
 
 #endif /* SOLVERDEFAULTIMPL1_IF_H */


### PR DESCRIPTION
## Scope

Characterize and minimally correct `source/tools/Continuous/SolverDefaultImpl1` without redesigning the continuous subsystem.

## Red checkpoint preserved in history

Initial test-only commits:

- `05747c9ec85a59319f9aa7bc46020c668b90ad65` — regression source;
- `cbaf7b207af27ec1af31023c2d999bb7250af667` — test target/aggregate integration.

Executed on merge commit `dd0be2c145330292f6c7f2790add21efbd546e4c`:

- ordinary configure/build passed;
- ordinary CTest failed;
- kernel configure passed and direct runner failed;
- smoke passed;
- GUI GMDD passed.

This isolated the new regression executable as intended.

## Confirmed defects

1. Composite Simpson 1/3 accepted an odd number of subintervals.
2. With 3 subintervals for `x^2` on `[0,1]`, the implementation produced `7/27 ≈ 0.2592592593`, rather than the exact `1/3`.
3. The first `derivate()` ignored `initValue`, used `p2` as state, used uninitialized `_stepSize`, and had incorrect RK4 staging.
4. The other three derivative overloads returned literal `0.0`.
5. The derivative implementation used non-standard variable-length arrays.
6. Repository search found no current callers of `derivate()` and the interface provides no step-size input/setter.

## Correction

Commit `cbb9fca9fcd89a082487b9ea8f47c53b990431b7`:

- consolidates the four integration overloads through one composite-Simpson kernel;
- normalizes the effective subinterval count to at least 2 and even;
- preserves the legacy direction of the precision-based spacing adjustment;
- handles zero-width intervals as zero integral;
- removes duplicated loops and non-standard VLAs;
- initializes `_stepSize`;
- makes every unsupported `derivate()` overload throw `std::logic_error` instead of returning silent or undefined numerical values.

Commit `1f22aafa1029a5ffd7efa5c3e03b30ca2932e6ab` updates derivative regressions to assert the explicit unsupported-operation contract.

Commit `5cc12395eaadb9f41b299c36262fad97bfb86adc` documents the support boundary in the class header.

## Test target

`genesys_test_tools_legacy_solver_regression`

- directly links `SolverDefaultImpl1.cpp`;
- labels: `unit;numerical;legacy-solver`;
- participates in ordinary aggregate and kernel direct-runner graph.

Nine tests:

1. even-step Simpson through all four overloads;
2. odd configured step count normalized through all four overloads;
3. all four undefined derivative overloads reject use with `std::logic_error`.

## Contract decision

This PR does not invent an ODE step size or reinterpret `p2..p5` as state variables. The historical derivative API is quarantined fail-fast until a separate explicit ODE interface is designed. Current repository clients use the quadrature path, not `derivate()`.

## Green Phase 0 evidence

Phase 0 run `29782025242`, run 5, tested merge commit `0a4cb54e319b081f0a3380692129d9e732093857`:

- `tests-smoke`: passed;
- `tests-kernel-unit` configure: passed;
- kernel build and direct runner: passed;
- kernel CTest inventory: 1,705 registered;
- executed/passed: 1,701;
- failed: 0;
- disabled: 4 existing SearchQueue/Remove tests;
- all nine legacy-solver tests are registered as tests #1–#9 and passed;
- total kernel CTest time: 16.65 seconds.

Artifact:

- ID: `8477128795`;
- name: `genesys-phase0-tests-kernel-unit`;
- digest: `sha256:47f38425dbdda7f0f2f0a2e02ef289662beb23438a0db72f2a45b7e30dc3f106`.

Focused GUI GMDD diagnostics in ordinary run `29782025248` also passed. The ordinary aggregate job remains in progress at this description update.

## Non-changes

- no public signature changed;
- no hypothesis-test API changed;
- no external dependency added;
- no continuous plugin or event-time synchronization changed;
- no broad solver framework refactor performed.

## Remaining validation gate

The PR remains draft until the ordinary `tests-unit` build and CTest job completes successfully.