### PR TITLE
tests: activate Search and Remove runtime coverage

### DIFF
--- a/source/tests/CMakeLists.txt
+++ b/source/tests/CMakeLists.txt
@@ -86,19 +86,9 @@ if(TARGET genesys_kernel_unit_tests)
     add_dependencies(genesys_kernel_unit_tests genesys_test_search_remove_runtime)
 endif()
 
-if(TARGET genesys_kernel_unit_tests_run)
-    set(GENESYS_SEARCH_REMOVE_DIAGNOSTICS_DIR
-        "${CMAKE_BINARY_DIR}/search-remove-diagnostics")
-    add_custom_target(genesys_test_search_remove_runtime_run
-        COMMAND ${CMAKE_COMMAND} -E make_directory
-                "${GENESYS_SEARCH_REMOVE_DIAGNOSTICS_DIR}"
-        COMMAND $<TARGET_FILE:genesys_test_search_remove_runtime>
-                --gtest_output=xml:${GENESYS_SEARCH_REMOVE_DIAGNOSTICS_DIR}/LastTest.log
-        DEPENDS genesys_test_search_remove_runtime
-        USES_TERMINAL
-    )
-    add_dependencies(genesys_kernel_unit_tests_run genesys_test_search_remove_runtime_run)
-endif()
+# Diagnostic checkpoint: keep this suite in the aggregate/CTest path while the
+# exact historical fixture mismatch is characterized. Reattach the explicit
+# direct-runner target after the focused suite is green.
 
 option(GENESYS_BUILD_SMOKE_TESTS "Build smoke tests under source/tests/smoke" ON)
 

--- a/source/tests/CMakeLists.txt
+++ b/source/tests/CMakeLists.txt
@@ -56,6 +56,45 @@ if(TARGET genesys_kernel_unit_tests_run)
     add_dependencies(genesys_kernel_unit_tests_run genesys_test_tools_legacy_solver_regression_run)
 endif()
 
+# The historical Search/Remove tests dispatch into the model calendar. Keep a
+# focused active suite that drains those scheduled events before assertions.
+add_executable(genesys_test_search_remove_runtime
+    unit/test_search_remove_runtime.cpp
+)
+
+target_include_directories(genesys_test_search_remove_runtime
+    PRIVATE
+        ${CMAKE_SOURCE_DIR}/source
+)
+
+target_link_libraries(genesys_test_search_remove_runtime
+    PRIVATE
+        GTest::gtest_main
+        "$<LINK_GROUP:RESCAN,genesys_kernel_util,genesys_kernel_statistics,genesys_parser,genesys_plugins_data,genesys_plugins_components_minimal,genesys_kernel_simulator_support,genesys_kernel_simulator_runtime>"
+)
+
+target_compile_features(genesys_test_search_remove_runtime PRIVATE cxx_std_23)
+
+set_property(TARGET genesys_test_search_remove_runtime PROPERTY FOLDER tests/unit)
+
+gtest_discover_tests(genesys_test_search_remove_runtime
+    PROPERTIES
+        LABELS "unit;runtime;search-remove"
+)
+
+if(TARGET genesys_kernel_unit_tests)
+    add_dependencies(genesys_kernel_unit_tests genesys_test_search_remove_runtime)
+endif()
+
+if(TARGET genesys_kernel_unit_tests_run)
+    add_custom_target(genesys_test_search_remove_runtime_run
+        COMMAND $<TARGET_FILE:genesys_test_search_remove_runtime>
+        DEPENDS genesys_test_search_remove_runtime
+        USES_TERMINAL
+    )
+    add_dependencies(genesys_kernel_unit_tests_run genesys_test_search_remove_runtime_run)
+endif()
+
 option(GENESYS_BUILD_SMOKE_TESTS "Build smoke tests under source/tests/smoke" ON)
 
 if(GENESYS_BUILD_SMOKE_TESTS)

--- a/source/tests/CMakeLists.txt
+++ b/source/tests/CMakeLists.txt
@@ -87,8 +87,13 @@ if(TARGET genesys_kernel_unit_tests)
 endif()
 
 if(TARGET genesys_kernel_unit_tests_run)
+    set(GENESYS_SEARCH_REMOVE_DIAGNOSTICS_DIR
+        "${CMAKE_BINARY_DIR}/search-remove-diagnostics")
     add_custom_target(genesys_test_search_remove_runtime_run
+        COMMAND ${CMAKE_COMMAND} -E make_directory
+                "${GENESYS_SEARCH_REMOVE_DIAGNOSTICS_DIR}"
         COMMAND $<TARGET_FILE:genesys_test_search_remove_runtime>
+                --gtest_output=xml:${GENESYS_SEARCH_REMOVE_DIAGNOSTICS_DIR}/LastTest.log
         DEPENDS genesys_test_search_remove_runtime
         USES_TERMINAL
     )

--- a/source/tests/CMakeLists.txt
+++ b/source/tests/CMakeLists.txt
@@ -57,7 +57,8 @@ if(TARGET genesys_kernel_unit_tests_run)
 endif()
 
 # The historical Search/Remove tests dispatch into the model calendar. Keep a
-# focused active suite that drains those scheduled events before assertions.
+# focused active suite that initializes its queue fixtures explicitly and drains
+# scheduled events before asserting routed entities.
 add_executable(genesys_test_search_remove_runtime
     unit/test_search_remove_runtime.cpp
 )
@@ -75,32 +76,25 @@ target_link_libraries(genesys_test_search_remove_runtime
 
 target_compile_features(genesys_test_search_remove_runtime PRIVATE cxx_std_23)
 
-target_compile_options(genesys_test_search_remove_runtime
-    PRIVATE
-        -fsanitize=address,undefined
-        -fno-omit-frame-pointer
-)
-
-target_link_options(genesys_test_search_remove_runtime
-    PRIVATE
-        -fsanitize=address,undefined
-)
-
 set_property(TARGET genesys_test_search_remove_runtime PROPERTY FOLDER tests/unit)
 
 gtest_discover_tests(genesys_test_search_remove_runtime
     PROPERTIES
         LABELS "unit;runtime;search-remove"
-        ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0:halt_on_error=1;UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1"
 )
 
 if(TARGET genesys_kernel_unit_tests)
     add_dependencies(genesys_kernel_unit_tests genesys_test_search_remove_runtime)
 endif()
 
-# Diagnostic checkpoint: keep this suite in the aggregate/CTest path while the
-# exact historical fixture mismatch is characterized. Reattach the explicit
-# direct-runner target after the focused suite is green.
+if(TARGET genesys_kernel_unit_tests_run)
+    add_custom_target(genesys_test_search_remove_runtime_run
+        COMMAND $<TARGET_FILE:genesys_test_search_remove_runtime>
+        DEPENDS genesys_test_search_remove_runtime
+        USES_TERMINAL
+    )
+    add_dependencies(genesys_kernel_unit_tests_run genesys_test_search_remove_runtime_run)
+endif()
 
 option(GENESYS_BUILD_SMOKE_TESTS "Build smoke tests under source/tests/smoke" ON)
 

--- a/source/tests/CMakeLists.txt
+++ b/source/tests/CMakeLists.txt
@@ -75,11 +75,23 @@ target_link_libraries(genesys_test_search_remove_runtime
 
 target_compile_features(genesys_test_search_remove_runtime PRIVATE cxx_std_23)
 
+target_compile_options(genesys_test_search_remove_runtime
+    PRIVATE
+        -fsanitize=address,undefined
+        -fno-omit-frame-pointer
+)
+
+target_link_options(genesys_test_search_remove_runtime
+    PRIVATE
+        -fsanitize=address,undefined
+)
+
 set_property(TARGET genesys_test_search_remove_runtime PROPERTY FOLDER tests/unit)
 
 gtest_discover_tests(genesys_test_search_remove_runtime
     PROPERTIES
         LABELS "unit;runtime;search-remove"
+        ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0:halt_on_error=1;UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1"
 )
 
 if(TARGET genesys_kernel_unit_tests)

--- a/source/tests/unit/test_search_remove_runtime.cpp
+++ b/source/tests/unit/test_search_remove_runtime.cpp
@@ -9,7 +9,6 @@
 #include "plugins/components/Decisions/Remove.h"
 #include "plugins/components/Decisions/Search.h"
 #include "plugins/data/DiscreteProcessing/Queue.h"
-#include "plugins/data/DiscreteProcessing/Waiting.h"
 
 #include <vector>
 

--- a/source/tests/unit/test_search_remove_runtime.cpp
+++ b/source/tests/unit/test_search_remove_runtime.cpp
@@ -1,0 +1,217 @@
+#include <gtest/gtest.h>
+
+#include "kernel/simulator/Event.h"
+#include "kernel/simulator/Simulator.h"
+#include "kernel/simulator/model/Model.h"
+#include "kernel/simulator/model/ModelComponent.h"
+#include "kernel/simulator/essentialPlugins/Attribute.h"
+#include "kernel/simulator/essentialPlugins/Entity.h"
+#include "plugins/components/Decisions/Remove.h"
+#include "plugins/components/Decisions/Search.h"
+#include "plugins/data/DiscreteProcessing/Queue.h"
+#include "plugins/data/DiscreteProcessing/Waiting.h"
+
+#include <vector>
+
+namespace {
+
+class CollectorSinkComponentProbe final : public ModelComponent {
+public:
+    CollectorSinkComponentProbe(Model* model, const std::string& name)
+        : ModelComponent(model, "CollectorSinkComponentProbe", name) {}
+
+    const std::vector<Entity*>& receivedEntities() const {
+        return _receivedEntities;
+    }
+
+protected:
+    void _onDispatchEvent(Entity* entity, unsigned int inputPortNumber) override {
+        (void)inputPortNumber;
+        _receivedEntities.push_back(entity);
+    }
+
+    bool _loadInstance(PersistenceRecord* fields) override {
+        return ModelComponent::_loadInstance(fields);
+    }
+
+    void _saveInstance(PersistenceRecord* fields, bool saveDefaultValues) override {
+        ModelComponent::_saveInstance(fields, saveDefaultValues);
+    }
+
+private:
+    std::vector<Entity*> _receivedEntities;
+};
+
+class SearchProbe final : public Search {
+public:
+    SearchProbe(Model* model, const std::string& name)
+        : Search(model, name) {}
+
+    void dispatch(Entity* entity) {
+        _onDispatchEvent(entity, 0u);
+    }
+};
+
+class RemoveProbe final : public Remove {
+public:
+    RemoveProbe(Model* model, const std::string& name)
+        : Remove(model, name) {}
+
+    void dispatch(Entity* entity) {
+        _onDispatchEvent(entity, 0u);
+    }
+};
+
+void drainFutureEvents(Model* model) {
+    ASSERT_NE(model, nullptr);
+    while (!model->getFutureEvents()->empty()) {
+        Event* event = model->getFutureEvents()->front();
+        model->getFutureEvents()->pop_front();
+        ModelComponent::DispatchEvent(event);
+        delete event;
+    }
+}
+
+} // namespace
+
+TEST(SearchRemoveRuntimeTest, SearchQueueFindsEntityInRangeSavesRankAndRoutesToFoundPort) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    SearchProbe search(model, "SearchFind");
+    Queue queue(model, "SearchFindQueue");
+    CollectorSinkComponentProbe notFoundSink(model, "SearchFindNotFound");
+    CollectorSinkComponentProbe foundSink(model, "SearchFindFound");
+    search.getConnectionManager()->insert(&notFoundSink);
+    search.getConnectionManager()->insert(&foundSink);
+    search.setSearchInType(Search::SearchInType::QUEUE);
+    search.setSearchIn(&queue);
+    search.setStartRank("1");
+    search.setEndRank("3");
+    search.setSearchCondition("1");
+    search.setSaveFounRankAttribute("SearchFoundRankAttr");
+    Attribute searchFoundRankAttribute(model, "SearchFoundRankAttr");
+
+    CollectorSinkComponentProbe producer(model, "SearchFindProducer");
+    queue.insertElement(new Waiting(model->createEntity("SearchFindQueueE0", true), 0.0, &producer));
+    queue.insertElement(new Waiting(model->createEntity("SearchFindQueueE1", true), 0.0, &producer));
+    queue.insertElement(new Waiting(model->createEntity("SearchFindQueueE2", true), 0.0, &producer));
+
+    Entity* trigger = model->createEntity("SearchFindTrigger", true);
+    search.dispatch(trigger);
+    drainFutureEvents(model);
+
+    EXPECT_DOUBLE_EQ(trigger->getAttributeValue("SearchFoundRankAttr"), 1.0);
+    EXPECT_TRUE(notFoundSink.receivedEntities().empty());
+    ASSERT_EQ(foundSink.receivedEntities().size(), 1u);
+    EXPECT_EQ(foundSink.receivedEntities().front(), trigger);
+}
+
+TEST(SearchRemoveRuntimeTest, SearchQueueNotFoundRoutesToPortZeroAndSavesZeroRank) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    SearchProbe search(model, "SearchNotFound");
+    Queue queue(model, "SearchNotFoundQueue");
+    CollectorSinkComponentProbe notFoundSink(model, "SearchNotFoundOut0");
+    CollectorSinkComponentProbe foundSink(model, "SearchNotFoundOut1");
+    search.getConnectionManager()->insert(&notFoundSink);
+    search.getConnectionManager()->insert(&foundSink);
+    search.setSearchInType(Search::SearchInType::QUEUE);
+    search.setSearchIn(&queue);
+    search.setStartRank("0");
+    search.setEndRank("2");
+    search.setSearchCondition("0");
+    search.setSaveFounRankAttribute("SearchNotFoundRankAttr");
+    Attribute searchNotFoundRankAttribute(model, "SearchNotFoundRankAttr");
+
+    CollectorSinkComponentProbe producer(model, "SearchNotFoundProducer");
+    queue.insertElement(new Waiting(model->createEntity("SearchNotFoundQueueE0", true), 0.0, &producer));
+    queue.insertElement(new Waiting(model->createEntity("SearchNotFoundQueueE1", true), 0.0, &producer));
+
+    Entity* trigger = model->createEntity("SearchNotFoundTrigger", true);
+    search.dispatch(trigger);
+    drainFutureEvents(model);
+
+    EXPECT_DOUBLE_EQ(trigger->getAttributeValue("SearchNotFoundRankAttr"), 0.0);
+    ASSERT_EQ(notFoundSink.receivedEntities().size(), 1u);
+    EXPECT_EQ(notFoundSink.receivedEntities().front(), trigger);
+    EXPECT_TRUE(foundSink.receivedEntities().empty());
+}
+
+TEST(SearchRemoveRuntimeTest, RemoveEqualStartAndEndRankRemovesExactlyOneAndRoutesCorrectly) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    RemoveProbe remove(model, "RemoveSingleRank");
+    Queue queue(model, "RemoveSingleRankQueue");
+    CollectorSinkComponentProbe mainSink(model, "RemoveSingleRankMain");
+    CollectorSinkComponentProbe removedSink(model, "RemoveSingleRankRemoved");
+    remove.getConnectionManager()->insert(&mainSink);
+    remove.getConnectionManager()->insert(&removedSink);
+    remove.setRemoveFromType(Remove::RemoveFromType::QUEUE);
+    remove.setRemoveFrom(&queue);
+    remove.setRemoveStartRank("1");
+    remove.setRemoveEndRank("1");
+
+    CollectorSinkComponentProbe producer(model, "RemoveSingleRankProducer");
+    Entity* q0 = model->createEntity("RemoveSingleRankQ0", true);
+    Entity* q1 = model->createEntity("RemoveSingleRankQ1", true);
+    Entity* q2 = model->createEntity("RemoveSingleRankQ2", true);
+    queue.insertElement(new Waiting(q0, 0.0, &producer));
+    queue.insertElement(new Waiting(q1, 0.0, &producer));
+    queue.insertElement(new Waiting(q2, 0.0, &producer));
+
+    Entity* trigger = model->createEntity("RemoveSingleRankTrigger", true);
+    remove.dispatch(trigger);
+    drainFutureEvents(model);
+
+    ASSERT_EQ(removedSink.receivedEntities().size(), 1u);
+    EXPECT_EQ(removedSink.receivedEntities().front(), q1);
+    EXPECT_EQ(queue.size(), 2u);
+    ASSERT_EQ(mainSink.receivedEntities().size(), 1u);
+    EXPECT_EQ(mainSink.receivedEntities().front(), trigger);
+}
+
+TEST(SearchRemoveRuntimeTest, RemoveRangeRemovesOnlyEntitiesInsideConfiguredInterval) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    RemoveProbe remove(model, "RemoveRange");
+    Queue queue(model, "RemoveRangeQueue");
+    CollectorSinkComponentProbe mainSink(model, "RemoveRangeMain");
+    CollectorSinkComponentProbe removedSink(model, "RemoveRangeRemoved");
+    remove.getConnectionManager()->insert(&mainSink);
+    remove.getConnectionManager()->insert(&removedSink);
+    remove.setRemoveFromType(Remove::RemoveFromType::QUEUE);
+    remove.setRemoveFrom(&queue);
+    remove.setRemoveStartRank("1");
+    remove.setRemoveEndRank("2");
+
+    CollectorSinkComponentProbe producer(model, "RemoveRangeProducer");
+    Entity* q0 = model->createEntity("RemoveRangeQ0", true);
+    Entity* q1 = model->createEntity("RemoveRangeQ1", true);
+    Entity* q2 = model->createEntity("RemoveRangeQ2", true);
+    Entity* q3 = model->createEntity("RemoveRangeQ3", true);
+    queue.insertElement(new Waiting(q0, 0.0, &producer));
+    queue.insertElement(new Waiting(q1, 0.0, &producer));
+    queue.insertElement(new Waiting(q2, 0.0, &producer));
+    queue.insertElement(new Waiting(q3, 0.0, &producer));
+
+    Entity* trigger = model->createEntity("RemoveRangeTrigger", true);
+    remove.dispatch(trigger);
+    drainFutureEvents(model);
+
+    ASSERT_EQ(removedSink.receivedEntities().size(), 2u);
+    EXPECT_EQ(removedSink.receivedEntities().at(0), q1);
+    EXPECT_EQ(removedSink.receivedEntities().at(1), q2);
+    EXPECT_EQ(queue.size(), 2u);
+    EXPECT_EQ(queue.getAtRank(0)->getEntity(), q0);
+    EXPECT_EQ(queue.getAtRank(1)->getEntity(), q3);
+    ASSERT_EQ(mainSink.receivedEntities().size(), 1u);
+    EXPECT_EQ(mainSink.receivedEntities().front(), trigger);
+}

--- a/source/tests/unit/test_search_remove_runtime.cpp
+++ b/source/tests/unit/test_search_remove_runtime.cpp
@@ -80,6 +80,7 @@ TEST(SearchRemoveRuntimeTest, SearchQueueFindsEntityInRangeSavesRankAndRoutesToF
 
     SearchProbe search(model, "SearchFind");
     Queue queue(model, "SearchFindQueue");
+    queue.setReportStatistics(false);
     CollectorSinkComponentProbe notFoundSink(model, "SearchFindNotFound");
     CollectorSinkComponentProbe foundSink(model, "SearchFindFound");
     search.getConnectionManager()->insert(&notFoundSink);
@@ -114,6 +115,7 @@ TEST(SearchRemoveRuntimeTest, SearchQueueNotFoundRoutesToPortZeroAndSavesZeroRan
 
     SearchProbe search(model, "SearchNotFound");
     Queue queue(model, "SearchNotFoundQueue");
+    queue.setReportStatistics(false);
     CollectorSinkComponentProbe notFoundSink(model, "SearchNotFoundOut0");
     CollectorSinkComponentProbe foundSink(model, "SearchNotFoundOut1");
     search.getConnectionManager()->insert(&notFoundSink);
@@ -147,6 +149,7 @@ TEST(SearchRemoveRuntimeTest, RemoveEqualStartAndEndRankRemovesExactlyOneAndRout
 
     RemoveProbe remove(model, "RemoveSingleRank");
     Queue queue(model, "RemoveSingleRankQueue");
+    queue.setReportStatistics(false);
     CollectorSinkComponentProbe mainSink(model, "RemoveSingleRankMain");
     CollectorSinkComponentProbe removedSink(model, "RemoveSingleRankRemoved");
     remove.getConnectionManager()->insert(&mainSink);
@@ -182,6 +185,7 @@ TEST(SearchRemoveRuntimeTest, RemoveRangeRemovesOnlyEntitiesInsideConfiguredInte
 
     RemoveProbe remove(model, "RemoveRange");
     Queue queue(model, "RemoveRangeQueue");
+    queue.setReportStatistics(false);
     CollectorSinkComponentProbe mainSink(model, "RemoveRangeMain");
     CollectorSinkComponentProbe removedSink(model, "RemoveRangeRemoved");
     remove.getConnectionManager()->insert(&mainSink);


### PR DESCRIPTION
## Scope

Activate four Search/Remove runtime scenarios with a focused suite that respects both the queue-initialization and event-calendar contracts.

No production source is changed.

## Historical coverage gap

`source/tests/unit/test_simulator_runtime.cpp` contains four disabled tests:

1. Search found/rank/output 1;
2. Search not-found/rank 0/output 0;
3. Remove one configured rank;
4. Remove a configured range.

## Confirmed diagnosis

Two fixture requirements were missing from the historical tests:

### 1. Queue statistics initialization

- `ModelDataDefinition` enables report statistics by default;
- `Queue::insertElement()` updates `_cstatNumberInQueue` when statistics are enabled;
- a freshly constructed Queue has not yet created its internal statistics collectors;
- inserting the first `Waiting` therefore dereferenced a null collector and produced SIGSEGV before Search/Remove executed.

The focused fixtures explicitly call:

```cpp
queue.setReportStatistics(false);
```

before inserting queued entities. This matches the unit-test intent: Search/Remove behavior is under test, not Queue statistics.

### 2. Asynchronous component routing

`Search` and `Remove` route entities through `Model::sendEntityToComponent`, which schedules future events. The focused tests drain the model event calendar before inspecting collector sinks.

## Change

New executable:

- `genesys_test_search_remove_runtime`;
- labels: `unit;runtime;search-remove`;
- included in the ordinary aggregate;
- included in the kernel direct-runner graph.

New source:

- `source/tests/unit/test_search_remove_runtime.cpp`.

Active scenarios:

1. Search finds the first matching queue entity in range, saves rank 1, and routes the trigger to output 1;
2. Search not-found saves rank 0 and routes the trigger to output 0;
3. Remove start=end removes exactly one entity and routes it to output 1;
4. Remove range 1..2 removes only q1/q2, preserves q0/q3, and routes the trigger to the main output.

## Diagnostic history

- `d0c4c835b80e2ff7309bd5f5d726350bc631d466` — focused tests;
- `eb2d0a9aab67382b7d762337c28d387a1d3c5de8` — aggregate/direct-runner integration;
- `5a89118ec3706893685f94faa66e30e0897bc7f3` — removed an invalid standalone `Waiting.h` include;
- `4fdbf749b31acd02d1a3e873386d4502829ed52c` and `81c08a6b1f2135e04f53127e5474e275bd68f3da` — temporary CTest diagnostic checkpoints;
- `d742ad1ca6bd18d008344dcfbfa9394d161af82e` — temporary sanitizer instrumentation;
- `1efef1373909cd1ba7edaa82855ef2b95dd41509` — initialize all four Queue fixtures safely;
- `858257872ee8bfc3bac9cb2faa071c83f88f3e46` — remove diagnostics/sanitizers and restore the direct runner.

Phase 0 diagnostic run `29784531618` captured four SIGSEGV cases in artifact `8478088090`; the root cause was the null Queue statistics collector described above, not an assertion mismatch in Search or Remove.

## Why a separate source file

The GitHub connector cannot safely perform a small partial edit in the existing ~10,000-line runtime test source without replacing the entire file. The disabled duplicates remain temporarily as historical records. The focused suite makes equivalent behavior mandatory now; a later local cleanup can remove the old duplicate blocks.

## Non-changes

- no Search/Remove production behavior changed;
- no Queue production behavior changed;
- no assertions weakened;
- no synchronous routing introduced;
- no sanitizer flags remain in the final target.

## Acceptance

- ordinary `tests-unit` configure/build/CTest passes;
- GUI GMDD diagnostics pass;
- kernel configure/build/direct runner/CTest passes;
- smoke passes;
- all four focused Search/Remove tests are registered and pass;
- the only disabled Search/Remove cases are the historical duplicate blocks.

The PR remains draft until the final head is green.