### PR TITLE
fix: initialize Queue statistics collectors on demand

### DIFF
--- a/source/plugins/data/DiscreteProcessing/Queue.cpp
+++ b/source/plugins/data/DiscreteProcessing/Queue.cpp
@@ -43,9 +43,9 @@ Queue::Queue(Model* model, std::string name) : ModelDataDefinition(model, Util::
 				std::bind(&Queue::setAttributeName, this, std::placeholders::_1),
 				Util::TypeOf<Queue>(), getName(), "AttributeName", "");
 	SimulationControlGenericEnum<Queue::OrderRule, Queue>* propOrderRule = new SimulationControlGenericEnum<Queue::OrderRule, Queue>(
-                std::bind(&Queue::getOrderRule, this),
-                std::bind(&Queue::setOrderRule, this, std::placeholders::_1),
-                Util::TypeOf<Queue>(), getName(), "OrderRule", "");
+				std::bind(&Queue::getOrderRule, this),
+				std::bind(&Queue::setOrderRule, this, std::placeholders::_1),
+				Util::TypeOf<Queue>(), getName(), "OrderRule", "");
 	SimulationControlGeneric<int>* propOrderRuleInt = new SimulationControlGeneric<int>(
 				std::bind(&Queue::getOrderRuleInt, this),
 				std::bind(&Queue::setOrderRuleInt, this, std::placeholders::_1),
@@ -56,8 +56,8 @@ Queue::Queue(Model* model, std::string name) : ModelDataDefinition(model, Util::
 	_parentModel->getControls()->insert(propOrderRuleInt);
 
 	// setting properties
-    _addSimulationControl(propAttributeName);
-    _addSimulationControl(propOrderRule);
+	_addSimulationControl(propAttributeName);
+	_addSimulationControl(propOrderRule);
 	_addSimulationControl(propOrderRuleInt);
 
 	_configureListComparator();
@@ -81,12 +81,13 @@ std::string Queue::show() {
 void Queue::insertElement(Waiting* modeldatum) {
 	modeldatum->setArrivalOrder(_nextArrivalOrder++);
 	if (_reportStatistics) {
+		_initCStats();
 		double tnow = 0.0;
 		if (_parentModel->getSimulation() != nullptr) {
 			tnow = _parentModel->getSimulation()->getSimulatedTime();
 		}
 		double duration = tnow - _lastTimeNumberInQueueChanged;
-		this->_cstatNumberInQueue->getStatistics()->getCollector()->addValue(_list->size(), duration); // save the OLD quantity and for how long it was there
+		_cstatNumberInQueue->getStatistics()->getCollector()->addValue(_list->size(), duration); // save the OLD quantity and for how long it was there
 		_lastTimeNumberInQueueChanged = tnow;
 	}
 	_list->insert(modeldatum);
@@ -97,15 +98,16 @@ void Queue::removeElement(Waiting* modeldatum) {
 		return;
 	}
 	if (_reportStatistics) {
+		_initCStats();
 		double tnow = 0.0;
 		if (_parentModel->getSimulation() != nullptr) {
 			tnow = _parentModel->getSimulation()->getSimulatedTime();
 		}
 		double duration = tnow - _lastTimeNumberInQueueChanged;
-		this->_cstatNumberInQueue->getStatistics()->getCollector()->addValue(_list->size(), duration); // save the OLD quantity and for how long it was there
+		_cstatNumberInQueue->getStatistics()->getCollector()->addValue(_list->size(), duration); // save the OLD quantity and for how long it was there
 		_lastTimeNumberInQueueChanged = tnow;
 		double timeInQueue = tnow - modeldatum->getTimeStartedWaiting();
-		this->_cstatTimeInQueue->getStatistics()->getCollector()->addValue(timeInQueue);
+		_cstatTimeInQueue->getStatistics()->getCollector()->addValue(timeInQueue);
 	}
 	_list->remove(modeldatum);
 	delete modeldatum;
@@ -218,6 +220,8 @@ void Queue::_createInternalStatisticReporters() {
 	if (_reportStatistics) {
 		if (_cstatNumberInQueue == nullptr) {
 			_cstatNumberInQueue = new StatisticsCollector(_parentModel, getName() + "." + "NumberInQueue", this);
+		}
+		if (_cstatTimeInQueue == nullptr) {
 			_cstatTimeInQueue = new StatisticsCollector(_parentModel, getName() + "." + "TimeInQueue", this);
 		}
 		if (_cstatNumberInQueue != nullptr) {
@@ -242,6 +246,12 @@ ParserChangesInformation * Queue::_getParserChangesInformation() {
 	//changes->getProductionToAdd()->insert(...);
 	//changes->getTokensToAdd()->insert(...);
 	return changes;
+}
+
+void Queue::_initCStats() {
+	if (_reportStatistics && (_cstatNumberInQueue == nullptr || _cstatTimeInQueue == nullptr)) {
+		_createInternalStatisticReporters();
+	}
 }
 
 void Queue::_configureListComparator() {

--- a/source/plugins/data/DiscreteProcessing/Queue.h
+++ b/source/plugins/data/DiscreteProcessing/Queue.h
@@ -150,7 +150,7 @@ private:
 	void _configureListComparator();
 private:
 	List<Waiting*>* _list = new List<Waiting*>();
-	double _lastTimeNumberInQueueChanged;
+	double _lastTimeNumberInQueueChanged = 0.0;
 	unsigned long long _nextArrivalOrder = 0;
 private: //1::1
 

--- a/source/tests/CMakeLists.txt
+++ b/source/tests/CMakeLists.txt
@@ -96,6 +96,45 @@ if(TARGET genesys_kernel_unit_tests_run)
     add_dependencies(genesys_kernel_unit_tests_run genesys_test_search_remove_runtime_run)
 endif()
 
+# Queue operations are public and may occur before the model-wide related-data
+# lifecycle. Verify that statistics collectors are initialized safely on demand.
+add_executable(genesys_test_queue_statistics_lifecycle
+    unit/test_queue_statistics_lifecycle.cpp
+)
+
+target_include_directories(genesys_test_queue_statistics_lifecycle
+    PRIVATE
+        ${CMAKE_SOURCE_DIR}/source
+)
+
+target_link_libraries(genesys_test_queue_statistics_lifecycle
+    PRIVATE
+        GTest::gtest_main
+        "$<LINK_GROUP:RESCAN,genesys_kernel_util,genesys_kernel_statistics,genesys_parser,genesys_plugins_data,genesys_plugins_components_minimal,genesys_kernel_simulator_support,genesys_kernel_simulator_runtime>"
+)
+
+target_compile_features(genesys_test_queue_statistics_lifecycle PRIVATE cxx_std_23)
+
+set_property(TARGET genesys_test_queue_statistics_lifecycle PROPERTY FOLDER tests/unit)
+
+gtest_discover_tests(genesys_test_queue_statistics_lifecycle
+    PROPERTIES
+        LABELS "unit;runtime;queue;statistics;lifecycle"
+)
+
+if(TARGET genesys_kernel_unit_tests)
+    add_dependencies(genesys_kernel_unit_tests genesys_test_queue_statistics_lifecycle)
+endif()
+
+if(TARGET genesys_kernel_unit_tests_run)
+    add_custom_target(genesys_test_queue_statistics_lifecycle_run
+        COMMAND $<TARGET_FILE:genesys_test_queue_statistics_lifecycle>
+        DEPENDS genesys_test_queue_statistics_lifecycle
+        USES_TERMINAL
+    )
+    add_dependencies(genesys_kernel_unit_tests_run genesys_test_queue_statistics_lifecycle_run)
+endif()
+
 option(GENESYS_BUILD_SMOKE_TESTS "Build smoke tests under source/tests/smoke" ON)
 
 if(GENESYS_BUILD_SMOKE_TESTS)

--- a/source/tests/unit/test_queue_statistics_lifecycle.cpp
+++ b/source/tests/unit/test_queue_statistics_lifecycle.cpp
@@ -1,0 +1,97 @@
+#include <gtest/gtest.h>
+
+#include "kernel/simulator/Simulator.h"
+#include "kernel/simulator/model/Model.h"
+#include "kernel/simulator/model/ModelComponent.h"
+#include "kernel/simulator/essentialPlugins/Entity.h"
+#include "plugins/data/DiscreteProcessing/Queue.h"
+
+namespace {
+
+class QueueProducerProbe final : public ModelComponent {
+public:
+    QueueProducerProbe(Model* model, const std::string& name)
+        : ModelComponent(model, "QueueProducerProbe", name) {}
+
+protected:
+    void _onDispatchEvent(Entity* entity, unsigned int inputPortNumber) override {
+        (void)entity;
+        (void)inputPortNumber;
+    }
+
+    bool _loadInstance(PersistenceRecord* fields) override {
+        return ModelComponent::_loadInstance(fields);
+    }
+
+    void _saveInstance(PersistenceRecord* fields, bool saveDefaultValues) override {
+        ModelComponent::_saveInstance(fields, saveDefaultValues);
+    }
+};
+
+} // namespace
+
+TEST(QueueStatisticsLifecycleTest, DefaultStatisticsInitializeOnFirstInsertion) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    Queue queue(model, "QueueLazyStatistics");
+    QueueProducerProbe producer(model, "QueueLazyStatisticsProducer");
+
+    ASSERT_TRUE(queue.isReportStatistics());
+    EXPECT_EQ(queue.getInternalData("NumberInQueue"), nullptr);
+    EXPECT_EQ(queue.getInternalData("TimeInQueue"), nullptr);
+
+    Entity* entity = model->createEntity("QueueLazyStatisticsEntity", true);
+    queue.insertElement(new Waiting(entity, 0.0, &producer));
+
+    EXPECT_EQ(queue.size(), 1u);
+    ASSERT_NE(queue.getInternalData("NumberInQueue"), nullptr);
+    ASSERT_NE(queue.getInternalData("TimeInQueue"), nullptr);
+
+    queue.removeElement(queue.first());
+    EXPECT_EQ(queue.size(), 0u);
+}
+
+TEST(QueueStatisticsLifecycleTest, RepeatedOperationsReuseTheSameCollectors) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    Queue queue(model, "QueueStableStatistics");
+    QueueProducerProbe producer(model, "QueueStableStatisticsProducer");
+
+    queue.insertElement(new Waiting(model->createEntity("QueueStableStatisticsE0", true), 0.0, &producer));
+    ModelDataDefinition* numberCollector = queue.getInternalData("NumberInQueue");
+    ModelDataDefinition* timeCollector = queue.getInternalData("TimeInQueue");
+    ASSERT_NE(numberCollector, nullptr);
+    ASSERT_NE(timeCollector, nullptr);
+
+    queue.insertElement(new Waiting(model->createEntity("QueueStableStatisticsE1", true), 0.0, &producer));
+
+    EXPECT_EQ(queue.getInternalData("NumberInQueue"), numberCollector);
+    EXPECT_EQ(queue.getInternalData("TimeInQueue"), timeCollector);
+
+    queue.removeElement(queue.first());
+    queue.removeElement(queue.first());
+    EXPECT_EQ(queue.size(), 0u);
+}
+
+TEST(QueueStatisticsLifecycleTest, DisabledStatisticsDoNotCreateCollectors) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    Queue queue(model, "QueueWithoutStatistics");
+    QueueProducerProbe producer(model, "QueueWithoutStatisticsProducer");
+    queue.setReportStatistics(false);
+
+    queue.insertElement(new Waiting(model->createEntity("QueueWithoutStatisticsEntity", true), 0.0, &producer));
+
+    EXPECT_EQ(queue.size(), 1u);
+    EXPECT_EQ(queue.getInternalData("NumberInQueue"), nullptr);
+    EXPECT_EQ(queue.getInternalData("TimeInQueue"), nullptr);
+
+    queue.removeElement(queue.first());
+    EXPECT_EQ(queue.size(), 0u);
+}


### PR DESCRIPTION
## Scope

Prevent `Queue::insertElement()` and `Queue::removeElement()` from dereferencing null statistics collectors when public queue operations occur before the model-wide related-data lifecycle.

## Confirmed defect

`ModelDataDefinition` enables report statistics by default. A newly constructed `Queue` therefore enters the statistics path immediately, but `_cstatNumberInQueue` and `_cstatTimeInQueue` remain null until `_createInternalStatisticReporters()` is called externally.

The first insertion could therefore dereference `_cstatNumberInQueue == nullptr`. The Search/Remove coverage work in PR #475 reproduced this as SIGSEGV before either component executed.

A second defect existed in the same path: `_lastTimeNumberInQueueChanged` was read before initialization.

## Changes

### Production

- initialize `_lastTimeNumberInQueueChanged` to `0.0`;
- implement the previously declared `_initCStats()` helper;
- invoke `_initCStats()` only when statistics are enabled and an insertion/removal needs collectors;
- allocate `NumberInQueue` and `TimeInQueue` independently so a partially initialized state is repaired;
- preserve the existing model-wide `_createInternalStatisticReporters()` lifecycle and association ownership.

### Tests

New focused executable: `genesys_test_queue_statistics_lifecycle`.

Coverage:

1. default-statistics queue initializes both collectors on the first insertion before model checking;
2. repeated operations reuse the same collector objects;
3. `reportStatistics=false` performs insertion/removal without creating collectors.

The executable participates in:

- ordinary `genesys_kernel_unit_tests` aggregate;
- kernel direct runner;
- CTest discovery with labels `unit;runtime;queue;statistics;lifecycle`.

## Files

- `source/plugins/data/DiscreteProcessing/Queue.cpp`;
- `source/plugins/data/DiscreteProcessing/Queue.h`;
- `source/tests/CMakeLists.txt`;
- `source/tests/unit/test_queue_statistics_lifecycle.cpp`.

## Non-changes

- no queue ordering behavior changed;
- no ownership model changed;
- no collector is created when statistics are disabled;
- no eager construction was added to the Queue constructor;
- no changes were made to `Station`, `Resource`, or other classes with similar lifecycle assumptions.

## Final validation

Validated head: `bfff161cccf2ea491afd9b231202bffae5e6c499`.

### Ordinary CI

Run `29791177042`:

- `tests-unit` configure: passed;
- aggregate build: passed;
- CTest: passed;
- GUI GMDD diagnostics: passed.

### Phase 0

Run `29791177003`:

- `tests-kernel-unit` configure/build/direct runner/inventory/CTest: passed;
- `tests-smoke`: passed;
- 1,712 tests registered;
- 1,708 tests executed and passed;
- 4 historical Search/Remove duplicate tests remain disabled;
- no failures;
- no increase in disabled tests.

The Queue lifecycle tests were registered as #14–#16 and all passed:

- `DefaultStatisticsInitializeOnFirstInsertion`;
- `RepeatedOperationsReuseTheSameCollectors`;
- `DisabledStatisticsDoNotCreateCollectors`.

Artifact: `genesys-phase0-tests-kernel-unit`, ID `8480444714`.

## Result

All acceptance criteria are satisfied. The PR is ready for integration.