### PR TITLE
fix: initialize Station statistics collectors on demand

### DIFF
--- a/source/plugins/data/MaterialHandling/Station.cpp
+++ b/source/plugins/data/MaterialHandling/Station.cpp
@@ -65,8 +65,10 @@ void Station::enter(Entity* entity) {
 	entity->setAttributeValue(attributeName, _parentModel->getSimulation()->getSimulatedTime());
 	entity->setAttributeValue("Entity.Station", _id);
 	_numberInStation++;
-	if (_reportStatistics)
-		this->_cstatNumberInStation->getStatistics()->getCollector()->addValue(_numberInStation);
+	if (_reportStatistics) {
+		_initCStats();
+		_cstatNumberInStation->getStatistics()->getCollector()->addValue(_numberInStation);
+	}
 }
 
 void Station::leave(Entity* entity) {
@@ -77,6 +79,7 @@ void Station::leave(Entity* entity) {
 	entity->setAttributeValue("Entity.Station", 0.0);
 	_numberInStation--;
 	if (_reportStatistics) {
+		_initCStats();
 		_cstatNumberInStation->getStatistics()->getCollector()->addValue(_numberInStation);
 		_cstatTimeInStation->getStatistics()->getCollector()->addValue(timeInStation);
 		if (entity->getEntityType()->isReportStatistics())
@@ -187,6 +190,8 @@ void Station::_createInternalStatisticReporters() {
 	if (_reportStatistics) {
 		if (_cstatNumberInStation == nullptr) {
 			_cstatNumberInStation = new StatisticsCollector(_parentModel, getName() + "." + "NumberInStation", this);
+		}
+		if (_cstatTimeInStation == nullptr) {
 			_cstatTimeInStation = new StatisticsCollector(_parentModel, getName() + "." + "TimeInStation", this);
 		}
 		if (_cstatNumberInStation != nullptr) {
@@ -196,19 +201,23 @@ void Station::_createInternalStatisticReporters() {
 			_statisticReporterInsert("TimeInStation", _cstatTimeInStation);
 		}
 		if (_cstatNumberInStation != nullptr || _cstatTimeInStation != nullptr) {
-			//
 			// include StatisticsCollector needed in EntityType
 			std::list<ModelDataDefinition*>* enttypes = _parentModel->getDataManager()->getDataDefinitionList(Util::TypeOf<EntityType>())->list();
 			for (ModelDataDefinition* modeldatum : *enttypes) {
 				if (modeldatum->isReportStatistics())
 					static_cast<EntityType*> (modeldatum)->addGetStatisticsCollector(modeldatum->getName() + ".TimeInStations"); // force create this CStat before simulation starts
 			}
-
 		}
 	} else if (_cstatNumberInStation != nullptr || _cstatTimeInStation != nullptr) {
 		_statisticReportersClear();
 		_cstatNumberInStation = nullptr;
 		_cstatTimeInStation = nullptr;
+	}
+}
+
+void Station::_initCStats() {
+	if (_reportStatistics && (_cstatNumberInStation == nullptr || _cstatTimeInStation == nullptr)) {
+		_createInternalStatisticReporters();
 	}
 }
 

--- a/source/plugins/data/MaterialHandling/Station.h
+++ b/source/plugins/data/MaterialHandling/Station.h
@@ -91,8 +91,9 @@ protected:
 	virtual void _createAttachedAttributes() override;
 
 private:
+	void _initCStats();
 	unsigned int _numberInStation = 0;
-	ModelComponent* _enterIntoStationComponent;
+	ModelComponent* _enterIntoStationComponent = nullptr;
 private: // inner elements
 	StatisticsCollector* _cstatNumberInStation = nullptr;
 	StatisticsCollector* _cstatTimeInStation = nullptr;

--- a/source/tests/CMakeLists.txt
+++ b/source/tests/CMakeLists.txt
@@ -135,6 +135,45 @@ if(TARGET genesys_kernel_unit_tests_run)
     add_dependencies(genesys_kernel_unit_tests_run genesys_test_queue_statistics_lifecycle_run)
 endif()
 
+# Station enter/leave operations are public and may occur before the model-wide
+# related-data lifecycle. Characterize statistics-enabled and disabled behavior.
+add_executable(genesys_test_station_statistics_lifecycle
+    unit/test_station_statistics_lifecycle.cpp
+)
+
+target_include_directories(genesys_test_station_statistics_lifecycle
+    PRIVATE
+        ${CMAKE_SOURCE_DIR}/source
+)
+
+target_link_libraries(genesys_test_station_statistics_lifecycle
+    PRIVATE
+        GTest::gtest_main
+        "$<LINK_GROUP:RESCAN,genesys_kernel_util,genesys_kernel_statistics,genesys_parser,genesys_plugins_data,genesys_plugins_components_minimal,genesys_kernel_simulator_support,genesys_kernel_simulator_runtime>"
+)
+
+target_compile_features(genesys_test_station_statistics_lifecycle PRIVATE cxx_std_23)
+
+set_property(TARGET genesys_test_station_statistics_lifecycle PROPERTY FOLDER tests/unit)
+
+gtest_discover_tests(genesys_test_station_statistics_lifecycle
+    PROPERTIES
+        LABELS "unit;runtime;station;statistics;lifecycle"
+)
+
+if(TARGET genesys_kernel_unit_tests)
+    add_dependencies(genesys_kernel_unit_tests genesys_test_station_statistics_lifecycle)
+endif()
+
+if(TARGET genesys_kernel_unit_tests_run)
+    add_custom_target(genesys_test_station_statistics_lifecycle_run
+        COMMAND $<TARGET_FILE:genesys_test_station_statistics_lifecycle>
+        DEPENDS genesys_test_station_statistics_lifecycle
+        USES_TERMINAL
+    )
+    add_dependencies(genesys_kernel_unit_tests_run genesys_test_station_statistics_lifecycle_run)
+endif()
+
 option(GENESYS_BUILD_SMOKE_TESTS "Build smoke tests under source/tests/smoke" ON)
 
 if(GENESYS_BUILD_SMOKE_TESTS)

--- a/source/tests/unit/test_station_statistics_lifecycle.cpp
+++ b/source/tests/unit/test_station_statistics_lifecycle.cpp
@@ -1,0 +1,74 @@
+#include <gtest/gtest.h>
+
+#include "kernel/simulator/Simulator.h"
+#include "kernel/simulator/model/Model.h"
+#include "kernel/simulator/essentialPlugins/Attribute.h"
+#include "kernel/simulator/essentialPlugins/Entity.h"
+#include "kernel/simulator/essentialPlugins/EntityType.h"
+#include "plugins/data/MaterialHandling/Station.h"
+
+namespace {
+
+Entity* createStationEntity(Model* model, Station* station, const std::string& name) {
+    EXPECT_NE(model, nullptr);
+    EXPECT_NE(station, nullptr);
+
+    new Attribute(model, "Entity.Station");
+    new Attribute(model, "Entity.ArrivalAt" + station->getName());
+
+    EntityType* entityType = new EntityType(model, name + "Type");
+    entityType->setReportStatistics(false);
+
+    Entity* entity = model->createEntity(name, true);
+    entity->setEntityType(entityType);
+    return entity;
+}
+
+} // namespace
+
+TEST(StationStatisticsLifecycleTest, DefaultStatisticsInitializeOnFirstEnterAndSupportLeave) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    Station station(model, "StationLazyStatistics");
+    Entity* entity = createStationEntity(model, &station, "StationLazyStatisticsEntity");
+    ASSERT_NE(entity, nullptr);
+
+    ASSERT_TRUE(station.isReportStatistics());
+    EXPECT_EQ(station.getInternalData("NumberInStation"), nullptr);
+    EXPECT_EQ(station.getInternalData("TimeInStation"), nullptr);
+
+    station.enter(entity);
+
+    ASSERT_NE(station.getInternalData("NumberInStation"), nullptr);
+    ASSERT_NE(station.getInternalData("TimeInStation"), nullptr);
+    EXPECT_DOUBLE_EQ(entity->getAttributeValue("Entity.Station"), static_cast<double>(station.getId()));
+
+    ModelDataDefinition* numberCollector = station.getInternalData("NumberInStation");
+    ModelDataDefinition* timeCollector = station.getInternalData("TimeInStation");
+
+    station.leave(entity);
+
+    EXPECT_DOUBLE_EQ(entity->getAttributeValue("Entity.Station"), 0.0);
+    EXPECT_EQ(station.getInternalData("NumberInStation"), numberCollector);
+    EXPECT_EQ(station.getInternalData("TimeInStation"), timeCollector);
+}
+
+TEST(StationStatisticsLifecycleTest, DisabledStatisticsDoNotCreateCollectors) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    Station station(model, "StationWithoutStatistics");
+    station.setReportStatistics(false);
+    Entity* entity = createStationEntity(model, &station, "StationWithoutStatisticsEntity");
+    ASSERT_NE(entity, nullptr);
+
+    station.enter(entity);
+    station.leave(entity);
+
+    EXPECT_EQ(station.getInternalData("NumberInStation"), nullptr);
+    EXPECT_EQ(station.getInternalData("TimeInStation"), nullptr);
+    EXPECT_DOUBLE_EQ(entity->getAttributeValue("Entity.Station"), 0.0);
+}


### PR DESCRIPTION
## Scope

Make `Station::enter()` / `Station::leave()` safe when public operations occur before the model-wide related-data lifecycle.

Tracks issue #477.

## Red checkpoint

The first two commits were test-only:

- `e74a0084ae18bdef728dbf3f0741f5f221307406` — focused Station lifecycle tests;
- `f310ed478631ab54eb4a11914153184fbd6437c3` — aggregate/direct-runner integration.

Phase 0 run `29791849186` confirmed:

- configure passed;
- smoke passed;
- kernel failed during the direct runner;
- no production source had been changed.

This matched the confirmed code path: report statistics default to enabled, while `_cstatNumberInStation` and `_cstatTimeInStation` were created only by `_createInternalStatisticReporters()`.

## Test isolation

The focused fixture explicitly creates:

- `Entity.Station`;
- `Entity.ArrivalAt<StationName>`;
- an `EntityType` assigned to the entity.

The entity type has statistics disabled so the test does not mix Station lifecycle with EntityType statistics creation.

## Production correction

- add `_initCStats()` as a private idempotent helper;
- call it only from `enter()` / `leave()` when Station statistics are enabled;
- allocate `NumberInStation` and `TimeInStation` independently so partially initialized state is repaired;
- preserve the model-wide `_createInternalStatisticReporters()` lifecycle and association ownership;
- initialize `_enterIntoStationComponent` to `nullptr`, eliminating an indeterminate pointer read in `show()`.

Production commits:

- `f0f297d8689533fa009624dcce76b5030e640caf` — lifecycle helper declaration and pointer initialization;
- `dd28e5d832989ff7f83c4a8aca06aabb9bbea92d` — on-demand collector initialization.

## Tests

1. `DefaultStatisticsInitializeOnFirstEnterAndSupportLeave`
   - collectors absent before first use;
   - `enter()` creates both collectors;
   - `leave()` reuses the same objects;
   - `Entity.Station` transitions from station id to zero.

2. `DisabledStatisticsDoNotCreateCollectors`
   - statistics disabled;
   - `enter()` / `leave()` complete;
   - no Station collectors are created.

New executable: `genesys_test_station_statistics_lifecycle`.

- ordinary aggregate dependency;
- kernel direct runner dependency;
- CTest labels: `unit;runtime;station;statistics;lifecycle`.

## Non-changes

- no Station counting semantics changed;
- no EntityType statistics behavior changed;
- no global `ModelDataDefinition` lifecycle change;
- no changes to `Delay` or `Resource`;
- no eager collector construction in the Station constructor.

## Final validation

Validated head: `dd28e5d832989ff7f83c4a8aca06aabb9bbea92d`.

### Ordinary CI

Run `29792383317`:

- configure: passed;
- aggregate build: passed;
- CTest: passed;
- GUI GMDD diagnostics: passed.

### Phase 0

Run `29792383322`:

- kernel configure/build/direct runner/inventory/CTest: passed;
- smoke: passed;
- 1,714 tests registered;
- 1,710 tests executed and passed;
- 4 historical Search/Remove duplicate tests remain disabled;
- no failures;
- no increase in disabled tests.

Station lifecycle tests #17 and #18 both passed.

Artifact: `genesys-phase0-tests-kernel-unit`, ID `8480874108`.

## Result

All acceptance criteria are satisfied. The PR is ready for integration.