### PR TITLE
fix: initialize Delay statistics collector on demand

### DIFF
--- a/source/plugins/components/DiscreteProcessing/Delay.cpp
+++ b/source/plugins/components/DiscreteProcessing/Delay.cpp
@@ -106,6 +106,7 @@ void Delay::_onDispatchEvent(Entity* entity, unsigned int inputPortNumber) {
 	Util::TimeUnit stu = _parentModel->getSimulation()->getReplicationBaseTimeUnit(); //getReplicationLengthTimeUnit();
 	waitTime *= Util::TimeUnitConvert(_delayTimeUnit, stu);
 	if (_reportStatistics) {
+		_initCStats();
 		std::string allocationCategory = Util::StrAllocation(_allocation);
         _cstatWaitTime->getStatistics()->getCollector()->addValue(waitTime);
 		if (entity->getEntityType()->isReportStatistics())
@@ -224,6 +225,12 @@ void Delay::_createInternalStatisticReporters() {
 		_statisticReportersClear();
 		_cstatWaitTime = nullptr;
 		// @TODO remove StatisticsCollector needed in EntityType
+	}
+}
+
+void Delay::_initCStats() {
+	if (_reportStatistics && _cstatWaitTime == nullptr) {
+		_createInternalStatisticReporters();
 	}
 }
 

--- a/source/plugins/components/DiscreteProcessing/Delay.h
+++ b/source/plugins/components/DiscreteProcessing/Delay.h
@@ -93,6 +93,7 @@ private:
 	std::vector<std::string> _allAllocationAttachedAttributeNames() const;
 	std::string _allocationAttachedAttributeName(Util::AllocationType allocation) const;
 	void _reconcileAllocationAttachedAttributes();
+	void _initCStats();
 private: // inner internal elements
 	friend class DelayProbe;
 	StatisticsCollector* _cstatWaitTime = nullptr;

--- a/source/tests/CMakeLists.txt
+++ b/source/tests/CMakeLists.txt
@@ -174,6 +174,45 @@ if(TARGET genesys_kernel_unit_tests_run)
     add_dependencies(genesys_kernel_unit_tests_run genesys_test_station_statistics_lifecycle_run)
 endif()
 
+# Delay dispatch is a public runtime path and may occur before the model-wide
+# related-data lifecycle. Characterize statistics-enabled and disabled behavior.
+add_executable(genesys_test_delay_statistics_lifecycle
+    unit/test_delay_statistics_lifecycle.cpp
+)
+
+target_include_directories(genesys_test_delay_statistics_lifecycle
+    PRIVATE
+        ${CMAKE_SOURCE_DIR}/source
+)
+
+target_link_libraries(genesys_test_delay_statistics_lifecycle
+    PRIVATE
+        GTest::gtest_main
+        "$<LINK_GROUP:RESCAN,genesys_kernel_util,genesys_kernel_statistics,genesys_parser,genesys_plugins_data,genesys_plugins_components_minimal,genesys_kernel_simulator_support,genesys_kernel_simulator_runtime>"
+)
+
+target_compile_features(genesys_test_delay_statistics_lifecycle PRIVATE cxx_std_23)
+
+set_property(TARGET genesys_test_delay_statistics_lifecycle PROPERTY FOLDER tests/unit)
+
+gtest_discover_tests(genesys_test_delay_statistics_lifecycle
+    PROPERTIES
+        LABELS "unit;runtime;delay;statistics;lifecycle"
+)
+
+if(TARGET genesys_kernel_unit_tests)
+    add_dependencies(genesys_kernel_unit_tests genesys_test_delay_statistics_lifecycle)
+endif()
+
+if(TARGET genesys_kernel_unit_tests_run)
+    add_custom_target(genesys_test_delay_statistics_lifecycle_run
+        COMMAND $<TARGET_FILE:genesys_test_delay_statistics_lifecycle>
+        DEPENDS genesys_test_delay_statistics_lifecycle
+        USES_TERMINAL
+    )
+    add_dependencies(genesys_kernel_unit_tests_run genesys_test_delay_statistics_lifecycle_run)
+endif()
+
 option(GENESYS_BUILD_SMOKE_TESTS "Build smoke tests under source/tests/smoke" ON)
 
 if(GENESYS_BUILD_SMOKE_TESTS)

--- a/source/tests/unit/test_delay_statistics_lifecycle.cpp
+++ b/source/tests/unit/test_delay_statistics_lifecycle.cpp
@@ -1,0 +1,123 @@
+#include <gtest/gtest.h>
+
+#include "kernel/simulator/Event.h"
+#include "kernel/simulator/Simulator.h"
+#include "kernel/simulator/model/Model.h"
+#include "kernel/simulator/model/ModelComponent.h"
+#include "kernel/simulator/essentialPlugins/Attribute.h"
+#include "kernel/simulator/essentialPlugins/Entity.h"
+#include "kernel/simulator/essentialPlugins/EntityType.h"
+#include "plugins/components/DiscreteProcessing/Delay.h"
+
+#include <vector>
+
+namespace {
+
+class DelayProbe final : public Delay {
+public:
+    DelayProbe(Model* model, const std::string& name)
+        : Delay(model, name) {}
+
+    void dispatch(Entity* entity) {
+        _onDispatchEvent(entity, 0u);
+    }
+};
+
+class DelayCollectorSink final : public ModelComponent {
+public:
+    DelayCollectorSink(Model* model, const std::string& name)
+        : ModelComponent(model, "DelayCollectorSink", name) {}
+
+    const std::vector<Entity*>& receivedEntities() const {
+        return _receivedEntities;
+    }
+
+protected:
+    void _onDispatchEvent(Entity* entity, unsigned int inputPortNumber) override {
+        (void)inputPortNumber;
+        _receivedEntities.push_back(entity);
+    }
+
+    bool _loadInstance(PersistenceRecord* fields) override {
+        return ModelComponent::_loadInstance(fields);
+    }
+
+    void _saveInstance(PersistenceRecord* fields, bool saveDefaultValues) override {
+        ModelComponent::_saveInstance(fields, saveDefaultValues);
+    }
+
+private:
+    std::vector<Entity*> _receivedEntities;
+};
+
+Entity* createDelayEntity(Model* model, const std::string& name) {
+    EXPECT_NE(model, nullptr);
+
+    new Attribute(model, "Entity.TotalWaitTime");
+
+    EntityType* entityType = new EntityType(model, name + "Type");
+    entityType->setReportStatistics(false);
+
+    Entity* entity = model->createEntity(name, true);
+    entity->setEntityType(entityType);
+    return entity;
+}
+
+void drainFutureEvents(Model* model) {
+    ASSERT_NE(model, nullptr);
+    while (!model->getFutureEvents()->empty()) {
+        Event* event = model->getFutureEvents()->front();
+        model->getFutureEvents()->pop_front();
+        ModelComponent::DispatchEvent(event);
+        delete event;
+    }
+}
+
+} // namespace
+
+TEST(DelayStatisticsLifecycleTest, DefaultStatisticsInitializeOnFirstDispatchAndRouteEntity) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    DelayProbe delay(model, "DelayLazyStatistics");
+    DelayCollectorSink sink(model, "DelayLazyStatisticsSink");
+    delay.getConnectionManager()->insert(&sink);
+    delay.setDelayExpression("0", Util::TimeUnit::second);
+
+    Entity* entity = createDelayEntity(model, "DelayLazyStatisticsEntity");
+    ASSERT_NE(entity, nullptr);
+
+    ASSERT_TRUE(delay.isReportStatistics());
+    EXPECT_EQ(delay.getInternalData("DelayTime"), nullptr);
+
+    delay.dispatch(entity);
+    drainFutureEvents(model);
+
+    ASSERT_NE(delay.getInternalData("DelayTime"), nullptr);
+    ASSERT_EQ(sink.receivedEntities().size(), 1u);
+    EXPECT_EQ(sink.receivedEntities().front(), entity);
+    EXPECT_DOUBLE_EQ(entity->getAttributeValue("Entity.TotalWaitTime"), 0.0);
+}
+
+TEST(DelayStatisticsLifecycleTest, DisabledStatisticsDoNotCreateCollector) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    DelayProbe delay(model, "DelayWithoutStatistics");
+    delay.setReportStatistics(false);
+    DelayCollectorSink sink(model, "DelayWithoutStatisticsSink");
+    delay.getConnectionManager()->insert(&sink);
+    delay.setDelayExpression("0", Util::TimeUnit::second);
+
+    Entity* entity = createDelayEntity(model, "DelayWithoutStatisticsEntity");
+    ASSERT_NE(entity, nullptr);
+
+    delay.dispatch(entity);
+    drainFutureEvents(model);
+
+    EXPECT_EQ(delay.getInternalData("DelayTime"), nullptr);
+    ASSERT_EQ(sink.receivedEntities().size(), 1u);
+    EXPECT_EQ(sink.receivedEntities().front(), entity);
+}


### PR DESCRIPTION
## Scope

Make `Delay::_onDispatchEvent()` safe when dispatch occurs before the model-wide related-data lifecycle.

Tracks issue #477.

## Red checkpoint

The first two commits were test-only:

- `cb8d45c391f55cc4df206ca27b115e87c3ecaa25` — focused Delay lifecycle tests;
- `1fac9ae964f43c23c0d9e2ff79754366fad0d86a` — aggregate/direct-runner integration.

Phase 0 run `29792985023` confirmed:

- configure passed;
- smoke passed;
- kernel failed during the direct runner;
- no production source had been changed.

The fixture satisfied connection, event-calendar, EntityType, allocation-attribute, and delay-expression preconditions. The remaining failing path was the null `_cstatWaitTime` dereference.

## Production correction

- add `_initCStats()` as a private idempotent helper;
- call it only when Delay statistics are enabled;
- preserve `_createInternalStatisticReporters()` as the single collector creation/association implementation;
- do not create a collector when statistics are disabled.

Production commits:

- `15e72d527bb33ff34f58d9b10505e7015a829301` — lifecycle helper declaration;
- `cd2b5f0dcb2ec500dd38ebade1d92099ca7a6829` — on-demand collector initialization.

## Tests

1. `DefaultStatisticsInitializeOnFirstDispatchAndRouteEntity`
   - collector absent before dispatch;
   - first dispatch creates `DelayTime`;
   - zero-time event reaches the connected sink;
   - allocated wait-time attribute remains numerically correct.

2. `DisabledStatisticsDoNotCreateCollector`
   - statistics disabled;
   - entity is routed normally;
   - no `DelayTime` collector is created.

New executable: `genesys_test_delay_statistics_lifecycle`.

- ordinary aggregate dependency;
- kernel direct runner dependency;
- CTest labels: `unit;runtime;delay;statistics;lifecycle`.

## Non-changes

- no delay-time calculation changed;
- no allocation category changed;
- no event scheduling changed;
- no connection behavior changed;
- no EntityType statistics behavior changed;
- no changes to `Resource` or base lifecycle classes.

## Final validation

Validated head: `cd2b5f0dcb2ec500dd38ebade1d92099ca7a6829`.

### Ordinary CI

Run `29793447950`:

- configure: passed;
- aggregate build: passed;
- CTest: passed;
- GUI GMDD diagnostics: passed.

### Phase 0

Run `29793447956`:

- kernel configure/build/direct runner/inventory/CTest: passed;
- smoke: passed;
- 1,716 tests registered;
- 1,712 tests executed and passed;
- 4 historical Search/Remove duplicate tests remain disabled;
- no failures;
- no increase in disabled tests.

Delay lifecycle tests #19 and #20 both passed:

- `DefaultStatisticsInitializeOnFirstDispatchAndRouteEntity`;
- `DisabledStatisticsDoNotCreateCollector`.

Artifact: `genesys-phase0-tests-kernel-unit`, ID `8481262018`.

Toolchain evidence:

- CMake 3.31.6;
- Ninja 1.13.2;
- G++ 13.3.0;
- Ubuntu 24.04 runner.

## Result

All acceptance criteria are satisfied. The PR is ready for integration.