### PR TITLE
fix: stabilize Resource accounting lifecycle

### DIFF
--- a/source/plugins/data/DiscreteProcessing/Resource.cpp
+++ b/source/plugins/data/DiscreteProcessing/Resource.cpp
@@ -227,6 +227,10 @@ void Resource::_active() {
         this, "Resource \"" + getName() + "\" has been activated. Capacity set back to " + std::to_string(_capacity));
 }
 
+//
+//
+//
+
 void Resource::setResourceState(ResourceState _resourceState) {
     this->_resourceState = _resourceState;
 }
@@ -335,6 +339,11 @@ Schedule* Resource::getCapacitySchedule() const {
     return _capacitySchedule;
 }
 
+
+//
+//
+//
+
 void Resource::_checkFailByCount() {
     for (Failure* failure : *_failures->list()) {
         if (failure->getFailureType() == Failure::FailureType::COUNT) {
@@ -342,6 +351,8 @@ void Resource::_checkFailByCount() {
         }
     }
 }
+
+//
 
 void Resource::_initBetweenReplications() {
     ModelDataDefinition::_initBetweenReplications();
@@ -418,6 +429,9 @@ void Resource::_saveInstance(PersistenceRecord* fields, bool saveDefaultValues) 
 }
 
 bool Resource::_check(std::string& errorMessage) {
+    /*!
+     * \brief Validate resource basic semantic constraints.
+     */
     bool resultAll = true;
     if (_capacity == 0) {
         errorMessage += "Resource capacity must be greater than zero. ";
@@ -454,13 +468,90 @@ void Resource::_onReplicationEnd(SimulationEvent* se) {
     double seizedTime = _counterTotalTimeSeized->getCountValue();
     double finalProportionSeized = seizedTime / totalTime;
     _cstatProportionSeized->getStatistics()->getCollector()->addValue(finalProportionSeized);
+    // final proportionSeized is just one more value to this cstat
 }
+
+// void Resource::_createInternalAndAttachedData() {
+//     if (_reportStatistics && _cstatTimeSeized == nullptr) {
+//         _cstatProportionSeized = new StatisticsCollector(_parentModel, getName() + "." + "ProportionSeized", this);
+//         _cstatCapacityUtilization = new
+//             StatisticsCollector(_parentModel, getName() + "." + "CapacityUtilization", this);
+//         _cstatTimeSeized = new StatisticsCollector(_parentModel, getName() + "." + "TimeSeized", this);
+//         _cstatTimeFailed = new StatisticsCollector(_parentModel, getName() + "." + "TimeFailed", this);
+//         _counterTotalTimeSeized = new Counter(_parentModel, getName() + "." + "TotalTimeSeized", this);
+//         _counterTotalTimeFailed = new Counter(_parentModel, getName() + "." + "TotalTimeFailed", this);
+//         _counterNumSeizes = new Counter(_parentModel, getName() + "." + "Seizes", this);
+//         _counterNumReleases = new Counter(_parentModel, getName() + "." + "Releases", this);
+//         _counterTotalCostBusy = new Counter(_parentModel, getName() + "." + "CostBusy", this);
+//         _counterTotalCostIdle = new Counter(_parentModel, getName() + "." + "CostIdle", this);
+//         _counterTotalCostPerUse = new Counter(_parentModel, getName() + "." + "CostPerUse", this);
+//         _parentModel->getOnEventManager()->addOnReplicationEndHandler(this, &Resource::_onReplicationEnd);
+//     }
+//     if (_reportStatistics) {
+//         if (_cstatProportionSeized != nullptr) _internalDataInsert("ProportionSeized", _cstatProportionSeized);
+//         if (_cstatCapacityUtilization != nullptr) _internalDataInsert("CapacityUtilization", _cstatCapacityUtilization);
+//         if (_cstatTimeSeized != nullptr) _internalDataInsert("TimeSeized", _cstatTimeSeized);
+//         if (_cstatTimeFailed != nullptr) _internalDataInsert("TimeFailed", _cstatTimeFailed);
+//         if (_counterTotalTimeSeized != nullptr) _internalDataInsert("TotalTimeSeized", _counterTotalTimeSeized);
+//         if (_counterTotalTimeFailed != nullptr) _internalDataInsert("TotalTimeFailed", _counterTotalTimeFailed);
+//         if (_counterNumSeizes != nullptr) _internalDataInsert("Seizes", _counterNumSeizes);
+//         if (_counterNumReleases != nullptr) _internalDataInsert("Releases", _counterNumReleases);
+//         if (_counterTotalCostBusy != nullptr) _internalDataInsert("CostBusy", _counterTotalCostBusy);
+//         if (_counterTotalCostIdle != nullptr) _internalDataInsert("CostIdle", _counterTotalCostIdle);
+//         if (_counterTotalCostPerUse != nullptr) _internalDataInsert("CostPerUse", _counterTotalCostPerUse);
+//     }
+//     else if (!_reportStatistics && _cstatTimeSeized != nullptr) {
+//         _internalDataClear();
+//         _cstatTimeSeized = nullptr;
+//         _cstatTimeFailed = nullptr;
+//         _cstatProportionSeized = nullptr;
+//         _cstatCapacityUtilization = nullptr;
+//         _counterTotalTimeSeized = nullptr;
+//         _counterTotalTimeFailed = nullptr;
+//         _counterNumSeizes = nullptr;
+//         _counterNumReleases = nullptr;
+//         _counterTotalCostPerUse = nullptr;
+//         _counterTotalCostBusy = nullptr;
+//         _counterTotalCostIdle = nullptr;
+//     }
+//
+//     const std::string scheduleKey = getName() + ".CapacitySchedule";
+//     if (_capacitySchedule != nullptr) {
+//         _attachedDataInsert(scheduleKey, _capacitySchedule);
+//     }
+//     else {
+//         _attachedDataRemove(scheduleKey);
+//     }
+//
+//     std::map<std::string, ModelDataDefinition*>* attachedData = getAttachedData();
+//     std::list<std::string> staleFailureKeys;
+//     const std::string failurePrefix = getName() + ".Failure.";
+//     for (const auto& pair : *attachedData) {
+//         if (pair.first.rfind(failurePrefix, 0) == 0) {
+//             staleFailureKeys.push_back(pair.first);
+//         }
+//     }
+//     for (const std::string& key : staleFailureKeys) {
+//         _attachedDataRemove(key);
+//     }
+//
+//     for (Failure* failure : *_failures->list()) {
+//         if (failure != nullptr) {
+//             _attachedDataInsert(failurePrefix + failure->getName(), failure);
+//         }
+//     }
+// }
+
+//
+//
+//
 
 PluginInformation* Resource::GetPluginInformation() {
     PluginInformation* info = new PluginInformation(Util::TypeOf<Resource>(), &Resource::LoadInstance,
                                                     &Resource::NewInstance);
     info->insertDynamicLibFileDependence("failure.so");
     info->insertDynamicLibFileDependence("schedule.so");
+    //info->set...
     info->setCategory("DiscreteProcessing");
     return info;
 }
@@ -474,6 +565,10 @@ ModelDataDefinition* Resource::LoadInstance(Model* model, PersistenceRecord* fie
     }
     return newElement;
 }
+
+// void Resource::_createInternalStatisticReporters() { }
+
+// void Resource::_createEditableDataDefinitions() { }
 
 void Resource::_initStatisticsAndAccounting() {
     if (!_reportStatistics) {

--- a/source/plugins/data/DiscreteProcessing/Resource.cpp
+++ b/source/plugins/data/DiscreteProcessing/Resource.cpp
@@ -133,6 +133,9 @@ std::string Resource::show() {
 
 bool Resource::seize(unsigned int quantity, double priority) {
     //@ TODO: Considere priority. (Is it here??)
+    if (_reportStatistics) {
+        _initStatisticsAndAccounting();
+    }
     double tnow = _parentModel->getSimulation()->getSimulatedTime();
     _sumCapacityOverTime += _lastTimeCapacityEvaluated * getCapacity();
     _lastTimeCapacityEvaluated = tnow;
@@ -141,14 +144,17 @@ bool Resource::seize(unsigned int quantity, double priority) {
     if (canSeize) {
         _sumNumberBusyOverTime += std::max<double>(_lastTimeReleased, _lastTimeSeized) * _lastTimeAnythingNumberBusy;
         _numberBusy += quantity;
-        if (_reportStatistics)
+        if (_reportStatistics) {
             _counterNumSeizes->incCountValue(quantity);
+            _counterTotalCostPerUse->incCountValue(_costPerUse);
+        }
         _lastTimeSeized = tnow; // instant when seized
         _lastTimeAnythingNumberBusy = _numberBusy;
-        _counterTotalCostPerUse->incCountValue(_costPerUse);
         if (_resourceState != Resource::ResourceState::BUSY) {
             _resourceState = Resource::ResourceState::BUSY;
-            _counterTotalCostIdle->incCountValue(_costIdleTimeUnit * (tnow - _lastTimeIdle));
+            if (_reportStatistics) {
+                _counterTotalCostIdle->incCountValue(_costIdleTimeUnit * (tnow - _lastTimeIdle));
+            }
             _lastTimeBusy = tnow;
         }
     }
@@ -156,6 +162,9 @@ bool Resource::seize(unsigned int quantity, double priority) {
 }
 
 void Resource::release(unsigned int quantity) {
+    if (_reportStatistics) {
+        _initStatisticsAndAccounting();
+    }
     double tnow = _parentModel->getSimulation()->getSimulatedTime();
     _sumNumberBusyOverTime += std::max<double>(_lastTimeReleased, _lastTimeSeized) * _lastTimeAnythingNumberBusy;
     _sumCapacityOverTime += _lastTimeCapacityEvaluated * getCapacity();
@@ -168,7 +177,9 @@ void Resource::release(unsigned int quantity) {
     }
     if (_numberBusy == 0) {
         _resourceState = Resource::ResourceState::IDLE;
-        _counterTotalCostBusy->incCountValue(_costBusyTimeUnit * (tnow - _lastTimeBusy));
+        if (_reportStatistics) {
+            _counterTotalCostBusy->incCountValue(_costBusyTimeUnit * (tnow - _lastTimeBusy));
+        }
         _lastTimeIdle = tnow;
     }
     _lastTimeReleased = tnow;
@@ -202,6 +213,7 @@ void Resource::_active() {
     _capacity = _originalCapacity;
     _lastTimeCapacityEvaluated = tnow;
     if (_reportStatistics) {
+        _initStatisticsAndAccounting();
         double failureTime = tnow - _lastTimeFailed;
         _counterTotalTimeFailed->incCountValue(failureTime);
         _cstatTimeFailed->getStatistics()->getCollector()->addValue(failureTime);
@@ -214,10 +226,6 @@ void Resource::_active() {
     traceSimulation(
         this, "Resource \"" + getName() + "\" has been activated. Capacity set back to " + std::to_string(_capacity));
 }
-
-//
-//
-//
 
 void Resource::setResourceState(ResourceState _resourceState) {
     this->_resourceState = _resourceState;
@@ -303,7 +311,7 @@ double Resource::getCapacityUtilization() const {
 
 double Resource::getSeizedUtilization() const {
     double tnow = _parentModel->getSimulation()->getSimulatedTime();
-    if (_parentModel != nullptr && tnow > 0)
+    if (_parentModel != nullptr && tnow > 0 && _counterTotalTimeSeized != nullptr)
         return _counterTotalTimeSeized->getCountValue() / tnow;
     else
         return 0.0;
@@ -327,11 +335,6 @@ Schedule* Resource::getCapacitySchedule() const {
     return _capacitySchedule;
 }
 
-
-//
-//
-//
-
 void Resource::_checkFailByCount() {
     for (Failure* failure : *_failures->list()) {
         if (failure->getFailureType() == Failure::FailureType::COUNT) {
@@ -339,8 +342,6 @@ void Resource::_checkFailByCount() {
         }
     }
 }
-
-//
 
 void Resource::_initBetweenReplications() {
     ModelDataDefinition::_initBetweenReplications();
@@ -417,9 +418,6 @@ void Resource::_saveInstance(PersistenceRecord* fields, bool saveDefaultValues) 
 }
 
 bool Resource::_check(std::string& errorMessage) {
-    /*!
-     * \brief Validate resource basic semantic constraints.
-     */
     bool resultAll = true;
     if (_capacity == 0) {
         errorMessage += "Resource capacity must be greater than zero. ";
@@ -448,94 +446,21 @@ bool Resource::_check(std::string& errorMessage) {
 }
 
 void Resource::_onReplicationEnd(SimulationEvent* se) {
+    if (!_reportStatistics || se == nullptr || _counterTotalTimeSeized == nullptr ||
+        _cstatProportionSeized == nullptr || se->getSimulatedTime() <= 0.0) {
+        return;
+    }
     double totalTime = se->getSimulatedTime();
     double seizedTime = _counterTotalTimeSeized->getCountValue();
     double finalProportionSeized = seizedTime / totalTime;
     _cstatProportionSeized->getStatistics()->getCollector()->addValue(finalProportionSeized);
-    // final proportionSeized is just one more value to this cstat
 }
-
-// void Resource::_createInternalAndAttachedData() {
-//     if (_reportStatistics && _cstatTimeSeized == nullptr) {
-//         _cstatProportionSeized = new StatisticsCollector(_parentModel, getName() + "." + "ProportionSeized", this);
-//         _cstatCapacityUtilization = new
-//             StatisticsCollector(_parentModel, getName() + "." + "CapacityUtilization", this);
-//         _cstatTimeSeized = new StatisticsCollector(_parentModel, getName() + "." + "TimeSeized", this);
-//         _cstatTimeFailed = new StatisticsCollector(_parentModel, getName() + "." + "TimeFailed", this);
-//         _counterTotalTimeSeized = new Counter(_parentModel, getName() + "." + "TotalTimeSeized", this);
-//         _counterTotalTimeFailed = new Counter(_parentModel, getName() + "." + "TotalTimeFailed", this);
-//         _counterNumSeizes = new Counter(_parentModel, getName() + "." + "Seizes", this);
-//         _counterNumReleases = new Counter(_parentModel, getName() + "." + "Releases", this);
-//         _counterTotalCostBusy = new Counter(_parentModel, getName() + "." + "CostBusy", this);
-//         _counterTotalCostIdle = new Counter(_parentModel, getName() + "." + "CostIdle", this);
-//         _counterTotalCostPerUse = new Counter(_parentModel, getName() + "." + "CostPerUse", this);
-//         _parentModel->getOnEventManager()->addOnReplicationEndHandler(this, &Resource::_onReplicationEnd);
-//     }
-//     if (_reportStatistics) {
-//         if (_cstatProportionSeized != nullptr) _internalDataInsert("ProportionSeized", _cstatProportionSeized);
-//         if (_cstatCapacityUtilization != nullptr) _internalDataInsert("CapacityUtilization", _cstatCapacityUtilization);
-//         if (_cstatTimeSeized != nullptr) _internalDataInsert("TimeSeized", _cstatTimeSeized);
-//         if (_cstatTimeFailed != nullptr) _internalDataInsert("TimeFailed", _cstatTimeFailed);
-//         if (_counterTotalTimeSeized != nullptr) _internalDataInsert("TotalTimeSeized", _counterTotalTimeSeized);
-//         if (_counterTotalTimeFailed != nullptr) _internalDataInsert("TotalTimeFailed", _counterTotalTimeFailed);
-//         if (_counterNumSeizes != nullptr) _internalDataInsert("Seizes", _counterNumSeizes);
-//         if (_counterNumReleases != nullptr) _internalDataInsert("Releases", _counterNumReleases);
-//         if (_counterTotalCostBusy != nullptr) _internalDataInsert("CostBusy", _counterTotalCostBusy);
-//         if (_counterTotalCostIdle != nullptr) _internalDataInsert("CostIdle", _counterTotalCostIdle);
-//         if (_counterTotalCostPerUse != nullptr) _internalDataInsert("CostPerUse", _counterTotalCostPerUse);
-//     }
-//     else if (!_reportStatistics && _cstatTimeSeized != nullptr) {
-//         _internalDataClear();
-//         _cstatTimeSeized = nullptr;
-//         _cstatTimeFailed = nullptr;
-//         _cstatProportionSeized = nullptr;
-//         _cstatCapacityUtilization = nullptr;
-//         _counterTotalTimeSeized = nullptr;
-//         _counterTotalTimeFailed = nullptr;
-//         _counterNumSeizes = nullptr;
-//         _counterNumReleases = nullptr;
-//         _counterTotalCostPerUse = nullptr;
-//         _counterTotalCostBusy = nullptr;
-//         _counterTotalCostIdle = nullptr;
-//     }
-//
-//     const std::string scheduleKey = getName() + ".CapacitySchedule";
-//     if (_capacitySchedule != nullptr) {
-//         _attachedDataInsert(scheduleKey, _capacitySchedule);
-//     }
-//     else {
-//         _attachedDataRemove(scheduleKey);
-//     }
-//
-//     std::map<std::string, ModelDataDefinition*>* attachedData = getAttachedData();
-//     std::list<std::string> staleFailureKeys;
-//     const std::string failurePrefix = getName() + ".Failure.";
-//     for (const auto& pair : *attachedData) {
-//         if (pair.first.rfind(failurePrefix, 0) == 0) {
-//             staleFailureKeys.push_back(pair.first);
-//         }
-//     }
-//     for (const std::string& key : staleFailureKeys) {
-//         _attachedDataRemove(key);
-//     }
-//
-//     for (Failure* failure : *_failures->list()) {
-//         if (failure != nullptr) {
-//             _attachedDataInsert(failurePrefix + failure->getName(), failure);
-//         }
-//     }
-// }
-
-//
-//
-//
 
 PluginInformation* Resource::GetPluginInformation() {
     PluginInformation* info = new PluginInformation(Util::TypeOf<Resource>(), &Resource::LoadInstance,
                                                     &Resource::NewInstance);
     info->insertDynamicLibFileDependence("failure.so");
     info->insertDynamicLibFileDependence("schedule.so");
-    //info->set...
     info->setCategory("DiscreteProcessing");
     return info;
 }
@@ -550,40 +475,68 @@ ModelDataDefinition* Resource::LoadInstance(Model* model, PersistenceRecord* fie
     return newElement;
 }
 
-// void Resource::_createInternalStatisticReporters() { }
-
-// void Resource::_createEditableDataDefinitions() { }
+void Resource::_initStatisticsAndAccounting() {
+    if (!_reportStatistics) {
+        return;
+    }
+    if (_cstatProportionSeized == nullptr || _cstatCapacityUtilization == nullptr ||
+        _cstatTimeSeized == nullptr || _cstatTimeFailed == nullptr ||
+        _counterTotalTimeSeized == nullptr || _counterTotalTimeFailed == nullptr ||
+        _counterNumSeizes == nullptr || _counterNumReleases == nullptr ||
+        _counterTotalCostBusy == nullptr || _counterTotalCostIdle == nullptr ||
+        _counterTotalCostPerUse == nullptr) {
+        _createAttachedAttributes();
+    }
+}
 
 void Resource::_createAttachedAttributes() {
-    if (_reportStatistics && _cstatTimeSeized == nullptr) {
-        _cstatProportionSeized = new StatisticsCollector(_parentModel, getName() + "." + "ProportionSeized", this);
-        _cstatCapacityUtilization = new
-            StatisticsCollector(_parentModel, getName() + "." + "CapacityUtilization", this);
-        _cstatTimeSeized = new StatisticsCollector(_parentModel, getName() + "." + "TimeSeized", this);
-        _cstatTimeFailed = new StatisticsCollector(_parentModel, getName() + "." + "TimeFailed", this);
-        _counterTotalTimeSeized = new Counter(_parentModel, getName() + "." + "TotalTimeSeized", this);
-        _counterTotalTimeFailed = new Counter(_parentModel, getName() + "." + "TotalTimeFailed", this);
-        _counterNumSeizes = new Counter(_parentModel, getName() + "." + "Seizes", this);
-        _counterNumReleases = new Counter(_parentModel, getName() + "." + "Releases", this);
-        _counterTotalCostBusy = new Counter(_parentModel, getName() + "." + "CostBusy", this);
-        _counterTotalCostIdle = new Counter(_parentModel, getName() + "." + "CostIdle", this);
-        _counterTotalCostPerUse = new Counter(_parentModel, getName() + "." + "CostPerUse", this);
-        _parentModel->getOnEventManager()->addOnReplicationEndHandler(this, &Resource::_onReplicationEnd);
-    }
     if (_reportStatistics) {
-        if (_cstatProportionSeized != nullptr) _mandatoryNonEditableDataDefinitionInsert("ProportionSeized", _cstatProportionSeized);
-        if (_cstatCapacityUtilization != nullptr) _mandatoryNonEditableDataDefinitionInsert("CapacityUtilization", _cstatCapacityUtilization);
-        if (_cstatTimeSeized != nullptr) _mandatoryNonEditableDataDefinitionInsert("TimeSeized", _cstatTimeSeized);
-        if (_cstatTimeFailed != nullptr) _mandatoryNonEditableDataDefinitionInsert("TimeFailed", _cstatTimeFailed);
-        if (_counterTotalTimeSeized != nullptr) _mandatoryNonEditableDataDefinitionInsert("TotalTimeSeized", _counterTotalTimeSeized);
-        if (_counterTotalTimeFailed != nullptr) _mandatoryNonEditableDataDefinitionInsert("TotalTimeFailed", _counterTotalTimeFailed);
-        if (_counterNumSeizes != nullptr) _mandatoryNonEditableDataDefinitionInsert("Seizes", _counterNumSeizes);
-        if (_counterNumReleases != nullptr) _mandatoryNonEditableDataDefinitionInsert("Releases", _counterNumReleases);
-        if (_counterTotalCostBusy != nullptr) _mandatoryNonEditableDataDefinitionInsert("CostBusy", _counterTotalCostBusy);
-        if (_counterTotalCostIdle != nullptr) _mandatoryNonEditableDataDefinitionInsert("CostIdle", _counterTotalCostIdle);
-        if (_counterTotalCostPerUse != nullptr) _mandatoryNonEditableDataDefinitionInsert("CostPerUse", _counterTotalCostPerUse);
+        if (_cstatProportionSeized == nullptr)
+            _cstatProportionSeized = new StatisticsCollector(_parentModel, getName() + ".ProportionSeized", this);
+        if (_cstatCapacityUtilization == nullptr)
+            _cstatCapacityUtilization = new StatisticsCollector(_parentModel, getName() + ".CapacityUtilization", this);
+        if (_cstatTimeSeized == nullptr)
+            _cstatTimeSeized = new StatisticsCollector(_parentModel, getName() + ".TimeSeized", this);
+        if (_cstatTimeFailed == nullptr)
+            _cstatTimeFailed = new StatisticsCollector(_parentModel, getName() + ".TimeFailed", this);
+        if (_counterTotalTimeSeized == nullptr)
+            _counterTotalTimeSeized = new Counter(_parentModel, getName() + ".TotalTimeSeized", this);
+        if (_counterTotalTimeFailed == nullptr)
+            _counterTotalTimeFailed = new Counter(_parentModel, getName() + ".TotalTimeFailed", this);
+        if (_counterNumSeizes == nullptr)
+            _counterNumSeizes = new Counter(_parentModel, getName() + ".Seizes", this);
+        if (_counterNumReleases == nullptr)
+            _counterNumReleases = new Counter(_parentModel, getName() + ".Releases", this);
+        if (_counterTotalCostBusy == nullptr)
+            _counterTotalCostBusy = new Counter(_parentModel, getName() + ".CostBusy", this);
+        if (_counterTotalCostIdle == nullptr)
+            _counterTotalCostIdle = new Counter(_parentModel, getName() + ".CostIdle", this);
+        if (_counterTotalCostPerUse == nullptr)
+            _counterTotalCostPerUse = new Counter(_parentModel, getName() + ".CostPerUse", this);
+
+        if (!_replicationEndHandlerRegistered) {
+            _parentModel->getOnEventManager()->addOnReplicationEndHandler(this, &Resource::_onReplicationEnd);
+            _replicationEndHandlerRegistered = true;
+        }
+
+        _mandatoryNonEditableDataDefinitionInsert("ProportionSeized", _cstatProportionSeized);
+        _mandatoryNonEditableDataDefinitionInsert("CapacityUtilization", _cstatCapacityUtilization);
+        _mandatoryNonEditableDataDefinitionInsert("TimeSeized", _cstatTimeSeized);
+        _mandatoryNonEditableDataDefinitionInsert("TimeFailed", _cstatTimeFailed);
+        _mandatoryNonEditableDataDefinitionInsert("TotalTimeSeized", _counterTotalTimeSeized);
+        _mandatoryNonEditableDataDefinitionInsert("TotalTimeFailed", _counterTotalTimeFailed);
+        _mandatoryNonEditableDataDefinitionInsert("Seizes", _counterNumSeizes);
+        _mandatoryNonEditableDataDefinitionInsert("Releases", _counterNumReleases);
+        _mandatoryNonEditableDataDefinitionInsert("CostBusy", _counterTotalCostBusy);
+        _mandatoryNonEditableDataDefinitionInsert("CostIdle", _counterTotalCostIdle);
+        _mandatoryNonEditableDataDefinitionInsert("CostPerUse", _counterTotalCostPerUse);
     }
-    else if (!_reportStatistics && _cstatTimeSeized != nullptr) {
+    else if (_cstatProportionSeized != nullptr || _cstatCapacityUtilization != nullptr ||
+             _cstatTimeSeized != nullptr || _cstatTimeFailed != nullptr ||
+             _counterTotalTimeSeized != nullptr || _counterTotalTimeFailed != nullptr ||
+             _counterNumSeizes != nullptr || _counterNumReleases != nullptr ||
+             _counterTotalCostBusy != nullptr || _counterTotalCostIdle != nullptr ||
+             _counterTotalCostPerUse != nullptr) {
         _mandatoryNonEditableDataDefinitionsClear();
         _cstatTimeSeized = nullptr;
         _cstatTimeFailed = nullptr;

--- a/source/plugins/data/DiscreteProcessing/Resource.h
+++ b/source/plugins/data/DiscreteProcessing/Resource.h
@@ -26,8 +26,6 @@
 
 #include <functional>
 
-
-
 class SeizableItem;
 
 /*!
@@ -99,10 +97,9 @@ public:
 	enum class ResourceState : int {
 		IDLE = 0, BUSY = 1, FAILED = 2, INACTIVE = 3, OTHER = 4, num_elements = 5
 	};
-public:	
+public:
 	static std::string convertEnumToStr(ResourceState state);
 public:
-	//Resource(Model* model);
 	Resource(Model* model, std::string name = "");
 	virtual ~Resource() override;
 public:
@@ -119,7 +116,7 @@ public:
 	double getInstantCapacityUtilization() const;
 	double getCapacityUtilization() const;
 	double getSeizedUtilization() const;
-	double getLastTimeSeized() const; // used only by "Release" component
+	double getLastTimeSeized() const;
 	void addReleaseResourceEventHandler(ResourceEventHandler eventHandler, ModelComponent* component, unsigned int priority);
 public: // g&s
 	void setResourceState(ResourceState _resourceState);
@@ -136,32 +133,27 @@ public: // g&s
 	Schedule* getCapacitySchedule() const;
 	unsigned int getNumberBusy() const;
 
-protected: // protected must override
+protected:
 	virtual bool _loadInstance(PersistenceRecord *fields) override;
 	virtual void _saveInstance(PersistenceRecord *fields, bool saveDefaultValues) override;
-protected: // protected could override
+protected:
 	virtual bool _check(std::string& errorMessage) override;
-	// virtual void _createInternalAndAttachedData() override;
 	virtual void _initBetweenReplications() override;
 
-
 protected:
-	// virtual void _createInternalStatisticReporters() override;
-	// virtual void _createNonEditableDataDefinitions() override;
-	// virtual void _createEditableDataDefinitions() override;
 	virtual void _createAttachedAttributes() override;
 
-private: //methods
-	void _notifyReleaseEventHandlers(); //!< Notify observer classes that some of the resource capacity has been released. It is useful for allocation components (such as Seize) to know when an entity waiting into a queue can try to seize the resource again
-	void _onReplicationEnd(SimulationEvent* se); //!< Nofified whe replication ended to update cstats based on final replication length
+private:
+	void _notifyReleaseEventHandlers();
+	void _onReplicationEnd(SimulationEvent* se);
 	void _fail();
 	void _active();
 	void _checkFailByCount();
+	void _initStatisticsAndAccounting();
 	friend class Failure;
 	friend class ResourceTestProbe;
 
 private:
-
 	const struct DEFAULT_VALUES {
 		const unsigned int capacity = 1;
 		const double cost = 1.0;
@@ -172,9 +164,9 @@ private:
 	double _costIdleTimeUnit = DEFAULT.cost;
 	double _costPerUse = DEFAULT.cost;
 	ResourceState _resourceState = DEFAULT.resourceState;
-private: // only gets
+private:
 	unsigned int _numberBusy = 0;
-	double _lastTimeSeized = 0.0; // @TODO: It won't work for resources with capacity>1, when not all capacity is seized and them some more are seized. Seized time of first units will be lost. I don't have a solution so far
+	double _lastTimeSeized = 0.0;
 	double _lastTimeReleased = 0.0;
 	double _lastTimeFailed = 0.0;
 	double _lastTimeCapacityEvaluated = 0.0;
@@ -184,14 +176,15 @@ private: // only gets
 	double _sumNumberBusyOverTime = 0.0;
 	double _sumCapacityOverTime = 0.0;
 	bool _isActive = true;
-private: // not gets nor sets
-	unsigned int _originalCapacity; // used for failing purposes, when _capacity changes to 0
-private: //1::n
+	bool _replicationEndHandlerRegistered = false;
+private:
+	unsigned int _originalCapacity;
+private:
 	List<SortedResourceEventHandler*>* _resourceEventHandlers = new List<SortedResourceEventHandler*>();
 	List<Failure*>* _failures = new List<Failure*>();
-private: // attached elements
+private:
 	Schedule* _capacitySchedule = nullptr;
-private: // internal elements
+private:
 	StatisticsCollector* _cstatTimeSeized = nullptr;
 	StatisticsCollector* _cstatTimeFailed = nullptr;
 	StatisticsCollector* _cstatProportionSeized = nullptr;

--- a/source/plugins/data/DiscreteProcessing/Resource.h
+++ b/source/plugins/data/DiscreteProcessing/Resource.h
@@ -26,6 +26,8 @@
 
 #include <functional>
 
+
+
 class SeizableItem;
 
 /*!
@@ -97,9 +99,10 @@ public:
 	enum class ResourceState : int {
 		IDLE = 0, BUSY = 1, FAILED = 2, INACTIVE = 3, OTHER = 4, num_elements = 5
 	};
-public:
+public:	
 	static std::string convertEnumToStr(ResourceState state);
 public:
+	//Resource(Model* model);
 	Resource(Model* model, std::string name = "");
 	virtual ~Resource() override;
 public:
@@ -116,7 +119,7 @@ public:
 	double getInstantCapacityUtilization() const;
 	double getCapacityUtilization() const;
 	double getSeizedUtilization() const;
-	double getLastTimeSeized() const;
+	double getLastTimeSeized() const; // used only by "Release" component
 	void addReleaseResourceEventHandler(ResourceEventHandler eventHandler, ModelComponent* component, unsigned int priority);
 public: // g&s
 	void setResourceState(ResourceState _resourceState);
@@ -133,19 +136,24 @@ public: // g&s
 	Schedule* getCapacitySchedule() const;
 	unsigned int getNumberBusy() const;
 
-protected:
+protected: // protected must override
 	virtual bool _loadInstance(PersistenceRecord *fields) override;
 	virtual void _saveInstance(PersistenceRecord *fields, bool saveDefaultValues) override;
-protected:
+protected: // protected could override
 	virtual bool _check(std::string& errorMessage) override;
+	// virtual void _createInternalAndAttachedData() override;
 	virtual void _initBetweenReplications() override;
 
+
 protected:
+	// virtual void _createInternalStatisticReporters() override;
+	// virtual void _createNonEditableDataDefinitions() override;
+	// virtual void _createEditableDataDefinitions() override;
 	virtual void _createAttachedAttributes() override;
 
-private:
-	void _notifyReleaseEventHandlers();
-	void _onReplicationEnd(SimulationEvent* se);
+private: //methods
+	void _notifyReleaseEventHandlers(); //!< Notify observer classes that some of the resource capacity has been released. It is useful for allocation components (such as Seize) to know when an entity waiting into a queue can try to seize the resource again
+	void _onReplicationEnd(SimulationEvent* se); //!< Nofified whe replication ended to update cstats based on final replication length
 	void _fail();
 	void _active();
 	void _checkFailByCount();
@@ -154,6 +162,7 @@ private:
 	friend class ResourceTestProbe;
 
 private:
+
 	const struct DEFAULT_VALUES {
 		const unsigned int capacity = 1;
 		const double cost = 1.0;
@@ -164,9 +173,9 @@ private:
 	double _costIdleTimeUnit = DEFAULT.cost;
 	double _costPerUse = DEFAULT.cost;
 	ResourceState _resourceState = DEFAULT.resourceState;
-private:
+private: // only gets
 	unsigned int _numberBusy = 0;
-	double _lastTimeSeized = 0.0;
+	double _lastTimeSeized = 0.0; // @TODO: It won't work for resources with capacity>1, when not all capacity is seized and them some more are seized. Seized time of first units will be lost. I don't have a solution so far
 	double _lastTimeReleased = 0.0;
 	double _lastTimeFailed = 0.0;
 	double _lastTimeCapacityEvaluated = 0.0;
@@ -177,14 +186,14 @@ private:
 	double _sumCapacityOverTime = 0.0;
 	bool _isActive = true;
 	bool _replicationEndHandlerRegistered = false;
-private:
-	unsigned int _originalCapacity;
-private:
+private: // not gets nor sets
+	unsigned int _originalCapacity; // used for failing purposes, when _capacity changes to 0
+private: //1::n
 	List<SortedResourceEventHandler*>* _resourceEventHandlers = new List<SortedResourceEventHandler*>();
 	List<Failure*>* _failures = new List<Failure*>();
-private:
+private: // attached elements
 	Schedule* _capacitySchedule = nullptr;
-private:
+private: // internal elements
 	StatisticsCollector* _cstatTimeSeized = nullptr;
 	StatisticsCollector* _cstatTimeFailed = nullptr;
 	StatisticsCollector* _cstatProportionSeized = nullptr;

--- a/source/tests/CMakeLists.txt
+++ b/source/tests/CMakeLists.txt
@@ -213,6 +213,46 @@ if(TARGET genesys_kernel_unit_tests_run)
     add_dependencies(genesys_kernel_unit_tests_run genesys_test_delay_statistics_lifecycle_run)
 endif()
 
+# Resource seize/release operations consume statistics and cost-accounting
+# objects that are currently created by the related-data lifecycle. Characterize
+# enabled, disabled, and repeated-operation behavior before changing production.
+add_executable(genesys_test_resource_accounting_lifecycle
+    unit/test_resource_accounting_lifecycle.cpp
+)
+
+target_include_directories(genesys_test_resource_accounting_lifecycle
+    PRIVATE
+        ${CMAKE_SOURCE_DIR}/source
+)
+
+target_link_libraries(genesys_test_resource_accounting_lifecycle
+    PRIVATE
+        GTest::gtest_main
+        "$<LINK_GROUP:RESCAN,genesys_kernel_util,genesys_kernel_statistics,genesys_parser,genesys_plugins_data,genesys_plugins_components_minimal,genesys_kernel_simulator_support,genesys_kernel_simulator_runtime>"
+)
+
+target_compile_features(genesys_test_resource_accounting_lifecycle PRIVATE cxx_std_23)
+
+set_property(TARGET genesys_test_resource_accounting_lifecycle PROPERTY FOLDER tests/unit)
+
+gtest_discover_tests(genesys_test_resource_accounting_lifecycle
+    PROPERTIES
+        LABELS "unit;runtime;resource;statistics;accounting;lifecycle"
+)
+
+if(TARGET genesys_kernel_unit_tests)
+    add_dependencies(genesys_kernel_unit_tests genesys_test_resource_accounting_lifecycle)
+endif()
+
+if(TARGET genesys_kernel_unit_tests_run)
+    add_custom_target(genesys_test_resource_accounting_lifecycle_run
+        COMMAND $<TARGET_FILE:genesys_test_resource_accounting_lifecycle>
+        DEPENDS genesys_test_resource_accounting_lifecycle
+        USES_TERMINAL
+    )
+    add_dependencies(genesys_kernel_unit_tests_run genesys_test_resource_accounting_lifecycle_run)
+endif()
+
 option(GENESYS_BUILD_SMOKE_TESTS "Build smoke tests under source/tests/smoke" ON)
 
 if(GENESYS_BUILD_SMOKE_TESTS)

--- a/source/tests/unit/test_resource_accounting_lifecycle.cpp
+++ b/source/tests/unit/test_resource_accounting_lifecycle.cpp
@@ -1,0 +1,106 @@
+#include <gtest/gtest.h>
+
+#include "kernel/simulator/Simulator.h"
+#include "kernel/simulator/model/Model.h"
+#include "plugins/data/DiscreteProcessing/Resource.h"
+
+namespace {
+
+const char* kResourceAccountingKeys[] = {
+    "ProportionSeized",
+    "CapacityUtilization",
+    "TimeSeized",
+    "TimeFailed",
+    "TotalTimeSeized",
+    "TotalTimeFailed",
+    "Seizes",
+    "Releases",
+    "CostBusy",
+    "CostIdle",
+    "CostPerUse"
+};
+
+void expectNoAccountingData(Resource* resource) {
+    ASSERT_NE(resource, nullptr);
+    for (const char* key : kResourceAccountingKeys) {
+        EXPECT_EQ(resource->getInternalData(key), nullptr) << key;
+    }
+}
+
+void expectAllAccountingData(Resource* resource) {
+    ASSERT_NE(resource, nullptr);
+    for (const char* key : kResourceAccountingKeys) {
+        EXPECT_NE(resource->getInternalData(key), nullptr) << key;
+    }
+}
+
+} // namespace
+
+TEST(ResourceAccountingLifecycleTest, DefaultStatisticsInitializeOnFirstSeizeAndSupportRelease) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    Resource resource(model, "ResourceLazyAccounting");
+    ASSERT_TRUE(resource.isReportStatistics());
+    expectNoAccountingData(&resource);
+
+    EXPECT_TRUE(resource.seize(1u));
+    EXPECT_EQ(resource.getNumberBusy(), 1u);
+    EXPECT_EQ(resource.getResourceState(), Resource::ResourceState::BUSY);
+    expectAllAccountingData(&resource);
+
+    ModelDataDefinition* seizesCounter = resource.getInternalData("Seizes");
+    ModelDataDefinition* releasesCounter = resource.getInternalData("Releases");
+    ModelDataDefinition* costPerUseCounter = resource.getInternalData("CostPerUse");
+
+    resource.release(1u);
+    EXPECT_EQ(resource.getNumberBusy(), 0u);
+    EXPECT_EQ(resource.getResourceState(), Resource::ResourceState::IDLE);
+
+    EXPECT_EQ(resource.getInternalData("Seizes"), seizesCounter);
+    EXPECT_EQ(resource.getInternalData("Releases"), releasesCounter);
+    EXPECT_EQ(resource.getInternalData("CostPerUse"), costPerUseCounter);
+}
+
+TEST(ResourceAccountingLifecycleTest, DisabledStatisticsSupportSeizeAndReleaseWithoutAccountingData) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    Resource resource(model, "ResourceWithoutAccounting");
+    resource.setReportStatistics(false);
+    expectNoAccountingData(&resource);
+
+    EXPECT_TRUE(resource.seize(1u));
+    EXPECT_EQ(resource.getNumberBusy(), 1u);
+    EXPECT_EQ(resource.getResourceState(), Resource::ResourceState::BUSY);
+
+    resource.release(1u);
+    EXPECT_EQ(resource.getNumberBusy(), 0u);
+    EXPECT_EQ(resource.getResourceState(), Resource::ResourceState::IDLE);
+    expectNoAccountingData(&resource);
+}
+
+TEST(ResourceAccountingLifecycleTest, RepeatedOperationsReuseAccountingObjects) {
+    Simulator simulator;
+    Model* model = simulator.getModelManager()->newModel();
+    ASSERT_NE(model, nullptr);
+
+    Resource resource(model, "ResourceStableAccounting");
+
+    ASSERT_TRUE(resource.seize(1u));
+    resource.release(1u);
+    expectAllAccountingData(&resource);
+
+    ModelDataDefinition* timeSeized = resource.getInternalData("TimeSeized");
+    ModelDataDefinition* totalTimeSeized = resource.getInternalData("TotalTimeSeized");
+    ModelDataDefinition* costBusy = resource.getInternalData("CostBusy");
+
+    ASSERT_TRUE(resource.seize(1u));
+    resource.release(1u);
+
+    EXPECT_EQ(resource.getInternalData("TimeSeized"), timeSeized);
+    EXPECT_EQ(resource.getInternalData("TotalTimeSeized"), totalTimeSeized);
+    EXPECT_EQ(resource.getInternalData("CostBusy"), costBusy);
+}


### PR DESCRIPTION
## Scope

Make direct `Resource::seize()` / `Resource::release()` calls safe before the model-wide related-data lifecycle, with explicit behavior for statistics enabled and disabled.

Tracks issue #477.

## Red checkpoint

The first two commits were test-only:

- `ef1f230b02fbdc4dac4feab9f2e4037521bf7050` — focused Resource accounting lifecycle tests;
- `9274304e1732db711032d3b8d84997df7d0eaddd` — aggregate/direct-runner integration.

Phase 0 run `29794139286` confirmed:

- configure passed;
- smoke passed;
- kernel failed during the direct runner;
- no production source had been changed.

The failure matches the code inventory:

- statistics-enabled operations reached null collectors/counters before `_createAttachedAttributes()`;
- statistics-disabled operations still dereferenced cost counters unconditionally.

## Accounting contract

`reportStatistics=false` means the 11 report/accounting data definitions are absent and must not be used. Resource capacity, busy count, state transitions, release handlers and failure checks remain operational.

`reportStatistics=true` means the complete accounting graph is initialized before the first operation and reused thereafter.

## Production correction

### First-use initialization

- add `_initStatisticsAndAccounting()`;
- call it before statistics-enabled `seize()`, `release()` and failure reactivation accounting;
- create all 11 objects independently, repairing partially initialized state.

### Disabled-statistics behavior

- cost-per-use, idle-cost and busy-cost counters are updated only when reporting is enabled;
- state and busy-count behavior remains unchanged;
- `getSeizedUtilization()` safely returns zero when no total-time counter exists.

### Replication-end safety

- add `_replicationEndHandlerRegistered`;
- register the callback once, even across repeated creation calls or disable/re-enable cycles;
- make `_onReplicationEnd()` return safely when statistics are disabled, internals are unavailable, or simulated time is non-positive.

Production commits:

- `7384c7171c94ac69775a1a87a9a5fb59d1bad7b2` — lifecycle state declaration;
- `33ad59fecee35d26b60f08ea2dc1421d65ab6a99` — accounting correction;
- `6abce8233d2230f7ac488a3f12be0571e5476f50` and `eddca45a8ab0c48b94b2e53f553c18a56729fc99` — restore existing documentation after full-file replacement required by the connector.

## Tests

New executable: `genesys_test_resource_accounting_lifecycle`.

1. `DefaultStatisticsInitializeOnFirstSeizeAndSupportRelease`
   - all 11 objects absent before first use;
   - first seize creates the complete graph;
   - release completes and preserves identities.

2. `DisabledStatisticsSupportSeizeAndReleaseWithoutAccountingData`
   - statistics disabled;
   - seize/release update busy count and state;
   - no accounting objects are created.

3. `RepeatedOperationsReuseAccountingObjects`
   - repeated cycles reuse the same objects;
   - no duplicate internal graph is created.

The executable participates in the ordinary aggregate, kernel direct runner and CTest with labels `unit;runtime;resource;statistics;accounting;lifecycle`.

## Non-changes

- no capacity-selection behavior changed;
- no schedule or failure association changed;
- no release-handler behavior changed;
- no persistence format changed;
- no timing formulas or utilization formulas were redesigned;
- no base-class lifecycle change.

## Final acceptance

- ordinary `tests-unit` configure/build/CTest passes;
- GUI GMDD diagnostics pass;
- Phase 0 kernel configure/build/direct runner/CTest passes;
- smoke passes;
- all three Resource lifecycle tests are registered and pass;
- disabled-test count does not increase;
- no duplicate callback or accounting graph is observed.

The PR remains draft until the final head is green.