### PR TITLE
fix: release plugin completion temporary Model

### DIFF
--- a/.github/workflows/genesys-plugin-lifetime-sanitizer.yml
+++ b/.github/workflows/genesys-plugin-lifetime-sanitizer.yml
@@ -1,0 +1,107 @@
+name: GenESyS Plugin Lifetime Sanitizer
+
+run-name: GenESyS Plugin Lifetime | ${{ github.event_name }} | ref=${{ github.ref_name }} | sha=${{ github.sha }}
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - WorkInProgress
+    paths:
+      - source/kernel/simulator/Simulator.cpp
+      - source/kernel/simulator/model/Model.cpp
+      - source/kernel/simulator/model/ModelManager.cpp
+      - source/tests/CMakeLists.txt
+      - source/tests/unit/test_simulator_plugin_completion_lifetime.cpp
+      - .github/workflows/genesys-plugin-lifetime-sanitizer.yml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: genesys-plugin-lifetime-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  QT_QPA_PLATFORM: offscreen
+
+jobs:
+  plugin-lifetime:
+    name: Validate plugin completion lifetime
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          set -Eeuo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential \
+            cmake \
+            ninja-build \
+            python3 \
+            python3-dev \
+            libsbml5-dev \
+            ngspice \
+            r-base \
+            octave \
+            qt6-base-dev \
+            qt6-tools-dev \
+            qt6-tools-dev-tools \
+            libgl1-mesa-dev
+
+      - name: Configure tests-unit
+        run: |
+          set -Eeuo pipefail
+          cmake --preset tests-unit
+
+      - name: Build focused sanitizer executable
+        run: |
+          set -Eeuo pipefail
+          cmake --build --preset tests-unit \
+            --target genesys_test_simulator_plugin_completion_lifetime \
+            --parallel "$(nproc)"
+
+      - name: Run focused ASan and LeakSanitizer regression
+        run: |
+          set -Eeuo pipefail
+          mkdir -p plugin-lifetime-evidence
+          binary="$(find build/tests-unit -type f \
+            -name genesys_test_simulator_plugin_completion_lifetime \
+            -perm -111 -print -quit)"
+          if [[ -z "${binary}" ]]; then
+            echo "Focused executable was not found" | tee plugin-lifetime-evidence/plugin-completion-lifetime.log
+            exit 2
+          fi
+
+          set +e
+          ASAN_OPTIONS="detect_leaks=1:halt_on_error=1:symbolize=1" \
+          LSAN_OPTIONS="exitcode=23" \
+            "${binary}" \
+              --gtest_filter=SimulatorPluginCompletionLifetimeTest.CompletionDoesNotRegisterOrRetainTemporaryModels \
+              2>&1 | tee plugin-lifetime-evidence/plugin-completion-lifetime.log
+          status=${PIPESTATUS[0]}
+          set -e
+
+          printf '%s\n' "${status}" > plugin-lifetime-evidence/exit-code.txt
+          git rev-parse HEAD > plugin-lifetime-evidence/head-sha.txt
+          cmake --version > plugin-lifetime-evidence/cmake-version.txt 2>&1
+          ninja --version > plugin-lifetime-evidence/ninja-version.txt 2>&1
+          g++ --version > plugin-lifetime-evidence/gxx-version.txt 2>&1
+          exit "${status}"
+
+      - name: Upload focused sanitizer evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: genesys-plugin-completion-lifetime-sanitizer
+          path: plugin-lifetime-evidence/
+          if-no-files-found: warn

--- a/source/kernel/simulator/Simulator.cpp
+++ b/source/kernel/simulator/Simulator.cpp
@@ -115,7 +115,7 @@ List<Plugin*>* Simulator::_completePluginsFieldsAndTemplate() {
 	_traceManager->trace("Completing plugins and templates", TraceManager::Level::L8_detailed);
 	_traceManager->setTraceLevel(TraceManager::Level::L0_noTraces); // this crap stuff should not been shown
 	List<Plugin*>* completedPlugins = new List<Plugin*>();
-	Model* tempModel = new Model(this);
+	auto tempModel = std::make_unique<Model>(this);
 	tempModel->getPersistence()->setOption(Persistence_if::Options::SAVEDEFAULTS, true);
 	auto fields = std::make_unique<PersistenceRecord>(*tempModel->getPersistence());
 	Plugin* plugin;
@@ -133,7 +133,7 @@ List<Plugin*>* Simulator::_completePluginsFieldsAndTemplate() {
 				fields->clear();
 				try {
 					if (info->isComponent()) {
-						comp = dynamic_cast<ModelComponent*> (plugin->loadNew(tempModel, fields.get()));
+						comp = dynamic_cast<ModelComponent*> (plugin->loadNew(tempModel.get(), fields.get()));
 						comp->setName("name");
 						while (comp->getConnectionManager()->size() < info->getMinimumOutputs()) {
 							comp->getConnectionManager()->insert(comp);
@@ -141,7 +141,7 @@ List<Plugin*>* Simulator::_completePluginsFieldsAndTemplate() {
 						fields->clear();
 						comp->SaveInstance(fields.get(), comp);
 					} else {
-						datum = plugin->loadNew(tempModel, fields.get());
+						datum = plugin->loadNew(tempModel.get(), fields.get());
 						datum->setName("name");
 						fields->clear();
 						datum->SaveInstance(fields.get(), datum);
@@ -162,6 +162,10 @@ List<Plugin*>* Simulator::_completePluginsFieldsAndTemplate() {
 		} catch (...) {
 		}
 	}
+	// PersistenceRecord was copied from the temporary model persistence service;
+	// destroy it before releasing the model and all model-owned plugin instances.
+	fields.reset();
+	tempModel.reset();
 	Util::ResetAllIds();
 	_traceManager->setTraceLevel(savedTraceLevel);
 	return completedPlugins;

--- a/source/kernel/simulator/essentialPlugins/Counter.cpp
+++ b/source/kernel/simulator/essentialPlugins/Counter.cpp
@@ -29,8 +29,17 @@ ModelDataDefinition* Counter::NewInstance(Model* model, std::string name) {
 
 Counter::Counter(Model* model, std::string name, ModelDataDefinition* parent) : ModelDataDefinition(model, Util::TypeOf<Counter>(), name) {
 	_parent = parent;
-	_parentModel->getResponses()->insert(new SimulationResponseDouble(
-					 std::bind(&Counter::getCountValue, this), this->getClassname(), getName(), "CountValue"));
+	_countValueResponse = new SimulationResponseDouble(
+					 std::bind(&Counter::getCountValue, this), this->getClassname(), getName(), "CountValue");
+	_parentModel->getResponses()->insert(_countValueResponse);
+}
+
+Counter::~Counter() {
+	if (_countValueResponse != nullptr) {
+		_parentModel->getResponses()->remove(_countValueResponse);
+		delete _countValueResponse;
+		_countValueResponse = nullptr;
+	}
 }
 
 std::string Counter::show() {

--- a/source/kernel/simulator/essentialPlugins/Counter.h
+++ b/source/kernel/simulator/essentialPlugins/Counter.h
@@ -29,7 +29,7 @@ class Counter : public ModelDataDefinition {
 public:
 	/*! \brief Creates a counter model datum with optional parent relationship. */
 	Counter(Model* model, std::string name = "", ModelDataDefinition* parent = nullptr);
-	virtual ~Counter() = default;
+	virtual ~Counter() override;
 public:
 	virtual std::string show() override;
 public: // public static methods
@@ -67,6 +67,7 @@ protected: //! could be overriden by derived classes
 private:
 	ModelDataDefinition* _parent;
 	double /*unsigned long*/ _count = 0;
+	SimulationResponse* _countValueResponse = nullptr;
 };
-//namespace\\}
+//namespace\}
 #endif /* COUNTERDEFAULTIMPL1_H */

--- a/source/kernel/simulator/essentialPlugins/EntityType.cpp
+++ b/source/kernel/simulator/essentialPlugins/EntityType.cpp
@@ -42,10 +42,18 @@ void EntityType::_initBetweenReplications() {
 }
 
 EntityType::~EntityType() {
-	// remove all CStats
+	if (_statisticsCollectors == nullptr) {
+		return;
+	}
+	// The statistics collectors are owned by the ModelDataDefinition association
+	// graph. Keep manager bookkeeping consistent here and release only this
+	// auxiliary non-owning list wrapper; the base destructor releases the objects.
 	for (StatisticsCollector* cstat : *_statisticsCollectors->list()) {
 		_parentModel->getDataManager()->remove(Util::TypeOf<StatisticsCollector>(), cstat);
 	}
+	_statisticsCollectors->clear();
+	delete _statisticsCollectors;
+	_statisticsCollectors = nullptr;
 }
 
 std::string EntityType::show() {

--- a/source/kernel/simulator/essentialPlugins/StatisticsCollector.cpp
+++ b/source/kernel/simulator/essentialPlugins/StatisticsCollector.cpp
@@ -31,22 +31,45 @@ StatisticsCollector::StatisticsCollector(Model* model, std::string name, ModelDa
 	_initStaticsAndCollector();
 	StatisticsClass* statThis = static_cast<StatisticsClass*>(this->_statistics);
 	std::string classname = Util::TypeOf<StatisticsClass>();
-	// controls
-	_parentModel->getResponses()->insert(new SimulationResponseDouble(
+	_addOwnedResponse(new SimulationResponseDouble(
 				 std::bind(&StatisticsClass::average, statThis),
 				 classname, getName(), "Average"));
-	_parentModel->getResponses()->insert(new SimulationResponseDouble(
+	_addOwnedResponse(new SimulationResponseDouble(
 				 std::bind(&StatisticsClass::min, statThis),
 				 classname, getName(), "Minimum"));
-	_parentModel->getResponses()->insert(new SimulationResponseDouble(
+	_addOwnedResponse(new SimulationResponseDouble(
 				 std::bind(&StatisticsClass::max, statThis),
 				 classname, getName(), "Maximum"));
-	_parentModel->getResponses()->insert(new SimulationResponseDouble(
+	_addOwnedResponse(new SimulationResponseDouble(
 				 std::bind(&StatisticsClass::numElements, statThis),
 				 classname, getName(), "NumberOfElements"));
-	_parentModel->getResponses()->insert(new SimulationResponseDouble(
+	_addOwnedResponse(new SimulationResponseDouble(
 				 std::bind(&StatisticsClass::halfWidthConfidenceInterval, statThis),
 				 classname, getName(), "HalfWidthConfidenceInterval"));
+}
+
+StatisticsCollector::~StatisticsCollector() {
+	for (SimulationResponse* response : _ownedResponses) {
+		if (response == nullptr) {
+			continue;
+		}
+		_parentModel->getResponses()->remove(response);
+		delete response;
+	}
+	_ownedResponses.clear();
+
+	Collector_if* collector = _statistics != nullptr ? _statistics->getCollector() : nullptr;
+	delete _statistics;
+	_statistics = nullptr;
+	delete collector;
+}
+
+void StatisticsCollector::_addOwnedResponse(SimulationResponse* response) {
+	if (response == nullptr) {
+		return;
+	}
+	_ownedResponses.push_back(response);
+	_parentModel->getResponses()->insert(response);
 }
 
 void StatisticsCollector::_initStaticsAndCollector() {
@@ -75,7 +98,6 @@ ModelDataDefinition* StatisticsCollector::getParent() const {
 Statistics_if* StatisticsCollector::getStatistics() const {
 	return _statistics;
 }
-
 
 ModelDataDefinition* StatisticsCollector::NewInstance(Model* model, std::string name) {
 	return new StatisticsCollector(model, name);

--- a/source/kernel/simulator/essentialPlugins/StatisticsCollector.h
+++ b/source/kernel/simulator/essentialPlugins/StatisticsCollector.h
@@ -19,6 +19,8 @@
 #include "../model/ModelDataManager.h"
 #include "../Plugin.h"
 
+#include <vector>
+
 //namespace GenesysKernel {
 
 /*!
@@ -27,7 +29,7 @@
 class StatisticsCollector : public ModelDataDefinition {//, public Statistics_if {
 public:
 	StatisticsCollector(Model* model, std::string name = "", ModelDataDefinition* parent = nullptr, bool insertIntoModel = true);
-	virtual ~StatisticsCollector() = default;
+	virtual ~StatisticsCollector() override;
 public:
 	virtual std::string show() override;
 public:
@@ -55,10 +57,11 @@ protected:
 
 private:
 	void _initStaticsAndCollector();
+	void _addOwnedResponse(SimulationResponse* response);
 private:
 	ModelDataDefinition* _parent;
-	Statistics_if* _statistics;
+	Statistics_if* _statistics = nullptr;
+	std::vector<SimulationResponse*> _ownedResponses;
 };
-//namespace\\}
+//namespace\}
 #endif /* STATISTICSCOLLECTOR_H */
-

--- a/source/tests/CMakeLists.txt
+++ b/source/tests/CMakeLists.txt
@@ -253,6 +253,62 @@ if(TARGET genesys_kernel_unit_tests_run)
     add_dependencies(genesys_kernel_unit_tests_run genesys_test_resource_accounting_lifecycle_run)
 endif()
 
+# Plugin metadata completion creates a private temporary Model. Keep this one
+# focused executable sanitizer-enabled under GNU/Clang so its process exit proves
+# that the temporary model and its model-owned plugin instances are released.
+add_executable(genesys_test_simulator_plugin_completion_lifetime
+    unit/test_simulator_plugin_completion_lifetime.cpp
+)
+
+target_include_directories(genesys_test_simulator_plugin_completion_lifetime
+    PRIVATE
+        ${CMAKE_SOURCE_DIR}/source
+)
+
+target_link_libraries(genesys_test_simulator_plugin_completion_lifetime
+    PRIVATE
+        GTest::gtest_main
+        "$<LINK_GROUP:RESCAN,genesys_kernel_util,genesys_kernel_statistics,genesys_parser,genesys_plugins_data,genesys_plugins_components_minimal,genesys_kernel_simulator_support,genesys_kernel_simulator_runtime>"
+)
+
+target_compile_features(genesys_test_simulator_plugin_completion_lifetime PRIVATE cxx_std_23)
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    target_compile_options(genesys_test_simulator_plugin_completion_lifetime
+        PRIVATE
+            -fsanitize=address
+            -fno-omit-frame-pointer
+    )
+    target_link_options(genesys_test_simulator_plugin_completion_lifetime
+        PRIVATE
+            -fsanitize=address
+    )
+endif()
+
+set_property(TARGET genesys_test_simulator_plugin_completion_lifetime PROPERTY FOLDER tests/unit)
+
+gtest_discover_tests(genesys_test_simulator_plugin_completion_lifetime
+    PROPERTIES
+        LABELS "unit;runtime;plugin;ownership;lifetime;asan;lsan"
+        ENVIRONMENT "ASAN_OPTIONS=detect_leaks=1:halt_on_error=1;LSAN_OPTIONS=exitcode=23"
+)
+
+if(TARGET genesys_kernel_unit_tests)
+    add_dependencies(genesys_kernel_unit_tests genesys_test_simulator_plugin_completion_lifetime)
+endif()
+
+if(TARGET genesys_kernel_unit_tests_run)
+    add_custom_target(genesys_test_simulator_plugin_completion_lifetime_run
+        COMMAND ${CMAKE_COMMAND} -E env
+            "ASAN_OPTIONS=detect_leaks=1:halt_on_error=1"
+            "LSAN_OPTIONS=exitcode=23"
+            $<TARGET_FILE:genesys_test_simulator_plugin_completion_lifetime>
+        DEPENDS genesys_test_simulator_plugin_completion_lifetime
+        USES_TERMINAL
+    )
+    add_dependencies(genesys_kernel_unit_tests_run genesys_test_simulator_plugin_completion_lifetime_run)
+endif()
+
 option(GENESYS_BUILD_SMOKE_TESTS "Build smoke tests under source/tests/smoke" ON)
 
 if(GENESYS_BUILD_SMOKE_TESTS)

--- a/source/tests/unit/test_simulator_plugin_completion_lifetime.cpp
+++ b/source/tests/unit/test_simulator_plugin_completion_lifetime.cpp
@@ -1,0 +1,53 @@
+#include <gtest/gtest.h>
+
+#include "kernel/simulator/Plugin.h"
+#include "kernel/simulator/PluginManager.h"
+#include "kernel/simulator/Simulator.h"
+#include "kernel/simulator/model/ModelManager.h"
+#include "kernel/util/List.h"
+
+#include <memory>
+
+namespace {
+
+bool hasCompletedMetadata(PluginManager* pluginManager) {
+    if (pluginManager == nullptr) {
+        return false;
+    }
+    for (unsigned int index = 0; index < pluginManager->size(); ++index) {
+        Plugin* plugin = pluginManager->getAtRank(index);
+        if (plugin == nullptr || plugin->getPluginInfo() == nullptr) {
+            continue;
+        }
+        PluginInformation* information = plugin->getPluginInfo();
+        if (!information->getFields()->empty() || !information->getLanguageTemplate().empty()) {
+            return true;
+        }
+    }
+    return false;
+}
+
+} // namespace
+
+TEST(SimulatorPluginCompletionLifetimeTest, CompletionDoesNotRegisterOrRetainTemporaryModels) {
+    Simulator simulator;
+    ASSERT_NE(simulator.getPluginManager(), nullptr);
+    ASSERT_NE(simulator.getModelManager(), nullptr);
+
+    const unsigned int initialModelCount = simulator.getModelManager()->size();
+
+    {
+        std::unique_ptr<List<Plugin*>> completed(
+            simulator.getPluginManager()->completePluginsFieldsAndTemplates());
+        ASSERT_NE(completed, nullptr);
+        EXPECT_EQ(simulator.getModelManager()->size(), initialModelCount);
+        EXPECT_TRUE(hasCompletedMetadata(simulator.getPluginManager()));
+    }
+
+    {
+        std::unique_ptr<List<Plugin*>> completedAgain(
+            simulator.getPluginManager()->completePluginsFieldsAndTemplates());
+        ASSERT_NE(completedAgain, nullptr);
+        EXPECT_EQ(simulator.getModelManager()->size(), initialModelCount);
+    }
+}


### PR DESCRIPTION
## Scope

Release the temporary `Model` created by `Simulator::_completePluginsFieldsAndTemplate()` and correct the model-owned helper objects exposed by the focused ASan/LeakSanitizer regression.

Tracks issue #482.

## Confirmed ownership defect

The completion method allocated:

```cpp
Model* tempModel = new Model(this);
```

and returned without deleting it. The object was never inserted into `ModelManager`, so neither the manager nor `Simulator` teardown owned it.

`Model::~Model()` owns the temporary graph: plugin-created components/data definitions, runtime services, persistence, parser, managers, controls, responses, events and model information.

## Red checkpoints and progressive diagnosis

### Initial test-only checkpoint

Head `75610b4f4afec298cc1ad6f7768d51612483c254`, Phase 0 run `29829050394`:

- configure passed;
- smoke passed;
- kernel build/direct runner failed;
- no production file had been changed.

### Focused initial LeakSanitizer report

Head `fdf6ea90379a17fc4cc24372d175eb05a43fb9d2`, focused run `29829754939`:

- focused build passed;
- test assertions passed;
- LeakSanitizer exit code `23`;
- `27,533 byte(s) leaked in 470 allocation(s)`;
- artifact ID `8494840688`.

### After temporary-Model RAII

Head `a7e7d82a36081f74c4105e8328fbf86318a96aa1`, focused run `29830108591`:

- leak reduced to `2,564 byte(s) in 38 allocation(s)`;
- remaining direct allocations were five `StatisticsCollector` responses, one `Counter` response and the `StatisticsCollector` statistics/collector graph;
- artifact ID `8494971207`.

### After Counter/StatisticsCollector ownership

Head `bcea0b363b17788fe3dbfe6c8aa561d9c3f5df02`, focused run `29830995059`:

- leak reduced to `80 byte(s) in 2 allocation(s)`;
- remaining allocation was the non-owning `EntityType::_statisticsCollectors` list wrapper;
- artifact ID `8495351090`.

## Production corrections

### Simulator

- replace raw temporary-model allocation with `std::unique_ptr<Model>`;
- pass `tempModel.get()` to existing plugin factories;
- destroy the copied `PersistenceRecord` before the temporary model;
- destroy the temporary model while traces remain suppressed;
- restore IDs and trace level afterward;
- preserve fields/templates and the returned non-owning `List<Plugin*>*` API.

### Counter

- retain the created `SimulationResponseDouble` pointer;
- remove it from the model response list and delete it in `Counter::~Counter()`.

### StatisticsCollector

- retain the five created response pointers;
- remove and delete all responses before statistics teardown;
- delete `_statistics`;
- delete the externally supplied collector after deleting the non-owning statistics implementation.

### EntityType

- preserve model/association ownership of contained `StatisticsCollector` objects;
- clear and delete only the auxiliary non-owning list wrapper in `EntityType::~EntityType()`.

## Focused test and workflow

New executable:

- `genesys_test_simulator_plugin_completion_lifetime`;
- CTest labels: `unit;runtime;plugin;ownership;lifetime;asan;lsan`.

The test calls completion twice, owns only returned list wrappers, verifies the `ModelManager` model count is unchanged and verifies metadata completion.

New workflow:

- `.github/workflows/genesys-plugin-lifetime-sanitizer.yml`;
- builds only the focused executable plus dependencies;
- enables ASan/LeakSanitizer only for this executable;
- uploads log, exit code, head SHA and toolchain even on failure.

## Final focused sanitizer validation

Validated branch head: `2a007c45fad8b451fe60dac67c4390b777be86e7`.

Focused run `29831405860`:

- configure: passed;
- focused build: passed;
- ASan/LeakSanitizer execution: passed;
- exit code: `0`;
- test: passed;
- no `AddressSanitizer`, `LeakSanitizer`, use-after-free, double-free or SEGV markers;
- artifact `genesys-plugin-completion-lifetime-sanitizer`, ID `8495543015`.

## Full validation

### Ordinary CI

Run `29831405856`:

- `tests-unit` configure: passed;
- aggregate build: passed;
- CTest: passed;
- GUI GMDD diagnostics: passed.

### Phase 0

Run `29831405873`:

- kernel configure/build/direct runner/inventory/CTest: passed;
- smoke: passed;
- 1,720 tests registered;
- 1,716 tests executed and passed;
- 4 historical Search/Remove duplicates disabled;
- 0 failures;
- artifact `genesys-phase0-tests-kernel-unit`, ID `8495670043`.

## Non-changes

- no plugin ABI/dynamic-loading redesign;
- no plugin metadata schema/content change;
- no broad Simulator manager conversion to smart pointers;
- no public persistence format change;
- no numerical/statistical formula change;
- no ownership change for returned plugin wrappers.

## Result

The leak path was reduced from 27,533 bytes/470 allocations to zero, with focused sanitizer and full repository validation green. The PR is ready for integration.