### PR TITLE
ci: validate standalone Genesys shell preset

### DIFF
--- a/.github/workflows/genesys-shell-validation.yml
+++ b/.github/workflows/genesys-shell-validation.yml
@@ -1,0 +1,126 @@
+name: GenESyS Shell Validation
+
+run-name: GenESyS Shell | ${{ github.event_name }} | ref=${{ github.ref_name }} | sha=${{ github.sha }}
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - WorkInProgress
+    paths:
+      - CMakeLists.txt
+      - CMakePresets.json
+      - autoloadplugins.txt
+      - source/applications/shell/**
+      - source/applications/BaseGenesysTerminalApplication.*
+      - source/kernel/**
+      - source/parser/**
+      - source/plugins/**
+      - source/tools/**
+      - .github/workflows/genesys-shell-validation.yml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: genesys-shell-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  validate-shell:
+    name: Configure, build and exercise genesys_shell
+    runs-on: ubuntu-24.04
+    timeout-minutes: 35
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          set -Eeuo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential \
+            cmake \
+            ninja-build \
+            python3 \
+            python3-dev \
+            libsbml5-dev \
+            libglpk-dev \
+            ngspice \
+            r-base \
+            octave
+
+      - name: Record toolchain
+        run: |
+          set -Eeuo pipefail
+          mkdir -p shell-evidence
+          git rev-parse HEAD | tee shell-evidence/head-sha.txt
+          cmake --version | tee shell-evidence/cmake-version.txt
+          ninja --version | tee shell-evidence/ninja-version.txt
+          g++ --version | tee shell-evidence/gxx-version.txt
+
+      - name: Configure shell preset
+        run: |
+          set -Eeuo pipefail
+          cmake --preset genesys_shell 2>&1 | tee shell-evidence/configure.log
+
+      - name: Build shell preset
+        run: |
+          set -Eeuo pipefail
+          cmake --build --preset genesys_shell --parallel "$(nproc)" 2>&1 \
+            | tee shell-evidence/build.log
+
+      - name: Locate shell executable
+        run: |
+          set -Eeuo pipefail
+          mapfile -t candidates < <(find build/genesys_shell -type f -name genesys_shell -perm -111 | sort)
+          if [[ ${#candidates[@]} -ne 1 ]]; then
+            printf 'Expected exactly one executable named genesys_shell, found %d\n' "${#candidates[@]}" >&2
+            printf '%s\n' "${candidates[@]}" >&2
+            exit 1
+          fi
+          printf '%s\n' "${candidates[0]}" | tee shell-evidence/executable-path.txt
+
+      - name: Run non-interactive shell workflow
+        run: |
+          set -Eeuo pipefail
+          executable="$(cat shell-evidence/executable-path.txt)"
+          timeout 30s "${executable}" \
+            "facade get-name" \
+            "facade get-version" \
+            "plugin count" \
+            "exit" \
+            > shell-evidence/shell-run.log 2>&1
+          cat shell-evidence/shell-run.log
+
+          grep -Fq "Genesys Shell is running." shell-evidence/shell-run.log
+          grep -Fq "Installed plugins:" shell-evidence/shell-run.log
+          grep -Fq "Quiting. Bye." shell-evidence/shell-run.log
+
+          if grep -Eq 'Command ".*" not found' shell-evidence/shell-run.log; then
+            echo "The scripted workflow contained an unknown shell command." >&2
+            exit 1
+          fi
+
+      - name: Collect diagnostics
+        if: always()
+        run: |
+          set +e
+          find build/genesys_shell -type f \( \
+            -name CMakeOutput.log \
+            -o -name CMakeError.log \
+          \) -exec cp --parents {} shell-evidence/ \; 2>/dev/null || true
+
+      - name: Upload shell evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: genesys-shell-validation
+          path: shell-evidence/
+          if-no-files-found: error


### PR DESCRIPTION
## Scope

Add an evidence-only workflow for the standalone `genesys_shell` preset while the static plugin target correction remains blocked on issue #492.

Tracks issue #494.

## Validation path

The workflow:

1. configures with the existing `genesys_shell` preset;
2. builds the existing `genesys_shell` build preset/target with Ninja;
3. locates the executable without assuming an undocumented output directory;
4. invokes the executable non-interactively with four complete argv commands:
   - `facade get-name`;
   - `facade get-version`;
   - `plugin count`;
   - `exit`;
5. enforces a 30-second timeout;
6. verifies the shell banner, plugin-count output, clean quit message, and absence of unknown-command diagnostics;
7. uploads configure/build/runtime logs, executable path, head SHA, and toolchain metadata.

## Why argv commands are valid

`GenesysShell::main()` stores every argv entry as one command string. `GenesysShell::run()` executes those entries before reading stdin, so the sequence is deterministic and does not require a pseudo-terminal.

## Final validation

Validated head: `2cd35d9afc58052a5bd7b3b4103fe7385f72d3af`.

### Focused shell workflow

Run `29885199488` passed all steps:

- configure preset: passed;
- Ninja build: passed;
- executable discovery: passed;
- non-interactive command sequence: passed;
- artifact upload: passed.

Artifact `genesys-shell-validation`, ID `8516303352`, recorded:

- CMake 3.31.6;
- Ninja 1.13.2;
- G++ 13.3.0;
- executable `build/genesys_shell/source/applications/shell/genesys_shell`;
- shell banner;
- GenESyS name/version;
- `Installed plugins: 123`;
- clean `Quiting. Bye.` termination.

### Ordinary CI

Run `29885199461` passed.

## Autoload limitation discovered

The runtime log also records:

```text
Could not open file "autoloadplugins.txt" (.../build/genesys_shell/source/applications/shell/autoloadplugins.txt)
```

`PluginManager` resolves relative plugin-list files against `Util::RunningPath()`, which is the executable directory, not the process working directory. The repository root currently does not contain a retrievable `autoloadplugins.txt` on `WorkInProgress`, despite stale documentation/path filters referring to it.

The shell then used the configured static-plugin fallback and exposed 123 plugins, so the build/argv workflow is valid. This PR does **not** claim file-based autoload validation. The path/deployment contract will be tracked separately and must be corrected without guessing whether the canonical file belongs beside the executable, in an install-data directory, or should be replaced by static discovery for this build profile.

## Files

- `.github/workflows/genesys-shell-validation.yml`.

## Non-changes

- no source code change;
- no CMake target or preset change;
- no plugin architecture or GLPK change;
- no model/simulation behavior change;
- no interactive TTY claim;
- no file-based autoload claim;
- no worker, GUI, or package validation.

## Result

The standalone shell preset builds and its deterministic non-interactive command path works. File-based plugin autoload remains a separate confirmed gap. The PR is ready for integration.